### PR TITLE
config: keep validation bundle identity stable

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -49,6 +49,7 @@ var newWipeClusterConnector = func(token string) cluster.AgentConnector {
 }
 
 const (
+	configBundleCreator      = "katlctl config bundle"
 	wipeClusterOperationKind = "destructive-reset"
 	wipeAcknowledgementText  = "I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity."
 )
@@ -951,7 +952,7 @@ func runConfigValidate(sourcePath string, stdout, stderr io.Writer) error {
 		SourcePath:     sourcePath,
 		KatlctlVersion: version,
 		KatlctlCommit:  commit,
-		CreatedBy:      "katlctl config validate",
+		CreatedBy:      configBundleCreator,
 	})
 	if err != nil {
 		return err
@@ -1032,7 +1033,7 @@ func runConfigBundle(opts configBundleOptions, stdout, stderr io.Writer) error {
 		SourcePath:     opts.sourcePath,
 		KatlctlVersion: version,
 		KatlctlCommit:  commit,
-		CreatedBy:      "katlctl config bundle",
+		CreatedBy:      configBundleCreator,
 	})
 	if err != nil {
 		return err
@@ -1110,7 +1111,7 @@ func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) 
 			SourcePath:     opts.sourcePath,
 			KatlctlVersion: version,
 			KatlctlCommit:  commit,
-			CreatedBy:      "katlctl config render-node",
+			CreatedBy:      configBundleCreator,
 		})
 		if buildErr != nil {
 			return nil, buildErr

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -234,6 +234,7 @@ func TestConfigRenderNodeFromSource(t *testing.T) {
 func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "cluster.yaml")
+	outputPath := filepath.Join(dir, "homelab.katlcfg")
 	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
@@ -264,6 +265,18 @@ func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	}
 	if len(report.Nodes) != 1 || report.Nodes[0] != (configValidationNode{Name: "cp-1", SystemRole: "control-plane"}) {
 		t.Fatalf("resolved nodes = %#v", report.Nodes)
+	}
+
+	stdout.Reset()
+	if err := run(context.Background(), []string{"config", "bundle", sourcePath, "--output", outputPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("bundle run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var bundleReport configBundleReport
+	if err := json.Unmarshal(stdout.Bytes(), &bundleReport); err != nil {
+		t.Fatalf("decode bundle stdout: %v\n%s", err, stdout.String())
+	}
+	if bundleReport.BundleDigest != report.BundleDigest {
+		t.Fatalf("bundle digest = %q, validation predicted %q", bundleReport.BundleDigest, report.BundleDigest)
 	}
 }
 


### PR DESCRIPTION
Make the documented validate-then-bundle flow produce one predictable internal bundle digest. Add a command-level regression test covering both commands.