### PR TITLE
install: make ClusterConfig the primary flow

### DIFF
--- a/cmd/katl-resource-lock/main_test.go
+++ b/cmd/katl-resource-lock/main_test.go
@@ -41,6 +41,27 @@ func TestRunRefreshAndVerify(t *testing.T) {
 	}
 }
 
+func TestRepositoryMkosiProfileDigestsAreLocked(t *testing.T) {
+	lockPath := resolveExistingPath("mkosi.profiles/resource-package-lock.json")
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read repository package lock: %v", err)
+	}
+	lock, err := resourcetest.DecodePackageLock(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode repository package lock: %v", err)
+	}
+	for _, profile := range lock.MkosiProfiles {
+		got, err := profileConfigDigest(profile.Path)
+		if err != nil {
+			t.Fatalf("hash mkosi profile %q: %v", profile.Name, err)
+		}
+		if got != profile.ConfigDigest {
+			t.Errorf("mkosi profile %q config SHA-256 = %s, lock has %s; refresh the resource package lock with the profile change", profile.Name, got, profile.ConfigDigest)
+		}
+	}
+}
+
 func TestRunVerifyRejectsPackageDrift(t *testing.T) {
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "resource-manifest.json")

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -17,10 +17,11 @@ Katl build output
 
 User-managed provisioning
   PXE, iPXE, matchbox, virtual media, USB, or another boot path
-  per-node install manifests and credentials
+  one compiled cluster config bundle, a selected node name, and credentials
 
 katlos-install
-  validates one install manifest and one KatlOS image
+  verifies the bundle and selects one node's compiled install plan
+  binds that plan to the embedded or explicitly supplied KatlOS image
   mutates the selected disk only after validation
   installs generation 0 and records installed-node handoff state
 
@@ -62,17 +63,17 @@ contains node identity or credentials.
 For PXE, publish the loose installer boot artifacts that match your boot path:
 
 ```text
-katl-installer-<version>-<arch>.efi
-katl-installer-<version>-<arch>.efi.sha256
-katl-installer-<version>-<arch>.efi.json
+katl-installer.efi
+katl-installer.efi.sha256
+katl-installer.efi.json
 
-katl-installer-<version>-<arch>.vmlinuz
-katl-installer-<version>-<arch>.vmlinuz.sha256
-katl-installer-<version>-<arch>.vmlinuz.json
+katl-installer.vmlinuz
+katl-installer.vmlinuz.sha256
+katl-installer.vmlinuz.json
 
-katl-installer-<version>-<arch>.initrd
-katl-installer-<version>-<arch>.initrd.sha256
-katl-installer-<version>-<arch>.initrd.json
+katl-installer.initrd
+katl-installer.initrd.sha256
+katl-installer.initrd.json
 ```
 
 and one KatlOS install payload:
@@ -87,7 +88,8 @@ The installer boot artifacts start the temporary installer environment. The
 KatlOS image is the payload that `katlos-install` verifies and writes into the
 installed system. Do not rebuild either artifact for each node. Put node
 identity, disk selection, networkd snippets, SSH authorized keys, system role,
-and bootstrap intent in the install manifest.
+and bootstrap intent in one `ClusterConfig`, then compile one bundle for all
+nodes.
 
 ### Verify release provenance
 
@@ -106,7 +108,7 @@ the Katl release workflow. Pin the expected tag in the verification policy:
 gh attestation verify katl-installer.iso \
   --repo katl-dev/katl \
   --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \
-  --source-ref refs/tags/v2026.7.0-dev.4
+  --source-ref refs/tags/v2026.7.0-alpha.1
 ```
 
 Repeat the attestation check for the KatlOS SquashFS or loose PXE artifact you
@@ -115,236 +117,220 @@ and source commit. It does not make the build vulnerability-free and is not a
 UEFI Secure Boot signature; production boot-key policy and node-side signature
 enforcement remain separate work.
 
-## Install Manifest
+## Author One ClusterConfig
 
-Each node needs an `install.katl.dev/v1alpha1` manifest. YAML is the preferred
-operator-facing format because it keeps native systemd and kubeadm snippets
-readable. JSON manifests are accepted for tooling compatibility.
+Normal installation starts from one `config.katl.dev/v1alpha1` `ClusterConfig`.
+The compiler resolves shared defaults and node overrides, embeds kubeadm inputs
+and bootstrap inventory, and produces one content-addressed `.katlcfg` archive.
+The same archive is used for every node; boot input selects the node by name.
 
-This example is a control-plane node that uses DHCP and the KatlOS image embedded
-in its installer ISO:
-
-```yaml
-apiVersion: install.katl.dev/v1alpha1
-kind: InstallManifest
-node:
-  identity:
-    hostname: cp-1
-    ssh:
-      authorizedKeys:
-        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
-  systemRole: control-plane
-  networkd:
-    files:
-      - name: 10-lan.network
-        content: |
-          [Match]
-          Name=enp1s0
-
-          [Network]
-          DHCP=yes
-  kubernetes:
-    kubeadm:
-      configRef: control-plane
-  bootstrap:
-    clusterName: katl-lab
-    inventoryNodeName: cp-1
-    nodeAddress: 192.0.2.11
-    controlPlaneEndpoint: api.katl.test:6443
-    bootstrapProfileRef: control-plane
-    kubernetesBundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-install:
-  wipeTarget: true
-  targetDisk:
-    byID: /dev/disk/by-id/ata-KATL_EXAMPLE_ROOT_DISK
-    minSizeMiB: 32768
-```
-
-When booted from the versioned ISO, omit `katlosImage`; the installer binds the
-manifest to the embedded image metadata and verifies the image before disk
-mutation. PXE and other loose-artifact flows must provide an explicit
-`katlosImage.url` or `katlosImage.localRef` with its digest and identity.
-
-Worker nodes use the same schema with `systemRole: worker` and a worker
-bootstrap profile reference when you want to preserve that intent for later
-`katlctl cluster bootstrap`.
-
-Worker node fields differ only where the node identity, role, disk selector, and
-bootstrap profile differ:
+This two-node example uses DHCP and the KatlOS image embedded in the release ISO.
+Replace the SSH key, Kubernetes OCI digest, node addresses, and stable disk IDs:
 
 ```yaml
-node:
-  identity:
-    hostname: worker-1
-    ssh:
-      authorizedKeys:
-        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
-  systemRole: worker
+apiVersion: config.katl.dev/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: katl-lab
+spec:
+  controlPlaneEndpoint: api.katl.test:6443
   kubernetes:
-    kubeadm:
-      configRef: worker
-  bootstrap:
-    clusterName: katl-lab
-    inventoryNodeName: worker-1
-    nodeAddress: 192.0.2.21
-    controlPlaneEndpoint: api.katl.test:6443
-    bootstrapProfileRef: worker
-    kubernetesBundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    version: v1.36.1
+    bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  defaults:
+    install:
+      wipeTarget: true
+      targetDiskDefaults:
+        minSizeMiB: 32768
+    identity:
+      ssh:
+        authorizedKeys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
+    networkd:
+      files:
+        - name: 10-lan.network
+          content: |
+            [Match]
+            Name=enp1s0
+
+            [Network]
+            DHCP=yes
+    bootstrap:
+      access:
+        method: agent
+        credentialRef: agent/default
+  systemRoleDefaults:
+    control-plane:
+      kubernetes:
+        kubeadm:
+          configRef: control-plane
+    worker:
+      kubernetes:
+        kubeadm:
+          configRef: worker
+  kubeadmConfigs:
+    control-plane:
+      config: |
+        apiVersion: kubeadm.k8s.io/v1beta4
+        kind: InitConfiguration
+        nodeRegistration:
+          criSocket: unix:///run/containerd/containerd.sock
+        ---
+        apiVersion: kubeadm.k8s.io/v1beta4
+        kind: ClusterConfiguration
+        kubernetesVersion: v1.36.1
+    worker:
+      config: |
+        apiVersion: kubeadm.k8s.io/v1beta4
+        kind: JoinConfiguration
+        nodeRegistration:
+          criSocket: unix:///run/containerd/containerd.sock
+  nodes:
+    - name: cp-1
+      systemRole: control-plane
+      overrides:
+        identity:
+          hostname: cp-1
+        bootstrap:
+          address: 192.0.2.11
+        install:
+          targetDisk:
+            byID: /dev/disk/by-id/ata-KATL_CP_1_ROOT
+    - name: worker-1
+      systemRole: worker
+      overrides:
+        identity:
+          hostname: worker-1
+        bootstrap:
+          address: 192.0.2.21
+        install:
+          targetDisk:
+            byID: /dev/disk/by-id/ata-KATL_WORKER_1_ROOT
 ```
 
-The destructive install guard is intentionally duplicated: the manifest must set
-`install.wipeTarget` to `true`, and the boot path must select an install mode
-that allows mutation. Prefer stable disk selectors such as
-`/dev/disk/by-id/...`, WWN, or serial. Do not use short kernel-assigned device
-names in manifests.
+The release ISO supplies `katlosImage`, so do not put an external KatlOS URL in
+this source for the ISO flow. PXE uses the same source but adds an explicit
+`spec.katlosImage` descriptor for the published loose SquashFS.
+
+Validate the complete source without writing output, then compile it:
+
+```sh
+katlctl config validate ./cluster.yaml
+katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
+sha256sum ./katl-lab.katlcfg
+```
+
+Save both values printed by these commands. `bundleDigest` identifies the
+verified bundle manifest inside the archive; the `sha256sum` value protects the
+archive bytes while a PXE node downloads them. They are different digests.
+
+The destructive guard has two parts: the resolved node must set
+`install.wipeTarget: true`, and boot input must set `katl.install.mode=auto`.
+Always inspect each resolved target disk before enabling automatic install.
+Use `byID`, WWN, or serial selectors, never `/dev/sda`-style names.
 
 ## PXE Or Matchbox
 
-For network boot, publish the split installer kernel/initrd and each node's
-install manifest through your own HTTP infrastructure. Your PXE, iPXE, or
-matchbox config passes only enough input for `katlos-install` to find and verify
-the manifest.
+Publish the loose installer kernel and initrd, the KatlOS SquashFS and metadata,
+and the single `.katlcfg` archive through your own HTTP infrastructure. Add the
+published KatlOS image descriptor to `spec.katlosImage` before validating and
+compiling the PXE bundle:
 
-Bootstrap-ready manifests that set `node.kubernetes.kubeadm.configRef` also need
-the referenced kubeadm sidecars in the installer material set:
-
-```text
-kubeadm-configs/<configRef>.yaml
-kubeadm/<configRef>.yaml
+```yaml
+spec:
+  katlosImage:
+    url: https://boot.example.invalid/katl/2026.7.0/katlos-install-2026.7.0-x86_64.squashfs
+    sha256: <KatlOS-SquashFS-SHA-256>
+    sizeBytes: <exact-size-in-bytes>
+    version: 2026.7.0
+    architecture: x86_64
+    runtimeInterface: katl-runtime-1
+    role: install
 ```
 
-The current URL boot path downloads the manifest itself. It does not yet fetch
-those sidecars over the network. If the node must preserve kubeadm bootstrap
-intent for later `katlctl cluster bootstrap`, provide the manifest and sidecars
-through local preseed or USB media, or ensure your installer wrapper places
-those directories beside the downloaded manifest before `katlos-install` runs.
-
-Current installer kernel arguments:
+Current bundle-oriented kernel arguments are:
 
 ```text
-katl.manifest.url=<InstallManifest URL>
-katl.manifest.sha256=<InstallManifest SHA-256>
-katl.manifest=<local manifest path>
+katl.bundle.url=<config bundle URL>
+katl.bundle.sha256=<config bundle archive SHA-256>
+katl.bundle.digest=<internal bundle manifest digest>
+katl.bundle=<local config bundle path>
 katl.node=<node name>
 katl.install.mode=auto
-katl.artifact-base-url=<artifact base URL>
 katl.wait-for-config=1
 katl.hold-for-debug=1
 console=...
 ip=...
 ```
 
-Use `katl.install.mode=auto` only when the manifest is correct and the target
-disk selector has been checked. URL manifests require `katl.manifest.sha256`; a
-URL without a digest fails before disk mutation. Without any manifest, or with
-`katl.wait-for-config=1`, the installer waits for local handoff input instead of
-mutating disks. `katl.hold-for-debug=1` keeps the installer in debug mode.
+A URL bundle must have `katl.bundle.sha256`; otherwise it cannot authorize disk
+mutation. Supplying `katl.bundle.digest` is strongly recommended and detects a
+valid archive that contains the wrong compiled cluster. Without input, or with
+`katl.wait-for-config=1`, the installer waits for handoff. Debug mode never
+starts an install.
 
-Illustrative iPXE entry:
+Illustrative iPXE entry for `cp-1`:
 
 ```ipxe
 #!ipxe
-set base https://boot.example.invalid/katl/2026.06.04
+set base https://boot.example.invalid/katl/2026.7.0
 set node cp-1
-set manifest_sha bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-kernel ${base}/katl-installer-2026.06.04-x86_64.vmlinuz initrd=katl-installer-2026.06.04-x86_64.initrd console=ttyS0,115200n8 katl.node=${node} katl.manifest.url=https://boot.example.invalid/katl/manifests/${node}.yaml katl.manifest.sha256=${manifest_sha} katl.install.mode=auto
-initrd ${base}/katl-installer-2026.06.04-x86_64.initrd
+set bundle_sha <config-bundle-archive-sha256>
+set bundle_digest sha256:<internal-bundle-manifest-digest>
+kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.bundle.sha256=${bundle_sha} katl.bundle.digest=${bundle_digest} katl.install.mode=auto
+initrd ${base}/katl-installer.initrd
 boot
 ```
 
-Illustrative matchbox profile:
+Matchbox profiles carry the same five `katl.*` arguments. Groups should select
+only `katl.node`; they do not need a different bundle URL or archive digest per
+node. Katl does not create or operate DHCP, iPXE, or matchbox configuration.
 
-```json
-{
-  "id": "katlos-installer-x86_64",
-  "name": "KatlOS installer",
-  "boot": {
-    "kernel": "https://boot.example.invalid/katl/2026.06.04/katl-installer-2026.06.04-x86_64.vmlinuz",
-    "initrd": [
-      "https://boot.example.invalid/katl/2026.06.04/katl-installer-2026.06.04-x86_64.initrd"
-    ],
-    "args": [
-      "console=ttyS0,115200n8",
-      "katl.node=${mac:hexhyp}",
-      "katl.manifest.url=https://boot.example.invalid/katl/manifests/${mac:hexhyp}.yaml",
-      "katl.manifest.sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-      "katl.install.mode=auto"
-    ]
-  }
-}
+## ISO Or Local Handoff
+
+Boot the same `katl-installer.iso` on each node without preseed input. The
+installer mounts its embedded KatlOS image read-only, prints a handoff URL and
+one-time token to the console and journal, and waits without mutating disks.
+
+For `cp-1`, submit the bundle and select that node:
+
+```sh
+curl --fail-with-body -X POST \
+  -H "Authorization: Bearer <one-time-token>" \
+  -H "Content-Type: application/vnd.katl.config.bundle.v1" \
+  --data-binary @katl-lab.katlcfg \
+  "http://<installer-ip>:8080/v1/config-bundle?node=cp-1&digest=<bundleDigest>"
 ```
 
-Illustrative matchbox group:
+For the worker, boot the same ISO and submit the same file with
+`node=worker-1`. Check `http://<installer-ip>:8080/v1/status` before and after
+submission. A valid request verifies the archive, internal bundle digest,
+selected node, compiled install material, and embedded KatlOS image before the
+installer can mutate the selected disk. The endpoint refuses later submissions.
 
-```json
-{
-  "id": "katlos-cp-1",
-  "name": "KatlOS cp-1",
-  "profile": "katlos-installer-x86_64",
-  "selector": {
-    "mac": "52:54:00:12:34:56"
-  },
-  "metadata": {
-    "node": "cp-1"
-  }
-}
-```
+The console advertises `/v1/config-bundle` as the preferred endpoint.
+`/v1/install` remains available for advanced compiled-manifest integrations.
 
-These snippets are examples of the boot input contract only. Katl does not
-create matchbox profiles or groups for you.
+Separate seed media with the `KATLSEED` label or `virtio-katl-seed` disk ID is
+only needed when provisioning input without the HTTP handoff.
 
-## USB Or Local Handoff
+## Advanced Compiled InstallManifest Boundary
 
-For hands-on installs, boot the versioned KatlOS ISO without a preseeded
-manifest. `katlos-install` mounts its payload read-only, enters local handoff mode,
-prints a URL and one-time token to the console and journal, and waits for one
-valid install manifest.
-
-Operator flow:
-
-```text
-1. Boot the installer artifact.
-2. Read the console line:
-   katlos-install waiting for config at http://<installer-ip>:8080/v1/install token=<token>
-3. Check status:
-   curl http://<installer-ip>:8080/v1/status
-4. Submit the same install manifest used by PXE:
-   curl -X POST \
-     -H "Authorization: Bearer <token>" \
-     -H "Content-Type: application/yaml" \
-     --data-binary @cp-1.install.yaml \
-     http://<installer-ip>:8080/v1/install
-```
-
-After a manifest is accepted, the handoff endpoint refuses later submissions.
-Invalid manifests keep the installer waiting and do not authorize disk mutation.
-
-The release ISO is already offline-capable, so the submitted node manifest omits
-`katlosImage`. Separate seed media with the `KATLSEED` label or the
-`virtio-katl-seed` disk ID is only needed for preseeded node configuration and
-credentials. Advanced custom media can still use `katlosImage.localRef`:
-
-```yaml
-katlosImage:
-  localRef: images/katlos-install-2026.06.04-x86_64.squashfs
-  sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  sizeBytes: 1073741824
-  version: "2026.06.04"
-  architecture: x86_64
-  runtimeInterface: katl-runtime-1
-  role: install
-```
-
-The full manifest still carries node identity, disk selection, role, kubeadm
-config reference, and bootstrap intent. An explicit image reference overrides
-media selection and changes only where the payload is read from.
+The bundle contains one compiled `install.katl.dev/v1alpha1` `InstallManifest`
+per node. That schema and the legacy `katl.manifest.*` kernel arguments remain
+an advanced integration boundary for installer tooling and debugging. They are
+not the normal authoring API: a raw manifest omits cluster-wide validation,
+embedded kubeadm sidecars, resolved inventory, and proof that every node was
+compiled from the same source. Author `ClusterConfig` and distribute its bundle
+unless you are deliberately integrating at that lower-level boundary.
 
 ## Installer Safety And Status
 
 `katlos-install` validates before destructive disk mutation:
 
 ```text
-install manifest schema
+config bundle archive and internal manifest digests
+selected node and compiled install manifest schema
 destructive install guard
 target disk selector and size
 KatlOS image SHA-256 and size
@@ -388,7 +374,7 @@ Kubernetes sysext. It stores the node role and bootstrap intent needed for a
 later explicit operator action.
 
 The Kubernetes bundle is one ordinary OCI image reference. For example,
-`node.bootstrap.kubernetesBundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1@sha256:<digest>`
+`spec.kubernetes.bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:<digest>`
 means bootstrap must select that exact OCI manifest. During the explicit
 bootstrap operation, `katlc` fetches that bundle, verifies the Katl bundle
 metadata and payload digests, stages the sysext locally, and selects it for
@@ -418,13 +404,48 @@ patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.
 
 After all nodes are installed and reachable through their node-local `katlc`
-management endpoints, run bootstrap from an operator workstation:
+management endpoints, create the current bootstrap inventory. The alpha CLI
+still requires this small duplicate view even though the config bundle already
+contains the same resolved inventory; direct bundle bootstrap is the next
+operator-flow change.
+
+```yaml
+controlPlaneEndpoint: api.katl.test:6443
+kubernetesVersion: v1.36.1
+kubernetesBundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:<OCI-manifest-digest>
+nodes:
+  - name: cp-1
+    address: 192.0.2.11
+    systemRole: control-plane
+    access:
+      method: agent
+      credentialRef: agent/default
+    kubeadmConfig:
+      ref: control-plane
+      path: /etc/katl/kubeadm/control-plane/config.yaml
+      intent: control-plane
+    kubernetesVersion: v1.36.1
+  - name: worker-1
+    address: 192.0.2.21
+    systemRole: worker
+    access:
+      method: agent
+      credentialRef: agent/default
+    kubeadmConfig:
+      ref: worker
+      path: /etc/katl/kubeadm/worker/config.yaml
+      intent: worker
+    kubernetesVersion: v1.36.1
+```
+
+Save it as `cluster.inventory.yaml`, then run bootstrap from the operator
+workstation:
 
 ```text
 katlctl cluster bootstrap \
-  --inventory cluster.yaml \
+  --inventory cluster.inventory.yaml \
   --init-node cp-1 \
-  --control-plane-endpoint api.katl.test:6443 \
+  --agent-token-file ./katlc-agent.token \
   --kubeconfig-out kubeconfig \
   --overwrite-kubeconfig
 ```
@@ -464,7 +485,7 @@ installer console output
 journalctl -b
 journalctl -b -u katlos-install.service
 /var/lib/katl/install status and copied manifest files
-the install manifest used for this node
+the config bundle, selected node name, and both bundle digests
 the KatlOS image metadata and SHA-256 file
 systemctl status katlc-agent.service
 systemctl status katl-boot-complete.target
@@ -473,16 +494,16 @@ systemctl status katl-boot-complete.target
 Common failures:
 
 ```text
-manifest rejected
-  Check apiVersion, kind, required node.identity.ssh.authorizedKeys,
-  node.systemRole, optional node.kubernetes.kubeadm.configRef, and targetDisk.
-  PXE manifests must also include the katlosImage fields; ISO installs derive
-  them from the embedded media descriptor.
+bundle or selected node rejected
+  Run katlctl config validate again. Check the selected node name, internal
+  bundleDigest, archive SHA-256, SSH authorized keys, system role, kubeadm
+  config reference, and target disk. PXE sources must include spec.katlosImage;
+  ISO installs derive it from the embedded media descriptor.
 
 destructive install refused
   Confirm install.wipeTarget is true and boot input selected
-  katl.install.mode=auto. For URL manifests, confirm katl.manifest.sha256 is
-  present and matches the published manifest bytes.
+  katl.install.mode=auto. For URL bundles, confirm katl.bundle.sha256 is present
+  and matches the published archive bytes.
 
 target disk not found
   Prefer /dev/disk/by-id, WWN, or serial selectors. Confirm firmware and HBA

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -117,6 +117,32 @@ func TestBuildArchiveDefersKatlosImageToInstallMedia(t *testing.T) {
 	}
 }
 
+func TestInstallingGuideClusterConfigCompiles(t *testing.T) {
+	data, err := os.ReadFile("../../../docs/installing.md")
+	if err != nil {
+		t.Fatalf("read installing guide: %v", err)
+	}
+	_, section, ok := strings.Cut(string(data), "## Author One ClusterConfig")
+	if !ok {
+		t.Fatal("installing guide is missing ClusterConfig section")
+	}
+	_, example, ok := strings.Cut(section, "```yaml\n")
+	if !ok {
+		t.Fatal("installing guide is missing ClusterConfig YAML example")
+	}
+	example, _, ok = strings.Cut(example, "\n```")
+	if !ok {
+		t.Fatal("installing guide ClusterConfig example is not terminated")
+	}
+	_, result, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, example)})
+	if err != nil {
+		t.Fatalf("compile installing guide ClusterConfig: %v", err)
+	}
+	if result.Manifest.ClusterName != "katl-lab" || len(result.Manifest.Nodes) != 2 {
+		t.Fatalf("installing guide bundle = cluster %q nodes %#v", result.Manifest.ClusterName, result.Manifest.Nodes)
+	}
+}
+
 func TestBuildArchiveNodeClassGoldenScenarios(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/installer/handoff/handoff.go
+++ b/internal/installer/handoff/handoff.go
@@ -124,7 +124,7 @@ func (s *HandoffServer) Status() HandoffStatus {
 }
 
 func (s *HandoffServer) Announcement(baseURL string) string {
-	return fmt.Sprintf("katlos-install waiting for config at %s/v1/install token=%s", strings.TrimRight(baseURL, "/"), s.token)
+	return fmt.Sprintf("katlos-install waiting for config at %s/v1/config-bundle token=%s", strings.TrimRight(baseURL, "/"), s.token)
 }
 
 func (s *HandoffServer) Handler() http.Handler {

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -44,7 +44,8 @@ func TestHandoffServerHealthStatusAndAnnouncement(t *testing.T) {
 	}
 
 	announcement := server.Announcement("http://192.0.2.10:8080/")
-	if !strings.Contains(announcement, "http://192.0.2.10:8080/v1/install") || !strings.Contains(announcement, "token=test-token") {
+	if !strings.Contains(announcement, "http://192.0.2.10:8080/v1/config-bundle") ||
+		!strings.Contains(announcement, "token=test-token") {
 		t.Fatalf("announcement = %q", announcement)
 	}
 }

--- a/internal/vmtest/first_install.go
+++ b/internal/vmtest/first_install.go
@@ -876,9 +876,6 @@ func handoffPayload(config FirstInstallConfig, manifest []byte) ([]byte, string,
 }
 
 func handoffPostURL(raw string, config FirstInstallConfig) string {
-	if strings.TrimSpace(config.ConfigBundle) == "" {
-		return raw
-	}
 	parsed, err := neturl.Parse(raw)
 	if err != nil {
 		return raw
@@ -887,7 +884,11 @@ func handoffPostURL(raw string, config FirstInstallConfig) string {
 	if parsed.Path == "" || parsed.Path == "/" || base == "." {
 		base = ""
 	}
-	parsed.Path = base + "/config-bundle"
+	endpoint := "/install"
+	if strings.TrimSpace(config.ConfigBundle) != "" {
+		endpoint = "/config-bundle"
+	}
+	parsed.Path = base + endpoint
 	query := parsed.Query()
 	if node := strings.TrimSpace(config.SelectedNode); node != "" {
 		query.Set("node", node)

--- a/internal/vmtest/first_install_test.go
+++ b/internal/vmtest/first_install_test.go
@@ -209,7 +209,7 @@ func TestFirstInstallGuestHandoffUsesAnnouncementURL(t *testing.T) {
 		t.Fatalf("Status = %q, failure = %q", result.Status, result.FailureSummary)
 	}
 	request := readLog(t, result.Artifacts.HandoffRequest)
-	if request.URL != "http://10.0.2.15:8080/v1/install" || request.PostURL != request.URL || request.GuestAddress != "10.0.2.15" || request.DomainName == "" || request.SerialLog == "" || !strings.Contains(request.SerialTail, "10.0.2.15") {
+	if request.URL != "http://10.0.2.15:8080/v1/config-bundle" || request.PostURL != "http://10.0.2.15:8080/v1/install" || request.GuestAddress != "10.0.2.15" || request.DomainName == "" || request.SerialLog == "" || !strings.Contains(request.SerialTail, "10.0.2.15") {
 		t.Fatalf("handoff request = %#v", request)
 	}
 	response := readLog(t, result.Artifacts.HandoffResponse)

--- a/internal/vmtest/first_install_world.go
+++ b/internal/vmtest/first_install_world.go
@@ -830,9 +830,16 @@ func ResolveFirstInstallWorldInput(scenario *WorldScenario, repo string, spec No
 			return input, err
 		}
 	}
-	if input.Installer.InstallerUKI == "" && input.Installer.InstallerKernel == "" && input.Installer.InstallerInitrd == "" {
-		if artifact, ok := index.artifact("installer-uki"); ok {
-			input.Installer.InstallerUKI = artifact.Path
+	if input.Installer.InstallerUKI == "" && input.Installer.InstallerISO == "" && input.Installer.InstallerKernel == "" && input.Installer.InstallerInitrd == "" {
+		if input.Mode == FirstInstallWorldGuestHandoff {
+			if artifact, ok := index.artifact("installer-iso"); ok {
+				input.Installer.InstallerISO = artifact.Path
+			}
+		}
+		if input.Installer.InstallerISO == "" {
+			if artifact, ok := index.artifact("installer-uki"); ok {
+				input.Installer.InstallerUKI = artifact.Path
+			}
 		}
 	}
 	if strings.TrimSpace(input.RuntimeArtifact) != "" {
@@ -844,7 +851,7 @@ func ResolveFirstInstallWorldInput(scenario *WorldScenario, repo string, spec No
 	input.UseInstalledESP = true
 	if input.InstallManifest == "" {
 		if input.ConfigBundle == "" {
-			bundlePath, manifestPath, err := writeFirstInstallWorldBundleSource(scenario, repo, spec, index)
+			bundlePath, manifestPath, err := writeFirstInstallWorldBundleSource(scenario, repo, spec, index, input.Mode == FirstInstallWorldGuestHandoff)
 			if err != nil {
 				return input, err
 			}
@@ -869,7 +876,11 @@ func ResolveFirstInstallWorldInput(scenario *WorldScenario, repo string, spec No
 }
 
 func writeSelectedInstallManifestFromBundle(_ *WorldScenario, bundlePath, nodeName string) (string, error) {
-	selected, err := configbundle.ReadSelectedNodeFile(bundlePath, configbundle.ReadOptions{NodeName: nodeName})
+	return writeSelectedInstallManifestFromBundleWithDefault(nil, bundlePath, nodeName, installmanifest.KatlosImage{})
+}
+
+func writeSelectedInstallManifestFromBundleWithDefault(_ *WorldScenario, bundlePath, nodeName string, defaultImage installmanifest.KatlosImage) (string, error) {
+	selected, err := configbundle.ReadSelectedNodeFile(bundlePath, configbundle.ReadOptions{NodeName: nodeName, DefaultKatlosImage: defaultImage})
 	if err != nil {
 		return "", err
 	}
@@ -980,7 +991,7 @@ func (index mkosiArtifactIndex) artifact(kind string) (mkosiArtifact, bool) {
 	return mkosiArtifact{}, false
 }
 
-func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, spec NodeSpec, index mkosiArtifactIndex) (string, string, error) {
+func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, spec NodeSpec, index mkosiArtifactIndex, bindInstallMedia bool) (string, string, error) {
 	image, ok := index.artifact("katlos-install-image")
 	if !ok {
 		var err error
@@ -1061,52 +1072,55 @@ func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, sp
 	}
 	nodes = append(nodes, firstInstallWorldSourceNode(spec.Name, spec.Role, "/dev/disk/by-id/virtio-katl-root"))
 
+	sourceSpec := map[string]any{
+		"controlPlaneEndpoint": "api.katl.test:6443",
+		"kubernetes": map[string]any{
+			"version": kubernetesVersion,
+		},
+		"defaults": map[string]any{
+			"install": map[string]any{
+				"wipeTarget": true,
+			},
+			"identity": map[string]any{
+				"ssh": map[string]any{
+					"authorizedKeys": []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"},
+				},
+			},
+			"networkd": map[string]any{
+				"files": []map[string]any{{
+					"name":    "80-katl-vmtest-dhcp.network",
+					"content": "[Match]\nName=en*\n\n[Network]\nDHCP=yes\n",
+				}},
+			},
+			"bootstrap": map[string]any{
+				"access": map[string]any{
+					"method":        "agent",
+					"credentialRef": "vsock:1234:10240",
+				},
+			},
+		},
+		"systemRoleDefaults": systemRoleDefaults,
+		"kubeadmConfigs":     kubeadmConfigs,
+		"nodes":              nodes,
+	}
+	if !bindInstallMedia {
+		sourceSpec["katlosImage"] = map[string]any{
+			"localRef":         localRef,
+			"sha256":           metadata.SHA256,
+			"sizeBytes":        metadata.SizeBytes,
+			"version":          metadata.Version,
+			"architecture":     metadata.Architecture,
+			"runtimeInterface": metadata.RuntimeInterface,
+			"role":             metadata.Role,
+		}
+	}
 	source := map[string]any{
 		"apiVersion": configbundle.APIVersion,
 		"kind":       configbundle.Kind,
 		"metadata": map[string]any{
 			"name": "katl-smoke",
 		},
-		"spec": map[string]any{
-			"controlPlaneEndpoint": "api.katl.test:6443",
-			"kubernetes": map[string]any{
-				"version": kubernetesVersion,
-			},
-			"katlosImage": map[string]any{
-				"localRef":         localRef,
-				"sha256":           metadata.SHA256,
-				"sizeBytes":        metadata.SizeBytes,
-				"version":          metadata.Version,
-				"architecture":     metadata.Architecture,
-				"runtimeInterface": metadata.RuntimeInterface,
-				"role":             metadata.Role,
-			},
-			"defaults": map[string]any{
-				"install": map[string]any{
-					"wipeTarget": true,
-				},
-				"identity": map[string]any{
-					"ssh": map[string]any{
-						"authorizedKeys": []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"},
-					},
-				},
-				"networkd": map[string]any{
-					"files": []map[string]any{{
-						"name":    "80-katl-vmtest-dhcp.network",
-						"content": "[Match]\nName=en*\n\n[Network]\nDHCP=yes\n",
-					}},
-				},
-				"bootstrap": map[string]any{
-					"access": map[string]any{
-						"method":        "agent",
-						"credentialRef": "vsock:1234:10240",
-					},
-				},
-			},
-			"systemRoleDefaults": systemRoleDefaults,
-			"kubeadmConfigs":     kubeadmConfigs,
-			"nodes":              nodes,
-		},
+		"spec": sourceSpec,
 	}
 	sourcePath := filepath.Join(sourceDir, "cluster.yaml")
 	sourceData, err := yaml.Marshal(source)
@@ -1120,7 +1134,19 @@ func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, sp
 	if _, err := configbundle.WriteArchive(bundlePath, configbundle.BuildRequest{SourcePath: sourcePath, CreatedBy: "vmtest first-install"}); err != nil {
 		return "", "", err
 	}
-	manifestPath, err := writeSelectedInstallManifestFromBundle(scenario, bundlePath, spec.Name)
+	defaultImage := installmanifest.KatlosImage{}
+	if bindInstallMedia {
+		defaultImage = installmanifest.KatlosImage{
+			LocalRef:         localRef,
+			SHA256:           metadata.SHA256,
+			SizeBytes:        metadata.SizeBytes,
+			Version:          metadata.Version,
+			Architecture:     metadata.Architecture,
+			RuntimeInterface: metadata.RuntimeInterface,
+			Role:             metadata.Role,
+		}
+	}
+	manifestPath, err := writeSelectedInstallManifestFromBundleWithDefault(scenario, bundlePath, spec.Name, defaultImage)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/vmtest/first_install_world_test.go
+++ b/internal/vmtest/first_install_world_test.go
@@ -420,6 +420,7 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 	repo := t.TempDir()
 	mkosiDir := filepath.Join(repo, "_build", "mkosi")
 	installer := writeFixtureFile(t, filepath.Join(mkosiDir, "katl-installer.efi"), "installer")
+	installerISO := writeFixtureFile(t, filepath.Join(mkosiDir, "katl-installer.iso"), "installer-iso")
 	writeFixtureFile(t, filepath.Join(mkosiDir, "katl-runtime-root.squashfs"), "runtime")
 	writeFixtureFile(t, filepath.Join(mkosiDir, "katl-kubernetes.raw"), "kubernetes")
 	writeFixtureFile(t, filepath.Join(mkosiDir, "katl-kubernetes.raw.json"), `{"payloadVersion":"v1.36.0"}`)
@@ -438,6 +439,7 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 	writeFixtureFile(t, filepath.Join(mkosiDir, "artifacts.json"), `{
   "artifacts": [
     {"kind":"installer-uki","path":"_build/mkosi/katl-installer.efi"},
+    {"kind":"installer-iso","path":"_build/mkosi/katl-installer.iso"},
     {"kind":"runtime-root","path":"_build/mkosi/katl-runtime-root.squashfs"}
   ]
 }`)
@@ -504,6 +506,20 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 		if !hasFixtureKind(scenarioManifest.Fixtures, kind) {
 			t.Fatalf("scenario fixtures missing %s: %#v", kind, scenarioManifest.Fixtures)
 		}
+	}
+
+	handoff, err := planFirstInstallWorldRun(world, "local mkosi handoff", repo, NodeSpec{Name: "cp-2", Role: ControlPlane}, firstInstallWorldInput{
+		Mode:           firstInstallWorldGuestHandoff,
+		TargetDiskSize: "20G",
+	}, KVMOff)
+	if err != nil {
+		t.Fatalf("planFirstInstallWorldRun(handoff) error = %v", err)
+	}
+	if handoff.Config.Installer.InstallerISO == "" || handoff.Config.Installer.InstallerISO == installerISO || handoff.Config.Installer.InstallerUKI != "" {
+		t.Fatalf("handoff installer input = %#v", handoff.Config.Installer)
+	}
+	if handoff.Config.ConfigBundle == "" || handoff.Config.SelectedNode != "cp-2" {
+		t.Fatalf("handoff bundle input = %#v", handoff.Config)
 	}
 }
 

--- a/internal/vmtest/installed_smoke_test.go
+++ b/internal/vmtest/installed_smoke_test.go
@@ -189,6 +189,7 @@ func TestFirstInstallTargetDiskSerialSmoke(t *testing.T) {
 	result, err = RunFirstInstall(ctx, runner, scenario, FirstInstallConfig{
 		Installer: InstallerBootConfig{
 			InstallerUKI:    worldRun.Config.Installer.InstallerUKI,
+			InstallerISO:    worldRun.Config.Installer.InstallerISO,
 			InstallerKernel: worldRun.Config.Installer.InstallerKernel,
 			InstallerInitrd: worldRun.Config.Installer.InstallerInitrd,
 			CommandLine:     worldRun.Config.Installer.CommandLine,
@@ -277,6 +278,7 @@ func TestFirstInstallTargetDiskLocalHandoffSmoke(t *testing.T) {
 	result, err = RunFirstInstall(ctx, runner, scenario, FirstInstallConfig{
 		Installer: InstallerBootConfig{
 			InstallerUKI:    worldRun.Config.Installer.InstallerUKI,
+			InstallerISO:    worldRun.Config.Installer.InstallerISO,
 			InstallerKernel: worldRun.Config.Installer.InstallerKernel,
 			InstallerInitrd: worldRun.Config.Installer.InstallerInitrd,
 			CommandLine:     worldRun.Config.Installer.CommandLine,
@@ -290,6 +292,8 @@ func TestFirstInstallTargetDiskLocalHandoffSmoke(t *testing.T) {
 		},
 		UseInstalledESP: worldRun.Config.UseInstalledESP,
 		ManifestPath:    worldRun.Config.ManifestPath,
+		ConfigBundle:    worldRun.Config.ConfigBundle,
+		SelectedNode:    worldRun.Config.SelectedNode,
 		GuestHandoff:    true,
 		TargetDisk:      worldRun.Config.TargetDisk,
 	})

--- a/internal/vmtest/world_fixtures.go
+++ b/internal/vmtest/world_fixtures.go
@@ -16,6 +16,7 @@ import (
 const (
 	FixtureMkosiArtifactIndex    = "mkosi-artifact-index"
 	FixtureInstallerUKI          = "installer-uki"
+	FixtureInstallerISO          = "installer-iso"
 	FixtureInstallerKernel       = "installer-kernel"
 	FixtureInstallerInitrd       = "installer-initrd"
 	FixtureRuntimeArtifact       = "runtime-artifact"
@@ -86,6 +87,17 @@ func (factory NodeFixtureFactory) MkosiArtifactIndex(source string) (FixtureReco
 
 func (factory NodeFixtureFactory) InstallerBoot(input InstallerBootConfig) (InstallerBootConfig, error) {
 	output := input
+	if strings.TrimSpace(input.InstallerISO) != "" {
+		iso, err := factory.stageFileFixture(FixtureInstallerISO, filepath.Base(input.InstallerISO), input.InstallerISO)
+		if err != nil {
+			return InstallerBootConfig{}, err
+		}
+		output.InstallerISO = iso.Path
+		output.InstallerUKI = ""
+		output.InstallerKernel = ""
+		output.InstallerInitrd = ""
+		return output, nil
+	}
 	if strings.TrimSpace(input.InstallerKernel) != "" || strings.TrimSpace(input.InstallerInitrd) != "" {
 		kernel, err := factory.stageFileFixture(FixtureInstallerKernel, filepath.Base(input.InstallerKernel), input.InstallerKernel)
 		if err != nil {

--- a/internal/vmtest/world_fixtures_test.go
+++ b/internal/vmtest/world_fixtures_test.go
@@ -149,6 +149,26 @@ func TestWorldFixturesStageDirectKernelInstallerBoot(t *testing.T) {
 	}
 }
 
+func TestWorldFixturesStageInstallerISO(t *testing.T) {
+	world := testWorld(t)
+	scenario := world.NewScenario(t, "installer ISO")
+	node := scenario.NewNode(t, NodeSpec{Name: "cp-1", Role: ControlPlane})
+	factory := scenario.NodeFixtures(node)
+	source := writeFixtureFile(t, filepath.Join(t.TempDir(), "katl-installer.iso"), "iso")
+
+	boot, err := factory.InstallerBoot(InstallerBootConfig{InstallerISO: source})
+	if err != nil {
+		t.Fatalf("InstallerBoot() error = %v", err)
+	}
+	if boot.InstallerISO == "" || boot.InstallerISO == source || boot.InstallerUKI != "" || boot.InstallerKernel != "" || boot.InstallerInitrd != "" {
+		t.Fatalf("staged ISO boot = %#v", boot)
+	}
+	manifest := readScenarioManifest(t, scenario.ManifestPath)
+	if !hasFixtureKind(manifest.Fixtures, FixtureInstallerISO) {
+		t.Fatalf("scenario fixtures missing ISO: %#v", manifest.Fixtures)
+	}
+}
+
 func TestWorldFixturesRejectStaleCachedFile(t *testing.T) {
 	world := testWorld(t)
 	scenario := world.NewScenario(t, "stale cache")

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -25,7 +25,7 @@
     {
       "name": "kubernetes-sysext",
       "path": "mkosi.profiles/kubernetes-sysext",
-      "configSHA256": "c834b604dc9f1a01d26af28e49b631f80a297a3cc0ec62ebc36b42d7949e2af5",
+      "configSHA256": "b2e56b113d30ace4c421af4843123216a27aa4f5b6603effe0fbe0ff802170d0",
       "packageSetRef": "kubernetes-sysext",
       "mkosiVersion": "26"
     }


### PR DESCRIPTION
Make one validated ClusterConfig bundle the documented ISO and PXE install input, with compiled manifests retained as an advanced boundary. Prove the flow through self-contained ISO local handoff and prevent stale mkosi profile locks from escaping fast checks.