### PR TITLE
release: scope strict package verification

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -150,7 +150,10 @@ jobs:
             -mode strict \
             -run-id "release-${KATL_VERSION}-${GITHUB_SHA:0:12}" \
             -git-revision "$GITHUB_SHA" \
-            -mkosi-version "$mkosi_version"
+            -mkosi-version "$mkosi_version" \
+            -package-set installer-image \
+            -package-set runtime \
+            -package-set katlos-install-image
 
       - name: Stage supported publication artifacts
         shell: bash

--- a/cmd/katl-resource-lock/main.go
+++ b/cmd/katl-resource-lock/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -214,6 +215,15 @@ func runPrepareMkosi(args []string, stdout, stderr io.Writer) error {
 	gitRevision := flags.String("git-revision", "", "git revision to record")
 	fedoraRepo := flags.String("fedora-repository", "fedora=", "Fedora repository in id=baseURL form")
 	mkosiVersionFlag := flags.String("mkosi-version", "auto", "mkosi version to record; auto detects mkosi and empty disables recording")
+	var packageSets []string
+	flags.Func("package-set", "package set required by strict verification; repeat to select a subset", func(value string) error {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return errors.New("package set must not be empty")
+		}
+		packageSets = append(packageSets, value)
+		return nil
+	})
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -269,6 +279,9 @@ func runPrepareMkosi(args []string, stdout, stderr io.Writer) error {
 	lockDigest := ""
 	switch *mode {
 	case "refresh":
+		if len(packageSets) != 0 {
+			return errors.New("--package-set requires --mode strict")
+		}
 		lock, err := resourcetest.PackageLockFromManifest(manifest)
 		if err != nil {
 			return err
@@ -297,7 +310,9 @@ func runPrepareMkosi(args []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("decode package lock %s: %w", *lockPath, err)
 		}
-		if err := resourcetest.VerifyPackageLock(resourcetest.PackageLockVerification{Lock: lock, Manifest: manifest, LockDigest: lockDigest}); err != nil {
+		if err := resourcetest.VerifyPackageLock(resourcetest.PackageLockVerification{
+			Lock: lock, Manifest: manifest, LockDigest: lockDigest, RequiredPackageSets: packageSets,
+		}); err != nil {
 			return err
 		}
 	default:

--- a/internal/resourcetest/packagelock.go
+++ b/internal/resourcetest/packagelock.go
@@ -45,9 +45,10 @@ type PackageRepository struct {
 }
 
 type PackageLockVerification struct {
-	Lock       PackageLock
-	Manifest   Manifest
-	LockDigest string
+	Lock                PackageLock
+	Manifest            Manifest
+	LockDigest          string
+	RequiredPackageSets []string
 }
 
 func DecodePackageLock(r io.Reader) (PackageLock, error) {
@@ -94,7 +95,22 @@ func VerifyPackageLock(verification PackageLockVerification) error {
 	for _, set := range verification.Lock.PackageSets {
 		lockSets[set.Name] = set
 	}
+	selectedSets, err := packageSetSelection(verification.RequiredPackageSets)
+	if err != nil {
+		return err
+	}
+	for name := range selectedSets {
+		if _, ok := lockSets[name]; !ok {
+			return fmt.Errorf("selected package set %q is missing from package lock", name)
+		}
+		if _, ok := manifestSets[name]; !ok {
+			return fmt.Errorf("selected package set %q is missing from resource manifest", name)
+		}
+	}
 	for _, manifestSet := range verification.Manifest.PackageSets {
+		if !packageSetSelected(manifestSet.Name, selectedSets) {
+			continue
+		}
 		lockedSet, ok := lockSets[manifestSet.Name]
 		if !ok {
 			return fmt.Errorf("package set %q is missing from package lock", manifestSet.Name)
@@ -104,12 +120,18 @@ func VerifyPackageLock(verification PackageLockVerification) error {
 		}
 	}
 	for _, lockedSet := range verification.Lock.PackageSets {
+		if !packageSetSelected(lockedSet.Name, selectedSets) {
+			continue
+		}
 		if _, ok := manifestSets[lockedSet.Name]; !ok {
 			return fmt.Errorf("package set %q is missing from resource manifest", lockedSet.Name)
 		}
 	}
 
 	for _, lockedProfile := range verification.Lock.MkosiProfiles {
+		if !packageSetSelected(lockedProfile.PackageSetRef, selectedSets) {
+			continue
+		}
 		manifestProfile, ok := manifestProfiles[lockedProfile.Name]
 		if !ok {
 			return fmt.Errorf("mkosi profile %q is missing from resource manifest", lockedProfile.Name)
@@ -143,6 +165,32 @@ func VerifyPackageLock(verification PackageLockVerification) error {
 		}
 	}
 	return nil
+}
+
+func packageSetSelection(names []string) (map[string]struct{}, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	selected := make(map[string]struct{}, len(names))
+	for _, value := range names {
+		name := strings.TrimSpace(value)
+		if name == "" {
+			return nil, errors.New("selected package set must not be empty")
+		}
+		if _, ok := selected[name]; ok {
+			return nil, fmt.Errorf("selected package set %q is duplicated", name)
+		}
+		selected[name] = struct{}{}
+	}
+	return selected, nil
+}
+
+func packageSetSelected(name string, selected map[string]struct{}) bool {
+	if len(selected) == 0 {
+		return true
+	}
+	_, ok := selected[name]
+	return ok
 }
 
 func PackageLockFromManifest(manifest Manifest) (PackageLock, error) {

--- a/internal/resourcetest/packagelock_test.go
+++ b/internal/resourcetest/packagelock_test.go
@@ -31,6 +31,36 @@ func TestVerifyPackageLockMatchesManifest(t *testing.T) {
 	}
 }
 
+func TestVerifyPackageLockSelection(t *testing.T) {
+	lock := validPackageLock()
+	extraSet := lock.PackageSets[0]
+	extraSet.Name = "kubernetes-sysext"
+	extraSet.Source = "mkosi.profiles/kubernetes-sysext"
+	lock.PackageSets = append(lock.PackageSets, extraSet)
+	extraProfile := lock.MkosiProfiles[0]
+	extraProfile.Name = "kubernetes-sysext"
+	extraProfile.Path = "mkosi.profiles/kubernetes-sysext"
+	extraProfile.PackageSetRef = extraSet.Name
+	lock.MkosiProfiles = append(lock.MkosiProfiles, extraProfile)
+	digest := digestForLock(t, lock)
+	manifest := manifestForPackageLock(digest)
+
+	if err := VerifyPackageLock(PackageLockVerification{
+		Lock: lock, Manifest: manifest, LockDigest: digest, RequiredPackageSets: []string{"runtime"},
+	}); err != nil {
+		t.Fatalf("VerifyPackageLock() selected error = %v", err)
+	}
+	if err := VerifyPackageLock(PackageLockVerification{Lock: lock, Manifest: manifest, LockDigest: digest}); err == nil || !strings.Contains(err.Error(), "kubernetes-sysext") {
+		t.Fatalf("VerifyPackageLock() unscoped error = %v, want missing kubernetes-sysext", err)
+	}
+	err := VerifyPackageLock(PackageLockVerification{
+		Lock: lock, Manifest: manifest, LockDigest: digest, RequiredPackageSets: []string{"missing"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "selected package set \"missing\" is missing from package lock") {
+		t.Fatalf("VerifyPackageLock() unknown selection error = %v", err)
+	}
+}
+
 func TestVerifyPackageLockRejectsPackageDrift(t *testing.T) {
 	lock := validPackageLock()
 	digest := digestForLock(t, lock)


### PR DESCRIPTION
Keep strict verification all-set by default, with explicit required-set selection for partial builders. KatlOS releases verify installer, runtime, and KatlOS image sets while Kubernetes stays in its separate workflow.