### PR TITLE
config: render media-supplied image bundles

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1103,7 +1103,11 @@ func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) 
 		return nil, fmt.Errorf("--config-bundle-digest is required with --config-bundle")
 	}
 
-	readOptions := configbundle.ReadOptions{ExpectedDigest: opts.bundleDigest, NodeName: opts.nodeName}
+	readOptions := configbundle.ReadOptions{
+		ExpectedDigest:          opts.bundleDigest,
+		NodeName:                opts.nodeName,
+		AllowMissingKatlosImage: true,
+	}
 	var selected configbundle.SelectedNodeMaterial
 	var err error
 	if fromSource {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -231,6 +231,46 @@ func TestConfigRenderNodeFromSource(t *testing.T) {
 	}
 }
 
+func TestConfigRenderNodeFromMediaBundle(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	source := configBundleSource()
+	imageStart := strings.Index(source, "  katlosImage:\n")
+	defaultsStart := strings.Index(source, "  defaults:\n")
+	if imageStart < 0 || defaultsStart <= imageStart {
+		t.Fatal("source image block not found")
+	}
+	if err := os.WriteFile(sourcePath, []byte(source[:imageStart]+source[defaultsStart:]), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	bundlePath := filepath.Join(dir, "cluster.katlcfg")
+	if err := os.WriteFile(bundlePath, archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{
+		"config", "render-node",
+		"--config-bundle", bundlePath,
+		"--config-bundle-digest", result.Digest,
+		"--node", "cp-1",
+		"--desired-version", "2",
+	}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	request, err := configapply.DecodeNodeConfigurationChange(strings.NewReader(stdout.String()), configapply.TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("decode rendered node config: %v\n%s", err, stdout.String())
+	}
+	if request.SourceID != "lab" || request.DesiredVersion != "2" {
+		t.Fatalf("rendered request metadata = %#v", request)
+	}
+}
+
 func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "cluster.yaml")

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -115,6 +115,13 @@ func TestBuildArchiveDefersKatlosImageToInstallMedia(t *testing.T) {
 	if _, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1"}); err == nil || !strings.Contains(err.Error(), "katlosImage") {
 		t.Fatalf("ReadSelectedNode() error = %v, want missing media image rejection", err)
 	}
+	selected, err = ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode() runtime rendering error = %v", err)
+	}
+	if !manifest.KatlosImageEmpty(selected.InstallManifest.KatlosImage) || selected.KatlosImageFromMedia {
+		t.Fatalf("selected runtime image = %#v, from media = %v", selected.InstallManifest.KatlosImage, selected.KatlosImageFromMedia)
+	}
 }
 
 func TestInstallingGuideClusterConfigCompiles(t *testing.T) {

--- a/internal/installer/configbundle/consume.go
+++ b/internal/installer/configbundle/consume.go
@@ -18,9 +18,10 @@ import (
 )
 
 type ReadOptions struct {
-	ExpectedDigest     string
-	NodeName           string
-	DefaultKatlosImage manifest.KatlosImage
+	ExpectedDigest          string
+	NodeName                string
+	DefaultKatlosImage      manifest.KatlosImage
+	AllowMissingKatlosImage bool
 }
 
 type SelectedNodeMaterial struct {
@@ -118,7 +119,10 @@ func ReadSelectedNode(reader io.Reader, options ReadOptions) (SelectedNodeMateri
 	if err != nil {
 		return SelectedNodeMaterial{}, fmt.Errorf("read selected install material: %w", err)
 	}
-	installManifest, defaulted, err := manifest.DecodeWithDefaultImage(bytes.NewReader(installData), options.DefaultKatlosImage)
+	installManifest, defaulted, err := manifest.DecodeWithOptions(bytes.NewReader(installData), manifest.DecodeOptions{
+		DefaultKatlosImage:      options.DefaultKatlosImage,
+		AllowMissingKatlosImage: options.AllowMissingKatlosImage,
+	})
 	if err != nil {
 		return SelectedNodeMaterial{}, fmt.Errorf("decode selected install material %q: %w", node.Name, err)
 	}
@@ -294,6 +298,9 @@ func validateBundleManifest(bundle BundleManifest) error {
 
 func validateSelectedCompatibility(bundle BundleManifest, installManifest manifest.Manifest) error {
 	image := installManifest.KatlosImage
+	if manifest.KatlosImageEmpty(image) {
+		return nil
+	}
 	if len(bundle.Compatibility.SupportedArchitectures) > 0 && !containsString(bundle.Compatibility.SupportedArchitectures, image.Architecture) {
 		return fmt.Errorf("config bundle does not support selected install architecture %q", image.Architecture)
 	}

--- a/internal/installer/manifest/manifest.go
+++ b/internal/installer/manifest/manifest.go
@@ -157,6 +157,15 @@ func Decode(reader io.Reader) (Manifest, error) {
 }
 
 func DecodeWithDefaultImage(reader io.Reader, defaultImage KatlosImage) (Manifest, bool, error) {
+	return DecodeWithOptions(reader, DecodeOptions{DefaultKatlosImage: defaultImage})
+}
+
+type DecodeOptions struct {
+	DefaultKatlosImage      KatlosImage
+	AllowMissingKatlosImage bool
+}
+
+func DecodeWithOptions(reader io.Reader, options DecodeOptions) (Manifest, bool, error) {
 	decoder := yaml.NewDecoder(reader)
 	decoder.KnownFields(true)
 
@@ -177,11 +186,11 @@ func DecodeWithDefaultImage(reader io.Reader, defaultImage KatlosImage) (Manifes
 		return Manifest{}, false, fmt.Errorf("kind must be %s", Kind)
 	}
 	defaulted := false
-	if KatlosImageEmpty(manifest.KatlosImage) && !KatlosImageEmpty(defaultImage) {
-		manifest.KatlosImage = defaultImage
+	if KatlosImageEmpty(manifest.KatlosImage) && !KatlosImageEmpty(options.DefaultKatlosImage) {
+		manifest.KatlosImage = options.DefaultKatlosImage
 		defaulted = true
 	}
-	if err := Validate(manifest); err != nil {
+	if err := ValidateWithOptions(manifest, ValidateOptions{AllowMissingKatlosImage: options.AllowMissingKatlosImage}); err != nil {
 		return Manifest{}, false, err
 	}
 	return manifest, defaulted, nil


### PR DESCRIPTION
Let runtime config rendering consume the same image-deferred bundle used by ISO installation. Installer and handoff reads remain strict, with tests covering both boundaries.