### PR TITLE
config: carry inline kubeadm inputs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -504,7 +504,28 @@ policy, system role, Kubernetes bundle selection, and kubeadm lifecycle state.
 Those changes require reinstall, host update, Kubernetes upgrade, or another
 explicit lifecycle operation. `--file` remains available for an advanced,
 pre-rendered `NodeConfigurationChange`, with `--node` selecting any
-`nodeOverrides` entry it contains.
+`nodeOverrides` entry it contains. An advanced request may carry a named
+desired kubeadm input and select it atomically:
+
+```yaml
+spec:
+  kubeadmConfigs:
+    control-plane-profiled:
+      config: |
+        apiVersion: kubeadm.k8s.io/v1beta4
+        kind: ClusterConfiguration
+        kubernetesVersion: v1.36.0
+  clusterDefaults:
+    kubernetes:
+      kubeadm:
+        configRef: control-plane-profiled
+```
+
+Inline `patches` may also map single file names to native kubeadm patch YAML.
+Applying the request renders the named desired input and records that a
+kubeadm-aware action is required; normal config apply still does not mutate
+kubeadm-owned cluster state. Run the explicit Katl kubeadm operation after the
+candidate generation is committed.
 
 ## Upgrades
 

--- a/internal/installer/configapply/runtime_request.go
+++ b/internal/installer/configapply/runtime_request.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
 
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -26,6 +31,12 @@ type nodeConfigurationChangeSpec struct {
 	ClusterDefaults     nodeConfigurationOverlay            `json:"clusterDefaults,omitempty" yaml:"clusterDefaults,omitempty"`
 	SystemRoleOverrides map[string]nodeConfigurationOverlay `json:"systemRoleOverrides,omitempty" yaml:"systemRoleOverrides,omitempty"`
 	NodeOverrides       map[string]nodeConfigurationOverlay `json:"nodeOverrides,omitempty" yaml:"nodeOverrides,omitempty"`
+	KubeadmConfigs      map[string]inlineKubeadmConfig      `json:"kubeadmConfigs,omitempty" yaml:"kubeadmConfigs,omitempty"`
+}
+
+type inlineKubeadmConfig struct {
+	Config  string            `json:"config" yaml:"config"`
+	Patches map[string]string `json:"patches,omitempty" yaml:"patches,omitempty"`
 }
 
 type nodeConfigurationOverlay struct {
@@ -59,9 +70,14 @@ func DecodeNodeConfigurationChange(reader io.Reader, base TrustedBundleRequest) 
 	request.SourceID = document.Metadata.SourceID
 	request.DesiredVersion = document.Metadata.DesiredVersion
 	request.ApplyMode = document.Apply.Mode
-	request.ClusterDefaults = document.Spec.ClusterDefaults.nodeOverlay()
-	request.SystemRoleOverrides = nodeOverlayMap(document.Spec.SystemRoleOverrides)
-	request.NodeOverrides = nodeOverlayMap(document.Spec.NodeOverrides)
+	kubeadmConfigs, changedKubeadmConfigs, err := mergeInlineKubeadmConfigs(base.KubeadmConfigs, document.Spec.KubeadmConfigs)
+	if err != nil {
+		return TrustedBundleRequest{}, err
+	}
+	request.KubeadmConfigs = kubeadmConfigs
+	request.ClusterDefaults = document.Spec.ClusterDefaults.nodeOverlay(changedKubeadmConfigs)
+	request.SystemRoleOverrides = nodeOverlayMap(document.Spec.SystemRoleOverrides, changedKubeadmConfigs)
+	request.NodeOverrides = nodeOverlayMap(document.Spec.NodeOverrides, changedKubeadmConfigs)
 	return request, nil
 }
 
@@ -73,24 +89,75 @@ func ApplyNodeConfigurationChange(ctx context.Context, reader io.Reader, base Tr
 	return ApplyTrustedBundle(ctx, request)
 }
 
-func nodeOverlayMap(overlays map[string]nodeConfigurationOverlay) map[string]NodeOverlay {
+func nodeOverlayMap(overlays map[string]nodeConfigurationOverlay, changedConfigs map[string]struct{}) map[string]NodeOverlay {
 	if len(overlays) == 0 {
 		return nil
 	}
 	out := make(map[string]NodeOverlay, len(overlays))
 	for name, overlay := range overlays {
-		out[name] = overlay.nodeOverlay()
+		out[name] = overlay.nodeOverlay(changedConfigs)
 	}
 	return out
 }
 
-func (overlay nodeConfigurationOverlay) nodeOverlay() NodeOverlay {
-	return NodeOverlay{
-		Identity:      overlay.Identity,
-		SystemRole:    overlay.SystemRole,
-		Networkd:      overlay.Networkd,
-		Sysctl:        overlay.Sysctl,
-		Kubernetes:    overlay.Kubernetes,
-		LivePreflight: overlay.LivePreflight,
+func (overlay nodeConfigurationOverlay) nodeOverlay(changedConfigs map[string]struct{}) NodeOverlay {
+	kubeadmChanged := false
+	if overlay.Kubernetes != nil {
+		_, kubeadmChanged = changedConfigs[strings.TrimSpace(overlay.Kubernetes.Kubeadm.ConfigRef)]
 	}
+	return NodeOverlay{
+		Identity:       overlay.Identity,
+		SystemRole:     overlay.SystemRole,
+		Networkd:       overlay.Networkd,
+		Sysctl:         overlay.Sysctl,
+		Kubernetes:     overlay.Kubernetes,
+		KubeadmChanged: kubeadmChanged,
+		LivePreflight:  overlay.LivePreflight,
+	}
+}
+
+func mergeInlineKubeadmConfigs(installed map[string]kubeadmconfig.Plan, inline map[string]inlineKubeadmConfig) (map[string]kubeadmconfig.Plan, map[string]struct{}, error) {
+	if len(inline) == 0 {
+		return installed, nil, nil
+	}
+	configs := make(map[string]kubeadmconfig.Plan, len(installed)+len(inline))
+	changed := make(map[string]struct{}, len(inline))
+	for name, plan := range installed {
+		configs[name] = plan
+	}
+	names := make([]string, 0, len(inline))
+	for name := range inline {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		input := inline[name]
+		files := []kubeadmconfig.File{{
+			RenderPath: "/etc/katl/kubeadm/" + name + "/config.yaml",
+			Content:    []byte(input.Config),
+			Mode:       0o644,
+		}}
+		patchNames := make([]string, 0, len(input.Patches))
+		for patchName := range input.Patches {
+			patchNames = append(patchNames, patchName)
+		}
+		sort.Strings(patchNames)
+		for _, patchName := range patchNames {
+			files = append(files, kubeadmconfig.File{
+				RenderPath: filepath.ToSlash(filepath.Join("/etc/katl/kubeadm", name, "patches", patchName)),
+				Content:    []byte(input.Patches[patchName]),
+				Mode:       0o644,
+			})
+		}
+		plan, err := kubeadmconfig.PlanFromRenderedFiles(name, files)
+		if err != nil {
+			return nil, nil, fmt.Errorf("spec.kubeadmConfigs.%s: %w", name, err)
+		}
+		previous, exists := installed[name]
+		if !exists || !reflect.DeepEqual(previous.NativeEtcFiles(), plan.NativeEtcFiles()) {
+			changed[name] = struct{}{}
+		}
+		configs[name] = plan
+	}
+	return configs, changed, nil
 }

--- a/internal/installer/configapply/runtime_request_test.go
+++ b/internal/installer/configapply/runtime_request_test.go
@@ -59,6 +59,47 @@ spec:
 	}
 }
 
+func TestDecodeNodeConfigurationChangeAddsInlineKubeadmConfig(t *testing.T) {
+	document := `
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: operator
+  desiredVersion: "2"
+apply:
+  mode: next-boot
+spec:
+  kubeadmConfigs:
+    control-plane-profiled:
+      config: |
+        apiVersion: kubeadm.k8s.io/v1beta4
+        kind: ClusterConfiguration
+        kubernetesVersion: v1.36.0
+  clusterDefaults:
+    kubernetes:
+      kubeadm:
+        configRef: control-plane-profiled
+`
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(document), TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() error = %v", err)
+	}
+	plan, ok := request.KubeadmConfigs["control-plane-profiled"]
+	if !ok || plan.Name != "control-plane-profiled" || !strings.Contains(string(plan.Config.Content), "kind: ClusterConfiguration") {
+		t.Fatalf("inline kubeadm plan = %#v", plan)
+	}
+	if request.ClusterDefaults.Kubernetes == nil || request.ClusterDefaults.Kubernetes.Kubeadm.ConfigRef != "control-plane-profiled" || !request.ClusterDefaults.KubeadmChanged {
+		t.Fatalf("cluster defaults = %#v", request.ClusterDefaults)
+	}
+	same, err := DecodeNodeConfigurationChange(strings.NewReader(document), TrustedBundleRequest{KubeadmConfigs: request.KubeadmConfigs})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() same config error = %v", err)
+	}
+	if same.ClusterDefaults.KubeadmChanged {
+		t.Fatalf("identical inline kubeadm config reported changed: %#v", same.ClusterDefaults)
+	}
+}
+
 func TestDecodeNodeConfigurationChangeRejectsUnknownFields(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/katlc/config/validate.go
+++ b/internal/katlc/config/validate.go
@@ -112,6 +112,7 @@ func validateDocument(root *yaml.Node, options Options, result *Result) {
 		result.add("invalid-field", "spec", "spec must be a mapping")
 		return
 	}
+	options.KubeadmConfigNames = mergedKubeadmConfigNames(options.KubeadmConfigNames, mappingValue(spec, "kubeadmConfigs"))
 	for _, pair := range mappingPairsWithPath(spec, "spec") {
 		switch pair.key {
 		case "clusterDefaults":
@@ -120,8 +121,69 @@ func validateDocument(root *yaml.Node, options Options, result *Result) {
 			validateOverlayMap(pair.value, pair.path, options, result)
 		case "nodeOverrides":
 			validateOverlayMap(pair.value, pair.path, options, result)
+		case "kubeadmConfigs":
+			validateInlineKubeadmConfigs(pair.value, pair.path, result)
 		default:
 			result.add(unsupportedCode(pair.key), pair.path, "configuration domain is not supported")
+		}
+	}
+}
+
+func mergedKubeadmConfigNames(installed map[string]struct{}, inline *yaml.Node) map[string]struct{} {
+	names := make(map[string]struct{}, len(installed))
+	for name := range installed {
+		names[name] = struct{}{}
+	}
+	if inline != nil && inline.Kind == yaml.MappingNode {
+		for _, pair := range mappingPairs(inline) {
+			names[pair.key] = struct{}{}
+		}
+	}
+	return names
+}
+
+func validateInlineKubeadmConfigs(node *yaml.Node, path string, result *Result) {
+	if node.Kind != yaml.MappingNode {
+		result.add("invalid-field", path, "kubeadmConfigs must be a mapping")
+		return
+	}
+	for _, config := range mappingPairsWithPath(node, path) {
+		if !validName(config.key) {
+			result.add("invalid-kubeadm-name", config.path, fmt.Sprintf("%q must be a DNS label", config.key))
+		}
+		if config.value.Kind != yaml.MappingNode {
+			result.add("invalid-field", config.path, "inline kubeadm config must be a mapping")
+			continue
+		}
+		for _, field := range mappingPairsWithPath(config.value, config.path) {
+			switch field.key {
+			case "config":
+				if strings.TrimSpace(scalarValue(field.value)) == "" {
+					result.add("missing-kubeadm-config", field.path, "config must contain kubeadm YAML")
+				}
+			case "patches":
+				validateInlineKubeadmPatches(field.value, field.path, result)
+			default:
+				result.add("unsupported-field", field.path, "inline kubeadm config field is not supported")
+			}
+		}
+		if mappingValue(config.value, "config") == nil {
+			result.add("missing-field", config.path+".config", "config is required")
+		}
+	}
+}
+
+func validateInlineKubeadmPatches(node *yaml.Node, path string, result *Result) {
+	if node.Kind != yaml.MappingNode {
+		result.add("invalid-field", path, "patches must be a mapping of file names to YAML content")
+		return
+	}
+	for _, patch := range mappingPairsWithPath(node, path) {
+		if err := validateNetworkdName(patch.key); err != nil {
+			result.add("unsafe-render-path", patch.path, err.Error())
+		}
+		if strings.TrimSpace(scalarValue(patch.value)) == "" {
+			result.add("missing-kubeadm-patch", patch.path, "patch must contain kubeadm patch YAML")
 		}
 	}
 }

--- a/internal/katlc/config/validate_test.go
+++ b/internal/katlc/config/validate_test.go
@@ -105,6 +105,33 @@ spec:
 	}
 }
 
+func TestValidateNodeConfigurationChangeAcceptsInlineKubeadmRef(t *testing.T) {
+	input := `
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: operator
+  desiredVersion: "2"
+apply:
+  mode: next-boot
+spec:
+  kubeadmConfigs:
+    control-plane-profiled:
+      config: |
+        apiVersion: kubeadm.k8s.io/v1beta4
+        kind: ClusterConfiguration
+        kubernetesVersion: v1.36.0
+  clusterDefaults:
+    kubernetes:
+      kubeadm:
+        configRef: control-plane-profiled
+`
+	result := ValidateNodeConfigurationChange(input, Options{CheckKubeadmRefs: true})
+	if !result.Accepted() {
+		t.Fatalf("diagnostics = %#v, want accepted", result.Strings())
+	}
+}
+
 func TestValidateNodeConfigurationChangeRejectsInvalidSysctlValues(t *testing.T) {
 	input := `
 apiVersion: katl.dev/v1alpha1

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -478,24 +478,13 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 		return err
 	}
 	requestPath := filepath.Join(proofDir, "config-apply.yaml")
-	request := fmt.Appendf(nil, "apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\nmetadata:\n  sourceID: vmtest\n  desiredVersion: \"20260711\"\napply:\n  mode: next-boot\nspec:\n  clusterDefaults:\n    kubernetes:\n      kubeadm:\n        configRef: %s\n", configName)
+	inlineConfig := strings.ReplaceAll(strings.TrimSuffix(string(desiredConfig), "\n"), "\n", "\n        ")
+	request := fmt.Appendf(nil, "apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\nmetadata:\n  sourceID: vmtest\n  desiredVersion: \"20260711\"\napply:\n  mode: next-boot\nspec:\n  kubeadmConfigs:\n    %s:\n      config: |\n        %s\n  clusterDefaults:\n    kubernetes:\n      kubeadm:\n        configRef: %s\n", configName, inlineConfig, configName)
 	if err := os.WriteFile(requestPath, request, 0o600); err != nil {
 		return err
 	}
 	katlctl := buildKatlctlCommand(t, ctx, katlRepoRoot(t))
 	for _, node := range nodes {
-		guestConfig := "/var/lib/katl/test-artifacts/control-plane-profiled.yaml"
-		if err := writeNodeFile(ctx, node, guestConfig, desiredConfig, 0o600, true); err != nil {
-			return fmt.Errorf("stage desired kubeadm config on %s: %w", node.Name, err)
-		}
-		installed := "/var/lib/katl/cluster/kubeadm/" + configName + "/config.yaml"
-		copyResult, err := runNodeCommandWithRetry(ctx, node, []string{"install", "-D", "-m", "0600", guestConfig, installed}, 16<<10)
-		if err != nil {
-			return fmt.Errorf("install desired kubeadm config on %s: %w", node.Name, err)
-		}
-		if copyResult.ExitStatus != 0 {
-			return fmt.Errorf("install desired kubeadm config on %s: %w", node.Name, commandErrorDetail(copyResult))
-		}
 		stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "stage-"+node.Name,
 			"config", "apply", "--endpoint", net.JoinHostPort(addresses[node.Name], "9443"), "--agent-token-file", tokenFiles[node.Name], "--file", requestPath, "--mode", "next-boot", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof")
 		if err != nil {


### PR DESCRIPTION
Allow advanced runtime configuration requests to carry named native kubeadm config and patch content with the selected ref. The generation renders the real desired input while cluster mutation remains behind the explicit kubeadm operation.