### PR TITLE
release: pin Fedora trust packages

### DIFF
--- a/internal/scriptstest/container_runtime_contract_test.go
+++ b/internal/scriptstest/container_runtime_contract_test.go
@@ -63,6 +63,23 @@ func TestBaseContainerRuntimeContractIsEnforced(t *testing.T) {
 	)
 }
 
+func TestReleaseProfilesPinTrustPackages(t *testing.T) {
+	repo := repoRoot(t)
+	wants := []string{
+		"p11-kit-0:0.26.2-1.fc44.x86_64",
+		"p11-kit-trust-0:0.26.2-1.fc44.x86_64",
+	}
+	for _, profile := range []string{"runtime", "installer-image"} {
+		config := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles", profile, "mkosi.conf")))
+		packages := mkosiPackages(config)
+		for _, want := range wants {
+			if !packages[want] {
+				t.Errorf("%s mkosi profile missing pinned package %q", profile, want)
+			}
+		}
+	}
+}
+
 func mkosiPackages(config string) map[string]bool {
 	packages := map[string]bool{}
 	inPackages := false

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -28,6 +28,9 @@ Packages=
         dosfstools
         coreutils
         bash
+        # Pin mirror-sensitive trust packages used by the release lock.
+        p11-kit-0:0.26.2-1.fc44.x86_64
+        p11-kit-trust-0:0.26.2-1.fc44.x86_64
 # Remove unsupported operator entrypoints and package-manager metadata that
 # arrive through retained Fedora packages.
 RemoveFiles=

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,14 +11,14 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "8ada65c74cbee77fc33d742114960339a74ab6e98db99b26fa23dda4479830c8",
+      "configSHA256": "b0d75846679f3675c160c6a72c64ddcb6f650a58cdea1d2c1f3d2e080f37192d",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },
     {
       "name": "runtime",
       "path": "mkosi.profiles/runtime",
-      "configSHA256": "2d25dc28c0ce7d91abc1e6bb4bf721c3f92f712163cbbdacf1c3c18e55be7bdb",
+      "configSHA256": "c8351bf8ba41f4a525b0dad6a016ee23ff94b67691375c09f19f97e54fd45c5d",
       "packageSetRef": "runtime",
       "mkosiVersion": "26"
     },
@@ -253,11 +253,11 @@
         },
         {
           "name": "libacl",
-          "nevra": "0:2.4.0-1.fc44.x86_64"
+          "nevra": "0:2.3.2-6.fc44.x86_64"
         },
         {
           "name": "libattr",
-          "nevra": "0:2.6.0-1.fc44.x86_64"
+          "nevra": "0:2.5.2-8.fc44.x86_64"
         },
         {
           "name": "libblkid",
@@ -851,11 +851,11 @@
         },
         {
           "name": "libacl",
-          "nevra": "0:2.4.0-1.fc44.x86_64"
+          "nevra": "0:2.3.2-6.fc44.x86_64"
         },
         {
           "name": "libattr",
-          "nevra": "0:2.6.0-1.fc44.x86_64"
+          "nevra": "0:2.5.2-8.fc44.x86_64"
         },
         {
           "name": "libblkid",

--- a/mkosi.profiles/runtime/mkosi.conf
+++ b/mkosi.profiles/runtime/mkosi.conf
@@ -34,6 +34,9 @@ Packages=
         # Minimal shell and core userspace expected by systemd units and operators.
         coreutils
         bash
+        # Pin mirror-sensitive trust packages used by the release lock.
+        p11-kit-0:0.26.2-1.fc44.x86_64
+        p11-kit-trust-0:0.26.2-1.fc44.x86_64
 # Remove unsupported operator entrypoints that arrive through retained packages.
 RemoveFiles=
         /etc/yum.repos.d


### PR DESCRIPTION
Pin the mirror-sensitive p11-kit packages in both release profiles and refresh the strict package lock from successful builds. Add a contract test that keeps the two profiles on the reviewed NEVRAs.