### PR TITLE
ci: require hermetic fast checks

### DIFF
--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "**"
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -43,36 +43,21 @@ jobs:
       - name: Show Go version
         run: go version
 
-      - name: Check Go formatting
-        shell: bash
-        run: |
-          mapfile -d '' files < <(git ls-files -z '*.go')
-          unformatted="$(gofmt -l "${files[@]}")"
-          if [ -n "$unformatted" ]; then
-            printf 'gofmt required for:\n%s\n' "$unformatted"
-            exit 1
-          fi
-
-      - name: Check patch whitespace
+      - name: Resolve comparison range
+        id: comparison
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git diff --check "origin/${{ github.base_ref }}...HEAD"
+            range="origin/${{ github.base_ref }}...HEAD"
           elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            git diff --check "${{ github.event.before }}..HEAD"
+            range="${{ github.event.before }}..HEAD"
           else
-            git diff --check --root HEAD
+            range="$(git hash-object -t tree /dev/null)..HEAD"
           fi
+          echo "range=$range" >> "$GITHUB_OUTPUT"
 
-      - name: Run unit and golden tests
-        run: go test ./...
-
-      - name: Run delivery fixture gate
-        run: |
-          go test ./internal/installer/sysextcatalog \
-            ./internal/installer/kubernetesbundle \
-            ./internal/installer/nodeextensionbundle \
-            -count=1
+      - name: Run fast checks
+        run: scripts/check-fast "${{ steps.comparison.outputs.range }}"
 
       # VM/libvirt/KVM, mkosi artifact builds, and publishing are intentionally
       # excluded from this low-cost workflow. Those gates run through the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,12 @@ Katl is a greenfield project that produces and maintains KatlOS: an installable,
 ## Git Workflow
 
 - Review `git status --short` before editing, staging, or committing.
+- Deliver changes through ready-for-review pull requests; use drafts only when
+  the user explicitly asks for one.
+- Keep pull request descriptions concise. Summarize the change and its reason
+  or root cause, but do not enumerate routine local validation commands.
+- Enable auto-merge after required checks when the repository supports it and
+  the user has authorized publishing the change.
 - Only stage and commit files that are part of the current task. Do not sweep unrelated local changes into a commit.
 - Prefer explicit path staging, for example `git add AGENTS.md docs/internal/initial-design.md`.
 - Agents must use `git commit-wrapped` for commits and must supply both a title and a body.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -189,17 +189,17 @@ scripts are not the supported way to run enabled VM or kubeadm suites.
 ## GitHub Fast Checks
 
 The low-cost pull-request workflow runs formatting, whitespace, unit/golden, and
-delivery fixture checks only:
+delivery fixture checks through the same command used locally. Before pushing a
+branch, run:
 
 ```sh
-git ls-files '*.go' | xargs gofmt -l
-git diff --check
-go test ./...
-go test ./internal/installer/sysextcatalog \
-  ./internal/installer/kubernetesbundle \
-  ./internal/installer/nodeextensionbundle \
-  -count=1
+scripts/check-fast origin/main...HEAD
 ```
+
+The command checks all tracked Go formatting, patch whitespace, and runs the
+complete Go suite with `-count=1` so cached test results cannot hide failures.
+Changes reach `main` through pull requests after the `Format And Unit Tests`
+check passes; direct pushes are not part of the supported development loop.
 
 It intentionally skips mkosi builds, libvirt/KVM setup, VM scenarios, and
 publishing. Those host-specific gates belong to the capable-host vmtest workflow

--- a/internal/scriptstest/katl_release_artifacts_test.go
+++ b/internal/scriptstest/katl_release_artifacts_test.go
@@ -92,7 +92,11 @@ func TestKatlReleaseArtifactNotes(t *testing.T) {
 
 	cmd := exec.Command(filepath.Join(repo, "scripts", "katl-release-artifacts"), "notes", "2026.7.0-dev.4")
 	cmd.Dir = gitDir
-	cmd.Env = append(os.Environ(), "KATL_RELEASE_REPOSITORY_URL=https://github.example/katl-dev/katl")
+	cmd.Env = append(environmentWithout("KATL_RELEASE_TARGET"),
+		"GITHUB_REF_TYPE=branch",
+		"GITHUB_SHA=not-a-commit-in-the-test-repository",
+		"KATL_RELEASE_REPOSITORY_URL=https://github.example/katl-dev/katl",
+	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("notes failed: %v\n%s", err, output)
@@ -117,6 +121,22 @@ func TestKatlReleaseArtifactNotes(t *testing.T) {
 			t.Fatalf("release notes unexpectedly contain %q:\n%s", value, notes)
 		}
 	}
+}
+
+func environmentWithout(names ...string) []string {
+	excluded := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		excluded[name] = struct{}{}
+	}
+
+	environment := make([]string, 0, len(os.Environ()))
+	for _, value := range os.Environ() {
+		name, _, _ := strings.Cut(value, "=")
+		if _, found := excluded[name]; !found {
+			environment = append(environment, value)
+		}
+	}
+	return environment
 }
 
 func TestKatlReleaseArtifactStage(t *testing.T) {

--- a/scripts/check-fast
+++ b/scripts/check-fast
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+cd "$repo_root"
+
+mapfile -d '' go_files < <(git ls-files -z '*.go')
+if ((${#go_files[@]} > 0)); then
+    unformatted="$(gofmt -l "${go_files[@]}")"
+    if [[ -n "$unformatted" ]]; then
+        printf 'gofmt required for:\n%s\n' "$unformatted" >&2
+        exit 1
+    fi
+fi
+
+if (($# > 1)); then
+    printf 'usage: scripts/check-fast [GIT_DIFF_RANGE]\n' >&2
+    exit 2
+fi
+git diff --check
+git diff --cached --check
+if (($# == 1)); then
+    git diff --check "$1"
+fi
+
+go test ./... -count=1

--- a/scripts/katl-release-artifacts
+++ b/scripts/katl-release-artifacts
@@ -32,14 +32,9 @@ generate_release_notes() {
     local -a commits=()
 
     validate_version "$version"
-    if [[ "${GITHUB_REF_TYPE:-}" != branch ]] &&
-        git rev-parse --verify --quiet "refs/tags/$current_tag^{commit}" >/dev/null; then
-        target="refs/tags/$current_tag^{commit}"
-    else
-        target="${KATL_RELEASE_TARGET:-${GITHUB_SHA:-HEAD}}"
-        git rev-parse --verify --quiet "$target^{commit}" >/dev/null ||
-            fail "release notes target is not a commit: $target"
-    fi
+    target="${KATL_RELEASE_TARGET:-HEAD}"
+    git rev-parse --verify --quiet "$target^{commit}" >/dev/null ||
+        fail "release notes target is not a commit: $target"
 
     while IFS= read -r tag; do
         is_katlos_tag "$tag" || continue


### PR DESCRIPTION
## Summary

Make release-note generation independent of ambient GitHub runner variables and add a regression for the temporary-repository boundary. Use one uncached fast-check command locally and in CI, avoid duplicate feature-branch runs, and document ready auto-merged pull requests as the development path.

## Root cause

The release-note test inherited a `GITHUB_SHA` from the outer Actions checkout and the production script tried to resolve it inside the test's temporary Git repository.
