### PR TITLE
release: publish installer package inventory

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -95,8 +95,10 @@ nodes.
 ### Verify release provenance
 
 Each KatlOS tag release includes `SHA256SUMS`, adjacent checksum files, and
-`PROVENANCE.md`. After downloading the required assets into one directory,
-verify their transport integrity:
+`PROVENANCE.md`. It also includes `katl-installer.packages.tsv`, the resolved
+package inventory for the temporary installer environment used to produce the
+boot media. After downloading the required assets into one directory, verify
+their transport integrity:
 
 ```sh
 sha256sum --ignore-missing --check SHA256SUMS

--- a/internal/scriptstest/katl_release_artifacts_test.go
+++ b/internal/scriptstest/katl_release_artifacts_test.go
@@ -250,6 +250,9 @@ func TestKatlReleaseArtifactStage(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "dist")
 	version := "2026.7.0-rc.0"
 	names := writeRequiredReleaseArtifacts(t, buildDir)
+	if err := os.WriteFile(filepath.Join(buildDir, "katl-installer.packages.tsv"), []byte("bash\t5.3.0\tx86_64\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	writeReleaseArtifact(t, buildDir, "katl-runtime.efi")
 	if err := os.WriteFile(filepath.Join(buildDir, "artifacts.json"), []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -274,7 +277,7 @@ func TestKatlReleaseArtifactStage(t *testing.T) {
 		got = append(got, entry.Name())
 	}
 	sort.Strings(got)
-	want := []string{"PROVENANCE.md", "RELEASE_NOTES.md", "SHA256SUMS", "SUPPORT.md"}
+	want := []string{"PROVENANCE.md", "RELEASE_NOTES.md", "SHA256SUMS", "SUPPORT.md", "katl-installer.packages.tsv"}
 	for _, name := range names {
 		want = append(want, name, name+".json", name+".sha256")
 	}
@@ -304,12 +307,12 @@ func TestKatlReleaseArtifactStage(t *testing.T) {
 	}
 
 	checksums := mustReadFile(t, filepath.Join(output, "SHA256SUMS"))
-	for _, name := range append([]string{"PROVENANCE.md", "RELEASE_NOTES.md", "SUPPORT.md"}, names...) {
+	for _, name := range append([]string{"PROVENANCE.md", "RELEASE_NOTES.md", "SUPPORT.md", "katl-installer.packages.tsv"}, names...) {
 		if !strings.Contains(string(checksums), "  "+name+"\n") {
 			t.Fatalf("SHA256SUMS missing %q: %q", name, checksums)
 		}
 		for _, suffix := range []string{".json", ".sha256"} {
-			if name == "PROVENANCE.md" || name == "RELEASE_NOTES.md" || name == "SUPPORT.md" {
+			if name == "PROVENANCE.md" || name == "RELEASE_NOTES.md" || name == "SUPPORT.md" || name == "katl-installer.packages.tsv" {
 				continue
 			}
 			if !strings.Contains(string(checksums), "  "+name+suffix+"\n") {

--- a/scripts/katl-release-artifacts
+++ b/scripts/katl-release-artifacts
@@ -224,6 +224,7 @@ stage_artifacts() {
         "katlos-upgrade-${version}-${architecture}.squashfs"
     )
     local operator_name="katlctl-${version}-linux-amd64"
+    local installer_packages="katl-installer.packages.tsv"
 
     validate_version "$version"
     [[ -n "$output" && "$output" != / && "$output" != . ]] ||
@@ -247,6 +248,7 @@ stage_artifacts() {
     done
     verify_artifact "$operator_name" "$version" amd64
     names+=("$operator_name")
+    [[ -f "$build_dir/$installer_packages" ]] || fail "release installer package inventory is missing: $build_dir/$installer_packages"
 
     mkdir -p "$output"
     for name in "${names[@]}"; do
@@ -254,6 +256,7 @@ stage_artifacts() {
             cp -- "$build_dir/$name$suffix" "$output/"
         done
     done
+    cp -- "$build_dir/$installer_packages" "$output/$installer_packages"
     [[ -f "$repo_root/docs/support.md" ]] || fail "release support boundary is missing: $repo_root/docs/support.md"
     cp -- "$repo_root/docs/support.md" "$output/SUPPORT.md"
     cat >"$output/PROVENANCE.md" <<'EOF'


### PR DESCRIPTION
Publish the resolved installer package inventory with each release and include it in aggregate checksums. This closes the strict-verification gap that prevented candidate installation media from being proven against the locked package inputs.