### PR TITLE
release: pin trust package closure

### DIFF
--- a/internal/scriptstest/container_runtime_contract_test.go
+++ b/internal/scriptstest/container_runtime_contract_test.go
@@ -66,6 +66,8 @@ func TestBaseContainerRuntimeContractIsEnforced(t *testing.T) {
 func TestReleaseProfilesPinTrustPackages(t *testing.T) {
 	repo := repoRoot(t)
 	wants := []string{
+		"libacl-0:2.3.2-6.fc44.x86_64",
+		"libattr-0:2.5.2-8.fc44.x86_64",
 		"p11-kit-0:0.26.2-1.fc44.x86_64",
 		"p11-kit-trust-0:0.26.2-1.fc44.x86_64",
 	}

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -29,6 +29,8 @@ Packages=
         coreutils
         bash
         # Pin mirror-sensitive trust packages used by the release lock.
+        libacl-0:2.3.2-6.fc44.x86_64
+        libattr-0:2.5.2-8.fc44.x86_64
         p11-kit-0:0.26.2-1.fc44.x86_64
         p11-kit-trust-0:0.26.2-1.fc44.x86_64
 # Remove unsupported operator entrypoints and package-manager metadata that

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,14 +11,14 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "b0d75846679f3675c160c6a72c64ddcb6f650a58cdea1d2c1f3d2e080f37192d",
+      "configSHA256": "1d03efec807d91c4b6a23e7ad49d86c7c11f02de951337d72b46050bf4a5f2e9",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },
     {
       "name": "runtime",
       "path": "mkosi.profiles/runtime",
-      "configSHA256": "c8351bf8ba41f4a525b0dad6a016ee23ff94b67691375c09f19f97e54fd45c5d",
+      "configSHA256": "4574e857fb3da0e8ab1ec0faa78cceb751300c2f3f7b06664fdcef4fd399e69e",
       "packageSetRef": "runtime",
       "mkosiVersion": "26"
     },

--- a/mkosi.profiles/runtime/mkosi.conf
+++ b/mkosi.profiles/runtime/mkosi.conf
@@ -35,6 +35,8 @@ Packages=
         coreutils
         bash
         # Pin mirror-sensitive trust packages used by the release lock.
+        libacl-0:2.3.2-6.fc44.x86_64
+        libattr-0:2.5.2-8.fc44.x86_64
         p11-kit-0:0.26.2-1.fc44.x86_64
         p11-kit-trust-0:0.26.2-1.fc44.x86_64
 # Remove unsupported operator entrypoints that arrive through retained packages.


### PR DESCRIPTION
Pin libacl and libattr alongside p11-kit after the strict release candidate exposed mirror-dependent dependency resolution. Refresh profile identities and extend the release-profile contract test.