### PR TITLE
bootstrap: consume verified config bundles

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1434,6 +1434,8 @@ func firstNonEmpty(values ...string) string {
 type clusterBootstrapOptions struct {
 	addresses                              addressOverrides
 	inventoryPath                          string
+	configBundlePath                       string
+	configBundleDigest                     string
 	initNode                               string
 	joinWorker                             string
 	controlPlaneEndpoint                   string
@@ -1454,13 +1456,15 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 	opts := clusterBootstrapOptions{}
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
-		Short: "Bootstrap a Kubernetes cluster from KatlOS node inventory",
+		Short: "Bootstrap Kubernetes from a Katl config bundle or node inventory",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runClusterBootstrap(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster bootstrap inventory")
+	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to verified Katl config bundle")
+	cmd.Flags().StringVar(&opts.configBundleDigest, "config-bundle-digest", "", "expected internal config bundle manifest digest")
 	cmd.Flags().StringVar(&opts.initNode, "init-node", "", "first control-plane node for kubeadm init")
 	cmd.Flags().StringVar(&opts.joinWorker, "join-worker", "", "join one fresh worker to an already initialized cluster without rerunning kubeadm init")
 	cmd.Flags().StringVar(&opts.controlPlaneEndpoint, "control-plane-endpoint", "", "control-plane endpoint host:port")
@@ -1481,10 +1485,7 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 
 func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	if strings.TrimSpace(opts.inventoryPath) == "" {
-		return fmt.Errorf("--inventory is required")
-	}
-	inv, err := loadInventory(opts.inventoryPath)
+	inv, err := bootstrapInventory(opts)
 	if err != nil {
 		return err
 	}
@@ -1536,6 +1537,34 @@ func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdo
 	}
 	printBootstrapResult(stdout, result)
 	return err
+}
+
+func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, error) {
+	inventoryPath := strings.TrimSpace(opts.inventoryPath)
+	bundlePath := strings.TrimSpace(opts.configBundlePath)
+	if inventoryPath == "" && bundlePath == "" {
+		return inventory.Inventory{}, fmt.Errorf("exactly one of --config-bundle or --inventory is required")
+	}
+	if inventoryPath != "" && bundlePath != "" {
+		return inventory.Inventory{}, fmt.Errorf("--config-bundle and --inventory are mutually exclusive")
+	}
+	if bundlePath == "" {
+		if strings.TrimSpace(opts.configBundleDigest) != "" {
+			return inventory.Inventory{}, fmt.Errorf("--config-bundle-digest requires --config-bundle")
+		}
+		return loadInventory(inventoryPath)
+	}
+	if strings.TrimSpace(opts.kubernetesBundle) != "" {
+		return inventory.Inventory{}, fmt.Errorf("--kubernetes-bundle conflicts with the selection embedded in --config-bundle")
+	}
+	if strings.TrimSpace(opts.controlPlaneEndpoint) != "" {
+		return inventory.Inventory{}, fmt.Errorf("--control-plane-endpoint conflicts with the endpoint embedded in --config-bundle")
+	}
+	bundle, err := configbundle.ReadBundleFile(bundlePath, opts.configBundleDigest)
+	if err != nil {
+		return inventory.Inventory{}, err
+	}
+	return bundle.Manifest.Cluster.BootstrapInventory, nil
 }
 
 func bootstrapDependencies(vmtestTranscriptDir string) cluster.Dependencies {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/bootstrap/readiness"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -601,8 +603,60 @@ func TestClusterBootstrapReturnsAgentBootstrapError(t *testing.T) {
 func TestClusterBootstrapRequiresInventory(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{"cluster", "bootstrap"}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "--inventory is required") {
-		t.Fatalf("run() error = %v, want inventory error", err)
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --config-bundle or --inventory is required") {
+		t.Fatalf("run() error = %v, want input error", err)
+	}
+}
+
+func TestClusterBootstrapUsesConfigBundleInventory(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	var got cluster.Request
+	old := runAgentBootstrap
+	runAgentBootstrap = func(_ context.Context, request cluster.Request, _ cluster.AgentBootstrapDependencies) (cluster.Result, error) {
+		got = request
+		return cluster.Result{Plan: inventory.Plan{InitNode: request.InitNode}}, nil
+	}
+	t.Cleanup(func() { runAgentBootstrap = old })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"cluster", "bootstrap",
+		"--config-bundle", bundlePath,
+		"--config-bundle-digest", bundleDigest,
+		"--init-node", "cp-1",
+		"--dry-run",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if got.Inventory.ControlPlaneEndpoint != "api.katl.test:6443" || got.Inventory.KubernetesVersion != "v1.36.1" || len(got.Inventory.Nodes) != 1 {
+		t.Fatalf("bundle inventory = %#v", got.Inventory)
+	}
+	if got.Inventory.KubernetesBundleRef == "" || got.Inventory.Nodes[0].Access.CredentialRef != "vsock:1234:10240" {
+		t.Fatalf("bundle selection = %#v", got.Inventory)
+	}
+}
+
+func TestClusterBootstrapRejectsConfigBundleConflicts(t *testing.T) {
+	bundlePath, _ := writeConfigBundle(t)
+	inventoryPath := writeInventory(t)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "inventory", args: []string{"--config-bundle", bundlePath, "--inventory", inventoryPath}, want: "mutually exclusive"},
+		{name: "Kubernetes", args: []string{"--config-bundle", bundlePath, "--kubernetes-bundle", "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.2"}, want: "conflicts with the selection embedded"},
+		{name: "endpoint", args: []string{"--config-bundle", bundlePath, "--control-plane-endpoint", "other.test:6443"}, want: "conflicts with the endpoint embedded"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"cluster", "bootstrap"}, tt.args...)
+			err := run(context.Background(), args, io.Discard, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("run() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 
@@ -1982,4 +2036,22 @@ spec:
           targetDisk:
             byID: /dev/disk/by-id/ata-cp-root
 `
+}
+
+func writeConfigBundle(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	bundlePath := filepath.Join(dir, "cluster.katlcfg")
+	if err := os.WriteFile(bundlePath, archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return bundlePath, result.Digest
 }

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -404,51 +404,30 @@ patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.
 
 After all nodes are installed and reachable through their node-local `katlc`
-management endpoints, create the current bootstrap inventory. The alpha CLI
-still requires this small duplicate view even though the config bundle already
-contains the same resolved inventory; direct bundle bootstrap is the next
-operator-flow change.
-
-```yaml
-controlPlaneEndpoint: api.katl.test:6443
-kubernetesVersion: v1.36.1
-kubernetesBundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:<OCI-manifest-digest>
-nodes:
-  - name: cp-1
-    address: 192.0.2.11
-    systemRole: control-plane
-    access:
-      method: agent
-      credentialRef: agent/default
-    kubeadmConfig:
-      ref: control-plane
-      path: /etc/katl/kubeadm/control-plane/config.yaml
-      intent: control-plane
-    kubernetesVersion: v1.36.1
-  - name: worker-1
-    address: 192.0.2.21
-    systemRole: worker
-    access:
-      method: agent
-      credentialRef: agent/default
-    kubeadmConfig:
-      ref: worker
-      path: /etc/katl/kubeadm/worker/config.yaml
-      intent: worker
-    kubernetesVersion: v1.36.1
-```
-
-Save it as `cluster.inventory.yaml`, then run bootstrap from the operator
-workstation:
+management endpoints, bootstrap directly from the same verified bundle. Use the
+`bundleDigest` printed by `katlctl config bundle`, not the archive SHA-256:
 
 ```text
 katlctl cluster bootstrap \
-  --inventory cluster.inventory.yaml \
+  --config-bundle katl-lab.katlcfg \
+  --config-bundle-digest <bundleDigest> \
   --init-node cp-1 \
   --agent-token-file ./katlc-agent.token \
   --kubeconfig-out kubeconfig \
   --overwrite-kubeconfig
 ```
+
+The bundle supplies the control-plane endpoint, node topology, roles, kubeadm
+references, Kubernetes version, and OCI bundle selection. Do not combine
+`--config-bundle` with `--inventory`, `--control-plane-endpoint`, or
+`--kubernetes-bundle`. `--node-address node=address` remains available for an
+operator-observed address that differs from the compiled source.
+
+`--agent-token-file` is the common fallback token. A node whose embedded
+`credentialRef` is `file:/path/to/token` reads that per-node file instead and
+overrides the common token. Other reference names such as `agent/default` do not
+embed secret material and use the common token until a credential provider is
+configured.
 
 `katlctl` is a bounded client. Node-local `katlc` validates and records the
 authoritative bootstrap operations, creates generation 1, runs `kubeadm`, and

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -376,6 +376,24 @@ func TestReadSelectedNodeVerifiesBundleAndSelectsNodeMaterial(t *testing.T) {
 	}
 }
 
+func TestReadBundleReturnsVerifiedBootstrapInventory(t *testing.T) {
+	archive, result, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, validSourceConfig())})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	bundle, err := ReadBundle(bytes.NewReader(archive), result.Digest)
+	if err != nil {
+		t.Fatalf("ReadBundle() error = %v", err)
+	}
+	inv := bundle.Manifest.Cluster.BootstrapInventory
+	if bundle.Digest != result.Digest || inv.ControlPlaneEndpoint != "api.katl.test:6443" || len(inv.Nodes) != 2 {
+		t.Fatalf("verified bundle = %#v inventory = %#v", bundle, inv)
+	}
+	if _, err := ReadBundle(bytes.NewReader(archive), "sha256:"+strings.Repeat("f", 64)); err == nil || !strings.Contains(err.Error(), "config bundle digest mismatch") {
+		t.Fatalf("ReadBundle() mismatch error = %v", err)
+	}
+}
+
 func TestReadSelectedNodeRejectsMissingNodeSelection(t *testing.T) {
 	archive, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, validSourceConfig())})
 	if err != nil {

--- a/internal/installer/configbundle/consume.go
+++ b/internal/installer/configbundle/consume.go
@@ -36,6 +36,42 @@ type SelectedNodeMaterial struct {
 	KatlosImageFromMedia  bool
 }
 
+type Bundle struct {
+	Manifest BundleManifest
+	Digest   string
+}
+
+func ReadBundleFile(path, expectedDigest string) (Bundle, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("open config bundle: %w", err)
+	}
+	defer file.Close()
+	return ReadBundle(file, expectedDigest)
+}
+
+func ReadBundle(reader io.Reader, expectedDigest string) (Bundle, error) {
+	archive, err := readOCIArchive(reader)
+	if err != nil {
+		return Bundle{}, err
+	}
+	bundleDigest, manifestData, err := archive.bundleManifest()
+	if err != nil {
+		return Bundle{}, err
+	}
+	if expected := normalizeDigest(expectedDigest); expected != "" && expected != bundleDigest {
+		return Bundle{}, fmt.Errorf("config bundle digest mismatch: got %s want %s", bundleDigest, expected)
+	}
+	var bundle BundleManifest
+	if err := json.Unmarshal(manifestData, &bundle); err != nil {
+		return Bundle{}, fmt.Errorf("decode config bundle manifest: %w", err)
+	}
+	if err := validateBundleManifest(bundle); err != nil {
+		return Bundle{}, err
+	}
+	return Bundle{Manifest: bundle, Digest: bundleDigest}, nil
+}
+
 func ReadSelectedNodeFile(path string, options ReadOptions) (SelectedNodeMaterial, error) {
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
Let cluster bootstrap use the verified inventory and Kubernetes selection embedded in the installation bundle. Reject duplicate topology inputs and document common and per-node token resolution.