### PR TITLE
config: preflight ClusterConfig sources

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -103,6 +103,8 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	configCmd := &cobra.Command{Use: "config", Short: "Katl configuration operations"}
 	configCmd.AddCommand(newConfigPathCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigTopologyCommand(stdout, stderr))
+	configCmd.AddCommand(newConfigValidateCommand(stdout, stderr))
+	configCmd.AddCommand(newConfigSchemaCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigBundleCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
 	cmd.AddCommand(configCmd)
@@ -903,6 +905,83 @@ func runConfigTopology(opts configTopologyOptions, stdout, stderr io.Writer) err
 type configBundleOptions struct {
 	sourcePath string
 	outputPath string
+}
+
+type configValidationNode struct {
+	Name       string `json:"name"`
+	SystemRole string `json:"systemRole"`
+}
+
+type configValidationReport struct {
+	APIVersion      string                 `json:"apiVersion"`
+	Kind            string                 `json:"kind"`
+	Source          string                 `json:"source"`
+	ClusterName     string                 `json:"clusterName"`
+	SourceDigest    string                 `json:"sourceDigest"`
+	BundleDigest    string                 `json:"bundleDigest"`
+	ArtifactVersion string                 `json:"artifactVersion"`
+	Nodes           []configValidationNode `json:"nodes"`
+}
+
+func newConfigValidateCommand(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate SOURCE",
+		Short: "Validate and resolve a cluster config without writing a bundle",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runConfigValidate(args[0], stdout, stderr)
+		},
+	}
+}
+
+func runConfigValidate(sourcePath string, stdout, stderr io.Writer) error {
+	_ = stderr
+	_, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
+		SourcePath:     sourcePath,
+		KatlctlVersion: version,
+		KatlctlCommit:  commit,
+		CreatedBy:      "katlctl config validate",
+	})
+	if err != nil {
+		return err
+	}
+	nodes := make([]configValidationNode, 0, len(result.Manifest.Nodes))
+	for _, node := range result.Manifest.Nodes {
+		nodes = append(nodes, configValidationNode{Name: node.Name, SystemRole: node.SystemRole})
+	}
+	report := configValidationReport{
+		APIVersion:      configbundle.APIVersion,
+		Kind:            "ClusterConfigValidation",
+		Source:          sourcePath,
+		ClusterName:     result.Manifest.ClusterName,
+		SourceDigest:    result.Manifest.Source.SourceDigest,
+		BundleDigest:    result.Digest,
+		ArtifactVersion: result.Manifest.ArtifactVersion,
+		Nodes:           nodes,
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config validation report: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func newConfigSchemaCommand(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "schema",
+		Short: "Print the ClusterConfig JSON Schema",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			_ = stderr
+			data, err := configbundle.SourceSchema()
+			if err != nil {
+				return err
+			}
+			_, err = stdout.Write(data)
+			return err
+		},
+	}
 }
 
 type configBundleReport struct {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -197,6 +197,78 @@ func TestConfigBundleCommandWritesBundle(t *testing.T) {
 	}
 }
 
+func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read temp directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "cluster.yaml" {
+		t.Fatalf("validation wrote files: %#v", entries)
+	}
+	var report configValidationReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if report.Kind != "ClusterConfigValidation" || report.ClusterName != "lab" || report.Source != sourcePath {
+		t.Fatalf("report = %#v", report)
+	}
+	if !strings.HasPrefix(report.SourceDigest, "sha256:") || !strings.HasPrefix(report.BundleDigest, "sha256:") || !strings.HasPrefix(report.ArtifactVersion, "sha256:") {
+		t.Fatalf("report digests = %#v", report)
+	}
+	if len(report.Nodes) != 1 || report.Nodes[0] != (configValidationNode{Name: "cp-1", SystemRole: "control-plane"}) {
+		t.Fatalf("resolved nodes = %#v", report.Nodes)
+	}
+}
+
+func TestConfigValidateReportsNestedFieldPath(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
+	source := strings.Replace(configBundleSource(), "targetDisk:\n            byID:", "targetDisk:\n            unsupportedSelector: true\n            byID:", 1)
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "spec.nodes[0].overrides.install.targetDisk.unsupportedSelector: field is not supported") {
+		t.Fatalf("run() error = %v, want nested field path", err)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("stdout=%q stderr=%q, want empty", stdout.String(), stderr.String())
+	}
+}
+
+func TestConfigSchemaCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "schema"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	var schema struct {
+		ID    string `json:"$id"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	if schema.ID != "https://katl.dev/schemas/config.katl.dev/v1alpha1/cluster-config.json" || schema.Title != "config.katl.dev/v1alpha1 ClusterConfig" {
+		t.Fatalf("schema identity = %#v", schema)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestLoadInventoryPreservesKubernetesBundleSelection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "inventory.yaml")
 	bundleRef := "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:" + strings.Repeat("a", 64)

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -23,6 +23,30 @@ spec: {}
 `spec` is the only policy-bearing top-level field. Unsupported top-level fields
 or unsupported fields under `spec` are rejected before bundle output is written.
 
+Before creating installation media or a bundle, run the non-writing compiler
+preflight:
+
+```console
+katlctl config validate ./cluster.yaml
+```
+
+The command resolves local references, applies every layer, compiles all node
+plans, and reports the cluster name, content digests, and resolved node names and
+roles. It does not create an output file. Errors identify the source field path,
+including node indexes, for example
+`spec.nodes[0].overrides.install.targetDisk.byPath`.
+
+Editors and validation tools can consume the exact structural schema shipped by
+the installed CLI:
+
+```console
+katlctl config schema > cluster-config-v1alpha1.schema.json
+```
+
+The JSON Schema is derived from the same Go types as the strict YAML decoder.
+The compiler remains authoritative for semantic rules such as destructive disk
+guards, Kubernetes selection, local-reference safety, and layer conflicts.
+
 ## Layer Model
 
 Every node is rendered from four explicit layers, in this order:
@@ -69,8 +93,6 @@ spec:
         authorizedKeys: []
     networkd:
       files: []
-    sysctl:
-      settings: {}
     kubernetes:
       version: v1.36.1
       bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:<OCI-manifest-digest>
@@ -84,8 +106,6 @@ spec:
           minSizeMiB: 65536
       networkd:
         files: []
-      sysctl:
-        settings: {}
       kubernetes:
         labels: {}
         taints: []

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -296,7 +296,24 @@ func WriteArchive(path string, request BuildRequest) (Result, error) {
 }
 
 func DecodeSource(reader io.Reader) (SourceConfig, error) {
-	decoder := yaml.NewDecoder(reader)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return SourceConfig{}, fmt.Errorf("read cluster config: %w", err)
+	}
+	var document yaml.Node
+	nodeDecoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := nodeDecoder.Decode(&document); err != nil {
+		return SourceConfig{}, fmt.Errorf("decode cluster config: %w", err)
+	}
+	var trailing yaml.Node
+	if err := nodeDecoder.Decode(&trailing); err != io.EOF {
+		return SourceConfig{}, fmt.Errorf("decode cluster config: multiple YAML documents")
+	}
+	if err := validateSourceFields(&document); err != nil {
+		return SourceConfig{}, fmt.Errorf("decode cluster config: %w", err)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	var config SourceConfig
 	if err := decoder.Decode(&config); err != nil {

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -3,7 +3,9 @@ package configbundle
 import (
 	"archive/tar"
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -239,7 +241,7 @@ spec:
   nodeRange:
     prefix: worker
 `,
-			want: "field nodeRange not found",
+			want: "spec.nodeRange: field is not supported",
 		},
 	}
 	for _, tt := range tests {
@@ -289,8 +291,38 @@ spec:
     count: 3
 `)
 	_, _, err := BuildArchive(BuildRequest{SourcePath: path})
-	if err == nil || !strings.Contains(err.Error(), "field nodeTemplate not found") {
+	if err == nil || !strings.Contains(err.Error(), "spec.nodeTemplate: field is not supported") {
 		t.Fatalf("BuildArchive() error = %v, want unknown template field", err)
+	}
+}
+
+func TestSourceSchemaGolden(t *testing.T) {
+	data, err := SourceSchema()
+	if err != nil {
+		t.Fatalf("SourceSchema() error = %v", err)
+	}
+	var document struct {
+		ID   string `json:"$id"`
+		Defs map[string]struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	if document.ID != SourceSchemaID {
+		t.Fatalf("schema id = %q, want %q", document.ID, SourceSchemaID)
+	}
+	root := document.Defs["configbundle.SourceConfig"]
+	for _, field := range []string{"apiVersion", "kind", "metadata", "spec"} {
+		if _, ok := root.Properties[field]; !ok {
+			t.Fatalf("root schema is missing %q", field)
+		}
+	}
+	got := fmt.Sprintf("%x", sha256.Sum256(data))
+	const want = "dc5d97319f79566dfba750852860dc360d441ce29b72254517865926229df2a6"
+	if got != want {
+		t.Fatalf("schema SHA-256 = %s, want %s; review the authoring contract before accepting a new golden", got, want)
 	}
 }
 

--- a/internal/installer/configbundle/schema.go
+++ b/internal/installer/configbundle/schema.go
@@ -1,0 +1,217 @@
+package configbundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"gopkg.in/yaml.v3"
+)
+
+const SourceSchemaID = "https://katl.dev/schemas/config.katl.dev/v1alpha1/cluster-config.json"
+
+type sourceSchema struct {
+	Schema string                  `json:"$schema"`
+	ID     string                  `json:"$id"`
+	Title  string                  `json:"title"`
+	Ref    string                  `json:"$ref"`
+	Defs   map[string]schemaObject `json:"$defs"`
+}
+
+type schemaObject struct {
+	Ref                  string                  `json:"$ref,omitempty"`
+	Type                 string                  `json:"type,omitempty"`
+	Const                string                  `json:"const,omitempty"`
+	Enum                 []string                `json:"enum,omitempty"`
+	Properties           map[string]schemaObject `json:"properties,omitempty"`
+	Required             []string                `json:"required,omitempty"`
+	AdditionalProperties any                     `json:"additionalProperties,omitempty"`
+	Items                *schemaObject           `json:"items,omitempty"`
+	Minimum              *int                    `json:"minimum,omitempty"`
+}
+
+// SourceSchema returns the JSON Schema for the ClusterConfig accepted by this
+// version of the compiler. The schema is derived from the decoder's Go types so
+// newly accepted fields cannot be added without changing the published schema.
+func SourceSchema() ([]byte, error) {
+	builder := schemaBuilder{defs: map[string]schemaObject{}}
+	root := reflect.TypeOf(SourceConfig{})
+	builder.schemaFor(root)
+	document := sourceSchema{
+		Schema: "https://json-schema.org/draft/2020-12/schema",
+		ID:     SourceSchemaID,
+		Title:  APIVersion + " " + Kind,
+		Ref:    "#/$defs/" + schemaTypeName(root),
+		Defs:   builder.defs,
+	}
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal ClusterConfig schema: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+type schemaBuilder struct {
+	defs map[string]schemaObject
+}
+
+func (builder *schemaBuilder) schemaFor(t reflect.Type) schemaObject {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == reflect.TypeOf(inventory.SystemRole("")) {
+		return schemaObject{Type: "string", Enum: []string{string(inventory.RoleControlPlane), string(inventory.RoleWorker)}}
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		name := schemaTypeName(t)
+		ref := schemaObject{Ref: "#/$defs/" + name}
+		if _, exists := builder.defs[name]; exists {
+			return ref
+		}
+		// Reserve the definition before descending so recursive types are safe.
+		builder.defs[name] = schemaObject{}
+		properties := map[string]schemaObject{}
+		var required []string
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			name, _, visible := yamlField(field)
+			if !visible {
+				continue
+			}
+			property := builder.schemaFor(field.Type)
+			if t == reflect.TypeOf(SourceConfig{}) {
+				switch name {
+				case "apiVersion":
+					property = schemaObject{Type: "string", Const: APIVersion}
+				case "kind":
+					property = schemaObject{Type: "string", Const: Kind}
+				}
+				required = append(required, name)
+			}
+			properties[name] = property
+		}
+		sort.Strings(required)
+		builder.defs[name] = schemaObject{
+			Type:                 "object",
+			Properties:           properties,
+			Required:             required,
+			AdditionalProperties: false,
+		}
+		return ref
+	case reflect.Slice, reflect.Array:
+		items := builder.schemaFor(t.Elem())
+		return schemaObject{Type: "array", Items: &items}
+	case reflect.Map:
+		value := builder.schemaFor(t.Elem())
+		return schemaObject{Type: "object", AdditionalProperties: value}
+	case reflect.Bool:
+		return schemaObject{Type: "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return schemaObject{Type: "integer"}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		zero := 0
+		return schemaObject{Type: "integer", Minimum: &zero}
+	case reflect.Float32, reflect.Float64:
+		return schemaObject{Type: "number"}
+	default:
+		return schemaObject{Type: "string"}
+	}
+}
+
+func schemaTypeName(t reflect.Type) string {
+	path := t.PkgPath()
+	if index := strings.LastIndexByte(path, '/'); index >= 0 {
+		path = path[index+1:]
+	}
+	return path + "." + t.Name()
+}
+
+func yamlField(field reflect.StructField) (name string, omitEmpty, visible bool) {
+	if field.PkgPath != "" {
+		return "", false, false
+	}
+	tag := field.Tag.Get("yaml")
+	parts := strings.Split(tag, ",")
+	if parts[0] == "-" {
+		return "", false, false
+	}
+	name = parts[0]
+	if name == "" {
+		name = strings.ToLower(field.Name[:1]) + field.Name[1:]
+	}
+	for _, option := range parts[1:] {
+		if option == "omitempty" {
+			omitEmpty = true
+		}
+	}
+	return name, omitEmpty, true
+}
+
+func validateSourceFields(node *yaml.Node) error {
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		node = node.Content[0]
+	}
+	return validateYAMLFields(node, reflect.TypeOf(SourceConfig{}), "")
+}
+
+func validateYAMLFields(node *yaml.Node, t reflect.Type, path string) error {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		if node.Kind != yaml.MappingNode {
+			return nil
+		}
+		fields := map[string]reflect.Type{}
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			name, _, visible := yamlField(field)
+			if visible {
+				fields[name] = field.Type
+			}
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			fieldType, ok := fields[key.Value]
+			fieldPath := joinFieldPath(path, key.Value)
+			if !ok {
+				return fmt.Errorf("%s: field is not supported (line %d)", fieldPath, key.Line)
+			}
+			if err := validateYAMLFields(value, fieldType, fieldPath); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		if node.Kind != yaml.MappingNode {
+			return nil
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if err := validateYAMLFields(node.Content[i+1], t.Elem(), joinFieldPath(path, node.Content[i].Value)); err != nil {
+				return err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		if node.Kind != yaml.SequenceNode {
+			return nil
+		}
+		for i, item := range node.Content {
+			itemPath := fmt.Sprintf("%s[%d]", path, i)
+			if err := validateYAMLFields(item, t.Elem(), itemPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func joinFieldPath(parent, field string) string {
+	if parent == "" {
+		return field
+	}
+	return parent + "." + field
+}


### PR DESCRIPTION
Add a non-writing ClusterConfig validation command with resolved-node reporting and actionable nested field paths. Expose the accepted v1alpha1 structure as a deterministic JSON Schema derived from the compiler types.