### PR TITLE
release: support alpha and beta versions

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: CalVer embedded in artifacts (for example 2026.7.0-dev.0)
+        description: CalVer embedded in artifacts (for example 2026.7.0-alpha.1)
         required: true
         type: string
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -213,11 +213,11 @@ with an explicit version for build verification. Release-branch and manual runs
 retain one GitHub Actions artifact; tag runs additionally publish those exact
 files as assets on the matching GitHub Release.
 
-KatlOS release versions use `YYYY.M.PATCH` calendar versions with `-dev.N` and
-`-rc.N` prereleases. The first development and release-candidate identities for
-the July 2026 line are `2026.7.0-dev.0` and `2026.7.0-rc.0`; the stable identity
-is `2026.7.0`. Use tags such as `v2026.7.0-rc.0` and release branches such as
-`release/2026.7.0-rc.0`. The workflow strips an optional `v` before embedding
+KatlOS release versions use `YYYY.M.PATCH` calendar versions with `-dev.N`,
+`-alpha.N`, `-beta.N`, and `-rc.N` prereleases. The first public alpha for the
+July 2026 line is `2026.7.0-alpha.1`; the stable identity is `2026.7.0`. Use
+tags such as `v2026.7.0-alpha.1` and release branches such as
+`release/2026.7.0-alpha.1`. The workflow strips an optional `v` before embedding
 the version and rejects noncanonical versions. See
 `docs/internal/adrs/adr-009-katlos-calendar-versioning.md` for the policy.
 

--- a/docs/internal/adrs/adr-009-katlos-calendar-versioning.md
+++ b/docs/internal/adrs/adr-009-katlos-calendar-versioning.md
@@ -6,9 +6,10 @@ Date: 2026-07-11.
 
 ## Context
 
-The v0.1 project milestone needs public development, release-candidate, and
-stable artifact identities. `v0.1` describes the milestone scope, but using it
-as the product version would discard the requested date-based release identity.
+The v0.1 project milestone needs public development, alpha, beta,
+release-candidate, and stable artifact identities. `v0.1` describes the
+milestone scope, but using it as the product version would discard the requested
+date-based release identity.
 
 The version is embedded in KatlOS image names and metadata, Go binaries,
 release-branch artifacts, Git tags, and GitHub Releases. It must sort in a
@@ -22,6 +23,8 @@ KatlOS uses calendar versions in this SemVer-compatible form:
 ```text
 YYYY.M.PATCH
 YYYY.M.PATCH-dev.N
+YYYY.M.PATCH-alpha.N
+YYYY.M.PATCH-beta.N
 YYYY.M.PATCH-rc.N
 ```
 
@@ -30,14 +33,16 @@ YYYY.M.PATCH-rc.N
 cut in the same month. A release keeps its original version after the month
 changes; the version records its release line, not the current date.
 
-`dev.N` identifies development publications and `rc.N` identifies release
-candidates. Both sequences start at `0` and increment for materially different
-published artifacts. Development builds precede release candidates, which
-precede the stable release:
+`dev.N` identifies development publications, `alpha.N` and `beta.N` communicate
+public API maturity, and `rc.N` identifies release candidates. Counters contain
+no leading zero and increment for materially different published artifacts.
+The intended maturity sequence is:
 
 ```text
 2026.7.0-dev.0
 2026.7.0-dev.1
+2026.7.0-alpha.1
+2026.7.0-beta.1
 2026.7.0-rc.0
 2026.7.0-rc.1
 2026.7.0
@@ -45,14 +50,19 @@ precede the stable release:
 
 The v0.1 project milestone is therefore a scope milestone, not the literal
 KatlOS product version. Its first development publication is
-`2026.7.0-dev.0`, and its first release candidate is `2026.7.0-rc.0`.
+`2026.7.0-dev.0`, and its first public alpha is `2026.7.0-alpha.1`.
 
-Git tags use a leading `v`, for example `v2026.7.0-rc.0`. Release branches use
+Git tags use a leading `v`, for example `v2026.7.0-alpha.1`. Release branches use
 the exact product version after `release/`, for example
-`release/2026.7.0-rc.0`. The release tooling accepts an optional `v` in either
+`release/2026.7.0-alpha.1`. The release tooling accepts an optional `v` in either
 place, removes it from embedded artifact metadata, and rejects zero-padded
 months, leading-zero counters, other prerelease labels, and non-calendar
 versions. Manual workflow runs use the product version without the `v`.
+
+SemVer compares textual prerelease identifiers lexically, which does not place
+`dev`, `alpha`, `beta`, and `rc` in Katl's maturity order. Release notes and
+automation therefore select the previous KatlOS release from first-parent Git
+history, not from lexical or `version:refname` tag ordering.
 
 The calendar version identifies a KatlOS release as a whole. Kubernetes payload
 bundles and node-extension bundles retain their independent payload versions
@@ -60,14 +70,14 @@ and compatibility metadata; they do not inherit the KatlOS calendar version.
 
 ## Consequences
 
-Release automation can distinguish development builds and release candidates
-using the prerelease suffix while retaining one date-based stable identity.
-Standard SemVer comparison places `dev` before `rc` and both before the stable
-version for the same release line.
+Release automation can distinguish development, alpha, beta, and release
+candidate builds using the prerelease suffix while retaining one date-based
+stable identity. All prereleases still compare before the stable version for
+the same release line.
 
 Cutting a new month does not automatically renumber unreleased artifacts. The
 release owner chooses the target calendar line, then increments its development
-or release-candidate counter for every materially different publication.
+or maturity-stage counter for every materially different publication.
 
 The workflow intentionally rejects loose labels such as `nightly`, literal
 milestone versions such as `0.1.0`, zero-padded forms such as `2026.07.0`, and

--- a/internal/scriptstest/katl_release_artifacts_test.go
+++ b/internal/scriptstest/katl_release_artifacts_test.go
@@ -25,6 +25,8 @@ func TestKatlReleaseArtifactVersion(t *testing.T) {
 	}{
 		{name: "stable tag", args: []string{"version", "push", "tag", "v2026.7.0"}, want: "2026.7.0"},
 		{name: "development tag", args: []string{"version", "push", "tag", "v2026.7.0-dev.0"}, want: "2026.7.0-dev.0"},
+		{name: "alpha tag", args: []string{"version", "push", "tag", "v2026.7.0-alpha.1"}, want: "2026.7.0-alpha.1"},
+		{name: "beta branch", args: []string{"version", "push", "branch", "release/2026.7.0-beta.2"}, want: "2026.7.0-beta.2"},
 		{name: "release candidate branch", args: []string{"version", "push", "branch", "release/2026.7.0-rc.1"}, want: "2026.7.0-rc.1"},
 		{name: "versioned branch", args: []string{"version", "push", "branch", "release/v2026.7.0"}, want: "2026.7.0"},
 		{name: "manual", args: []string{"version", "workflow_dispatch", "branch", "main", "2026.7.0-dev.1"}, want: "2026.7.0-dev.1"},
@@ -58,6 +60,52 @@ func TestKatlReleaseArtifactVersion(t *testing.T) {
 				t.Fatalf("version = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKatlReleaseArtifactNotesFollowReleaseHistory(t *testing.T) {
+	repo := repoRoot(t)
+	gitDir := t.TempDir()
+	runGit(t, gitDir, "init", "--quiet")
+	runGit(t, gitDir, "config", "user.name", "Katl Test")
+	runGit(t, gitDir, "config", "user.email", "test@katl.dev")
+
+	for index, release := range []struct {
+		tag     string
+		subject string
+	}{
+		{tag: "v2026.7.0-dev.4", subject: "release: finish development train"},
+		{tag: "v2026.7.0-alpha.1", subject: "release: publish first alpha"},
+		{tag: "v2026.7.0-beta.1", subject: "release: publish first beta"},
+	} {
+		path := filepath.Join(gitDir, fmt.Sprintf("release-%d", index))
+		if err := os.WriteFile(path, []byte(release.subject+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, gitDir, "add", filepath.Base(path))
+		runGit(t, gitDir, "commit", "--quiet", "-m", release.subject)
+		runGit(t, gitDir, "tag", release.tag)
+	}
+
+	cmd := exec.Command(filepath.Join(repo, "scripts", "katl-release-artifacts"), "notes", "2026.7.0-beta.1")
+	cmd.Dir = gitDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("notes failed: %v\n%s", err, output)
+	}
+	notes := string(output)
+	for _, value := range []string{
+		"publish first beta",
+		"v2026.7.0-alpha.1...v2026.7.0-beta.1",
+	} {
+		if !strings.Contains(notes, value) {
+			t.Fatalf("release notes missing %q:\n%s", value, notes)
+		}
+	}
+	for _, value := range []string{"publish first alpha", "finish development train"} {
+		if strings.Contains(notes, value) {
+			t.Fatalf("release notes unexpectedly contain %q:\n%s", value, notes)
+		}
 	}
 }
 

--- a/scripts/katl-release-artifacts
+++ b/scripts/katl-release-artifacts
@@ -23,7 +23,22 @@ EOF
 
 is_katlos_tag() {
     local tag="$1"
-    [[ "$tag" =~ ^v[0-9]{4}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)(-(dev|rc)\.(0|[1-9][0-9]*))?$ ]]
+    [[ "$tag" =~ ^v[0-9]{4}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)(-(dev|alpha|beta|rc)\.(0|[1-9][0-9]*))?$ ]]
+}
+
+previous_katlos_tag() {
+    local target="$1"
+    local current_tag="$2"
+    local commit tag
+
+    while IFS= read -r commit; do
+        while IFS= read -r tag; do
+            is_katlos_tag "$tag" || continue
+            [[ "$tag" != "$current_tag" ]] || continue
+            printf '%s\n' "$tag"
+            return 0
+        done < <(git tag --points-at "$commit" --list 'v*' --sort=refname)
+    done < <(git rev-list --first-parent "$target")
 }
 
 generate_release_notes() {
@@ -38,12 +53,7 @@ generate_release_notes() {
     git rev-parse --verify --quiet "$target^{commit}" >/dev/null ||
         fail "release notes target is not a commit: $target"
 
-    while IFS= read -r tag; do
-        is_katlos_tag "$tag" || continue
-        [[ "$tag" != "$current_tag" ]] || continue
-        previous_tag="$tag"
-        break
-    done < <(git tag --merged "$target" --list 'v*' --sort=-version:refname)
+    previous_tag="$(previous_katlos_tag "$target" "$current_tag" || true)"
 
     if [[ -n "$previous_tag" ]]; then
         range="$previous_tag..$target"
@@ -86,8 +96,8 @@ validate_version() {
     local version="$1"
     [[ -n "$version" ]] || fail "release version is empty"
     ((${#version} <= 80)) || fail "release version is longer than 80 characters"
-    [[ "$version" =~ ^[0-9]{4}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)(-(dev|rc)\.(0|[1-9][0-9]*))?$ ]] ||
-        fail "release version is not canonical KatlOS CalVer (YYYY.M.PATCH[-dev.N|-rc.N]): $version"
+    [[ "$version" =~ ^[0-9]{4}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)(-(dev|alpha|beta|rc)\.(0|[1-9][0-9]*))?$ ]] ||
+        fail "release version is not canonical KatlOS CalVer (YYYY.M.PATCH[-dev.N|-alpha.N|-beta.N|-rc.N]): $version"
 }
 
 verify_artifact() {


### PR DESCRIPTION
## Summary

Support `alpha.N` and `beta.N` KatlOS CalVer prereleases. Select changelog predecessors from first-parent release history so lexical SemVer ordering cannot choose the wrong prior release.
