### PR TITLE
install: add observable katlctl handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,29 @@ different layers and are not interchangeable.
 
 Attach or write `katl-installer.iso` using your normal UEFI virtual-media or USB
 workflow, then boot it. Without preseed input, the installer waits safely and
-prints an HTTP handoff URL and one-time token. Submit the same bundle to every
-node while selecting that node by name:
+prints an HTTP handoff URL and one-time token. Store the token in a protected
+temporary file, then submit the same bundle to every node while selecting that
+node by name:
 
 ```sh
-curl --fail-with-body -X POST \
-  -H "Authorization: Bearer <one-time-token>" \
-  -H "Content-Type: application/vnd.katl.config.bundle.v1" \
-  --data-binary @katl-lab.katlcfg \
-  "http://<installer-ip>:8080/v1/config-bundle?node=cp-1&digest=<bundleDigest>"
+INSTALLER_ENDPOINT=http://192.0.2.10:8080
+BUNDLE_DIGEST='sha256:...'
+umask 077
+read -rsp 'Installer token: ' INSTALL_TOKEN; printf '\n'
+printf '%s\n' "$INSTALL_TOKEN" > ./installer.token
+unset INSTALL_TOKEN
+
+katlctl install apply \
+  --endpoint "$INSTALLER_ENDPOINT" \
+  --token-file ./installer.token \
+  --config-bundle ./katl-lab.katlcfg \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
+  --node cp-1
 ```
+
+The command validates the bundle and selected node locally, confirms the
+installer is waiting, submits once, and waits for reboot-ready or a classified
+failure. Remove the temporary token file after the handoff.
 
 Installation is destructive only when both the resolved node sets
 `install.wipeTarget: true` and boot input authorizes automatic installation.

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/handoff"
+	installstatus "github.com/katl-dev/katl/internal/installer/status"
+	"github.com/spf13/cobra"
+)
+
+const (
+	maxInstallBundleSize   = 64 << 20
+	maxInstallResponseSize = 1 << 20
+	maxInstallTokenSize    = 4 << 10
+)
+
+type installApplyOptions struct {
+	endpoint     string
+	token        string
+	tokenFile    string
+	bundlePath   string
+	bundleDigest string
+	nodeName     string
+	noWait       bool
+	timeout      time.Duration
+	output       string
+}
+
+type installStatusOptions struct {
+	endpoint string
+	timeout  time.Duration
+	output   string
+}
+
+type installHandoffReport struct {
+	APIVersion   string                `json:"apiVersion"`
+	Kind         string                `json:"kind"`
+	Endpoint     string                `json:"endpoint"`
+	SelectedNode string                `json:"selectedNode,omitempty"`
+	BundleDigest string                `json:"bundleDigest,omitempty"`
+	Handoff      handoff.HandoffStatus `json:"handoff"`
+}
+
+func newInstallCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{Use: "install", Short: "KatlOS installer handoff operations"}
+	cmd.AddCommand(newInstallApplyCommand(ctx, stdout, stderr))
+	cmd.AddCommand(newInstallStatusCommand(ctx, stdout, stderr))
+	return cmd
+}
+
+func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := installApplyOptions{timeout: 30 * time.Minute, output: "json"}
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Submit one verified config bundle to a waiting KatlOS installer",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runInstallApply(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL such as http://192.0.2.10:8080")
+	cmd.Flags().StringVar(&opts.token, "token", "", "one-time installer token; --token-file avoids shell history exposure")
+	cmd.Flags().StringVar(&opts.tokenFile, "token-file", "", "protected file containing the one-time installer token")
+	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "verified Katl config bundle")
+	cmd.Flags().StringVar(&opts.bundleDigest, "config-bundle-digest", "", "expected internal config bundle manifest digest")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the config bundle")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
+	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	return cmd
+}
+
+func newInstallStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := installStatusOptions{timeout: 15 * time.Second, output: "json"}
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Report a waiting or running KatlOS installer",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runInstallStatus(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL such as http://192.0.2.10:8080")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "status request timeout")
+	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	return cmd
+}
+
+func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stderr io.Writer) error {
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want json", opts.output)
+	}
+	endpoint, err := normalizeInstallerEndpoint(opts.endpoint)
+	if err != nil {
+		return err
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	token, err := readInstallToken(opts.token, opts.tokenFile)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.bundlePath) == "" {
+		return fmt.Errorf("--config-bundle is required")
+	}
+	if strings.TrimSpace(opts.bundleDigest) == "" {
+		return fmt.Errorf("--config-bundle-digest is required")
+	}
+	if strings.TrimSpace(opts.nodeName) == "" {
+		return fmt.Errorf("--node is required")
+	}
+	if err := validateInstallBundleSize(opts.bundlePath); err != nil {
+		return err
+	}
+	selected, err := configbundle.ReadSelectedNodeFile(opts.bundlePath, configbundle.ReadOptions{
+		ExpectedDigest:          opts.bundleDigest,
+		NodeName:                opts.nodeName,
+		AllowMissingKatlosImage: true,
+	})
+	if err != nil {
+		return fmt.Errorf("validate config bundle: %w", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	client := &http.Client{Timeout: requestTimeout(opts.timeout)}
+	before, err := fetchInstallStatus(waitCtx, client, endpoint)
+	if err != nil {
+		return redactInstallError(err, token)
+	}
+	if before.State != handoff.HandoffWaiting {
+		return fmt.Errorf("installer is not accepting config: state=%s selectedNode=%s", before.State, before.SelectedNode)
+	}
+
+	accepted, err := submitInstallBundle(waitCtx, client, endpoint, token, opts.bundlePath, selected.BundleDigest, selected.Node.Name)
+	if err != nil {
+		return redactInstallError(err, token)
+	}
+	report := newInstallHandoffReport(endpoint, selected.Node.Name, selected.BundleDigest, accepted)
+	if opts.noWait {
+		return writeInstallReport(stdout, report)
+	}
+	status, err := waitForInstall(waitCtx, client, endpoint, accepted, stderr)
+	if err != nil {
+		return redactInstallError(err, token)
+	}
+	report.Handoff = status
+	if err := writeInstallReport(stdout, report); err != nil {
+		return err
+	}
+	if installFailed(status.InstallStatus.State) {
+		return fmt.Errorf("installer finished in %s: %s", status.InstallStatus.State, installFailure(status.InstallStatus))
+	}
+	return nil
+}
+
+func runInstallStatus(ctx context.Context, opts installStatusOptions, stdout, stderr io.Writer) error {
+	_ = stderr
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want json", opts.output)
+	}
+	endpoint, err := normalizeInstallerEndpoint(opts.endpoint)
+	if err != nil {
+		return err
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	status, err := fetchInstallStatus(requestCtx, &http.Client{Timeout: requestTimeout(opts.timeout)}, endpoint)
+	if err != nil {
+		return err
+	}
+	return writeInstallReport(stdout, newInstallHandoffReport(endpoint, status.SelectedNode, status.InstallStatus.BundleDigest, status))
+}
+
+func normalizeInstallerEndpoint(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("--endpoint is required")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("--endpoint is invalid: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("--endpoint scheme must be http or https")
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("--endpoint host is required")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("--endpoint must not contain user information")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("--endpoint must not contain a query or fragment")
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("--endpoint must be a base URL without a path")
+	}
+	parsed.Path = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func readInstallToken(value, path string) (string, error) {
+	value = strings.TrimSpace(value)
+	path = strings.TrimSpace(path)
+	if (value == "") == (path == "") {
+		return "", fmt.Errorf("exactly one of --token or --token-file is required")
+	}
+	if path != "" {
+		file, err := os.Open(path)
+		if err != nil {
+			return "", fmt.Errorf("open installer token file: %w", err)
+		}
+		defer file.Close()
+		info, err := file.Stat()
+		if err != nil {
+			return "", fmt.Errorf("stat installer token file: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("installer token file must be a regular file")
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return "", fmt.Errorf("installer token file permissions must not allow group or other access")
+		}
+		data, err := io.ReadAll(io.LimitReader(file, maxInstallTokenSize+1))
+		if err != nil {
+			return "", fmt.Errorf("read installer token file: %w", err)
+		}
+		if len(data) > maxInstallTokenSize {
+			return "", fmt.Errorf("installer token file exceeds %d bytes", maxInstallTokenSize)
+		}
+		value = strings.TrimSpace(string(data))
+	}
+	if value == "" {
+		return "", fmt.Errorf("installer token is empty")
+	}
+	if strings.ContainsAny(value, "\r\n") {
+		return "", fmt.Errorf("installer token must be one line")
+	}
+	return value, nil
+}
+
+func validateInstallBundleSize(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat config bundle: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("config bundle must be a regular file")
+	}
+	if info.Size() <= 0 {
+		return fmt.Errorf("config bundle is empty")
+	}
+	if info.Size() > maxInstallBundleSize {
+		return fmt.Errorf("config bundle size %d exceeds %d bytes", info.Size(), maxInstallBundleSize)
+	}
+	return nil
+}
+
+func fetchInstallStatus(ctx context.Context, client *http.Client, endpoint string) (handoff.HandoffStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/v1/status", nil)
+	if err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("create installer status request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	return doInstallRequest(client, req, "read installer status")
+}
+
+func submitInstallBundle(ctx context.Context, client *http.Client, endpoint, token, path, digest, node string) (handoff.HandoffStatus, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("open config bundle: %w", err)
+	}
+	defer file.Close()
+	requestURL, err := url.Parse(endpoint + "/v1/config-bundle")
+	if err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("create installer handoff URL: %w", err)
+	}
+	query := requestURL.Query()
+	query.Set("node", node)
+	query.Set("digest", digest)
+	requestURL.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), file)
+	if err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("create installer handoff request: %w", err)
+	}
+	if info, statErr := file.Stat(); statErr == nil {
+		req.ContentLength = info.Size()
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/vnd.katl.config.bundle.v1")
+	req.Header.Set("Accept", "application/json")
+	return doInstallRequest(client, req, "submit installer config bundle")
+}
+
+func doInstallRequest(client *http.Client, req *http.Request, action string) (handoff.HandoffStatus, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("%s: %w", action, err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxInstallResponseSize+1))
+	if err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("%s response: %w", action, err)
+	}
+	if len(data) > maxInstallResponseSize {
+		return handoff.HandoffStatus{}, fmt.Errorf("%s response exceeds %d bytes", action, maxInstallResponseSize)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := strings.TrimSpace(string(data))
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return handoff.HandoffStatus{}, fmt.Errorf("%s: HTTP %d: %s", action, resp.StatusCode, message)
+	}
+	var status handoff.HandoffStatus
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&status); err != nil {
+		return handoff.HandoffStatus{}, fmt.Errorf("%s response is invalid: %w", action, err)
+	}
+	if strings.TrimSpace(string(status.State)) == "" || strings.TrimSpace(status.InstallStatus.State) == "" {
+		return handoff.HandoffStatus{}, fmt.Errorf("%s response is missing installer state", action)
+	}
+	return status, nil
+}
+
+func waitForInstall(ctx context.Context, client *http.Client, endpoint string, initial handoff.HandoffStatus, stderr io.Writer) (handoff.HandoffStatus, error) {
+	last := initial
+	lastProgress := ""
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		progress := last.InstallStatus.State + "/" + last.InstallStatus.CurrentStep
+		if progress != lastProgress {
+			fmt.Fprintf(stderr, "katlctl install state=%s step=%s\n", last.InstallStatus.State, last.InstallStatus.CurrentStep)
+			lastProgress = progress
+		}
+		if installTerminal(last.InstallStatus.State) {
+			return last, nil
+		}
+		select {
+		case <-ctx.Done():
+			return handoff.HandoffStatus{}, fmt.Errorf("wait for installer after state=%s step=%s: %w", last.InstallStatus.State, last.InstallStatus.CurrentStep, ctx.Err())
+		case <-ticker.C:
+			status, err := fetchInstallStatus(ctx, client, endpoint)
+			if err != nil {
+				return handoff.HandoffStatus{}, fmt.Errorf("installer status became unavailable after state=%s step=%s: %w", last.InstallStatus.State, last.InstallStatus.CurrentStep, err)
+			}
+			last = status
+		}
+	}
+}
+
+func installTerminal(state string) bool {
+	switch state {
+	case installstatus.StateRebootRequested,
+		installstatus.StateInstallRefused,
+		installstatus.StateFailedBeforeMutation,
+		installstatus.StateFailedAfterMutation:
+		return true
+	default:
+		return false
+	}
+}
+
+func installFailed(state string) bool {
+	return installTerminal(state) && state != installstatus.StateRebootRequested
+}
+
+func installFailure(status installstatus.Record) string {
+	for _, value := range []string{status.RefusalReason, status.LastError, status.RetryHint} {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return "inspect installer status and console"
+}
+
+func requestTimeout(overall time.Duration) time.Duration {
+	const maximum = 15 * time.Second
+	if overall < maximum {
+		return overall
+	}
+	return maximum
+}
+
+func newInstallHandoffReport(endpoint, node, digest string, status handoff.HandoffStatus) installHandoffReport {
+	return installHandoffReport{
+		APIVersion:   installstatus.APIVersion,
+		Kind:         "InstallHandoffReport",
+		Endpoint:     endpoint,
+		SelectedNode: node,
+		BundleDigest: digest,
+		Handoff:      status,
+	}
+}
+
+func writeInstallReport(stdout io.Writer, report installHandoffReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal installer handoff report: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func redactInstallError(err error, token string) error {
+	if err == nil || strings.TrimSpace(token) == "" {
+		return err
+	}
+	return fmt.Errorf("%s", strings.ReplaceAll(err.Error(), token, "<redacted>"))
+}

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/handoff"
+	installstatus "github.com/katl-dev/katl/internal/installer/status"
+)
+
+func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
+	server, err := handoff.NewHandoffServer("install-token", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{"install", "status", "--endpoint", ts.URL}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	var report installHandoffReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if report.Kind != "InstallHandoffReport" || report.Endpoint != ts.URL || report.Handoff.State != handoff.HandoffWaiting || report.Handoff.InstallStatus.State != installstatus.StateWaitingForConfig {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	server, err := handoff.NewHandoffServer("install-token", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{
+		"install", "apply",
+		"--endpoint", ts.URL,
+		"--token", "install-token",
+		"--config-bundle", bundlePath,
+		"--config-bundle-digest", bundleDigest,
+		"--node", "cp-1",
+		"--no-wait",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	var report installHandoffReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if report.SelectedNode != "cp-1" || report.BundleDigest != bundleDigest || report.Handoff.State != handoff.HandoffAccepted || !report.Handoff.BundleAccepted {
+		t.Fatalf("report = %#v", report)
+	}
+	payload := server.Bundle()
+	if payload.NodeName != "cp-1" || len(payload.Data) == 0 {
+		t.Fatalf("server bundle = node=%q bytes=%d", payload.NodeName, len(payload.Data))
+	}
+}
+
+func TestInstallApplyReadsProtectedTokenFile(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	server, err := handoff.NewHandoffServer("file-token", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+	tokenPath := filepath.Join(t.TempDir(), "installer.token")
+	if err := os.WriteFile(tokenPath, []byte("file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{
+		"install", "apply",
+		"--endpoint", ts.URL,
+		"--token-file", tokenPath,
+		"--config-bundle", bundlePath,
+		"--config-bundle-digest", bundleDigest,
+		"--node", "cp-1",
+		"--no-wait",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+}
+
+func TestInstallApplyWaitsForRebootReady(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	var statusRequests atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		request := statusRequests.Add(1)
+		status := installTestStatus(handoff.HandoffWaiting, installstatus.StateWaitingForConfig, "")
+		if request > 1 {
+			status = installTestStatus(handoff.HandoffAccepted, installstatus.StateRebootRequested, "Reboot")
+			status.BundleAccepted = true
+			status.SelectedNode = "cp-1"
+		}
+		_ = json.NewEncoder(w).Encode(status)
+	})
+	mux.HandleFunc("POST /v1/config-bundle", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer wait-token" || r.URL.Query().Get("node") != "cp-1" || r.URL.Query().Get("digest") != bundleDigest {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		status := installTestStatus(handoff.HandoffAccepted, installstatus.StateRunning, "WaitForLocalConfig")
+		status.BundleAccepted = true
+		status.SelectedNode = "cp-1"
+		_ = json.NewEncoder(w).Encode(status)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "apply",
+		"--endpoint", ts.URL,
+		"--token", "wait-token",
+		"--config-bundle", bundlePath,
+		"--config-bundle-digest", bundleDigest,
+		"--node", "cp-1",
+		"--timeout", "5s",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	var report installHandoffReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Handoff.InstallStatus.State != installstatus.StateRebootRequested || !strings.Contains(stderr.String(), "state=reboot-requested") {
+		t.Fatalf("report=%#v stderr=%q", report, stderr.String())
+	}
+}
+
+func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	var statusRequests atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		state := installTestStatus(handoff.HandoffWaiting, installstatus.StateWaitingForConfig, "")
+		if statusRequests.Add(1) > 1 {
+			state = installTestStatus(handoff.HandoffAccepted, installstatus.StateFailedBeforeMutation, "Validate")
+			state.InstallStatus.LastError = "target disk was not found"
+		}
+		_ = json.NewEncoder(w).Encode(state)
+	})
+	mux.HandleFunc("POST /v1/config-bundle", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(installTestStatus(handoff.HandoffAccepted, installstatus.StateRunning, "Validate"))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "apply", "--endpoint", ts.URL, "--token", "failure-token",
+		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest,
+		"--node", "cp-1", "--timeout", "5s",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "failed-before-mutation") || !strings.Contains(err.Error(), "target disk was not found") {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("classified failure did not print final report")
+	}
+}
+
+func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
+	bundlePath, _ := writeConfigBundle(t)
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "apply", "--endpoint", ts.URL, "--token", "local-token",
+		"--config-bundle", bundlePath, "--config-bundle-digest", "sha256:" + strings.Repeat("0", 64),
+		"--node", "cp-1", "--no-wait",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("run() error = %v", err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("network requests = %d, want 0", requests.Load())
+	}
+}
+
+func TestInstallApplyRedactsTokenFromHTTPFailure(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	const token = "secret-install-token"
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(installTestStatus(handoff.HandoffWaiting, installstatus.StateWaitingForConfig, ""))
+			return
+		}
+		requests.Add(1)
+		http.Error(w, "rejected "+token, http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "apply", "--endpoint", ts.URL, "--token", token,
+		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest,
+		"--node", "cp-1", "--no-wait",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "<redacted>") || strings.Contains(err.Error(), token) {
+		t.Fatalf("run() error = %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("POST requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestInstallApplyRejectsInvalidEndpointAndOversizedBundle(t *testing.T) {
+	for _, endpoint := range []string{"installer.test:8080", "ftp://installer.test", "http://user@installer.test", "http://installer.test/path", "http://installer.test?token=secret"} {
+		var stdout, stderr bytes.Buffer
+		err := run(context.Background(), []string{"install", "status", "--endpoint", endpoint}, &stdout, &stderr)
+		if err == nil {
+			t.Fatalf("endpoint %q succeeded", endpoint)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "large.katlcfg")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxInstallBundleSize + 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{
+		"install", "apply", "--endpoint", "http://installer.test:8080", "--token", "token",
+		"--config-bundle", path, "--config-bundle-digest", "sha256:" + strings.Repeat("0", 64), "--node", "cp-1",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversized bundle error = %v", err)
+	}
+}
+
+func installTestStatus(handoffState handoff.HandoffState, state, step string) handoff.HandoffStatus {
+	return handoff.HandoffStatus{
+		State: handoffState,
+		InstallStatus: installstatus.Record{
+			APIVersion:  installstatus.APIVersion,
+			Kind:        installstatus.Kind,
+			State:       state,
+			CurrentStep: step,
+			UpdatedAt:   time.Now().UTC(),
+		},
+	}
+}
+
+func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	var submitted atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			submitted.Store(true)
+			_ = json.NewEncoder(w).Encode(installTestStatus(handoff.HandoffAccepted, installstatus.StateRunning, "Partition"))
+			return
+		}
+		if submitted.Load() {
+			http.Error(w, "gone", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(installTestStatus(handoff.HandoffWaiting, installstatus.StateWaitingForConfig, ""))
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "apply", "--endpoint", ts.URL, "--token", "token",
+		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest,
+		"--node", "cp-1", "--timeout", "3s",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "became unavailable") || !strings.Contains(err.Error(), "Partition") {
+		t.Fatalf("run() error = %v", err)
+	}
+}
+
+func TestInstallTokenFlagsAreExclusive(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	for _, args := range [][]string{
+		{"--token", "a", "--token-file", "token-file"},
+		{},
+	} {
+		base := []string{"install", "apply", "--endpoint", "http://installer.test:8080", "--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest, "--node", "cp-1", "--no-wait"}
+		base = append(base, args...)
+		var stdout, stderr bytes.Buffer
+		err := run(context.Background(), base, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "exactly one") {
+			t.Fatalf("args=%v error=%v", args, err)
+		}
+	}
+}
+
+func TestInstallTokenFileMustBePrivate(t *testing.T) {
+	bundlePath, bundleDigest := writeConfigBundle(t)
+	tokenPath := filepath.Join(t.TempDir(), "installer.token")
+	if err := os.WriteFile(tokenPath, []byte("token\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "apply", "--endpoint", "http://installer.test:8080", "--token-file", tokenPath,
+		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest, "--node", "cp-1", "--no-wait",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("run() error = %v", err)
+	}
+}
+
+func TestInstallRequestRejectsOversizedResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, strings.Repeat("x", maxInstallResponseSize+1))
+	}))
+	defer ts.Close()
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"install", "status", "--endpoint", ts.URL}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("run() error = %v", err)
+	}
+}

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -111,6 +111,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	configCmd.AddCommand(newConfigRenderNodeCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
 	cmd.AddCommand(configCmd)
+	cmd.AddCommand(newInstallCommand(ctx, stdout, stderr))
 
 	hostCmd := &cobra.Command{Use: "host", Short: "KatlOS host lifecycle operations"}
 	hostCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))

--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -543,6 +543,9 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 	if err != nil {
 		return err
 	}
+	server.SetStatusReader(func() (installstatus.Record, error) {
+		return installstatus.ReadFile(filepath.Join(runDir, "state", "status.json"))
+	})
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("listen for handoff: %w", err)
@@ -578,7 +581,9 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 				return fmt.Errorf("write handoff config bundle: %w", err)
 			}
 			fmt.Fprintf(stdout, "katlos-install handoff accepted bundle=%s node=%s\n", bundlePath, bundle.NodeName)
-			return runBundle(ctx, bundlePath, bundle.NodeName, "", filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, bundlePath, stdout)
+			err := runBundle(ctx, bundlePath, bundle.NodeName, "", filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, bundlePath, stdout)
+			waitForHandoffStatusObservation(ctx)
+			return err
 		}
 		if len(server.Manifest()) > 0 {
 			manifestPath := filepath.Join(runDir, "install-manifest.json")
@@ -592,7 +597,9 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 				return err
 			}
 			fmt.Fprintf(stdout, "katlos-install handoff accepted manifest=%s\n", manifestPath)
-			return runManifest(ctx, manifestPath, filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, manifestPath, stdout)
+			err := runManifest(ctx, manifestPath, filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, manifestPath, stdout)
+			waitForHandoffStatusObservation(ctx)
+			return err
 		}
 		select {
 		case <-ctx.Done():
@@ -601,6 +608,15 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 			return err
 		case <-ticker.C:
 		}
+	}
+}
+
+func waitForHandoffStatusObservation(ctx context.Context) {
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
 	}
 }
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -304,21 +304,46 @@ Boot the same `katl-installer.iso` on each node without preseed input. The
 installer mounts its embedded KatlOS image read-only, prints a handoff URL and
 one-time token to the console and journal, and waits without mutating disks.
 
-For `cp-1`, submit the bundle and select that node:
+The current handoff uses a bearer token over unencrypted HTTP. Use only an
+isolated provisioning network, never expose port 8080 to an untrusted network,
+and remove the temporary token file after use.
+
+For `cp-1`, first confirm the installer is waiting:
 
 ```sh
-curl --fail-with-body -X POST \
-  -H "Authorization: Bearer <one-time-token>" \
-  -H "Content-Type: application/vnd.katl.config.bundle.v1" \
-  --data-binary @katl-lab.katlcfg \
-  "http://<installer-ip>:8080/v1/config-bundle?node=cp-1&digest=<bundleDigest>"
+INSTALLER_ENDPOINT=http://192.0.2.10:8080
+katlctl install status --endpoint "$INSTALLER_ENDPOINT"
+```
+
+Copy the one-time token from the console into a protected temporary file, then
+submit the verified bundle:
+
+```sh
+BUNDLE_DIGEST='sha256:...'
+umask 077
+read -rsp 'Installer token: ' INSTALL_TOKEN; printf '\n'
+printf '%s\n' "$INSTALL_TOKEN" > ./installer.token
+unset INSTALL_TOKEN
+
+katlctl install apply \
+  --endpoint "$INSTALLER_ENDPOINT" \
+  --token-file ./installer.token \
+  --config-bundle ./katl-lab.katlcfg \
+  --config-bundle-digest "$BUNDLE_DIGEST" \
+  --node cp-1
+
+rm -f ./installer.token
 ```
 
 For the worker, boot the same ISO and submit the same file with
-`node=worker-1`. Check `http://<installer-ip>:8080/v1/status` before and after
-submission. A valid request verifies the archive, internal bundle digest,
-selected node, compiled install material, and embedded KatlOS image before the
-installer can mutate the selected disk. The endpoint refuses later submissions.
+`--node worker-1`. `katlctl install apply` validates the archive, internal
+bundle digest, and selected node before contacting the installer. The installer
+then validates the compiled install material and embedded KatlOS image before
+it can mutate the selected disk. The endpoint refuses later submissions.
+
+The command waits by default and returns structured status when installation is
+reboot-ready or reaches a classified failure. Pass `--no-wait` only when
+another operator process will monitor `katlctl install status` and the console.
 
 The console advertises `/v1/config-bundle` as the preferred endpoint.
 `/v1/install` remains available for advanced compiled-manifest integrations.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,8 +5,9 @@ with the task that matches the current node state; do not skip directly to a
 mutating command.
 
 KatlOS is experimental. Read the [support boundary](../support.md) before using
-these procedures. The current management API uses bearer authentication over
-unencrypted TCP and is suitable only on an isolated evaluation network.
+these procedures. The current installer handoff and management API use bearer
+authentication over unencrypted HTTP/TCP and are suitable only on isolated
+evaluation networks.
 
 ## Lifecycle Map
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -42,6 +42,10 @@ TCP. Restrict port 9443 to an isolated evaluation management network. It is not
 a production-grade remote-management trust boundary, even when artifact
 provenance verification succeeds.
 
+The ISO install handoff similarly sends its one-time bearer token over
+unencrypted HTTP. Restrict port 8080 to an isolated provisioning network and
+remove copied token files after the installer accepts the bundle.
+
 This proves which repository workflow produced the bytes. It does not provide:
 
 - UEFI Secure Boot signatures or a production boot-key policy;

--- a/internal/installer/handoff/handoff.go
+++ b/internal/installer/handoff/handoff.go
@@ -28,6 +28,7 @@ type HandoffServer struct {
 	token              string
 	validate           func([]byte) error
 	defaultKatlosImage manifest.KatlosImage
+	statusReader       func() (installstatus.Record, error)
 
 	mu       sync.Mutex
 	state    HandoffState
@@ -112,15 +113,28 @@ func (s *HandoffServer) Bundle() BundlePayload {
 
 func (s *HandoffServer) Status() HandoffStatus {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return HandoffStatus{
+	status := HandoffStatus{
 		State:            s.state,
 		ManifestAccepted: len(s.manifest) > 0,
 		BundleAccepted:   len(s.bundle) > 0,
 		SelectedNode:     s.nodeName,
 		InstallStatus:    s.status,
 	}
+	reader := s.statusReader
+	s.mu.Unlock()
+
+	if reader != nil {
+		if durable, err := reader(); err == nil {
+			status.InstallStatus = durable
+		}
+	}
+	return status
+}
+
+func (s *HandoffServer) SetStatusReader(reader func() (installstatus.Record, error)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statusReader = reader
 }
 
 func (s *HandoffServer) Announcement(baseURL string) string {

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/configbundle"
+	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
 
 func TestHandoffServerHealthStatusAndAnnouncement(t *testing.T) {
@@ -47,6 +48,29 @@ func TestHandoffServerHealthStatusAndAnnouncement(t *testing.T) {
 	if !strings.Contains(announcement, "http://192.0.2.10:8080/v1/config-bundle") ||
 		!strings.Contains(announcement, "token=test-token") {
 		t.Fatalf("announcement = %q", announcement)
+	}
+}
+
+func TestHandoffStatusUsesDurableInstallerState(t *testing.T) {
+	server := newTestHandoffServer(t)
+	durable := server.Status().InstallStatus
+	durable.State = "reboot-requested"
+	durable.CurrentStep = "Reboot"
+	durable.InstalledGeneration = "0"
+	server.SetStatusReader(func() (installstatus.Record, error) {
+		return durable, nil
+	})
+
+	status := server.Status()
+	if status.InstallStatus.State != "reboot-requested" || status.InstallStatus.CurrentStep != "Reboot" || status.InstallStatus.InstalledGeneration != "0" {
+		t.Fatalf("durable install status = %#v", status.InstallStatus)
+	}
+
+	server.SetStatusReader(func() (installstatus.Record, error) {
+		return installstatus.Record{}, os.ErrNotExist
+	})
+	if fallback := server.Status().InstallStatus; fallback.State != "waiting-for-config" {
+		t.Fatalf("fallback status = %#v", fallback)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add supported katlctl install apply and status commands
- validate config bundles before submission and report durable installer progress
- replace raw curl guidance and state the current isolated-network security boundary