### PR TITLE
ux: derive runtime apply from cluster config

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/bootstrap/readiness"
+	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
@@ -106,6 +107,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	configCmd.AddCommand(newConfigValidateCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigSchemaCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigBundleCommand(stdout, stderr))
+	configCmd.AddCommand(newConfigRenderNodeCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
 	cmd.AddCommand(configCmd)
 
@@ -907,6 +909,15 @@ type configBundleOptions struct {
 	outputPath string
 }
 
+type nodeConfigInputOptions struct {
+	sourcePath     string
+	bundlePath     string
+	bundleDigest   string
+	nodeName       string
+	sourceID       string
+	desiredVersion string
+}
+
 type configValidationNode struct {
 	Name       string `json:"name"`
 	SystemRole string `json:"systemRole"`
@@ -1041,10 +1052,94 @@ func runConfigBundle(opts configBundleOptions, stdout, stderr io.Writer) error {
 	return err
 }
 
+func newConfigRenderNodeCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := nodeConfigInputOptions{}
+	mode := generation.ApplyModeAuto
+	cmd := &cobra.Command{
+		Use:   "render-node",
+		Short: "Render one node's runtime configuration from cluster intent",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			_ = stderr
+			data, err := renderNodeConfig(opts, mode)
+			if err != nil {
+				return err
+			}
+			_, err = stdout.Write(data)
+			return err
+		},
+	}
+	addNodeConfigInputFlags(cmd, &opts)
+	cmd.Flags().StringVar(&mode, "mode", mode, "apply mode: auto, live, or next-boot")
+	return cmd
+}
+
+func addNodeConfigInputFlags(cmd *cobra.Command, opts *nodeConfigInputOptions) {
+	cmd.Flags().StringVar(&opts.sourcePath, "source", "", "ClusterConfig source YAML")
+	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "verified Katl config bundle")
+	cmd.Flags().StringVar(&opts.bundleDigest, "config-bundle-digest", "", "expected internal config bundle manifest digest")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from cluster intent")
+	cmd.Flags().StringVar(&opts.sourceID, "source-id", "", "runtime configuration source id; defaults to the cluster name")
+	cmd.Flags().StringVar(&opts.desiredVersion, "desired-version", "", "monotonic unsigned runtime configuration version")
+}
+
+func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) {
+	fromSource := strings.TrimSpace(opts.sourcePath) != ""
+	fromBundle := strings.TrimSpace(opts.bundlePath) != ""
+	if fromSource == fromBundle {
+		return nil, fmt.Errorf("exactly one of --source or --config-bundle is required")
+	}
+	if strings.TrimSpace(opts.nodeName) == "" {
+		return nil, fmt.Errorf("--node is required")
+	}
+	if strings.TrimSpace(opts.desiredVersion) == "" {
+		return nil, fmt.Errorf("--desired-version is required")
+	}
+	if fromSource && strings.TrimSpace(opts.bundleDigest) != "" {
+		return nil, fmt.Errorf("--config-bundle-digest requires --config-bundle")
+	}
+	if fromBundle && strings.TrimSpace(opts.bundleDigest) == "" {
+		return nil, fmt.Errorf("--config-bundle-digest is required with --config-bundle")
+	}
+
+	readOptions := configbundle.ReadOptions{ExpectedDigest: opts.bundleDigest, NodeName: opts.nodeName}
+	var selected configbundle.SelectedNodeMaterial
+	var err error
+	if fromSource {
+		archive, _, buildErr := configbundle.BuildArchive(configbundle.BuildRequest{
+			SourcePath:     opts.sourcePath,
+			KatlctlVersion: version,
+			KatlctlCommit:  commit,
+			CreatedBy:      "katlctl config render-node",
+		})
+		if buildErr != nil {
+			return nil, buildErr
+		}
+		selected, err = configbundle.ReadSelectedNode(bytes.NewReader(archive), readOptions)
+	} else {
+		selected, err = configbundle.ReadSelectedNodeFile(opts.bundlePath, readOptions)
+	}
+	if err != nil {
+		return nil, err
+	}
+	sourceID := strings.TrimSpace(opts.sourceID)
+	if sourceID == "" {
+		sourceID = selected.BundleManifest.ClusterName
+	}
+	return configapply.RenderNodeConfigurationChange(configapply.RenderNodeRequest{
+		NodeName:       selected.Node.Name,
+		Manifest:       selected.InstallManifest,
+		SourceID:       sourceID,
+		DesiredVersion: opts.desiredVersion,
+		ApplyMode:      mode,
+	})
+}
+
 type configApplyOptions struct {
 	endpoint            string
 	agentTokenFile      string
 	configPath          string
+	nodeConfig          nodeConfigInputOptions
 	mode                string
 	candidateGeneration string
 	clientRequestID     string
@@ -1086,7 +1181,8 @@ func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
-	cmd.Flags().StringVar(&opts.configPath, "file", "", "Katl node configuration YAML")
+	cmd.Flags().StringVar(&opts.configPath, "file", "", "pre-rendered NodeConfigurationChange YAML")
+	addNodeConfigInputFlags(cmd, &opts.nodeConfig)
 	cmd.Flags().StringVar(&opts.mode, "mode", opts.mode, "apply mode: auto, live, or next-boot")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "idempotency key for this apply request")
@@ -1103,15 +1199,29 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if strings.TrimSpace(opts.endpoint) == "" {
 		return fmt.Errorf("--endpoint is required")
 	}
-	if strings.TrimSpace(opts.configPath) == "" {
-		return fmt.Errorf("--file is required")
-	}
 	if strings.TrimSpace(opts.clientRequestID) == "" {
 		return fmt.Errorf("--client-request-id is required")
 	}
-	configYAML, err := os.ReadFile(opts.configPath)
-	if err != nil {
-		return fmt.Errorf("read config file: %w", err)
+	fileInput := strings.TrimSpace(opts.configPath) != ""
+	intentInput := strings.TrimSpace(opts.nodeConfig.sourcePath) != "" || strings.TrimSpace(opts.nodeConfig.bundlePath) != ""
+	if fileInput == intentInput {
+		return fmt.Errorf("exactly one of --file, --source, or --config-bundle is required")
+	}
+	var configYAML []byte
+	var err error
+	if fileInput {
+		if strings.TrimSpace(opts.nodeConfig.bundleDigest) != "" || strings.TrimSpace(opts.nodeConfig.sourceID) != "" || strings.TrimSpace(opts.nodeConfig.desiredVersion) != "" {
+			return fmt.Errorf("--config-bundle-digest, --source-id, and --desired-version require --source or --config-bundle")
+		}
+		configYAML, err = os.ReadFile(opts.configPath)
+		if err != nil {
+			return fmt.Errorf("read config file: %w", err)
+		}
+	} else {
+		configYAML, err = renderNodeConfig(opts.nodeConfig, opts.mode)
+		if err != nil {
+			return err
+		}
 	}
 	token, err := readAgentToken(opts.agentTokenFile)
 	if err != nil {
@@ -1133,6 +1243,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			Actor:                 opts.actor,
 			ApplyMode:             opts.mode,
 			CandidateGenerationId: opts.candidateGeneration,
+			NodeName:              opts.nodeConfig.nodeName,
 			ConfigYaml:            string(configYAML),
 		})
 		if err != nil {
@@ -1152,6 +1263,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		ClientRequestId:       opts.clientRequestID,
 		Actor:                 opts.actor,
 		CandidateGenerationId: opts.candidateGeneration,
+		NodeName:              opts.nodeConfig.nodeName,
 		ConfigYaml:            string(configYAML),
 	}
 	var accepted *agentapi.OperationAccepted
@@ -1171,6 +1283,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			Actor:                 opts.actor,
 			ApplyMode:             requestedMode,
 			CandidateGenerationId: opts.candidateGeneration,
+			NodeName:              opts.nodeConfig.nodeName,
 			ConfigYaml:            string(configYAML),
 		})
 		if err != nil {
@@ -1195,6 +1308,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			ConfigApply: &agentapi.ConfigApplyOperationRequest{
 				CandidateGenerationId: opts.candidateGeneration,
 				ApplyMode:             requestedMode,
+				NodeName:              opts.nodeConfig.nodeName,
 				ConfigYaml:            string(configYAML),
 			},
 		})

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/bootstrap/readiness"
+	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
@@ -196,6 +197,37 @@ func TestConfigBundleCommandWritesBundle(t *testing.T) {
 	}
 	if report.Kind != "ConfigBundleReport" || report.Output != outputPath || !strings.HasPrefix(report.BundleDigest, "sha256:") {
 		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestConfigRenderNodeFromSource(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
+	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{
+		"config", "render-node",
+		"--source", sourcePath,
+		"--node", "cp-1",
+		"--desired-version", "2",
+	}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	request, err := configapply.DecodeNodeConfigurationChange(strings.NewReader(stdout.String()), configapply.TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("decode rendered node config: %v\n%s", err, stdout.String())
+	}
+	if request.SourceID != "lab" || request.DesiredVersion != "2" || request.ApplyMode != generation.ApplyModeAuto {
+		t.Fatalf("rendered request metadata = %#v", request)
+	}
+	overlay := request.NodeOverrides["cp-1"]
+	if overlay.Identity == nil || overlay.Identity.Hostname != "cp-1" || len(overlay.Identity.AuthorizedKeys) != 1 {
+		t.Fatalf("rendered node overlay = %#v", overlay)
+	}
+	if overlay.SystemRole != "" || overlay.Kubernetes != nil {
+		t.Fatalf("rendered node overlay contains lifecycle state = %#v", overlay)
 	}
 }
 
@@ -1432,6 +1464,63 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 		t.Fatalf("decode stdout = %v: %s", err, stdout.String())
 	}
 	if output["accepted"] != true || output["candidateGenerationId"] != "generation-plan" || !strings.Contains(stdout.String(), `"networkd"`) {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	fake := &fakeKatlcAgentClient{
+		validateResult: &agentapi.ConfigValidationResult{
+			Accepted:              true,
+			RequestDigest:         strings.Repeat("c", 64),
+			AcceptedApplyMode:     generation.ApplyModeLive,
+			CandidateGenerationId: "generation-bundle",
+			ChangedDomains:        []string{"node-identity", "networkd"},
+		},
+		stageAccepted: &agentapi.OperationAccepted{
+			OperationId:   "generation-bundle-apply",
+			OperationKind: "generation-apply",
+			RequestDigest: strings.Repeat("d", 64),
+		},
+	}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(_ context.Context, endpoint string, token string) (katlcAgentConnection, error) {
+		if endpoint != "node-a.example.test:9443" || token != "" {
+			t.Fatalf("dial endpoint=%q token=%q", endpoint, token)
+		}
+		return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "apply",
+		"--endpoint", "node-a.example.test:9443",
+		"--config-bundle", bundlePath,
+		"--config-bundle-digest", bundleDigest,
+		"--node", "cp-1",
+		"--desired-version", "2",
+		"--candidate-generation", "generation-bundle",
+		"--client-request-id", "req-bundle",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if fake.validateRequest == nil || fake.validateRequest.NodeName != "cp-1" {
+		t.Fatalf("validate request = %+v", fake.validateRequest)
+	}
+	if fake.submitRequest == nil || fake.submitRequest.GetConfigApply().GetNodeName() != "cp-1" {
+		t.Fatalf("submit request = %+v", fake.submitRequest)
+	}
+	request, err := configapply.DecodeNodeConfigurationChange(strings.NewReader(fake.validateRequest.ConfigYaml), configapply.TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("decode rendered config: %v\n%s", err, fake.validateRequest.ConfigYaml)
+	}
+	if request.SourceID != "lab" || request.DesiredVersion != "2" || request.NodeOverrides["cp-1"].Identity == nil {
+		t.Fatalf("rendered request = %#v", request)
+	}
+	if !strings.Contains(stdout.String(), "generation-bundle-apply") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -440,6 +440,69 @@ storage classes, and cluster add-ons. Test fixtures may apply a small CNI or
 workload manifest to prove handoff behavior, but Katl is not a Kubernetes
 distribution or add-on manager.
 
+## Apply Runtime Configuration
+
+`ClusterConfig` is the user-authored source for installation and supported
+node runtime configuration. `NodeConfigurationChange` is the node-agent
+operation envelope; normal users do not need to reverse-engineer or maintain it
+by hand.
+
+Inspect the exact per-node runtime request without contacting a node:
+
+```text
+katlctl config render-node \
+  --source ./cluster.yaml \
+  --node cp-1 \
+  --desired-version 2 > cp-1.runtime.yaml
+```
+
+`--desired-version` is a monotonically increasing unsigned number for this
+configuration source. It provides replay and stale-change protection. The
+source id defaults to `metadata.name`; use `--source-id` only when the same
+cluster needs independently versioned configuration streams.
+
+Plan the change through the node agent before accepting an operation:
+
+```text
+katlctl config apply validate \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./katlc-agent.token \
+  --source ./cluster.yaml \
+  --node cp-1 \
+  --desired-version 2 \
+  --candidate-generation config-2 \
+  --client-request-id cp-1-config-2
+```
+
+If the source has already been compiled, use the verified bundle instead of
+recompiling it:
+
+```text
+katlctl config apply validate \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./katlc-agent.token \
+  --config-bundle ./katl-lab.katlcfg \
+  --config-bundle-digest <bundleDigest> \
+  --node cp-1 \
+  --desired-version 2 \
+  --candidate-generation config-2 \
+  --client-request-id cp-1-config-2
+```
+
+Remove `validate` to submit the accepted plan. The default `--mode auto` uses
+the agent's domain matrix to choose live apply or next boot; `--mode live` and
+`--mode next-boot` request an explicit policy and are rejected when unsafe.
+Keep the same inputs when submitting; the client request id becomes the
+idempotency key for the accepted operation.
+
+The renderer currently carries hostname, SSH authorized keys, and systemd-
+networkd files from the selected node. It deliberately excludes disk/install
+policy, system role, Kubernetes bundle selection, and kubeadm lifecycle state.
+Those changes require reinstall, host update, Kubernetes upgrade, or another
+explicit lifecycle operation. `--file` remains available for an advanced,
+pre-rendered `NodeConfigurationChange`, with `--node` selecting any
+`nodeOverrides` entry it contains.
+
 ## Upgrades
 
 KatlOS upgrades also consume one KatlOS image artifact. The image records

--- a/internal/installer/configapply/render.go
+++ b/internal/installer/configapply/render.go
@@ -1,0 +1,90 @@
+package configapply
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+type RenderNodeRequest struct {
+	NodeName       string
+	Manifest       manifest.Manifest
+	SourceID       string
+	DesiredVersion string
+	ApplyMode      string
+}
+
+type renderedNodeConfigurationChange struct {
+	APIVersion string                              `yaml:"apiVersion"`
+	Kind       string                              `yaml:"kind"`
+	Metadata   renderedNodeConfigurationMetadata   `yaml:"metadata"`
+	Apply      Apply                               `yaml:"apply"`
+	Spec       renderedNodeConfigurationChangeSpec `yaml:"spec"`
+}
+
+type renderedNodeConfigurationMetadata struct {
+	SourceID       string `yaml:"sourceID"`
+	DesiredVersion string `yaml:"desiredVersion"`
+}
+
+type renderedNodeConfigurationChangeSpec struct {
+	NodeOverrides map[string]renderedNodeConfigurationOverlay `yaml:"nodeOverrides"`
+}
+
+type renderedNodeConfigurationOverlay struct {
+	Identity renderedNodeIdentity    `yaml:"identity"`
+	Networkd manifest.NetworkdConfig `yaml:"networkd"`
+}
+
+type renderedNodeIdentity struct {
+	Hostname       string   `yaml:"hostname"`
+	AuthorizedKeys []string `yaml:"authorizedKeys"`
+}
+
+func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
+	nodeName := strings.TrimSpace(request.NodeName)
+	if nodeName == "" {
+		return nil, fmt.Errorf("selected node name is required")
+	}
+	sourceID, err := cleanAuditSegment("sourceID", request.SourceID)
+	if err != nil {
+		return nil, err
+	}
+	desiredVersion, err := cleanDesiredVersion(request.DesiredVersion)
+	if err != nil {
+		return nil, err
+	}
+	applyMode, err := normalizeRequestedMode(request.ApplyMode)
+	if err != nil {
+		return nil, err
+	}
+
+	node := request.Manifest.Node
+	document := renderedNodeConfigurationChange{
+		APIVersion: NodeConfigurationChangeAPIVersion,
+		Kind:       NodeConfigurationChangeKind,
+		Metadata: renderedNodeConfigurationMetadata{
+			SourceID:       sourceID,
+			DesiredVersion: desiredVersion,
+		},
+		Apply: Apply{Mode: applyMode},
+		Spec: renderedNodeConfigurationChangeSpec{
+			NodeOverrides: map[string]renderedNodeConfigurationOverlay{
+				nodeName: {
+					Identity: renderedNodeIdentity{
+						Hostname:       node.Identity.Hostname,
+						AuthorizedKeys: append([]string{}, node.Identity.SSH.AuthorizedKeys...),
+					},
+					Networkd: node.Networkd,
+				},
+			},
+		},
+	}
+	data, err := yaml.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("marshal node configuration change: %w", err)
+	}
+	return data, nil
+}

--- a/internal/installer/configapply/render_test.go
+++ b/internal/installer/configapply/render_test.go
@@ -1,0 +1,104 @@
+package configapply
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/manifest"
+)
+
+func TestRenderNodeConfigurationChange(t *testing.T) {
+	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
+		NodeName: "cp-1",
+		Manifest: manifest.Manifest{
+			Node: manifest.NodeConfig{
+				Identity: manifest.NodeIdentity{
+					Hostname: "cp-1",
+					SSH: manifest.SSHIdentity{AuthorizedKeys: []string{
+						"ssh-ed25519 AAAA katl@example",
+					}},
+				},
+				SystemRole: "control-plane",
+				Networkd: manifest.NetworkdConfig{Files: []manifest.NetworkdFile{{
+					Name:    "10-lan.network",
+					Content: "[Network]\nDHCP=yes\n",
+				}}},
+				Kubernetes: manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: "control-plane"}},
+			},
+		},
+		SourceID:       "lab",
+		DesiredVersion: "2",
+		ApplyMode:      "auto",
+	})
+	if err != nil {
+		t.Fatalf("RenderNodeConfigurationChange() error = %v", err)
+	}
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(string(data)), TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() error = %v\n%s", err, data)
+	}
+	overlay := request.NodeOverrides["cp-1"]
+	if request.SourceID != "lab" || request.DesiredVersion != "2" || request.ApplyMode != "auto" {
+		t.Fatalf("rendered metadata = source %q version %q mode %q", request.SourceID, request.DesiredVersion, request.ApplyMode)
+	}
+	if overlay.Identity == nil || overlay.Identity.Hostname != "cp-1" || len(overlay.Identity.AuthorizedKeys) != 1 {
+		t.Fatalf("rendered identity = %#v", overlay.Identity)
+	}
+	if overlay.Networkd == nil || len(overlay.Networkd.Files) != 1 || overlay.Networkd.Files[0].Name != "10-lan.network" {
+		t.Fatalf("rendered networkd = %#v", overlay.Networkd)
+	}
+	if overlay.SystemRole != "" || overlay.Kubernetes != nil || strings.Contains(string(data), "systemRole:") || strings.Contains(string(data), "kubernetes:") || strings.Contains(string(data), "install:") {
+		t.Fatalf("rendered change contains lifecycle or install fields:\n%s", data)
+	}
+}
+
+func TestRenderNodeConfigurationChangePreservesEmptyAuthorizedKeys(t *testing.T) {
+	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
+		NodeName: "worker-1",
+		Manifest: manifest.Manifest{Node: manifest.NodeConfig{
+			Identity: manifest.NodeIdentity{Hostname: "worker-1"},
+		}},
+		SourceID:       "lab",
+		DesiredVersion: "3",
+	})
+	if err != nil {
+		t.Fatalf("RenderNodeConfigurationChange() error = %v", err)
+	}
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(string(data)), TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() error = %v\n%s", err, data)
+	}
+	keys := request.NodeOverrides["worker-1"].Identity.AuthorizedKeys
+	if keys == nil || len(keys) != 0 {
+		t.Fatalf("authorized keys = %#v, want explicit empty list", keys)
+	}
+}
+
+func TestRenderedNodeConfigurationDoesNotPlanUnchangedDomains(t *testing.T) {
+	desired := manifest.Manifest{Node: manifest.NodeConfig{
+		Identity: manifest.NodeIdentity{
+			Hostname: "worker-1",
+			SSH:      manifest.SSHIdentity{AuthorizedKeys: []string{"ssh-ed25519 AAAA katl@example"}},
+		},
+		Networkd: manifest.NetworkdConfig{Files: []manifest.NetworkdFile{{Name: "10-lan.network", Content: "[Network]\nDHCP=yes\n"}}},
+	}}
+	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
+		NodeName:       "worker-1",
+		Manifest:       desired,
+		SourceID:       "lab",
+		DesiredVersion: "4",
+	})
+	if err != nil {
+		t.Fatalf("RenderNodeConfigurationChange() error = %v", err)
+	}
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(string(data)), TrustedBundleRequest{
+		NodeName:        "worker-1",
+		CurrentManifest: desired,
+	})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() error = %v", err)
+	}
+	if _, _, _, err := mergeRuntimeConfig(request); err == nil || !strings.Contains(err.Error(), "desired state already matches") {
+		t.Fatalf("mergeRuntimeConfig() error = %v, want unchanged desired state", err)
+	}
+}

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -411,7 +413,7 @@ func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Chan
 		applyOverlay(&merged.Node, nodeOverlay, &domains, &unsafeFiles)
 	}
 	if len(domains.domains) == 0 {
-		return manifest.Manifest{}, nil, nil, fmt.Errorf("runtime configuration change has no supported changed domains")
+		return manifest.Manifest{}, nil, nil, fmt.Errorf("runtime configuration change has no supported changed domains; desired state already matches")
 	}
 	return merged, domains.changes(request.ClusterDefaults, roleOverlay, nodeOverlay), unsafeFiles, nil
 }
@@ -426,32 +428,50 @@ func validateOverlay(path string, overlay NodeOverlay) error {
 func applyOverlay(node *manifest.NodeConfig, overlay NodeOverlay, domains *domainAccumulator, unsafeFiles *[]confext.NativeEtcFile) {
 	if overlay.Identity != nil {
 		if overlay.Identity.Hostname != "" {
+			changed := node.Identity.Hostname != overlay.Identity.Hostname
 			node.Identity.Hostname = overlay.Identity.Hostname
-			domains.add(DomainNodeIdentity)
-			domains.add(DomainBootstrapNodeMetadata)
+			if changed {
+				domains.add(DomainNodeIdentity)
+				domains.add(DomainBootstrapNodeMetadata)
+			}
 		}
 		if overlay.Identity.AuthorizedKeys != nil {
+			changed := !slices.Equal(node.Identity.SSH.AuthorizedKeys, overlay.Identity.AuthorizedKeys)
 			node.Identity.SSH.AuthorizedKeys = append([]string(nil), overlay.Identity.AuthorizedKeys...)
-			domains.add(DomainSSHOperatorAccess)
+			if changed {
+				domains.add(DomainSSHOperatorAccess)
+			}
 		}
 	}
 	if overlay.SystemRole != "" {
+		changed := node.SystemRole != overlay.SystemRole
 		node.SystemRole = overlay.SystemRole
-		domains.add(DomainSystemRole)
-		domains.add(DomainBootstrapNodeMetadata)
+		if changed {
+			domains.add(DomainSystemRole)
+			domains.add(DomainBootstrapNodeMetadata)
+		}
 	}
 	if overlay.Networkd != nil {
+		changed := !slices.Equal(node.Networkd.Files, overlay.Networkd.Files)
 		node.Networkd = *overlay.Networkd
-		domains.add(DomainNetworkd)
+		if changed {
+			domains.add(DomainNetworkd)
+		}
 	}
 	if overlay.Sysctl != nil {
+		changed := !maps.Equal(node.Sysctl.Settings, overlay.Sysctl.Settings)
 		node.Sysctl = *overlay.Sysctl
-		domains.add(DomainSysctl)
+		if changed {
+			domains.add(DomainSysctl)
+		}
 	}
 	if overlay.Kubernetes != nil {
+		changed := node.Kubernetes != *overlay.Kubernetes
 		node.Kubernetes = *overlay.Kubernetes
-		domains.add(DomainSelectedKubeadmConfig)
-		domains.add(DomainBootstrapNodeMetadata)
+		if changed {
+			domains.add(DomainSelectedKubeadmConfig)
+			domains.add(DomainBootstrapNodeMetadata)
+		}
 	}
 	if overlay.KubeadmChanged {
 		domains.add(DomainKubeadmConfig)

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -212,10 +212,13 @@ func TestApplyTrustedBundleResolvesRoleAndNodeOverlaysForNextBoot(t *testing.T) 
 	if result.Manifest.Node.SystemRole != "control-plane" || result.Manifest.Node.Identity.Hostname != "worker-1" {
 		t.Fatalf("merged node = %#v", result.Manifest.Node)
 	}
-	for _, domain := range []string{DomainNetworkd, DomainSSHOperatorAccess, DomainNodeIdentity, DomainBootstrapNodeMetadata} {
+	for _, domain := range []string{DomainNetworkd, DomainNodeIdentity, DomainBootstrapNodeMetadata} {
 		if !containsDomain(result.Plan.Decision.ChangedDomains, domain) {
 			t.Fatalf("changed domains = %#v, missing %s", result.Plan.Decision.ChangedDomains, domain)
 		}
+	}
+	if containsDomain(result.Plan.Decision.ChangedDomains, DomainSSHOperatorAccess) {
+		t.Fatalf("unchanged SSH access reported as changed: %#v", result.Plan.Decision.ChangedDomains)
 	}
 	if result.Status.Phase != generation.ConfigApplyPhaseNextBoot {
 		t.Fatalf("status phase = %q", result.Status.Phase)

--- a/internal/installer/configapply/runtime_request_test.go
+++ b/internal/installer/configapply/runtime_request_test.go
@@ -51,7 +51,7 @@ spec:
 	if result.Manifest.Node.Identity.Hostname != "cp-1-renamed" {
 		t.Fatalf("hostname = %q", result.Manifest.Node.Identity.Hostname)
 	}
-	if !containsDomain(result.Plan.Decision.ChangedDomains, DomainNetworkd) || !containsDomain(result.Plan.Decision.ChangedDomains, DomainSSHOperatorAccess) {
+	if !containsDomain(result.Plan.Decision.ChangedDomains, DomainNetworkd) || containsDomain(result.Plan.Decision.ChangedDomains, DomainSSHOperatorAccess) {
 		t.Fatalf("changed domains = %#v", result.Plan.Decision.ChangedDomains)
 	}
 	if _, err := generation.ReadRecord(filepath.Join(root, "var/lib/katl/generations/2026.06.05-002/metadata.json")); err != nil {

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -36,11 +36,13 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 	runtime := InstalledRuntimeConfig{}
 	var plannedAddress string
 	var plannedMAC string
+	var worldScenario *WorldScenario
 	if worldRun, ok := installedRuntimeWorldRunFor(t, "installed-runtime-config-apply-modes", NodeSpec{Name: "cp-1", Role: ControlPlane}); ok {
 		runner = worldRun.Runner
 		runtime = worldRun.Config
 		plannedAddress = worldRun.Node.Address
 		plannedMAC = worldRun.Node.MACAddress
+		worldScenario = worldRun.Scenario
 	} else {
 		_ = RequireWorld(t)
 	}
@@ -119,6 +121,11 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 	node.Result.finish(StatusPassed, "", runner.time())
 	if err := runner.Write(scenario, node.Result); err != nil {
 		t.Fatalf("Write() error = %v", err)
+	}
+	if worldScenario != nil {
+		if err := worldScenario.WriteResult(WorldStatusPassed, ""); err != nil {
+			t.Fatalf("write world scenario result: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Lets operators render, plan, and submit per-node runtime configuration from ClusterConfig source or a verified bundle. Excludes lifecycle-owned fields and reports only real value changes. Also fixes missing config-apply VM world-result publication.