### PR TITLE
docs: add task-oriented operator runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,18 @@ Authenticate the installer against the release workflow, replacing `<tag>`
 with the exact tag you downloaded:
 
 ```sh
+TAG=v2026.7.0-alpha.2
 gh attestation verify katl-installer.iso \
   --repo katl-dev/katl \
   --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \
-  --source-ref refs/tags/<tag>
+  --source-ref "refs/tags/$TAG"
 ```
 
 Install the matching operator CLI and confirm its embedded identity:
 
 ```sh
-install -m 0755 katlctl-<version>-linux-amd64 ~/.local/bin/katlctl
+VERSION=2026.7.0-alpha.2
+install -m 0755 "katlctl-$VERSION-linux-amd64" ~/.local/bin/katlctl
 katlctl version
 ```
 
@@ -171,14 +173,16 @@ activation. Kubernetes bootstrap is a separate operator action.
 ### 4. Bootstrap Kubernetes
 
 Once all installed nodes are reachable through their `katlc` endpoints, use the
-same config bundle and its internal digest:
+same config bundle and its internal digest. First retrieve each node's distinct
+agent token over SSH and populate the per-node `file:` credential references as
+described in [Access installed nodes](docs/operations/access.md):
 
 ```sh
+BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest <bundleDigest> \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
-  --agent-token-file ./katlc-agent.token \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig
 ```
@@ -209,15 +213,20 @@ Host upgrades consume the published `katlos-upgrade-<version>-<arch>.squashfs`
 artifact. Plan before accepting a next-boot generation:
 
 ```sh
+TAG=v2026.7.0-alpha.2
+VERSION=${TAG#v}
+IMAGE="katlos-upgrade-$VERSION-x86_64.squashfs"
+IMAGE_SHA256=$(sha256sum "$IMAGE" | awk '{print $1}')
+IMAGE_SIZE=$(stat -c %s "$IMAGE")
 katlctl host upgrade \
   --plan \
   --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./katlc-agent.token \
-  --candidate-generation katlos-<version> \
-  --client-request-id cp-1-katlos-<version> \
-  --image-url https://github.com/katl-dev/katl/releases/download/<tag>/katlos-upgrade-<version>-x86_64.squashfs \
-  --image-sha256 <sha256> \
-  --image-size-bytes <bytes>
+  --agent-token-file ./tokens/cp-1.token \
+  --candidate-generation "katlos-$VERSION" \
+  --client-request-id "cp-1-katlos-$VERSION" \
+  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE" \
+  --image-sha256 "$IMAGE_SHA256" \
+  --image-size-bytes "$IMAGE_SIZE"
 ```
 
 Remove `--plan` only after reviewing the response. Automated fleet rollout and
@@ -248,6 +257,8 @@ matching loose artifacts, one explicitly selected disk per node, the matching
 bundle. Hardware claims extend only to retained release evidence.
 
 - [Installing KatlOS](docs/installing.md) — complete ISO and PXE workflows.
+- [Operating KatlOS](docs/operations/README.md) — task-oriented runbooks for
+  access, bootstrap, configuration, upgrades, wipe/reinstall, and diagnosis.
 - [Support boundary](docs/support.md) — compatibility, trust, recovery, and
   reporting expectations.
 - [Developing Katl](docs/developing.md) — build, test, and contribution loop.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -3,6 +3,11 @@
 Status: early user-facing guide. KatlOS is experimental alpha software; read
 the [support boundary](support.md) before installing it.
 
+This document is the installation reference for ISO and PXE paths. After
+generation 0 boots, continue with the task-oriented
+[KatlOS Operator Guide](operations/README.md) for management access, Kubernetes
+bootstrap, configuration, upgrades, recovery, and troubleshooting.
+
 Katl publishes a versioned installer ISO containing the matching KatlOS payload.
 Write or attach that one artifact, then provide node-specific install input at
 boot time. Loose boot and payload artifacts remain available for PXE. Katl does
@@ -45,7 +50,8 @@ Install it under the stable command name and confirm that its embedded release
 identity matches the KatlOS release:
 
 ```sh
-install -m 0755 katlctl-<version>-linux-amd64 ~/.local/bin/katlctl
+VERSION=2026.7.0-alpha.2
+install -m 0755 "katlctl-$VERSION-linux-amd64" ~/.local/bin/katlctl
 katlctl version
 ```
 
@@ -108,10 +114,11 @@ Then authenticate each asset against the keyless GitHub attestation issued to
 the Katl release workflow. Pin the expected tag in the verification policy:
 
 ```sh
+TAG=v2026.7.0-alpha.2
 gh attestation verify katl-installer.iso \
   --repo katl-dev/katl \
   --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \
-  --source-ref refs/tags/<tag>
+  --source-ref "refs/tags/$TAG"
 ```
 
 Repeat the attestation check for the KatlOS SquashFS or loose PXE artifact you
@@ -158,10 +165,6 @@ spec:
 
             [Network]
             DHCP=yes
-    bootstrap:
-      access:
-        method: agent
-        credentialRef: agent/default
   systemRoleDefaults:
     control-plane:
       kubernetes:
@@ -196,6 +199,9 @@ spec:
           hostname: cp-1
         bootstrap:
           address: 192.0.2.11
+          access:
+            method: agent
+            credentialRef: file:/absolute/path/to/tokens/cp-1.token
         install:
           targetDisk:
             byID: /dev/disk/by-id/ata-KATL_CP_1_ROOT
@@ -206,6 +212,9 @@ spec:
           hostname: worker-1
         bootstrap:
           address: 192.0.2.21
+          access:
+            method: agent
+            credentialRef: file:/absolute/path/to/tokens/worker-1.token
         install:
           targetDisk:
             byID: /dev/disk/by-id/ata-KATL_WORKER_1_ROOT
@@ -411,11 +420,11 @@ management endpoints, bootstrap directly from the same verified bundle. Use the
 `bundleDigest` printed by `katlctl config bundle`, not the archive SHA-256:
 
 ```text
+BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --config-bundle katl-lab.katlcfg \
-  --config-bundle-digest <bundleDigest> \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
-  --agent-token-file ./katlc-agent.token \
   --kubeconfig-out kubeconfig \
   --overwrite-kubeconfig
 ```
@@ -426,11 +435,12 @@ references, Kubernetes version, and OCI bundle selection. Do not combine
 `--kubernetes-bundle`. `--node-address node=address` remains available for an
 operator-observed address that differs from the compiled source.
 
-`--agent-token-file` is the common fallback token. A node whose embedded
-`credentialRef` is `file:/path/to/token` reads that per-node file instead and
-overrides the common token. Other reference names such as `agent/default` do not
-embed secret material and use the common token until a credential provider is
-configured.
+Each freshly installed node generates a distinct agent token. Retrieve it over
+SSH as described in [Access installed KatlOS nodes](operations/access.md), then
+store its workstation path in that node's `file:` credential reference. Do not
+put the token value in `ClusterConfig`. A common `--agent-token-file` is only a
+fallback when every selected node was deliberately provisioned with the same
+token; fresh installs do not have that property.
 
 `katlctl` is a bounded client. Node-local `katlc` validates and records the
 authoritative bootstrap operations, creates generation 1, runs `kubeadm`, and
@@ -469,7 +479,7 @@ Plan the change through the node agent before accepting an operation:
 ```text
 katlctl config apply validate \
   --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./katlc-agent.token \
+  --agent-token-file ./tokens/cp-1.token \
   --source ./cluster.yaml \
   --node cp-1 \
   --desired-version 2 \
@@ -481,11 +491,12 @@ If the source has already been compiled, use the verified bundle instead of
 recompiling it:
 
 ```text
+BUNDLE_DIGEST='sha256:...'
 katlctl config apply validate \
   --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./katlc-agent.token \
+  --agent-token-file ./tokens/cp-1.token \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest <bundleDigest> \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
   --node cp-1 \
   --desired-version 2 \
   --candidate-generation config-2 \

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,66 @@
+# KatlOS Operator Guide
+
+These runbooks describe the implemented KatlOS alpha operating surface. Start
+with the task that matches the current node state; do not skip directly to a
+mutating command.
+
+KatlOS is experimental. Read the [support boundary](../support.md) before using
+these procedures. The current management API uses bearer authentication over
+unencrypted TCP and is suitable only on an isolated evaluation network.
+
+## Lifecycle Map
+
+| Current state | Operator goal | Runbook |
+| --- | --- | --- |
+| No KatlOS media downloaded | Authenticate a release | [Verify release artifacts](verify-release.md) |
+| Bare or disposable machine | Install generation 0 | [Install KatlOS](../installing.md) |
+| Generation 0 booted | Establish node management access | [Access installed nodes](access.md) |
+| All intended nodes installed | Create the kubeadm cluster | [Bootstrap Kubernetes](bootstrap-kubernetes.md) |
+| Installed or bootstrapped node | Change supported runtime configuration | [Apply node configuration](configure-nodes.md) |
+| Healthy installed node | Stage a new KatlOS release | [Upgrade a KatlOS host](upgrade-host.md) |
+| Cluster is intentionally being discarded | Reset boot state and reinstall | [Wipe and reinstall](wipe-reinstall.md) |
+| A step failed or its state is unclear | Collect evidence and classify the failure | [Troubleshoot KatlOS](troubleshoot.md) |
+
+## Operating Rules
+
+The operator workstation needs the `katlctl` binary from the matching release,
+`ssh`, `curl`, GNU `sha256sum`, and `jq`. Provenance verification additionally
+uses GitHub CLI `gh`; cluster handoff checks use a `kubectl` version compatible
+with the selected Kubernetes release. These tools run on the workstation, not
+inside the KatlOS image.
+
+Keep these artifacts together for the life of an evaluation:
+
+- the exact KatlOS release URL, assets, checksums, and provenance result;
+- the source `ClusterConfig` and compiled `.katlcfg` bundle;
+- both the config bundle archive SHA-256 and its internal `bundleDigest`;
+- the digest-pinned Kubernetes OCI reference;
+- one protected agent token file per node;
+- the kubeconfig, operation IDs, generation IDs, and relevant timestamps; and
+- independent etcd, application, and persistent-data backups.
+
+Treat command outcomes precisely:
+
+- **validated/planned** means no operation was accepted;
+- **accepted** means the node persisted an operation, not that it completed;
+- **terminal succeeded** means the operation completed its current-boot work;
+- **boot health passed** means a staged generation survived its trial boot; and
+- **failed-needs-repair** means do not blindly retry or assume host rollback
+  reverted Kubernetes state.
+
+Use a unique, stable `--client-request-id` for each intended mutation. Reuse it
+only when retrying the exact same request. Changing inputs requires a new ID.
+
+## Boundaries That Matter During Operations
+
+KatlOS generations own the immutable root, UKI, selected sysexts, and compiled
+node configuration. They do not own or roll back etcd, kubeadm mutations,
+Kubernetes API objects, CNI state, persistent volumes, or workloads.
+
+Normal configuration apply currently covers hostname, SSH authorized keys, and
+systemd-networkd files. Disk policy, system role, Kubernetes bundle selection,
+and kubeadm lifecycle changes require a named lifecycle operation or reinstall.
+
+There is no supported alpha workflow for automatic fleet rollout, Kubernetes
+version upgrades, etcd disaster recovery, failed control-plane replacement,
+agent-token rotation, or general cluster reconciliation.

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -1,0 +1,93 @@
+# Access Installed KatlOS Nodes
+
+Complete this runbook after generation 0 boots and before bootstrap, config
+apply, host upgrade, or wipe operations.
+
+## Security Boundary
+
+The alpha `katlc` agent listens on TCP port `9443` and authenticates a bearer
+token, but its gRPC transport is not encrypted. Do not expose it to the public
+Internet, an untrusted LAN, or a shared production network. Use an isolated
+evaluation management network and restrict port `9443` at the surrounding
+firewall.
+
+SSH is the supported way to retrieve the initial per-node token. Treat token
+files like private keys: store them with mode `0600`, never commit them, never
+put token values in `ClusterConfig`, and redact them from logs and issues.
+
+## Confirm Generation 0
+
+On each node:
+
+```sh
+systemctl is-active katl-boot-complete.target
+systemctl is-active katlc-agent.service
+systemctl status katl-runtime-handoff-status.service --no-pager
+journalctl -b -u katl-runtime-handoff-status.service -u katlc-agent.service
+```
+
+Expected state before Kubernetes bootstrap:
+
+- `katl-boot-complete.target` is active;
+- `katlc-agent.service` is active;
+- runtime handoff reports `waiting-for-cluster-bootstrap`; and
+- `katl-kubeadm-ready.target` is not active yet.
+
+## Collect One Token Per Node
+
+Create a protected workstation directory, then copy each token over SSH using
+the node address selected during installation:
+
+```sh
+install -d -m 0700 ./tokens
+umask 077
+ssh root@192.0.2.11 'cat /var/lib/katl/agent/token' > ./tokens/cp-1.token
+ssh root@192.0.2.21 'cat /var/lib/katl/agent/token' > ./tokens/worker-1.token
+chmod 0600 ./tokens/*.token
+```
+
+Each freshly installed node generates its own token. Do not assume one fallback
+token authenticates to the entire cluster.
+
+In `ClusterConfig`, use a reference to each workstation token path, not secret
+material. `file:` paths are read by `katlctl` on the workstation:
+
+```yaml
+nodes:
+  - name: cp-1
+    systemRole: control-plane
+    overrides:
+      bootstrap:
+        address: 192.0.2.11
+        access:
+          method: agent
+          credentialRef: file:/absolute/path/to/tokens/cp-1.token
+  - name: worker-1
+    systemRole: worker
+    overrides:
+      bootstrap:
+        address: 192.0.2.21
+        access:
+          method: agent
+          credentialRef: file:/absolute/path/to/tokens/worker-1.token
+```
+
+The paths may exist after the bundle is compiled, but they must contain the
+matching node tokens before `katlctl cluster bootstrap` runs.
+
+## Connectivity Check
+
+From the operator workstation, confirm only that the intended isolated path is
+reachable:
+
+```sh
+nc -vz 192.0.2.11 9443
+nc -vz 192.0.2.21 9443
+```
+
+A TCP connection is not proof of authenticated agent health. The first
+plan/dry-run command in each lifecycle runbook is the authenticated preflight.
+
+There is no supported alpha token-rotation workflow. If a token is exposed,
+isolate the node and treat the evaluation identity as compromised; do not
+silently replace the file and assume recovery is complete.

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -1,0 +1,124 @@
+# Bootstrap Kubernetes on KatlOS
+
+This procedure turns healthy generation 0 nodes into one kubeadm cluster. It is
+an explicit mutation of node-local kubeadm state and the Kubernetes API.
+
+## Prerequisites
+
+- every intended node completed [generation 0 handoff](access.md);
+- the same verified `.katlcfg` bundle used for installation is available;
+- its internal `bundleDigest` is recorded;
+- each node has a reachable address and protected per-node token file;
+- the Kubernetes bundle reference is digest-pinned and compatible with the
+  KatlOS runtime;
+- the control-plane endpoint resolves or routes as designed; and
+- independent recovery/backup expectations are understood.
+
+Katl fetches the Kubernetes bundle during this operation. Nodes need registry
+and CA access to `ghcr.io` unless the bundle is supplied through an explicitly
+supported local mechanism.
+
+## Review the Compiled Intent
+
+Revalidate the source and, if needed, rebuild the bundle before any node has
+been installed. Do not silently replace the bundle after installation:
+
+```sh
+katlctl config validate ./cluster.yaml
+katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
+sha256sum ./katl-lab.katlcfg
+```
+
+Use the `bundleDigest` printed by `config bundle`, not the archive SHA-256, in
+the bootstrap command.
+
+## Dry Run
+
+Validate topology, node access, bundle selection, and bootstrap ordering without
+running kubeadm:
+
+```sh
+BUNDLE_DIGEST='sha256:...'
+katlctl cluster bootstrap \
+  --dry-run \
+  --config-bundle ./katl-lab.katlcfg \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
+  --init-node cp-1 \
+  --kubeconfig-out ./kubeconfig
+```
+
+When every node has a `file:` credential reference, do not add a common
+`--agent-token-file`; `katlctl` reads the per-node files. Use
+`--node-address node=address` only for an observed address that differs from the
+compiled source.
+
+Review the plan, selected init node, node order, control-plane endpoint,
+Kubernetes version, and bundle reference. A dry run must not create generation
+1 or invoke kubeadm.
+
+## Execute Bootstrap
+
+Run the same command without `--dry-run`:
+
+```sh
+BUNDLE_DIGEST='sha256:...'
+katlctl cluster bootstrap \
+  --config-bundle ./katl-lab.katlcfg \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
+  --init-node cp-1 \
+  --kubeconfig-out ./kubeconfig \
+  --overwrite-kubeconfig
+```
+
+The normal sequence verifies and stages the Kubernetes sysext, initializes the
+first control plane, creates join material, joins remaining nodes, checks
+post-kubeadm health, commits generation 1, and writes the operator kubeconfig.
+Save the command output and returned operation IDs.
+
+## Establish Cluster Networking
+
+Kubeadm nodes normally remain `NotReady` until a CNI is installed. Katl does not
+choose or operate a CNI. Either apply it after bootstrap with your cluster
+management workflow, or explicitly include reviewed manifests and readiness
+conditions:
+
+```sh
+BUNDLE_DIGEST='sha256:...'
+katlctl cluster bootstrap \
+  --config-bundle ./katl-lab.katlcfg \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
+  --init-node cp-1 \
+  --kubeconfig-out ./kubeconfig \
+  --bootstrap-manifest ./cni.yaml \
+  --bootstrap-wait nodes-ready
+```
+
+Do not treat an arbitrary downloaded manifest as trusted merely because
+`katlctl` can apply it.
+
+## Verify Handoff
+
+```sh
+kubectl --kubeconfig ./kubeconfig get nodes -o wide
+kubectl --kubeconfig ./kubeconfig get pods -A
+```
+
+On each node, confirm the agent and kubelet state:
+
+```sh
+systemctl is-active katlc-agent.service
+systemctl status kubelet --no-pager
+systemctl status katl-kubeadm-ready.target --no-pager
+```
+
+Bootstrap is complete only when the command succeeds, expected generation and
+operation records are terminal, the API is reachable through the intended
+endpoint, and node readiness matches the chosen CNI stage.
+
+## Failure Boundary
+
+Do not assume rerunning bootstrap is safe. If kubeadm or API mutation began,
+host generation rollback does not erase it. Preserve operation IDs and follow
+[Troubleshoot KatlOS](troubleshoot.md). Additional-control-plane repair,
+Kubernetes version upgrade, and general reconciliation are not supported alpha
+operations.

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -1,0 +1,104 @@
+# Apply KatlOS Node Configuration
+
+Use config apply for supported host configuration after installation. It is not
+a general Kubernetes, disk, kubeadm, or operating-system upgrade mechanism.
+
+## Supported Input
+
+The normal source is the same `ClusterConfig` used for installation. The current
+renderer carries:
+
+- hostname;
+- SSH authorized keys; and
+- systemd-networkd files.
+
+It excludes disk/install policy, system role, Kubernetes bundle selection, and
+kubeadm lifecycle state. A desired kubeadm input may be rendered and recorded as
+requiring a later explicit action; config apply does not run kubeadm.
+
+## Render and Review
+
+Use a monotonically increasing desired version for this source:
+
+```sh
+katlctl config render-node \
+  --source ./cluster.yaml \
+  --node cp-1 \
+  --desired-version 2 > cp-1.runtime.yaml
+```
+
+Review the rendered files before contacting the node. Do not place private
+keys, bearer tokens, or other secret values in source configuration.
+
+## Validate Through the Node
+
+```sh
+katlctl config apply validate \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --source ./cluster.yaml \
+  --node cp-1 \
+  --desired-version 2 \
+  --candidate-generation config-2 \
+  --client-request-id cp-1-config-2
+```
+
+Validation reports the changed domains and accepted apply mode without
+accepting an operation. The default `auto` lets the domain policy select live or
+next-boot application. Request `--mode live` or `--mode next-boot` only when you
+intend to constrain that policy; unsafe requests are refused.
+
+If the source has already been compiled, replace `--source` with:
+
+```text
+--config-bundle ./katl-lab.katlcfg
+--config-bundle-digest "$BUNDLE_DIGEST"
+```
+
+Set `BUNDLE_DIGEST` to the printed internal digest before using those arguments.
+
+## Apply the Reviewed Request
+
+Run the same arguments without the `validate` subcommand:
+
+```sh
+katlctl config apply \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --source ./cluster.yaml \
+  --node cp-1 \
+  --desired-version 2 \
+  --candidate-generation config-2 \
+  --client-request-id cp-1-config-2
+```
+
+Keep the inputs and client request ID identical to the reviewed plan. The JSON
+response records the operation ID, request digest, and initial status. Accepted
+does not mean complete.
+
+## Check Generation Status
+
+Query the candidate through the agent:
+
+```sh
+katlctl config apply status \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --generation config-2
+```
+
+For a live change, require committed state and healthy config-apply evidence.
+For a next-boot change, require committed staged state, reboot in a controlled
+window, then require the candidate to become healthy after
+`katl-boot-complete.target`.
+
+On-node evidence remains available under:
+
+```text
+/var/lib/katl/generations/<generation>/
+/var/lib/katl/operations/<operation-id>/
+/var/lib/katl/boot/selection.json
+```
+
+If status reports rollback failure, `failed-needs-repair`, or a kubeadm action
+requirement, stop and classify it before submitting another configuration.

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -1,0 +1,105 @@
+# Troubleshoot KatlOS
+
+Troubleshooting starts by identifying the lifecycle boundary that failed. Do
+not retry a mutating command until its durable state and mutation boundary are
+known.
+
+## First Classification
+
+| Symptom | Primary evidence |
+| --- | --- |
+| Installer never becomes ready | installer console; `katlos-install.service` journal |
+| Config bundle rejected | bundle command output; selected node; both bundle digests |
+| Installed node does not complete boot | boot console; boot-health and handoff services |
+| Agent cannot be reached | network path to TCP 9443; `katlc-agent.service`; token file mapping |
+| Bootstrap or join fails | `katlctl` phase output; node operation record; kubelet/containerd/kubeadm journals |
+| Config apply stalls or rolls back | `katlctl config apply status`; generation and operation records |
+| Host upgrade does not stage or boot | host-upgrade operation; boot selection; boot-health journal |
+| Wipe is refused | wipe JSON refusals; selected topology; Kubernetes cleanup diagnostics |
+
+## Collect Installed-Node Evidence
+
+Run on the affected node and preserve timestamps:
+
+```sh
+systemctl --failed --no-pager
+systemctl status katl-boot-complete.target katl-boot-health.service --no-pager
+systemctl status katl-runtime-handoff-status.service katlc-agent.service --no-pager
+journalctl -b --no-pager
+journalctl -b -u katl-boot-health.service -u katlc-agent.service --no-pager
+cat /var/lib/katl/boot/selection.json
+find /var/lib/katl/generations -maxdepth 2 -type f -print
+find /var/lib/katl/operations -maxdepth 3 -type f -print
+```
+
+For one accepted operation, stream its durable record to `jq` on the operator
+workstation:
+
+```sh
+OPERATION_ID=operation-id-from-katlctl
+ssh root@affected-node \
+  "cat '/var/lib/katl/operations/$OPERATION_ID/record.json'" | \
+  jq '.payload.record | {
+  operationID, operationKind, requestDigest, phase, completedPhases,
+  terminal, result, externalMutationStarted, mutationScopes,
+  recoveryRequired, failureReason, nextAction, diagnosticArtifacts
+}'
+```
+
+The journal directory is authoritative when a snapshot looks stale:
+
+```text
+/var/lib/katl/operations/$OPERATION_ID/journal/
+```
+
+Do not edit operation, generation, or boot-selection records as a repair method.
+
+## Installer Evidence
+
+From the installer environment collect:
+
+```sh
+journalctl -b -u katlos-install.service --no-pager
+find /var/lib/katl/install -maxdepth 2 -type f -print
+```
+
+Also retain the installer console, exact release filename and SHA-256, config
+bundle, selected node, archive SHA-256, internal `bundleDigest`, and disk
+identity. A failure before validation completes must not repartition the disk;
+record disk state before attempting anything else.
+
+## Interpret Operation State
+
+- `terminal: false`: the operation may still be running or interrupted. Check
+  the latest journal event and agent service before acting.
+- `result: succeeded`: the operation completed its current phase; a staged
+  generation may still need reboot and boot-health promotion.
+- `result: failed-needs-repair` or `recoveryRequired: true`: preserve evidence
+  and stop automatic retry.
+- `externalMutationStarted: true`: assume the named mutation scopes may have
+  changed even if the command returned an error.
+- lost client connection: does not cancel the node-local operation.
+
+Host rollback changes KatlOS artifacts around persistent state. It does not
+prove kubeadm, etcd, Kubernetes API, CNI, or workload mutations were reverted.
+
+## Agent Access Failures
+
+Confirm the service and listener on the isolated management network:
+
+```sh
+systemctl status katlc-agent.service --no-pager
+ss -lntp | grep ':9443'
+stat -c '%a %U:%G %n' /var/lib/katl/agent/token
+```
+
+Then confirm the workstation is using the token from that exact node. Do not
+print the token into diagnostics. The alpha agent transport is unencrypted; do
+not solve reachability by exposing port `9443` to an untrusted network.
+
+## Reporting
+
+Follow the [support-boundary reporting checklist](../support.md#reporting-a-problem).
+Redact bearer tokens, private keys, kubeconfigs, join commands, certificate
+material, registry credentials, and workload secrets. Use GitHub private
+vulnerability reporting for security-sensitive findings.

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -1,0 +1,90 @@
+# Upgrade a KatlOS Host
+
+KatlOS host upgrades are explicit, one-node-at-a-time, next-boot operations.
+They stage a verified root and UKI into the inactive slot and arm a bounded trial
+boot. They do not upgrade Kubernetes or orchestrate fleet availability.
+
+## Preconditions
+
+- the node is healthy on a known-good generation;
+- no other mutating node operation is active;
+- the exact upgrade SquashFS, metadata, checksum, and provenance are verified;
+- the upgrade declares a compatible architecture and runtime interface;
+- the node can fetch the HTTPS image URL, or the image is already in its local
+  artifact store;
+- an operator controls the reboot window; and
+- Kubernetes and workload availability have been handled outside Katl.
+
+Follow [Verify release artifacts](verify-release.md) first. Record the exact
+image SHA-256 and size:
+
+```sh
+TAG=v2026.7.0-alpha.2
+VERSION=${TAG#v}
+IMAGE="katlos-upgrade-$VERSION-x86_64.squashfs"
+IMAGE_SHA256=$(sha256sum "$IMAGE" | awk '{print $1}')
+IMAGE_SIZE=$(stat -c %s "$IMAGE")
+```
+
+## Plan
+
+```sh
+katlctl host upgrade \
+  --plan \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --candidate-generation "katlos-$VERSION" \
+  --client-request-id "cp-1-katlos-$VERSION" \
+  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE" \
+  --image-sha256 "$IMAGE_SHA256" \
+  --image-size-bytes "$IMAGE_SIZE"
+```
+
+A plan response has dry-run status and no durable mutation. Review the image,
+candidate generation, resource locks, and refusal diagnostics.
+
+## Stage the Trial
+
+Run the identical command without `--plan`. Save the returned `operationId` and
+`requestDigest`. The response means accepted, not staged successfully.
+
+Until a general remote operation-status command is exposed, inspect the durable
+record on the node over SSH:
+
+```sh
+OPERATION_ID=host-upgrade-...
+ssh root@cp-1.example.test \
+  "cat '/var/lib/katl/operations/$OPERATION_ID/record.json'" | \
+  jq '.payload.record | {operationID, operationKind, phase, terminal, result, candidateGenerationID, bootHealthPending, recoveryRequired, failureReason, nextAction}'
+```
+
+Do not reboot until the operation is terminal with `result: succeeded` and
+`nextAction` says to reboot into the bounded candidate trial. A terminal staging
+success still has `bootHealthPending: true`.
+
+## Reboot and Verify
+
+Reboot one node during the controlled window:
+
+```sh
+ssh root@cp-1.example.test systemctl reboot
+```
+
+After it returns:
+
+```sh
+ssh root@cp-1.example.test systemctl is-active katl-boot-complete.target
+ssh root@cp-1.example.test systemctl status katl-boot-health.service --no-pager
+ssh root@cp-1.example.test cat /var/lib/katl/boot/selection.json
+```
+
+Require the candidate generation to be the booted/default generation with no
+pending health validation before moving to another node. Also verify kubelet,
+the Kubernetes Node, and workload availability.
+
+## Failure Boundary
+
+Boot health may select the previous known-good host generation. That does not
+undo Kubernetes, etcd, workload, or external-infrastructure changes. If the
+operation record says `recoveryRequired: true`, or the node fails to return,
+stop the rollout and collect the evidence in [Troubleshoot KatlOS](troubleshoot.md).

--- a/docs/operations/verify-release.md
+++ b/docs/operations/verify-release.md
@@ -1,0 +1,89 @@
+# Verify KatlOS Release Artifacts
+
+Use this procedure before booting installation media or staging an upgrade.
+Download every asset in a verification set from one GitHub release; never mix
+files from different tags.
+
+## Inputs
+
+- exact KatlOS tag, such as `v2026.7.0-alpha.2`;
+- assets required for the chosen operation;
+- `SHA256SUMS`; and
+- `PROVENANCE.md`.
+
+For an ISO install, the minimum payload set is:
+
+```text
+katl-installer.iso
+katl-installer.iso.sha256
+katlctl-<version>-linux-amd64
+katlctl-<version>-linux-amd64.sha256
+SHA256SUMS
+PROVENANCE.md
+```
+
+For a host upgrade, use the matching
+`katlos-upgrade-<version>-<arch>.squashfs` plus its adjacent `.json` and
+`.sha256` files.
+
+## Verify Integrity
+
+Run from the directory containing the downloaded assets:
+
+```sh
+sha256sum --ignore-missing --check SHA256SUMS
+```
+
+Every downloaded file named by `SHA256SUMS` must report `OK`. An adjacent
+checksum can verify one file, but it does not replace the release-wide manifest:
+
+```sh
+sha256sum --check katl-installer.iso.sha256
+```
+
+Stop if a digest fails. Delete the mismatched file and fetch it again from the
+same release. Do not edit a release artifact or its metadata.
+
+## Verify Build Provenance
+
+Authenticate each executable or image asset against the exact tag and Katl
+release workflow:
+
+```sh
+TAG=v2026.7.0-alpha.2
+gh attestation verify katl-installer.iso \
+  --repo katl-dev/katl \
+  --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \
+  --source-ref "refs/tags/$TAG"
+```
+
+Repeat for `katlctl`, a loose PXE artifact, or the upgrade SquashFS you will
+actually use. Record the tag, source commit, filename, SHA-256, and whether
+attestation verification passed.
+
+## Confirm Release Identity
+
+Install the matching CLI under its stable name and inspect its identity:
+
+```sh
+VERSION=2026.7.0-alpha.2
+install -m 0755 "katlctl-$VERSION-linux-amd64" ~/.local/bin/katlctl
+katlctl version
+```
+
+The CLI and KatlOS assets must come from the same release unless release notes
+explicitly declare another combination supported.
+
+## Trust Boundary
+
+Checksums detect changed bytes. GitHub attestations bind bytes to a repository,
+workflow, source ref, and commit. They do not provide Secure Boot signatures,
+node-side signature enforcement, revocation, downgrade prevention, vulnerability
+scanning guarantees, or a production incident-response commitment.
+
+Kubernetes bundles have their own OCI digest and GitHub provenance. Prefer a
+reference containing both the readable tag and immutable manifest digest:
+
+```text
+ghcr.io/katl-dev/kubernetes:<version>@sha256:<oci-manifest-digest>
+```

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -1,0 +1,117 @@
+# Wipe and Reinstall KatlOS
+
+This is destructive cluster-discard or node-replacement preparation. It is not
+backup, etcd recovery, same-cluster repair, or rollback.
+
+The wipe operation removes KatlOS disk boot artifacts so the next boot must use
+installer media or PXE. Existing on-disk Kubernetes and Katl state remain until
+the installer subsequently wipes the selected disk. Keep installer media ready
+before accepting the operation.
+
+## Before Planning
+
+- preserve any required external backups and recovery material;
+- confirm which cluster identity is being discarded;
+- save the inventory, release assets, config source, bundle, kubeconfig, and
+  operation evidence;
+- ensure all selected nodes can boot the intended installer path; and
+- stop if a control-plane or etcd member is expected to remain part of the same
+  cluster.
+
+The current wipe commands accept a low-level bootstrap inventory, not the
+verified `.katlcfg` directly. This is an acknowledged alpha UX gap. The
+inventory must describe the same installed nodes, addresses, roles, per-node
+token references, Kubernetes version, and digest-pinned bundle recorded in the
+compiled cluster intent. Do not use an older inventory merely because its nodes
+are reachable. A two-node shape is:
+
+```yaml
+controlPlaneEndpoint: api.katl.test:6443
+kubernetesVersion: v1.36.0
+kubernetesBundle: ghcr.io/katl-dev/kubernetes:<version>@sha256:<digest>
+nodes:
+  - name: cp-1
+    address: 192.0.2.11
+    systemRole: control-plane
+    access:
+      method: agent
+      credentialRef: file:/absolute/path/to/tokens/cp-1.token
+    kubeadmConfig:
+      ref: control-plane
+      path: /etc/katl/kubeadm/control-plane/config.yaml
+      intent: control-plane
+    kubernetesVersion: v1.36.0
+  - name: worker-1
+    address: 192.0.2.21
+    systemRole: worker
+    access:
+      method: agent
+      credentialRef: file:/absolute/path/to/tokens/worker-1.token
+    kubeadmConfig:
+      ref: worker
+      path: /etc/katl/kubeadm/worker/config.yaml
+      intent: worker
+    kubernetesVersion: v1.36.0
+```
+
+Compare it with the retained config source, bundle report, and live cluster
+before planning. Native config-bundle input is tracked for a future release.
+
+The required acknowledgement is intentionally exact:
+
+```text
+I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.
+```
+
+## Plan a Whole-Cluster Wipe
+
+```sh
+katlctl cluster wipe \
+  --plan \
+  --inventory ./cluster-inventory.yaml \
+  --all \
+  --confirm-destructive-wipe \
+  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.' \
+  --client-request-id discard-katl-lab-1
+```
+
+Even a plan requires the acknowledgement so automation cannot casually turn a
+review command into a destructive one. Review every target, address, role,
+wiped surface, preserved surface, and refusal.
+
+Run the identical command without `--plan` only when the cluster is intentionally
+being discarded. The command submits node-local destructive-reset operations
+and reports their operation IDs and terminal results.
+
+## Plan One Worker Replacement
+
+Single-node wipe coordinates Kubernetes Node cleanup before the node-local reset:
+
+```sh
+katlctl cluster wipe node \
+  --plan \
+  --inventory ./cluster-inventory.yaml \
+  --node worker-1 \
+  --confirm-destructive-wipe \
+  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.' \
+  --client-request-id replace-worker-1-1
+```
+
+Execution additionally requires `--kubeconfig ./kubeconfig`. If Kubernetes
+cleanup fails, Katl reports recovery required and refuses the node-local wipe.
+Single control-plane wipe is refused because etcd membership coordination is
+not implemented as a supported operation.
+
+## Reinstall
+
+After every selected wipe operation succeeds:
+
+1. boot the verified installer ISO or PXE path;
+2. submit the intended config bundle and node selection;
+3. inspect the target disk again before authorizing installer wipe;
+4. complete generation 0 handoff; and
+5. treat the result as a new cluster identity unless a future supported
+   recovery operation explicitly says otherwise.
+
+Do not claim preserved `/var/lib/etcd`, kubelet state, or Katl operation records
+as recovered merely because they remained on disk between reset and reinstall.

--- a/docs/support.md
+++ b/docs/support.md
@@ -37,6 +37,11 @@ provenance attestations. Kubernetes bundles are digest-addressable OCI
 artifacts with GitHub provenance. Verify both before use and prefer immutable
 digest-pinned bundle references.
 
+The current `katlc` management API uses bearer authentication over unencrypted
+TCP. Restrict port 9443 to an isolated evaluation management network. It is not
+a production-grade remote-management trust boundary, even when artifact
+provenance verification succeeds.
+
 This proves which repository workflow produced the bytes. It does not provide:
 
 - UEFI Secure Boot signatures or a production boot-key policy;


### PR DESCRIPTION
Add lifecycle-focused runbooks for release verification, installed-node access, Kubernetes bootstrap, configuration, host upgrades, wipe/reinstall, and troubleshooting. Correct the fresh-install flow to use distinct per-node agent tokens and document the current transport, status, and recovery limits explicitly.