### PR TITLE
agent: own executor worker lifecycle

### DIFF
--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -64,11 +64,17 @@ type Executor struct {
 	BundleClient         *http.Client
 	ResolveHostUpgrade   HostUpgradeResolver
 	Async                bool
+	workerMu             sync.Mutex
+	workerWG             sync.WaitGroup
+	workerCtx            context.Context
+	workerCancel         context.CancelFunc
+	stopped              bool
 }
 
 type toolPlan = operation.ExecutorPlan
 
 func NewExecutor(root string, store operation.Store, agentStartID string) *Executor {
+	workerCtx, workerCancel := context.WithCancel(context.Background())
 	executor := &Executor{
 		Root:          strings.TrimSpace(root),
 		Store:         store,
@@ -79,6 +85,8 @@ func NewExecutor(root string, store operation.Store, agentStartID string) *Execu
 		RunPostHealth: runPostKubeadmHealthCommand,
 		MountBootRoot: mountRuntimeBootRoot,
 		Async:         true,
+		workerCtx:     workerCtx,
+		workerCancel:  workerCancel,
 	}
 	if runtimeRoot(executor.Root) == "/" {
 		executor.SetBootOneshot = setBootOneshot
@@ -101,16 +109,52 @@ func AuditStartup(store operation.Store, now time.Time) (operation.ReconcileRepo
 }
 
 func (e *Executor) Dispatch(ctx context.Context, record operation.OperationRecord) error {
+	e.workerMu.Lock()
+	if e.stopped {
+		e.workerMu.Unlock()
+		return fmt.Errorf("agent executor is shutting down")
+	}
 	if e.Async {
+		workerCtx := e.workerCtx
+		e.workerWG.Add(1)
+		e.workerMu.Unlock()
 		go func() {
-			if err := e.Execute(context.Background(), record); err != nil {
+			defer e.workerWG.Done()
+			if err := e.Execute(workerCtx, record); err != nil {
 				e.recordUnhandledExecutionFailure(record.OperationID, err)
 			}
 		}()
 		return nil
 	}
+	e.workerMu.Unlock()
 	_ = e.Execute(ctx, record)
 	return nil
+}
+
+func (e *Executor) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	e.workerMu.Lock()
+	if !e.stopped {
+		e.stopped = true
+		if e.workerCancel != nil {
+			e.workerCancel()
+		}
+	}
+	e.workerMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		e.workerWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for agent executor shutdown: %w", ctx.Err())
+	}
 }
 
 func (e *Executor) recordUnhandledExecutionFailure(operationID string, cause error) {

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -297,6 +297,14 @@ func TestExecutorDispatchSurvivesClientCancellation(t *testing.T) {
 	waitForOperation(t, server.Store, accepted.OperationId, func(record operation.OperationRecord) bool {
 		return record.Terminal && record.Result == operation.ResultSucceeded
 	})
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := executor.Shutdown(shutdownCtx); err != nil {
+		t.Fatal(err)
+	}
+	if err := executor.Dispatch(context.Background(), operation.OperationRecord{OperationID: "op-after-shutdown"}); err == nil {
+		t.Fatal("executor accepted dispatch after shutdown")
+	}
 }
 
 func TestExecutorRecordsFailedChildProcess(t *testing.T) {

--- a/internal/katlc/agent/service.go
+++ b/internal/katlc/agent/service.go
@@ -31,6 +31,12 @@ type ServeConfig struct {
 	Dispatcher                     Dispatcher
 }
 
+type dispatcherShutdown interface {
+	Shutdown(context.Context) error
+}
+
+const dispatcherShutdownTimeout = 30 * time.Second
+
 func Serve(ctx context.Context, config ServeConfig) error {
 	root := strings.TrimSpace(config.Root)
 	if root == "" {
@@ -83,10 +89,20 @@ func Serve(ctx context.Context, config ServeConfig) error {
 	select {
 	case <-ctx.Done():
 		server.GracefulStop()
-		return ctx.Err()
+		return errors.Join(ctx.Err(), shutdownDispatcher(dispatcher))
 	case err := <-errc:
-		return err
+		return errors.Join(err, shutdownDispatcher(dispatcher))
 	}
+}
+
+func shutdownDispatcher(dispatcher Dispatcher) error {
+	shutdown, ok := dispatcher.(dispatcherShutdown)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), dispatcherShutdownTimeout)
+	defer cancel()
+	return shutdown.Shutdown(ctx)
 }
 
 func InitToken(path string) error {

--- a/internal/katlc/agent/service_test.go
+++ b/internal/katlc/agent/service_test.go
@@ -1,11 +1,48 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/operation"
 )
+
+type shutdownTestDispatcher struct {
+	called chan struct{}
+}
+
+func (d *shutdownTestDispatcher) Dispatch(context.Context, operation.OperationRecord) error {
+	return nil
+}
+
+func (d *shutdownTestDispatcher) Shutdown(context.Context) error {
+	close(d.called)
+	return nil
+}
+
+func TestServeShutsDownDispatcher(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dispatcher := &shutdownTestDispatcher{called: make(chan struct{})}
+	err := Serve(ctx, ServeConfig{
+		Root:                           t.TempDir(),
+		Listen:                         "tcp://127.0.0.1:0",
+		AllowUnauthenticatedForTesting: true,
+		Dispatcher:                     dispatcher,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Serve() error = %v, want context cancellation", err)
+	}
+	select {
+	case <-dispatcher.called:
+	default:
+		t.Fatal("Serve did not shut down its dispatcher")
+	}
+}
 
 func TestParseListenAcceptsTCPOnly(t *testing.T) {
 	network, address, err := parseListen("tcp://0.0.0.0:9443")


### PR DESCRIPTION
## Summary

Own asynchronous executor workers through the agent service lifecycle. Client cancellation no longer affects accepted operations, while service shutdown stops dispatch, cancels and awaits workers, and prevents persistence writes from racing process or test cleanup.
