### PR TITLE
ci: stabilize KatlOS 0.1 candidate checks

### DIFF
--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Show Go version
         run: go version
 
+      - name: Install test image tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes mtools
+
       - name: Check Go formatting
         shell: bash
         run: |

--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -17,7 +17,8 @@ jobs:
     name: ${{ matrix.gate.name }}
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
+      (vars.KATL_VMTEST_PR_ENABLED == '1' &&
+       !github.event.pull_request.draft &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on:
       - self-hosted

--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -71,7 +71,6 @@ jobs:
       KATL_VMTEST_DEBUG_ON_FAILURE: "0"
       KATL_VMTEST_REQUIRE_SCENARIO_RESULT: "1"
       KATL_VMTEST_RUN_ID: gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.gate.id }}
-      KATL_VMTEST_RUN_DIR: ${{ runner.temp }}/katl-vmtest/${{ matrix.gate.id }}
 
     steps:
       - name: Check out repository
@@ -84,6 +83,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Set vmtest run directory
+        shell: bash
+        run: echo "KATL_VMTEST_RUN_DIR=$RUNNER_TEMP/katl-vmtest/${{ matrix.gate.id }}" >> "$GITHUB_ENV"
 
       - name: Declare runner capabilities
         shell: bash

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -208,11 +208,12 @@ and release gates.
 ## GitHub VM Tests
 
 The heavy pull-request workflow is `.github/workflows/vmtest.yml`. It runs for
-same-repository, non-draft pull requests and manual dispatches on self-hosted
-runners labeled `katl-vmtest`, `libvirt`, `kvm`, `ovmf`, and `vsock`. The
-runner must provide the same capable-host tools and environment as the local VM
-shell, including `nix develop .#vm`, readable `KATL_OVMF_CODE`, and readable
-`KATL_OVMF_VARS`.
+manual dispatches and, when the repository variable
+`KATL_VMTEST_PR_ENABLED=1` is set, same-repository non-draft pull requests. It
+uses self-hosted runners labeled `katl-vmtest`, `libvirt`, `kvm`, `ovmf`, and
+`vsock`. The runner must provide the same capable-host tools and environment as
+the local VM shell, including `nix develop .#vm`, readable `KATL_OVMF_CODE`, and
+readable `KATL_OVMF_VARS`.
 
 The workflow runs a serialized matrix so fail-fast behavior does not leave many
 VMs active at once:

--- a/docs/internal/v0.1-release-gate-matrix.md
+++ b/docs/internal/v0.1-release-gate-matrix.md
@@ -112,8 +112,9 @@ Command surface: `.github/workflows/vmtest.yml`.
 
 Tier: 1 and selected Tier 2 capable-host gates.
 
-The pull-request VM workflow runs for same-repository, non-draft pull requests
-and manual dispatches on self-hosted capable runners labeled for `katl-vmtest`,
+The pull-request VM workflow runs for manual dispatches and, when the repository
+variable `KATL_VMTEST_PR_ENABLED=1` is set, same-repository non-draft pull
+requests. It uses self-hosted capable runners labeled for `katl-vmtest`,
 `libvirt`, `kvm`, `ovmf`, and `vsock`. It serializes the direct runtime,
 first-install, installed-runtime ready/config-apply, and two-node bootstrap
 gates through `nix develop .#vm` using the same `scripts/vmtest-run` commands

--- a/internal/scriptstest/vmtest_run_script_test.go
+++ b/internal/scriptstest/vmtest_run_script_test.go
@@ -55,7 +55,7 @@ case "$1" in
   metadata)
     case "$2" in
       katl-old|katl-current)
-        printf '<vmtest>katl/vmtest</vmtest>\n'
+        printf '<vmtest xmlns:vmtest="https://katlos.io/xmlns/vmtest/1">katl/vmtest</vmtest>\n'
         ;;
       *)
         printf '\n'

--- a/internal/vmtest/libvirt_vm.go
+++ b/internal/vmtest/libvirt_vm.go
@@ -239,6 +239,13 @@ func (e LibvirtVMExecutor) Run(ctx context.Context, _ string, _ []string, serial
 		if err == nil {
 			switch strings.TrimSpace(state) {
 			case "shut off":
+				if consoleDone != nil {
+					select {
+					case <-consoleDone:
+						consoleDone = nil
+					case <-time.After(e.cleanupTimeout()):
+					}
+				}
 				return nil
 			case "crashed":
 				return errors.New("libvirt domain crashed")

--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -28,7 +28,7 @@ func TestVMTestRunInjectsWorld(t *testing.T) {
 		"-timeout", "2m",
 	)
 	cmd.Dir = repo
-	cmd.Env = appendHostEnv(os.Environ(), host,
+	cmd.Env = appendHostEnv(removeEnv(removeEnv(os.Environ(), "CI"), "KATL_VMTEST_DEBUG_ON_FAILURE"), host,
 		"KATL_VMTEST_GO="+fakeGo,
 		"KATL_FAKE_GO_ARGS="+goArgsPath,
 		"KATL_FAKE_CHILD="+fakeChild,

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -39,6 +39,8 @@ libvirt_storage_pool="${KATL_VMTEST_LIBVIRT_STORAGE_POOL:-default}"
 libvirt_storage_path="${KATL_VMTEST_LIBVIRT_STORAGE_PATH:-/var/lib/libvirt/images}"
 libvirt_domain_prefix="${KATL_VMTEST_LIBVIRT_DOMAIN_PREFIX:-katl-${run_id}}"
 libvirt_vmtest_metadata_uri="https://katlos.io/xmlns/vmtest/1"
+# virsh may preserve the default namespace or render it with a generated prefix.
+libvirt_vmtest_metadata_pattern='^<vmtest([[:space:]]+xmlns(:[A-Za-z_][A-Za-z0-9_.-]*)?="https://katlos.io/xmlns/vmtest/1")?>katl/vmtest</vmtest>$'
 network_cidr="${KATL_VMTEST_CIDR:-10.77.0.0/24}"
 network_gateway="${KATL_VMTEST_GATEWAY:-10.77.0.1}"
 ovmf_code="${KATL_OVMF_CODE:-}"
@@ -600,7 +602,7 @@ cleanup_existing_vmtest_domains() {
         fi
         metadata="$("$virsh_bin" -c "$libvirt_uri" metadata "$domain" --uri "$libvirt_vmtest_metadata_uri" 2>/dev/null || true)"
         metadata="${metadata//$'\r'/}"
-        if [[ "$metadata" == "<vmtest>katl/vmtest</vmtest>" ]]; then
+        if [[ "$metadata" =~ $libvirt_vmtest_metadata_pattern ]]; then
             domains+=("$domain")
         fi
     done < <("$virsh_bin" -c "$libvirt_uri" list --all --name 2>/dev/null || true)


### PR DESCRIPTION
## What changed

- mark Katl vmtest libvirt domains with namespaced ownership metadata
- clean only domains carrying that exact marker, leaving unrelated domains untouched
- recognize the namespace-bearing metadata serialization returned by `virsh`
- install `mtools` for hosted unit tests that prepare FAT images
- derive the VM run directory at step runtime so GitHub accepts the workflow

## Why

Release-candidate validation was blocked by stale vmtest domains, missing hosted-runner image tools, and a VM workflow expression that GitHub rejected before creating jobs.

## Validation

- `go test ./...`
- delivery fixture gate with `-count=1`
- focused vmtest cleanup isolation test with `-count=1`
- actionlint, excluding the repository's intentional custom self-hosted runner labels
- `scripts/mkosi build-runtime`
- `scripts/mkosi build-installer`
- `scripts/mkosi build-katlos-install-image`
- libvirt metadata serialization reproduced with the `test:///default` driver

The draft PR exists to run the required GitHub-hosted and capable self-hosted checks before merge.
