### PR TITLE
release: verify public Kubernetes bundle

### DIFF
--- a/.github/workflows/public-kubernetes-bundle.yml
+++ b/.github/workflows/public-kubernetes-bundle.yml
@@ -1,0 +1,40 @@
+name: Public Kubernetes Bundle
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  verify:
+    name: Anonymous Pull And Verify
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Fetch and verify selected alpha bundle anonymously
+        run: |
+          scripts/check-public-kubernetes-bundle \
+            ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3 \
+            sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
+
+      - name: Authenticate provenance client to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Verify GitHub provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify \
+            oci://ghcr.io/katl-dev/kubernetes@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b \
+            --repo katl-dev/katl \
+            --signer-workflow katl-dev/katl/.github/workflows/kubernetes-bundles.yml \
+            --source-ref refs/heads/main

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -135,8 +135,8 @@ metadata:
 spec:
   controlPlaneEndpoint: api.katl.test:6443
   kubernetes:
-    version: v1.36.1
-    bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    version: v1.36.0
+    bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
   defaults:
     install:
       wipeTarget: true
@@ -178,7 +178,7 @@ spec:
         ---
         apiVersion: kubeadm.k8s.io/v1beta4
         kind: ClusterConfiguration
-        kubernetesVersion: v1.36.1
+        kubernetesVersion: v1.36.0
     worker:
       config: |
         apiVersion: kubeadm.k8s.io/v1beta4
@@ -374,31 +374,31 @@ Kubernetes sysext. It stores the node role and bootstrap intent needed for a
 later explicit operator action.
 
 The Kubernetes bundle is one ordinary OCI image reference. For example,
-`spec.kubernetes.bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:<digest>`
+`spec.kubernetes.bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b`
 means bootstrap must select that exact OCI manifest. During the explicit
 bootstrap operation, `katlc` fetches that bundle, verifies the Katl bundle
 metadata and payload digests, stages the sysext locally, and selects it for
-generation 1. To bootstrap a fresh cluster on `v1.36.1`, keep the KatlOS install
-image when runtime compatibility permits it and supply a bundle reference that
-resolves to the `v1.36.1` payload.
+generation 1. The selected alpha reference above supplies the `v1.36.0`
+payload; a different Kubernetes version requires its matching bundle reference
+and a KatlOS runtime compatible with that bundle.
 
 Katl publishes development Kubernetes bundles as custom OCI artifacts in the
 public `ghcr.io/katl-dev/kubernetes` package. A tag-only reference is accepted:
 
 ```text
-ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1
+ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3
 ```
 
 Pinning the OCI manifest is strongly recommended for reproducible provisioning:
 
 ```text
-ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1@sha256:<OCI-manifest-digest>
+ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
 ```
 
 `katlc` verifies the resolved OCI manifest, the Katl bundle config, every layer
 digest and size, and
 Katl runtime compatibility, and only then stages the sysext. The readable
-`ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1` tag is suitable for Renovate's
+`ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3` tag is suitable for Renovate's
 Docker datasource; the full patch precision lets Renovate propose Kubernetes
 patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -85,6 +85,47 @@ func TestKubernetesBundleWorkflowContract(t *testing.T) {
 	}
 }
 
+func TestPublicKubernetesBundleWorkflowContract(t *testing.T) {
+	repo := repoRoot(t)
+	workflow := string(mustReadFile(t, repo+"/.github/workflows/public-kubernetes-bundle.yml"))
+	check := string(mustReadFile(t, repo+"/scripts/check-public-kubernetes-bundle"))
+
+	for _, value := range []string{
+		"schedule:",
+		"workflow_dispatch:",
+		"packages: read",
+		"scripts/check-public-kubernetes-bundle",
+		"ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3",
+		"sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b",
+		"gh attestation verify",
+		"docker login ghcr.io",
+		"--repo katl-dev/katl",
+		"--signer-workflow katl-dev/katl/.github/workflows/kubernetes-bundles.yml",
+		"--source-ref refs/heads/main",
+	} {
+		if !strings.Contains(workflow, value) {
+			t.Fatalf("public Kubernetes bundle workflow missing %q", value)
+		}
+	}
+
+	for _, value := range []string{
+		"https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull",
+		`fetch_manifest "$tag"`,
+		`fetch_manifest "$expected_digest"`,
+		`cmp --silent "$work/tag.json" "$work/digest.json"`,
+		`sha256sum "$blob"`,
+		`actual_size="$(stat -c %s "$blob")"`,
+		`.artifactVersion == $artifact_version`,
+		`.payloadVersion == $payload_version`,
+		`index("katl-runtime-1")`,
+		`index("kubeadm.k8s.io/v1beta4")`,
+	} {
+		if !strings.Contains(check, value) {
+			t.Fatalf("public Kubernetes bundle check missing %q", value)
+		}
+	}
+}
+
 func TestKubernetesBundleRenovateContract(t *testing.T) {
 	repo := repoRoot(t)
 	config := string(mustReadFile(t, repo+"/renovate.json"))

--- a/scripts/check-public-kubernetes-bundle
+++ b/scripts/check-public-kubernetes-bundle
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:-}"
+expected_digest="${2:-}"
+if [[ ! "$image" =~ ^ghcr\.io/katl-dev/kubernetes:([A-Za-z0-9._-]+)$ ]]; then
+    echo "usage: scripts/check-public-kubernetes-bundle ghcr.io/katl-dev/kubernetes:TAG sha256:DIGEST" >&2
+    exit 2
+fi
+tag="${BASH_REMATCH[1]}"
+payload_version="${tag%-katl.*}"
+if [[ ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "error: expected OCI manifest digest must be sha256 followed by 64 lowercase hex characters" >&2
+    exit 2
+fi
+
+repository="katl-dev/kubernetes"
+work="$(mktemp -d "${TMPDIR:-/tmp}/katl-public-bundle.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+token="$(curl --fail --silent --show-error --location \
+    "https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull" | jq -r '.token')"
+if [[ -z "$token" || "$token" == null ]]; then
+    echo "error: GHCR did not issue an anonymous pull token" >&2
+    exit 1
+fi
+
+fetch_manifest() {
+    local reference="$1"
+    local output="$2"
+    curl --fail --silent --show-error --location \
+        --header "Authorization: Bearer $token" \
+        --header 'Accept: application/vnd.oci.image.manifest.v1+json' \
+        "https://ghcr.io/v2/${repository}/manifests/${reference}" \
+        --output "$output"
+}
+
+fetch_manifest "$tag" "$work/tag.json"
+fetch_manifest "$expected_digest" "$work/digest.json"
+if ! cmp --silent "$work/tag.json" "$work/digest.json"; then
+    echo "error: tag and expected digest resolved to different OCI manifests" >&2
+    exit 1
+fi
+
+if ! jq -e --arg tag "$tag" '
+    .schemaVersion == 2 and
+    .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+    .artifactType == "application/vnd.katl.kubernetes.payload.bundle.v1" and
+    .config.mediaType == "application/vnd.katl.kubernetes.payload.bundle.v1+json" and
+    (.layers | length) == 4 and
+    .annotations["org.opencontainers.image.version"] == $tag and
+    .annotations["org.opencontainers.image.source"] == "https://github.com/katl-dev/katl" and
+    .annotations["org.opencontainers.image.licenses"] == "MIT"
+' "$work/tag.json" >/dev/null; then
+    echo "error: OCI manifest metadata does not match the public Kubernetes bundle contract" >&2
+    exit 1
+fi
+
+jq -r '[.config] + .layers | .[] | [.digest, (.size | tostring), .mediaType] | @tsv' "$work/tag.json" |
+while IFS=$'\t' read -r digest size media_type; do
+    blob="$work/${digest#sha256:}"
+    curl --fail --silent --show-error --location \
+        --header "Authorization: Bearer $token" \
+        "https://ghcr.io/v2/${repository}/blobs/${digest}" \
+        --output "$blob"
+    actual_digest="sha256:$(sha256sum "$blob" | cut -d ' ' -f 1)"
+    actual_size="$(stat -c %s "$blob")"
+    if [[ "$actual_digest" != "$digest" || "$actual_size" != "$size" ]]; then
+        echo "error: blob verification failed for $digest" >&2
+        exit 1
+    fi
+    if [[ "$media_type" == "application/vnd.katl.kubernetes.payload.bundle.v1+json" ]]; then
+        if ! jq -e --arg artifact_version "$tag" --arg payload_version "$payload_version" '
+            .apiVersion == "payload.katl.dev/v1alpha1" and
+            .kind == "KubernetesPayloadBundle" and
+            .name == "katl-kubernetes" and
+            .artifactVersion == $artifact_version and
+            .payloadVersion == $payload_version and
+            (.supportedRuntimeInterfaces | index("katl-runtime-1")) != null and
+            (.supportedKubeadmConfigAPIFamilies | index("kubeadm.k8s.io/v1beta4")) != null and
+            (.packageVersions.kubeadm | type) == "string" and
+            (.packageVersions.kubeadm | length) > 0
+        ' "$blob" >/dev/null; then
+            echo "error: Kubernetes bundle config metadata does not match the selected public reference" >&2
+            jq '{apiVersion, kind, name, artifactVersion, payloadVersion, supportedRuntimeInterfaces, supportedKubeadmConfigAPIFamilies, kubeadmPackageVersion: .packageVersions.kubeadm}' "$blob" >&2
+            exit 1
+        fi
+    fi
+    printf 'verified %s %s %s\n' "$digest" "$size" "$media_type"
+    rm -f "$blob"
+done
+
+echo "verified anonymous Kubernetes bundle ${image}@${expected_digest}"


### PR DESCRIPTION
Pins the install guide to the anonymously verified Kubernetes bundle. Adds a scheduled check for public pullability, immutable content, bundle metadata, and GitHub provenance.