### PR TITLE
release: publish katlctl operator binary

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -114,6 +114,7 @@ jobs:
           scripts/mkosi build-katlos-install-image
           scripts/mkosi build-installer-iso
           KATL_KATLOS_IMAGE_ROLE=upgrade scripts/mkosi build-katlos-install-image
+          scripts/katl-release-artifacts build-katlctl "$KATL_VERSION"
 
       - name: Verify built artifacts
         shell: bash

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -221,8 +221,9 @@ is `2026.7.0`. Use tags such as `v2026.7.0-rc.0` and release branches such as
 the version and rejects noncanonical versions. See
 `docs/internal/adrs/adr-009-katlos-calendar-versioning.md` for the policy.
 
-The published set contains the KatlOS install and upgrade SquashFS images and
-the installer UKI, kernel, initrd, and UEFI-bootable ISO variants, each with
+The published set contains the Linux amd64 `katlctl` operator CLI, the KatlOS
+install and upgrade SquashFS images, and the installer UKI, kernel, initrd, and
+UEFI-bootable ISO variants, each with
 adjacent JSON metadata and SHA-256 files. The ISO embeds the matching KatlOS
 install image and its metadata, so it is the primary self-contained install
 artifact. It remains generic because node identity, disk selection, network,

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -30,6 +30,23 @@ katlctl cluster bootstrap
 
 ## Artifacts
 
+Download the operator CLI for the workstation that will compile configuration
+and bootstrap the cluster:
+
+```text
+katlctl-<version>-linux-amd64
+katlctl-<version>-linux-amd64.sha256
+katlctl-<version>-linux-amd64.json
+```
+
+Install it under the stable command name and confirm that its embedded release
+identity matches the KatlOS release:
+
+```sh
+install -m 0755 katlctl-<version>-linux-amd64 ~/.local/bin/katlctl
+katlctl version
+```
+
 For USB, optical, or virtual media, use the primary release artifact:
 
 ```text

--- a/internal/scriptstest/katl_release_artifacts_test.go
+++ b/internal/scriptstest/katl_release_artifacts_test.go
@@ -123,6 +123,61 @@ func TestKatlReleaseArtifactNotes(t *testing.T) {
 	}
 }
 
+func TestKatlReleaseArtifactBuildKatlctl(t *testing.T) {
+	repo := repoRoot(t)
+	buildDir := t.TempDir()
+	version := "2026.7.0-rc.1"
+	commit := strings.Repeat("a", 40)
+	cmd := exec.Command(filepath.Join(repo, "scripts", "katl-release-artifacts"), "build-katlctl", version)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"KATL_MKOSI_BUILD_DIR="+buildDir,
+		"KATL_ARCHITECTURE=x86_64",
+		"KATL_BUILD_COMMIT="+commit,
+		"KATL_BUILD_DATE=2026-07-11T00:00:00Z",
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build katlctl failed: %v\n%s", err, output)
+	}
+
+	name := "katlctl-" + version + "-linux-amd64"
+	path := filepath.Join(buildDir, name)
+	output, err := exec.Command(path, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("run released katlctl: %v\n%s", err, output)
+	}
+	for _, value := range []string{version, commit, "2026-07-11T00:00:00Z"} {
+		if !strings.Contains(string(output), value) {
+			t.Fatalf("katlctl version output missing %q: %q", value, output)
+		}
+	}
+	var metadata struct {
+		ArtifactKind string `json:"artifactKind"`
+		Version      string `json:"version"`
+		Architecture string `json:"architecture"`
+		SHA256       string `json:"sha256"`
+		SizeBytes    int64  `json:"sizeBytes"`
+	}
+	if err := json.Unmarshal(mustReadFile(t, path+".json"), &metadata); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(mustReadFile(t, path))
+	if metadata.ArtifactKind != "katl.operator-cli.v1" || metadata.Version != version || metadata.Architecture != "amd64" || metadata.SHA256 != hex.EncodeToString(digest[:]) {
+		t.Fatalf("katlctl metadata = %#v", metadata)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.SizeBytes != info.Size() {
+		t.Fatalf("katlctl size = %d, metadata = %d", info.Size(), metadata.SizeBytes)
+	}
+	checksum := string(mustReadFile(t, path+".sha256"))
+	if !strings.Contains(checksum, metadata.SHA256+"  "+name) {
+		t.Fatalf("katlctl checksum = %q", checksum)
+	}
+}
+
 func environmentWithout(names ...string) []string {
 	excluded := make(map[string]struct{}, len(names))
 	for _, name := range names {
@@ -144,17 +199,7 @@ func TestKatlReleaseArtifactStage(t *testing.T) {
 	buildDir := t.TempDir()
 	output := filepath.Join(t.TempDir(), "dist")
 	version := "2026.7.0-rc.0"
-	names := []string{
-		"katl-installer.efi",
-		"katl-installer.vmlinuz",
-		"katl-installer.initrd",
-		"katl-installer.iso",
-		"katlos-install-2026.7.0-rc.0-x86_64.squashfs",
-		"katlos-upgrade-2026.7.0-rc.0-x86_64.squashfs",
-	}
-	for _, name := range names {
-		writeReleaseArtifact(t, buildDir, name)
-	}
+	names := writeRequiredReleaseArtifacts(t, buildDir)
 	writeReleaseArtifact(t, buildDir, "katl-runtime.efi")
 	if err := os.WriteFile(filepath.Join(buildDir, "artifacts.json"), []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -241,16 +286,7 @@ func runGit(t *testing.T, dir string, args ...string) string {
 func TestKatlReleaseArtifactStageRejectsDigestMismatch(t *testing.T) {
 	repo := repoRoot(t)
 	buildDir := t.TempDir()
-	for _, name := range []string{
-		"katl-installer.efi",
-		"katl-installer.vmlinuz",
-		"katl-installer.initrd",
-		"katl-installer.iso",
-		"katlos-install-2026.7.0-rc.0-x86_64.squashfs",
-		"katlos-upgrade-2026.7.0-rc.0-x86_64.squashfs",
-	} {
-		writeReleaseArtifact(t, buildDir, name)
-	}
+	writeRequiredReleaseArtifacts(t, buildDir)
 	if err := os.WriteFile(filepath.Join(buildDir, "katl-installer.efi"), []byte("changed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -270,16 +306,7 @@ func TestKatlReleaseArtifactStageRejectsDigestMismatch(t *testing.T) {
 func TestKatlReleaseArtifactStageRejectsMetadataMismatch(t *testing.T) {
 	repo := repoRoot(t)
 	buildDir := t.TempDir()
-	for _, name := range []string{
-		"katl-installer.efi",
-		"katl-installer.vmlinuz",
-		"katl-installer.initrd",
-		"katl-installer.iso",
-		"katlos-install-2026.7.0-rc.0-x86_64.squashfs",
-		"katlos-upgrade-2026.7.0-rc.0-x86_64.squashfs",
-	} {
-		writeReleaseArtifact(t, buildDir, name)
-	}
+	writeRequiredReleaseArtifacts(t, buildDir)
 	metadata, err := json.Marshal(struct {
 		SHA256    string `json:"sha256"`
 		SizeBytes int    `json:"sizeBytes"`
@@ -309,16 +336,7 @@ func TestKatlReleaseArtifactStageRejectsMetadataMismatch(t *testing.T) {
 func TestKatlReleaseArtifactStageRejectsVersionMismatch(t *testing.T) {
 	repo := repoRoot(t)
 	buildDir := t.TempDir()
-	for _, name := range []string{
-		"katl-installer.efi",
-		"katl-installer.vmlinuz",
-		"katl-installer.initrd",
-		"katl-installer.iso",
-		"katlos-install-2026.7.0-rc.0-x86_64.squashfs",
-		"katlos-upgrade-2026.7.0-rc.0-x86_64.squashfs",
-	} {
-		writeReleaseArtifact(t, buildDir, name)
-	}
+	writeRequiredReleaseArtifacts(t, buildDir)
 	path := filepath.Join(buildDir, "katl-installer.efi.json")
 	var metadata map[string]any
 	if err := json.Unmarshal(mustReadFile(t, path), &metadata); err != nil {
@@ -373,6 +391,41 @@ func writeReleaseArtifact(t *testing.T, dir, name string) {
 	}
 	checksum := fmt.Sprintf("%s  %s\n", digestHex, name)
 	if err := os.WriteFile(filepath.Join(dir, name+".sha256"), []byte(checksum), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRequiredReleaseArtifacts(t *testing.T, dir string) []string {
+	t.Helper()
+	names := []string{
+		"katl-installer.efi",
+		"katl-installer.vmlinuz",
+		"katl-installer.initrd",
+		"katl-installer.iso",
+		"katlos-install-2026.7.0-rc.0-x86_64.squashfs",
+		"katlos-upgrade-2026.7.0-rc.0-x86_64.squashfs",
+		"katlctl-2026.7.0-rc.0-linux-amd64",
+	}
+	for _, name := range names {
+		writeReleaseArtifact(t, dir, name)
+	}
+	setReleaseArtifactArchitecture(t, dir, "katlctl-2026.7.0-rc.0-linux-amd64", "amd64")
+	return names
+}
+
+func setReleaseArtifactArchitecture(t *testing.T, dir, name, architecture string) {
+	t.Helper()
+	path := filepath.Join(dir, name+".json")
+	var metadata map[string]any
+	if err := json.Unmarshal(mustReadFile(t, path), &metadata); err != nil {
+		t.Fatal(err)
+	}
+	metadata["architecture"] = architecture
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -74,6 +74,7 @@ func TestKubernetesBundleWorkflowContract(t *testing.T) {
 		`--source-digest "$GITHUB_SHA"`,
 		"fetch-depth: 0",
 		"--notes-file dist/RELEASE_NOTES.md",
+		`katl-release-artifacts build-katlctl "$KATL_VERSION"`,
 	} {
 		if !strings.Contains(releaseWorkflow, value) {
 			t.Fatalf("KatlOS release workflow missing %q", value)

--- a/scripts/katl-release-artifacts
+++ b/scripts/katl-release-artifacts
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 build_dir="${KATL_MKOSI_BUILD_DIR:-$repo_root/_build/mkosi}"
 architecture="${KATL_ARCHITECTURE:-$(uname -m)}"
+go_command="${KATL_RELEASE_GO:-go}"
 
 fail() {
     echo "error: $*" >&2
@@ -14,6 +15,7 @@ usage() {
     cat >&2 <<'EOF'
 usage: scripts/katl-release-artifacts version EVENT REF_TYPE REF_NAME [MANUAL_VERSION]
        scripts/katl-release-artifacts notes VERSION
+       scripts/katl-release-artifacts build-katlctl VERSION
        scripts/katl-release-artifacts stage VERSION OUTPUT_DIR
 EOF
     exit 2
@@ -91,17 +93,67 @@ validate_version() {
 verify_artifact() {
     local name="$1"
     local version="$2"
+    local expected_architecture="${3:-$architecture}"
     local digest size
 
     (cd "$build_dir" && sha256sum -c "$name.sha256")
     digest="$(sha256sum "$build_dir/$name" | awk '{print $1}')"
     size="$(stat -c %s "$build_dir/$name")"
     jq -e --arg digest "$digest" --argjson size "$size" \
-        --arg version "$version" --arg architecture "$architecture" \
+        --arg version "$version" --arg architecture "$expected_architecture" \
         '.sha256 == $digest and .sizeBytes == $size and
          .version == $version and .architecture == $architecture' \
         "$build_dir/$name.json" >/dev/null ||
         fail "release metadata does not match artifact or release identity: $name.json"
+}
+
+build_katlctl() {
+    local version="$1"
+    local goarch name path digest size build_commit build_date
+
+    validate_version "$version"
+    case "$architecture" in
+        x86_64 | amd64)
+            goarch=amd64
+            ;;
+        *)
+            fail "katlctl release architecture is unsupported: $architecture"
+            ;;
+    esac
+    name="katlctl-${version}-linux-${goarch}"
+    path="$build_dir/$name"
+    build_commit="${KATL_BUILD_COMMIT:-$(git -C "$repo_root" rev-parse HEAD)}"
+    build_date="${KATL_BUILD_DATE:-1970-01-01T00:00:00Z}"
+    mkdir -p "$build_dir"
+    (
+        cd "$repo_root"
+        CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" "$go_command" build \
+            -trimpath \
+            -ldflags="-s -w -X main.version=$version -X main.commit=$build_commit -X main.date=$build_date" \
+            -o "$path" ./cmd/katlctl
+    )
+    digest="$(sha256sum "$path" | awk '{print $1}')"
+    size="$(stat -c %s "$path")"
+    printf '%s  %s\n' "$digest" "$name" >"$path.sha256"
+    jq -n \
+        --arg version "$version" \
+        --arg commit "$build_commit" \
+        --arg buildDate "$build_date" \
+        --arg sha256 "$digest" \
+        --argjson sizeBytes "$size" \
+        '{
+            schemaVersion: 1,
+            artifactKind: "katl.operator-cli.v1",
+            name: "katlctl",
+            version: $version,
+            commit: $commit,
+            buildDate: $buildDate,
+            os: "linux",
+            architecture: "amd64",
+            sha256: $sha256,
+            sizeBytes: $sizeBytes
+        }' >"$path.json"
+    verify_artifact "$name" "$version" amd64
 }
 
 version_for_ref() {
@@ -155,6 +207,7 @@ stage_artifacts() {
         "katlos-install-${version}-${architecture}.squashfs"
         "katlos-upgrade-${version}-${architecture}.squashfs"
     )
+    local operator_name="katlctl-${version}-linux-amd64"
 
     validate_version "$version"
     [[ -n "$output" && "$output" != / && "$output" != . ]] ||
@@ -172,6 +225,12 @@ stage_artifacts() {
         done
         verify_artifact "$name" "$version"
     done
+    for suffix in "" .json .sha256; do
+        path="$build_dir/$operator_name$suffix"
+        [[ -f "$path" ]] || fail "release artifact is missing: $path"
+    done
+    verify_artifact "$operator_name" "$version" amd64
+    names+=("$operator_name")
 
     mkdir -p "$output"
     for name in "${names[@]}"; do
@@ -218,6 +277,10 @@ case "${1:-}" in
     notes)
         [[ $# -eq 2 ]] || usage
         generate_release_notes "$2"
+        ;;
+    build-katlctl)
+        [[ $# -eq 2 ]] || usage
+        build_katlctl "$2"
         ;;
     stage)
         [[ $# -eq 3 ]] || usage


### PR DESCRIPTION
## Summary

Publish a versioned static Linux amd64 `katlctl` beside KatlOS release artifacts. Embed the release identity and verify its metadata, bytes, size, architecture, checksums, and provenance through the existing staging boundary.
