### PR TITLE
vmtest: resolve relative run directories

### DIFF
--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -16,7 +16,24 @@ func TestVMTestRunInjectsWorld(t *testing.T) {
 	tmp := t.TempDir()
 	fakeGo, fakeChild := writeFakeGoTools(t, tmp)
 	host := writeFakeHostTools(t, tmp, true)
-	runDir := filepath.Join(tmp, "run")
+	buildDir := filepath.Join(repo, "_build")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatalf("create build dir: %v", err)
+	}
+	runRoot, err := os.MkdirTemp(buildDir, "vmtest-relative-run-")
+	if err != nil {
+		t.Fatalf("create relative run root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(runRoot); err != nil {
+			t.Errorf("remove relative run root: %v", err)
+		}
+	})
+	runDir := filepath.Join(runRoot, "run")
+	relativeRunDir, err := filepath.Rel(repo, runDir)
+	if err != nil {
+		t.Fatalf("relative run dir: %v", err)
+	}
 	goArgsPath := filepath.Join(tmp, "go-args.txt")
 	childArgsPath := filepath.Join(tmp, "child-args.txt")
 	childEnvPath := filepath.Join(tmp, "child-env.txt")
@@ -35,7 +52,7 @@ func TestVMTestRunInjectsWorld(t *testing.T) {
 		"KATL_FAKE_CHILD_ARGS="+childArgsPath,
 		"KATL_FAKE_CHILD_ENV="+childEnvPath,
 		"KATL_VMTEST_RUN_ID=run-1",
-		"KATL_VMTEST_RUN_DIR="+runDir,
+		"KATL_VMTEST_RUN_DIR="+relativeRunDir,
 		"TMPDIR="+tmp,
 	)
 	output, err := cmd.CombinedOutput()

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -12,6 +12,12 @@ go_test_timeout="90m"
 tmp_parent="${TMPDIR:-/tmp}/katl-vmtest"
 run_id="${KATL_VMTEST_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 run_dir="${KATL_VMTEST_RUN_DIR:-$tmp_parent/$run_id}"
+if [[ "$run_dir" != /* ]]; then
+    run_dir="$repo_root/$run_dir"
+    if command -v realpath >/dev/null 2>&1; then
+        run_dir="$(realpath -m -- "$run_dir")"
+    fi
+fi
 run_dir_preexisting=0
 if [[ -e "$run_dir" ]]; then
     run_dir_preexisting=1


### PR DESCRIPTION
Resolve relative VM evidence directories against the repository root before exporting scenario paths. This prevents enabled Go tests from losing the world manifest when their package working directory differs from the caller's.