### PR TITLE
release: publish alpha support boundary

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,62 @@
+name: KatlOS bug report
+description: Report a reproducible KatlOS alpha failure with release evidence
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        KatlOS is experimental alpha software without a support SLA. Remove tokens, private keys, kubeconfigs, join commands, and other secrets. For sensitive security reports, use the repository's [private vulnerability reporting](https://github.com/katl-dev/katl/security/advisories/new) instead.
+  - type: input
+    id: version
+    attributes:
+      label: KatlOS release
+      description: Provide the version, release URL, and katlctl version output.
+      placeholder: v2026.7.0-alpha.1; https://github.com/katl-dev/katl/releases/tag/...; katlctl version=...
+    validations:
+      required: true
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Artifact identity and verification
+      description: List exact filenames and SHA-256 values, the Kubernetes OCI tag@digest, and whether checksum and provenance verification passed.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Hardware or virtual environment
+      description: Include hypervisor or machine model, UEFI firmware, CPU architecture, storage controller and target disk identity, and network devices.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Provide the smallest redacted ClusterConfig and exact command or boot sequence. Never include credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected and actual behavior
+      description: State what you expected and what happened instead, including the failure timestamp.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted runtime evidence
+      description: Include operation and generation IDs, bundle digest and selected node, relevant systemctl/journalctl output, or the retained vmtest run directory.
+    validations:
+      required: true
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety checks
+      options:
+        - label: I removed credentials, tokens, private keys, kubeconfigs, join commands, and other secrets.
+          required: true
+        - label: I understand this alpha has no production support or compatibility guarantee.
+          required: true

--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ runtime behavior are expected to change. Do not use Katl for production
 clusters.
 
 For the current install boundary and PXE/USB handoff examples, see
-[`docs/installing.md`](docs/installing.md).
+[`docs/installing.md`](docs/installing.md). Before evaluating a release, read
+the [KatlOS support boundary](docs/support.md) for the tested surface, trust and
+compatibility limits, recovery scope, and required bug-report evidence.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,6 +1,7 @@
 # Installing KatlOS
 
-Status: early user-facing guide.
+Status: early user-facing guide. KatlOS is experimental alpha software; read
+the [support boundary](support.md) before installing it.
 
 Katl publishes a versioned installer ISO containing the matching KatlOS payload.
 Write or attach that one artifact, then provide node-specific install input at
@@ -577,4 +578,6 @@ production signing, revocation, and private artifact distribution policy
 ```
 
 Those areas need separate design and tests before they become supported
-operator workflows.
+operator workflows. The complete production, compatibility, trust, recovery,
+hardware-evidence, and issue-reporting boundary is maintained in
+[`support.md`](support.md).

--- a/docs/internal/alpha-release-readiness.md
+++ b/docs/internal/alpha-release-readiness.md
@@ -58,29 +58,29 @@ The capable-host workflow remains tracked by `katl-dty.13.3`. An alpha must not
 claim a VM, install, update, or Kubernetes gate passed merely because
 `go test ./...` passed.
 
-## Documentation Defects Found During Audit
+## Public-UX Defects Resolved During Audit
 
-The current guide does not match the published and implemented interfaces:
+The alpha hardening work corrected these user-facing gaps:
 
-- release PXE boot assets are named `katl-installer.efi`,
-  `katl-installer.vmlinuz`, and `katl-installer.initrd`, while the guide shows
-  versioned loose filenames;
-- the currently published Kubernetes bundle revision differs from the examples;
-- bundle URL, digest, node-selection kernel arguments and the bundle handoff
-  endpoint are implemented but absent from the guide;
-- `katlctl config bundle` and the `ClusterConfig` contract are absent from the
-  primary install journey;
-- the bootstrap command cannot yet consume the inventory already embedded in
-  the config bundle;
-- no released asset provides the `katlctl` command required by the guide.
+- release asset names and the tested immutable Kubernetes bundle reference now
+  match the guide;
+- bundle URL, digest, node selection, local handoff, and PXE input are
+  documented around one `ClusterConfig` and one compiled bundle;
+- the release includes `katlctl`, non-writing validation, and the source schema;
+- bootstrap consumes the verified bundle's embedded inventory and Kubernetes
+  selection;
+- runtime configuration derives a bounded per-node request from the same source
+  or verified bundle; and
+- `SUPPORT.md` ships beside every release with the alpha boundary and issue
+  evidence requirements.
 
-These are release blockers because they prevent a new user from reproducing the
-implemented happy path without reading internal design documents or building
-the repository.
+The remaining release blocker is proof of the complete journey against the
+exact public release artifacts, tracked by `katl-dty.16.25.7`.
 
 ## Accepted Alpha Limitations
 
-The alpha may ship with these explicit boundaries:
+The public, release-shipped contract is [`../support.md`](../support.md). In
+summary, the alpha may ship with these explicit boundaries:
 
 - x86-64 and EFI-only;
 - experimental `v1alpha1` configuration APIs with no beta compatibility

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,109 @@
+# KatlOS Support Boundary
+
+KatlOS is experimental alpha software for evaluation and development. It is not
+supported for production clusters, security-sensitive workloads, compliance
+environments, or systems whose availability depends on KatlOS. There is no
+support SLA, security-response SLA, or compatibility guarantee.
+
+## Supported Evaluation Surface
+
+The first alpha release surface is deliberately narrow:
+
+- x86-64 machines booted with UEFI;
+- the self-contained installer ISO, or the matching loose UEFI/PXE artifacts;
+- one `config.katl.dev/v1alpha1` `ClusterConfig` compiled by the matching
+  `katlctl` release;
+- one explicitly selected target disk per node, with destructive wipe consent;
+- kubeadm bootstrap using the published Kubernetes bundle named in the install
+  guide; and
+- node-local runtime configuration for the domains exposed by
+  `katlctl config render-node`.
+
+Release claims extend only to the exact VM and physical-hardware paths named in
+that release's retained evidence. The automated capable-host path uses libvirt,
+KVM, and OVMF. A successful VM run is not a general hardware compatibility
+claim. Firmware, storage controllers, network devices, and physical machines
+not named in release evidence are unverified.
+
+Katl prepares kubeadm-ready nodes and performs bounded bootstrap operations. It
+does not provide a Kubernetes distribution. Users own DHCP/PXE infrastructure,
+DNS, CNI, GitOps, storage, ingress, workload policy, monitoring, backup, and
+application lifecycle.
+
+## Artifact Trust
+
+KatlOS release assets provide SHA-256 checksums and keyless GitHub build-
+provenance attestations. Kubernetes bundles are digest-addressable OCI
+artifacts with GitHub provenance. Verify both before use and prefer immutable
+digest-pinned bundle references.
+
+This proves which repository workflow produced the bytes. It does not provide:
+
+- UEFI Secure Boot signatures or a production boot-key policy;
+- node-side signature-policy enforcement;
+- artifact revocation, downgrade prevention, or a vulnerability-free claim;
+- confidential secret distribution; or
+- a production supply-chain or incident-response guarantee.
+
+## Compatibility Promise
+
+All `v1alpha1` source, bundle, operation, API, and persisted-state formats are
+experimental. They may change incompatibly between alpha releases. Katl does
+not promise forward or backward compatibility with another alpha, automatic
+state migration, or an upgrade path from every development build. Preserve the
+source `ClusterConfig`, exact release assets, checksums, OCI digests, and
+recovery data. Reinstall may be required after an incompatible change.
+
+Use the `katlctl` binary from the same KatlOS release to validate and compile
+configuration. Mixing release trains is outside the tested surface unless the
+release notes explicitly say otherwise.
+
+## Upgrade And Recovery Limits
+
+KatlOS host update and rollback are node-local root, UKI, sysext, and confext
+operations. They do not roll back etcd, kubeadm mutations, Kubernetes API
+objects, persistent volumes, application data, or external infrastructure.
+After a partial kubeadm or Kubernetes mutation, the node may report that manual
+recovery is required.
+
+Kubernetes version upgrade execution, automated fleet rollout, etcd disaster
+recovery, failed control-plane replacement, and general cluster reconciliation
+are not supported alpha workflows. Wipe/reinstall is destructive recovery, not
+backup or same-cluster disaster recovery. Keep independent etcd, workload, and
+data backups; do not rely on Katl generation rollback as a cluster backup.
+
+## Explicitly Unsupported
+
+Do not use the alpha as the basis for:
+
+- production, regulated, multi-tenant, or security-critical clusters;
+- an availability or disaster-recovery commitment;
+- unattended host or Kubernetes fleet upgrades;
+- Secure Boot or measured-boot policy enforcement;
+- hardware enablement beyond retained release evidence;
+- stable API, schema, on-disk-state, or long-term Kubernetes support promises;
+  or
+- private artifact and credential distribution policy.
+
+## Reporting A Problem
+
+Open a [Katl GitHub issue](https://github.com/katl-dev/katl/issues/new/choose)
+using the bug report form. Remove tokens, private keys, kubeconfigs, join
+commands, and other secrets before attaching anything. Include:
+
+- the KatlOS version, release URL, and `katlctl version` output;
+- exact artifact filenames, SHA-256 values, Kubernetes OCI reference and
+  digest, and whether provenance verification passed;
+- hardware or hypervisor, firmware/UEFI mode, CPU, storage controller and disk
+  identity, and network devices;
+- the smallest redacted `ClusterConfig` and exact command sequence that
+  reproduces the problem;
+- relevant operation IDs, generation IDs, config bundle digest, selected node,
+  and failure timestamps; and
+- redacted installer output, `systemctl` status, `journalctl` output, or retained
+  `scripts/vmtest-run` run directory named by the failure.
+
+A report is evidence for investigation, not a support entitlement. Security
+reports that should not be public must use the repository's
+[private vulnerability reporting](https://github.com/katl-dev/katl/security/advisories/new)
+rather than a public issue.

--- a/internal/scriptstest/katl_release_artifacts_test.go
+++ b/internal/scriptstest/katl_release_artifacts_test.go
@@ -151,6 +151,8 @@ func TestKatlReleaseArtifactNotes(t *testing.T) {
 	}
 	notes := string(output)
 	for _, value := range []string{
+		"## Support boundary",
+		"SUPPORT.md",
 		"## Changes",
 		"- **release:** attest KatlOS artifacts",
 		"- **release:** automate Kubernetes bundles",
@@ -272,7 +274,7 @@ func TestKatlReleaseArtifactStage(t *testing.T) {
 		got = append(got, entry.Name())
 	}
 	sort.Strings(got)
-	want := []string{"PROVENANCE.md", "RELEASE_NOTES.md", "SHA256SUMS"}
+	want := []string{"PROVENANCE.md", "RELEASE_NOTES.md", "SHA256SUMS", "SUPPORT.md"}
 	for _, name := range names {
 		want = append(want, name, name+".json", name+".sha256")
 	}
@@ -295,19 +297,19 @@ func TestKatlReleaseArtifactStage(t *testing.T) {
 		}
 	}
 	releaseNotes := string(mustReadFile(t, filepath.Join(output, "RELEASE_NOTES.md")))
-	for _, value := range []string{"## Changes", "## Verify downloads", "`PROVENANCE.md`"} {
+	for _, value := range []string{"## Support boundary", "SUPPORT.md", "## Changes", "## Verify downloads", "`PROVENANCE.md`"} {
 		if !strings.Contains(releaseNotes, value) {
 			t.Fatalf("release notes missing %q: %q", value, releaseNotes)
 		}
 	}
 
 	checksums := mustReadFile(t, filepath.Join(output, "SHA256SUMS"))
-	for _, name := range append([]string{"PROVENANCE.md", "RELEASE_NOTES.md"}, names...) {
+	for _, name := range append([]string{"PROVENANCE.md", "RELEASE_NOTES.md", "SUPPORT.md"}, names...) {
 		if !strings.Contains(string(checksums), "  "+name+"\n") {
 			t.Fatalf("SHA256SUMS missing %q: %q", name, checksums)
 		}
 		for _, suffix := range []string{".json", ".sha256"} {
-			if name == "PROVENANCE.md" || name == "RELEASE_NOTES.md" {
+			if name == "PROVENANCE.md" || name == "RELEASE_NOTES.md" || name == "SUPPORT.md" {
 				continue
 			}
 			if !strings.Contains(string(checksums), "  "+name+suffix+"\n") {

--- a/internal/scriptstest/support_boundary_test.go
+++ b/internal/scriptstest/support_boundary_test.go
@@ -1,0 +1,60 @@
+package scriptstest
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPublishedSupportBoundaryContract(t *testing.T) {
+	repo := repoRoot(t)
+	support := string(mustReadFile(t, repo+"/docs/support.md"))
+	for _, value := range []string{
+		"experimental alpha software",
+		"production clusters",
+		"x86-64 machines booted with UEFI",
+		"libvirt",
+		"KVM",
+		"OVMF",
+		"exact VM and physical-hardware paths named",
+		"SHA-256 checksums",
+		"keyless GitHub",
+		"provenance attestations",
+		"UEFI Secure Boot signatures",
+		"All `v1alpha1` source",
+		"persisted-state formats",
+		"Reinstall may be required",
+		"do not roll back etcd",
+		"Kubernetes version upgrade execution",
+		"support SLA",
+		"Katl GitHub issue",
+		"private vulnerability",
+		"Remove tokens, private keys, kubeconfigs",
+	} {
+		if !strings.Contains(support, value) {
+			t.Fatalf("support boundary missing %q", value)
+		}
+	}
+
+	issueForm := string(mustReadFile(t, repo+"/.github/ISSUE_TEMPLATE/bug.yml"))
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(issueForm), &parsed); err != nil {
+		t.Fatalf("parse bug report form: %v", err)
+	}
+	for _, value := range []string{
+		"id: version",
+		"id: artifacts",
+		"id: environment",
+		"id: reproduce",
+		"id: expected",
+		"id: evidence",
+		"private vulnerability reporting",
+		"I removed credentials",
+		"required: true",
+	} {
+		if !strings.Contains(issueForm, value) {
+			t.Fatalf("bug report form missing %q", value)
+		}
+	}
+}

--- a/scripts/katl-release-artifacts
+++ b/scripts/katl-release-artifacts
@@ -62,6 +62,12 @@ generate_release_notes() {
     fi
 
     mapfile -t commits < <(git log --format='%H%x09%s' "$range")
+    printf '## Support boundary\n\n'
+    if [[ "$version" == *-alpha.* ]]; then
+        printf 'This is an experimental alpha release, not a production-supported release. '
+    fi
+    printf 'Read SUPPORT.md before installation for the tested surface, trust and compatibility limits, recovery scope, and required issue evidence.\n\n'
+
     printf '## Changes\n\n'
     if ((${#commits[@]} == 0)); then
         printf '_No commits were added since the previous KatlOS release._\n'
@@ -248,6 +254,8 @@ stage_artifacts() {
             cp -- "$build_dir/$name$suffix" "$output/"
         done
     done
+    [[ -f "$repo_root/docs/support.md" ]] || fail "release support boundary is missing: $repo_root/docs/support.md"
+    cp -- "$repo_root/docs/support.md" "$output/SUPPORT.md"
     cat >"$output/PROVENANCE.md" <<'EOF'
 # KatlOS release provenance
 


### PR DESCRIPTION
Ships the alpha support, compatibility, trust, recovery, and hardware-evidence boundary with release assets. Adds actionable public/private reporting paths and surfaces the boundary before release changes.