### PR TITLE
operations: expose durable status in katlctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,23 @@ katlctl host upgrade \
 Remove `--plan` only after reviewing the response. Automated fleet rollout and
 Kubernetes version upgrade execution are not supported alpha workflows.
 
+Every accepted config, host-upgrade, bootstrap, and destructive-reset response
+includes an `operationId` and `requestDigest`. Query a snapshot or follow it to
+terminal state through the same node agent:
+
+```sh
+katlctl operation status \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --watch
+```
+
+The digest binds the query to the exact accepted request. Watch streams are an
+optimization; `katlctl` falls back to the node's authoritative persisted status
+if a stream is interrupted.
+
 ## Release artifacts
 
 | Artifact | Purpose |

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -112,6 +112,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	configCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
 	cmd.AddCommand(configCmd)
 	cmd.AddCommand(newInstallCommand(ctx, stdout, stderr))
+	cmd.AddCommand(newOperationCommand(ctx, stdout, stderr))
 
 	hostCmd := &cobra.Command{Use: "host", Short: "KatlOS host lifecycle operations"}
 	hostCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))
@@ -1742,15 +1743,7 @@ func dialKatlcAgentTCP(ctx context.Context, endpoint string, token string) (katl
 	if endpoint == "" {
 		return katlcAgentConnection{}, fmt.Errorf("katlc agent endpoint is required")
 	}
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	}
-	if strings.TrimSpace(token) != "" {
-		opts = append(opts, grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			return invoker(metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+strings.TrimSpace(token)), method, req, reply, cc, opts...)
-		}))
-	}
-	conn, err := grpc.DialContext(ctx, endpoint, opts...)
+	conn, err := grpc.DialContext(ctx, endpoint, katlcAgentDialOptions(token)...)
 	if err != nil {
 		return katlcAgentConnection{}, err
 	}
@@ -1758,6 +1751,24 @@ func dialKatlcAgentTCP(ctx context.Context, endpoint string, token string) (katl
 		Client: agentapi.NewKatlcAgentClient(conn),
 		Close:  conn.Close,
 	}, nil
+}
+
+func katlcAgentDialOptions(token string) []grpc.DialOption {
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	if strings.TrimSpace(token) != "" {
+		authorization := "Bearer " + strings.TrimSpace(token)
+		opts = append(opts,
+			grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+				return invoker(metadata.AppendToOutgoingContext(ctx, "authorization", authorization), method, req, reply, cc, opts...)
+			}),
+			grpc.WithStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+				return streamer(metadata.AppendToOutgoingContext(ctx, "authorization", authorization), desc, cc, method, opts...)
+			}),
+		)
+	}
+	return opts
 }
 
 func printBootstrapResult(stdout io.Writer, result cluster.Result) {
@@ -1768,11 +1779,15 @@ func printBootstrapResult(stdout io.Writer, result cluster.Result) {
 		}
 	}
 	for _, phase := range result.Phases {
+		operationFields := ""
+		if phase.OperationID != "" {
+			operationFields = fmt.Sprintf(" operation-id=%s request-digest=%s", phase.OperationID, phase.RequestDigest)
+		}
 		if phase.Node != "" {
-			fmt.Fprintf(stdout, "phase=%s node=%s status=%s\n", phase.Name, phase.Node, phase.Status)
+			fmt.Fprintf(stdout, "phase=%s node=%s status=%s%s\n", phase.Name, phase.Node, phase.Status, operationFields)
 			continue
 		}
-		fmt.Fprintf(stdout, "phase=%s status=%s\n", phase.Name, phase.Status)
+		fmt.Fprintf(stdout, "phase=%s status=%s%s\n", phase.Name, phase.Status, operationFields)
 	}
 	if result.NextStep != "" {
 		fmt.Fprintf(stdout, "next: %s\n", result.NextStep)

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1684,6 +1684,20 @@ func TestAddressOverrideValidation(t *testing.T) {
 	}
 }
 
+func TestPrintBootstrapResultIncludesOperationReference(t *testing.T) {
+	var stdout bytes.Buffer
+	printBootstrapResult(&stdout, cluster.Result{Phases: []cluster.Phase{{
+		Name:          "bootstrap-init",
+		Node:          "cp-1",
+		Status:        "failed",
+		OperationID:   "bootstrap-init-1",
+		RequestDigest: "digest-1",
+	}}})
+	if got := stdout.String(); !strings.Contains(got, "operation-id=bootstrap-init-1 request-digest=digest-1") {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
 type configApplyFixture struct {
 	GenerationID       string
 	PreviousGeneration string
@@ -1709,6 +1723,7 @@ type fakeKatlcAgentClient struct {
 	generation        *agentapi.Generation
 	generationRequest *agentapi.GetGenerationRequest
 	operationStatus   *agentapi.OperationStatus
+	operationRequest  *agentapi.GetOperationRequest
 }
 
 type fakeWipeClusterConnector struct {
@@ -1807,7 +1822,8 @@ func (c *fakeKatlcAgentClient) CreateWorkerJoinMaterial(context.Context, *agenta
 	return nil, nil
 }
 
-func (c *fakeKatlcAgentClient) GetOperation(context.Context, *agentapi.GetOperationRequest, ...grpc.CallOption) (*agentapi.OperationStatus, error) {
+func (c *fakeKatlcAgentClient) GetOperation(_ context.Context, req *agentapi.GetOperationRequest, _ ...grpc.CallOption) (*agentapi.OperationStatus, error) {
+	c.operationRequest = req
 	return c.operationStatus, nil
 }
 

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const operationWatchRPCDuration = 5 * time.Second
+
+const operationPollInterval = 500 * time.Millisecond
+
+type operationClient interface {
+	GetOperation(context.Context, *agentapi.GetOperationRequest, ...grpc.CallOption) (*agentapi.OperationStatus, error)
+	WatchOperation(context.Context, *agentapi.WatchOperationRequest, ...grpc.CallOption) (agentapi.KatlcAgent_WatchOperationClient, error)
+}
+
+type operationStatusOptions struct {
+	endpoint       string
+	agentTokenFile string
+	operationID    string
+	requestDigest  string
+	diagnostics    string
+	watch          bool
+	timeout        time.Duration
+	output         string
+}
+
+func newOperationCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{Use: "operation", Short: "KatlOS operation status"}
+	cmd.AddCommand(newOperationStatusCommand(ctx, stdout, stderr))
+	return cmd
+}
+
+func newOperationStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := operationStatusOptions{diagnostics: "normal", timeout: 30 * time.Minute, output: "json"}
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Query or follow one accepted KatlOS operation",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runOperationStatus(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
+	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().StringVar(&opts.operationID, "operation-id", "", "accepted operation id")
+	cmd.Flags().StringVar(&opts.requestDigest, "request-digest", "", "expected request digest returned at acceptance")
+	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
+	cmd.Flags().BoolVar(&opts.watch, "watch", false, "follow the operation until it reaches terminal state")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall status or watch timeout")
+	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	return cmd
+}
+
+func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout, stderr io.Writer) error {
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want json", opts.output)
+	}
+	if strings.TrimSpace(opts.endpoint) == "" {
+		return fmt.Errorf("--endpoint is required")
+	}
+	if strings.TrimSpace(opts.operationID) == "" {
+		return fmt.Errorf("--operation-id is required")
+	}
+	if opts.diagnostics != "normal" && opts.diagnostics != "verbose" {
+		return fmt.Errorf("--diagnostics must be %q or %q", "normal", "verbose")
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	token, err := readAgentToken(opts.agentTokenFile)
+	if err != nil {
+		return err
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	conn, err := dialKatlcAgent(requestCtx, opts.endpoint, token)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	request := &agentapi.GetOperationRequest{
+		OperationId:           strings.TrimSpace(opts.operationID),
+		ExpectedRequestDigest: strings.TrimSpace(opts.requestDigest),
+		IncludeDiagnostics:    opts.diagnostics,
+	}
+	status, err := conn.Client.GetOperation(requestCtx, request)
+	if err != nil {
+		return fmt.Errorf("get operation %s: %w", request.OperationId, err)
+	}
+	if status == nil {
+		return fmt.Errorf("agent returned an empty operation status")
+	}
+	if !opts.watch {
+		return writeOperationStatus(stdout, status)
+	}
+	if status.GetTerminal() {
+		if err := writeOperationStatus(stdout, status); err != nil {
+			return err
+		}
+		return operationResultError(status)
+	}
+
+	status, err = followOperation(requestCtx, conn.Client, request, status, stderr)
+	if writeErr := writeOperationStatus(stdout, status); writeErr != nil {
+		return writeErr
+	}
+	if err != nil {
+		return err
+	}
+	return operationResultError(status)
+}
+
+func followOperation(ctx context.Context, client operationClient, request *agentapi.GetOperationRequest, current *agentapi.OperationStatus, stderr io.Writer) (*agentapi.OperationStatus, error) {
+	status := current
+	seq := status.GetLatestJournalSeq()
+	lastProgress := ""
+	streamWarning := false
+	watchAvailable := true
+	for {
+		progress := fmt.Sprintf("%s/%s/%t/%s", status.GetOperationKind(), status.GetPhase(), status.GetTerminal(), status.GetResult())
+		if progress != lastProgress {
+			fmt.Fprintf(stderr, "katlctl operation id=%s kind=%s phase=%s terminal=%t result=%s\n", status.GetOperationId(), status.GetOperationKind(), status.GetPhase(), status.GetTerminal(), status.GetResult())
+			lastProgress = progress
+		}
+		if status.GetTerminal() {
+			return status, nil
+		}
+		var watchErr error
+		if watchAvailable {
+			stream, err := client.WatchOperation(ctx, &agentapi.WatchOperationRequest{
+				OperationId:           request.OperationId,
+				ExpectedRequestDigest: request.ExpectedRequestDigest,
+				AfterJournalSeq:       seq,
+				WatchTimeout:          operationWatchRPCDuration.String(),
+				IncludeDiagnostics:    request.IncludeDiagnostics,
+			})
+			watchErr = err
+			if err == nil {
+				for {
+					event, recvErr := stream.Recv()
+					if recvErr != nil {
+						watchErr = recvErr
+						break
+					}
+					if event.GetJournalSeq() > seq {
+						seq = event.GetJournalSeq()
+					}
+					if event.GetStatus() != nil {
+						status = event.GetStatus()
+					}
+					if event.GetTerminal() && status.GetTerminal() {
+						return status, nil
+					}
+				}
+			}
+		}
+		if watchErr != nil && !errors.Is(watchErr, io.EOF) && !errors.Is(watchErr, context.DeadlineExceeded) && !errors.Is(watchErr, context.Canceled) && !streamWarning {
+			fmt.Fprintf(stderr, "katlctl operation watch interrupted; falling back to authoritative status polling: %v\n", watchErr)
+			streamWarning = true
+			watchAvailable = false
+		}
+		polled, pollErr := client.GetOperation(ctx, request)
+		if pollErr != nil {
+			if ctx.Err() != nil {
+				return status, fmt.Errorf("watch operation %s after phase=%s: %w", request.OperationId, status.GetPhase(), ctx.Err())
+			}
+			return status, fmt.Errorf("poll operation %s after watch interruption: %w", request.OperationId, pollErr)
+		}
+		status = polled
+		if status.GetLatestJournalSeq() > seq {
+			seq = status.GetLatestJournalSeq()
+		}
+		if ctx.Err() != nil {
+			return status, fmt.Errorf("watch operation %s after phase=%s: %w", request.OperationId, status.GetPhase(), ctx.Err())
+		}
+		if !watchAvailable {
+			timer := time.NewTimer(operationPollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return status, fmt.Errorf("watch operation %s after phase=%s: %w", request.OperationId, status.GetPhase(), ctx.Err())
+			case <-timer.C:
+			}
+		}
+	}
+}
+
+func writeOperationStatus(stdout io.Writer, status *agentapi.OperationStatus) error {
+	if status == nil {
+		return fmt.Errorf("agent returned an empty operation status")
+	}
+	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("marshal operation status: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func operationResultError(status *agentapi.OperationStatus) error {
+	if status == nil || !status.GetTerminal() || status.GetResult() == "succeeded" {
+		return nil
+	}
+	detail := strings.TrimSpace(status.GetFailureReason())
+	if detail == "" {
+		detail = strings.TrimSpace(status.GetNextAction())
+	}
+	if detail == "" {
+		detail = "inspect operation status and diagnostics"
+	}
+	return fmt.Errorf("operation %s finished with result %s: %s", status.GetOperationId(), status.GetResult(), detail)
+}

--- a/cmd/katlctl/operation_test.go
+++ b/cmd/katlctl/operation_test.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
+	for _, kind := range []string{"host-upgrade", "bootstrap-init", "generation-apply", "destructive-reset"} {
+		t.Run(kind, func(t *testing.T) {
+			client := &fakeKatlcAgentClient{operationStatus: &agentapi.OperationStatus{
+				OperationId:             "operation-1",
+				OperationKind:           kind,
+				RequestDigest:           strings.Repeat("a", 64),
+				Phase:                   "complete",
+				Terminal:                true,
+				Result:                  "failed",
+				RecoveryRequired:        true,
+				FailureReason:           "operator recovery is required",
+				ExternalMutationStarted: true,
+			}}
+			oldDial := dialKatlcAgent
+			dialKatlcAgent = func(_ context.Context, endpoint, token string) (katlcAgentConnection, error) {
+				if endpoint != "node.test:9443" || token != "agent-token" {
+					t.Fatalf("dial endpoint=%q token=%q", endpoint, token)
+				}
+				return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+			}
+			t.Cleanup(func() { dialKatlcAgent = oldDial })
+			tokenPath := writeOperationToken(t)
+
+			var stdout, stderr bytes.Buffer
+			err := run(context.Background(), []string{
+				"operation", "status",
+				"--endpoint", "node.test:9443",
+				"--agent-token-file", tokenPath,
+				"--operation-id", "operation-1",
+				"--request-digest", strings.Repeat("a", 64),
+				"--diagnostics", "verbose",
+			}, &stdout, &stderr)
+			if err != nil {
+				t.Fatalf("run() error = %v", err)
+			}
+			var got agentapi.OperationStatus
+			if err := protojson.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("decode status: %v\n%s", err, stdout.String())
+			}
+			if got.GetOperationKind() != kind || !got.GetRecoveryRequired() || got.GetFailureReason() != "operator recovery is required" {
+				t.Fatalf("status = %#v", &got)
+			}
+			if client.operationRequest.GetExpectedRequestDigest() != strings.Repeat("a", 64) || client.operationRequest.GetIncludeDiagnostics() != "verbose" {
+				t.Fatalf("request = %#v", client.operationRequest)
+			}
+		})
+	}
+}
+
+func TestFollowOperationUsesWatchSequence(t *testing.T) {
+	terminal := &agentapi.OperationStatus{OperationId: "operation-1", OperationKind: "host-upgrade", Phase: "complete", LatestJournalSeq: 4, Terminal: true, Result: "succeeded"}
+	client := &fakeOperationClient{streams: []*fakeOperationStream{{events: []*agentapi.OperationEvent{{OperationId: "operation-1", JournalSeq: 4, Terminal: true, Status: terminal}}}}}
+	request := &agentapi.GetOperationRequest{OperationId: "operation-1", ExpectedRequestDigest: strings.Repeat("b", 64), IncludeDiagnostics: "verbose"}
+	var stderr bytes.Buffer
+
+	status, err := followOperation(context.Background(), client, request, &agentapi.OperationStatus{OperationId: "operation-1", OperationKind: "host-upgrade", Phase: "download", LatestJournalSeq: 3}, &stderr)
+	if err != nil {
+		t.Fatalf("followOperation() error = %v", err)
+	}
+	if status != terminal {
+		t.Fatalf("status = %#v", status)
+	}
+	if len(client.watchRequests) != 1 || client.watchRequests[0].GetAfterJournalSeq() != 3 || client.watchRequests[0].GetExpectedRequestDigest() != request.ExpectedRequestDigest || client.watchRequests[0].GetIncludeDiagnostics() != "verbose" {
+		t.Fatalf("watch requests = %#v", client.watchRequests)
+	}
+}
+
+func TestFollowOperationFallsBackToPolling(t *testing.T) {
+	terminal := &agentapi.OperationStatus{OperationId: "operation-1", OperationKind: "destructive-reset", Phase: "complete", LatestJournalSeq: 9, Terminal: true, Result: "succeeded"}
+	client := &fakeOperationClient{watchErrs: []error{errors.New("stream unavailable")}, statuses: []*agentapi.OperationStatus{terminal}}
+	var stderr bytes.Buffer
+
+	status, err := followOperation(context.Background(), client, &agentapi.GetOperationRequest{OperationId: "operation-1"}, &agentapi.OperationStatus{OperationId: "operation-1", Phase: "accepted"}, &stderr)
+	if err != nil {
+		t.Fatalf("followOperation() error = %v", err)
+	}
+	if status != terminal || len(client.getRequests) != 1 {
+		t.Fatalf("status=%#v get requests=%d", status, len(client.getRequests))
+	}
+	if !strings.Contains(stderr.String(), "falling back to authoritative status polling") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestFollowOperationTimeoutReturnsLastStatus(t *testing.T) {
+	current := &agentapi.OperationStatus{OperationId: "operation-1", OperationKind: "bootstrap-init", Phase: "kubeadm-init"}
+	client := &fakeOperationClient{watchErrs: []error{errors.New("stream unavailable")}, statuses: []*agentapi.OperationStatus{current}}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	status, err := followOperation(ctx, client, &agentapi.GetOperationRequest{OperationId: "operation-1"}, current, io.Discard)
+	if !errors.Is(err, context.DeadlineExceeded) || status != current {
+		t.Fatalf("status=%#v error=%v", status, err)
+	}
+}
+
+func TestOperationStatusValidatesFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"operation", "status"},
+		{"operation", "status", "--endpoint", "node:9443"},
+		{"operation", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--diagnostics", "everything"},
+		{"operation", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--timeout", "0s"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if err := run(context.Background(), args, &stdout, &stderr); err == nil {
+			t.Fatalf("args %v succeeded", args)
+		}
+	}
+}
+
+func TestOperationWatchReturnsFailureAfterStatus(t *testing.T) {
+	client := &fakeKatlcAgentClient{operationStatus: &agentapi.OperationStatus{
+		OperationId: "operation-1", Terminal: true, Result: "failed", FailureReason: "disk mutation requires recovery",
+	}}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(context.Context, string, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"operation", "status", "--endpoint", "node:9443", "--operation-id", "operation-1", "--watch"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "disk mutation requires recovery") {
+		t.Fatalf("run() error = %v", err)
+	}
+	var got agentapi.OperationStatus
+	if decodeErr := protojson.Unmarshal(stdout.Bytes(), &got); decodeErr != nil || got.GetResult() != "failed" {
+		t.Fatalf("status=%#v decode error=%v\n%s", &got, decodeErr, stdout.String())
+	}
+}
+
+func TestKatlcAgentDialOptionsAuthenticateWatchStream(t *testing.T) {
+	listener := bufconn.Listen(1 << 20)
+	server := grpc.NewServer()
+	capture := &streamAuthorizationServer{authorization: make(chan string, 1)}
+	agentapi.RegisterKatlcAgentServer(server, capture)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+	opts := append(katlcAgentDialOptions("stream-token"), grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}))
+	conn, err := grpc.DialContext(context.Background(), "passthrough:///bufnet", opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	stream, err := agentapi.NewKatlcAgentClient(conn).WatchOperation(context.Background(), &agentapi.WatchOperationRequest{OperationId: "operation-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-capture.authorization:
+		if got != "Bearer stream-token" {
+			t.Fatalf("authorization = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream authorization was not observed")
+	}
+}
+
+type fakeOperationClient struct {
+	statuses      []*agentapi.OperationStatus
+	getErrs       []error
+	streams       []*fakeOperationStream
+	watchErrs     []error
+	getRequests   []*agentapi.GetOperationRequest
+	watchRequests []*agentapi.WatchOperationRequest
+}
+
+func (c *fakeOperationClient) GetOperation(_ context.Context, req *agentapi.GetOperationRequest, _ ...grpc.CallOption) (*agentapi.OperationStatus, error) {
+	c.getRequests = append(c.getRequests, req)
+	var err error
+	if len(c.getErrs) > 0 {
+		err, c.getErrs = c.getErrs[0], c.getErrs[1:]
+	}
+	if len(c.statuses) == 0 {
+		return nil, err
+	}
+	status := c.statuses[0]
+	if len(c.statuses) > 1 {
+		c.statuses = c.statuses[1:]
+	}
+	return status, err
+}
+
+func (c *fakeOperationClient) WatchOperation(_ context.Context, req *agentapi.WatchOperationRequest, _ ...grpc.CallOption) (agentapi.KatlcAgent_WatchOperationClient, error) {
+	c.watchRequests = append(c.watchRequests, req)
+	var err error
+	if len(c.watchErrs) > 0 {
+		err, c.watchErrs = c.watchErrs[0], c.watchErrs[1:]
+	}
+	if err != nil || len(c.streams) == 0 {
+		return nil, err
+	}
+	stream := c.streams[0]
+	c.streams = c.streams[1:]
+	return stream, nil
+}
+
+type fakeOperationStream struct {
+	grpc.ClientStream
+	events []*agentapi.OperationEvent
+	err    error
+}
+
+func (s *fakeOperationStream) Recv() (*agentapi.OperationEvent, error) {
+	if len(s.events) == 0 {
+		if s.err != nil {
+			err := s.err
+			s.err = nil
+			return nil, err
+		}
+		return nil, io.EOF
+	}
+	event := s.events[0]
+	s.events = s.events[1:]
+	return event, nil
+}
+
+func writeOperationToken(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir() + "/agent.token"
+	if err := os.WriteFile(path, []byte("agent-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type streamAuthorizationServer struct {
+	agentapi.UnimplementedKatlcAgentServer
+	authorization chan string
+}
+
+func (s *streamAuthorizationServer) WatchOperation(_ *agentapi.WatchOperationRequest, stream agentapi.KatlcAgent_WatchOperationServer) error {
+	values := metadata.ValueFromIncomingContext(stream.Context(), "authorization")
+	if len(values) > 0 {
+		s.authorization <- values[0]
+	}
+	return stream.Send(&agentapi.OperationEvent{OperationId: "operation-1", Terminal: true, Status: &agentapi.OperationStatus{OperationId: "operation-1", Terminal: true, Result: "succeeded"}})
+}

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -52,6 +52,25 @@ Treat command outcomes precisely:
 Use a unique, stable `--client-request-id` for each intended mutation. Reuse it
 only when retrying the exact same request. Changing inputs requires a new ID.
 
+For every accepted mutation, retain both `operationId` and `requestDigest`.
+Use the generic status path for config apply, host upgrade, bootstrap, and
+destructive reset:
+
+```sh
+katlctl operation status \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --watch
+```
+
+Without `--watch`, the command returns one authoritative snapshot. With it,
+progress is written to stderr and final structured status to stdout. A lost
+watch automatically falls back to polling the durable node record. Use
+`--diagnostics verbose` when the normal redacted status is insufficient. A
+watched terminal failure still prints its final JSON status and exits nonzero.
+
 ## Boundaries That Matter During Operations
 
 KatlOS generations own the immutable root, UKI, selected sysexts, and compiled

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -75,6 +75,19 @@ first control plane, creates join material, joins remaining nodes, checks
 post-kubeadm health, commits generation 1, and writes the operator kubeconfig.
 Save the command output and returned operation IDs.
 
+Bootstrap waits for its submitted operations, but their node-local records
+remain queryable afterward. If the workstation disconnects or a result is
+unclear, query the affected node with the returned ID and digest:
+
+```sh
+katlctl operation status \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --watch
+```
+
 ## Establish Cluster Networking
 
 Kubeadm nodes normally remain `NotReady` until a CNI is installed. Katl does not

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -76,6 +76,21 @@ Keep the inputs and client request ID identical to the reviewed plan. The JSON
 response records the operation ID, request digest, and initial status. Accepted
 does not mean complete.
 
+Follow the accepted operation before evaluating generation health:
+
+```sh
+katlctl operation status \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --watch
+```
+
+Require `terminal: true` and `result: succeeded`. If `recoveryRequired` is
+true, stop and follow `failureReason` and `nextAction`; do not submit a new
+apply merely because the watch disconnected.
+
 ## Check Generation Status
 
 Query the candidate through the agent:

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -32,23 +32,24 @@ find /var/lib/katl/generations -maxdepth 2 -type f -print
 find /var/lib/katl/operations -maxdepth 3 -type f -print
 ```
 
-For one accepted operation, stream its durable record to `jq` on the operator
-workstation:
+For one accepted operation, first query its redacted durable status through the
+agent:
 
 ```sh
-OPERATION_ID=operation-id-from-katlctl
-ssh root@affected-node \
-  "cat '/var/lib/katl/operations/$OPERATION_ID/record.json'" | \
-  jq '.payload.record | {
-  operationID, operationKind, requestDigest, phase, completedPhases,
-  terminal, result, externalMutationStarted, mutationScopes,
-  recoveryRequired, failureReason, nextAction, diagnosticArtifacts
-}'
+katlctl operation status \
+  --endpoint affected-node.example.test:9443 \
+  --agent-token-file ./tokens/affected-node.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --diagnostics verbose
 ```
 
-The journal directory is authoritative when a snapshot looks stale:
+If the agent is unavailable, use SSH as a break-glass evidence path and read
+the record without editing it. The journal directory is authoritative when a
+snapshot looks stale:
 
 ```text
+/var/lib/katl/operations/$OPERATION_ID/record.json
 /var/lib/katl/operations/$OPERATION_ID/journal/
 ```
 

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -48,14 +48,16 @@ candidate generation, resource locks, and refusal diagnostics.
 Run the identical command without `--plan`. Save the returned `operationId` and
 `requestDigest`. The response means accepted, not staged successfully.
 
-Until a general remote operation-status command is exposed, inspect the durable
-record on the node over SSH:
+Follow the accepted operation through the node agent, binding the query to the
+returned request digest:
 
 ```sh
-OPERATION_ID=host-upgrade-...
-ssh root@cp-1.example.test \
-  "cat '/var/lib/katl/operations/$OPERATION_ID/record.json'" | \
-  jq '.payload.record | {operationID, operationKind, phase, terminal, result, candidateGenerationID, bootHealthPending, recoveryRequired, failureReason, nextAction}'
+katlctl operation status \
+  --endpoint cp-1.example.test:9443 \
+  --agent-token-file ./tokens/cp-1.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --watch
 ```
 
 Do not reboot until the operation is terminal with `result: succeeded` and

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -81,7 +81,22 @@ wiped surface, preserved surface, and refusal.
 
 Run the identical command without `--plan` only when the cluster is intentionally
 being discarded. The command submits node-local destructive-reset operations
-and reports their operation IDs and terminal results.
+and reports their operation IDs, request digests, and initial status.
+
+For each reported node endpoint, operation ID, and request digest, follow the
+node-local reset to terminal state:
+
+```sh
+katlctl operation status \
+  --endpoint worker-1.example.test:9443 \
+  --agent-token-file ./tokens/worker-1.token \
+  --operation-id "$OPERATION_ID" \
+  --request-digest "$REQUEST_DIGEST" \
+  --watch
+```
+
+Do not proceed to reinstall until every intended reset reports `terminal: true`
+and `result: succeeded`. Treat `recoveryRequired: true` as a stop condition.
 
 ## Plan One Worker Replacement
 

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -176,33 +176,35 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	status := statuses[initNode.Name]
 	initResult, err := submitAndWaitBootstrapInit(ctx, initNode, plan, status, deps)
 	if err != nil {
-		result.addPhase("bootstrap-init", initNode.Name, inventory.ActionInit, "failed")
+		result.addOperationPhase("bootstrap-init", initNode.Name, inventory.ActionInit, "failed", initResult.Operation)
 		return result, fmt.Errorf("bootstrap-init operation on %s: %s", initNode.Name, inventory.Redact(err.Error()))
 	}
-	result.addPhase("bootstrap-init", initNode.Name, inventory.ActionInit, "passed")
+	result.addOperationPhase("bootstrap-init", initNode.Name, inventory.ActionInit, "passed", initResult.Operation)
 	for _, node := range controlPlaneJoinNodes(plan) {
-		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.OperationID, deps)
+		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, deps)
 		if err != nil {
 			result.addPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "failed")
 			return result, fmt.Errorf("control-plane join material for %s: %s", node.Name, inventory.Redact(err.Error()))
 		}
-		if err := submitAndWaitControlPlaneJoin(ctx, node, plan, statuses[node.Name], material, deps); err != nil {
-			result.addPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "failed")
+		operationRef, err := submitAndWaitControlPlaneJoin(ctx, node, plan, statuses[node.Name], material, deps)
+		if err != nil {
+			result.addOperationPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "failed", operationRef)
 			return result, fmt.Errorf("control-plane join operation on %s: %s", node.Name, inventory.Redact(err.Error()))
 		}
-		result.addPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "passed")
+		result.addOperationPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "passed", operationRef)
 	}
 	for _, node := range workerNodes(plan) {
-		material, err := createWorkerJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.OperationID, deps)
+		material, err := createWorkerJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, deps)
 		if err != nil {
 			result.addPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "failed")
 			return result, fmt.Errorf("worker join material for %s: %s", node.Name, inventory.Redact(err.Error()))
 		}
-		if err := submitAndWaitWorkerJoin(ctx, node, plan, statuses[node.Name], material, deps); err != nil {
-			result.addPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "failed")
+		operationRef, err := submitAndWaitWorkerJoin(ctx, node, plan, statuses[node.Name], material, deps)
+		if err != nil {
+			result.addOperationPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "failed", operationRef)
 			return result, fmt.Errorf("worker join operation on %s: %s", node.Name, inventory.Redact(err.Error()))
 		}
-		result.addPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "passed")
+		result.addOperationPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "passed", operationRef)
 	}
 	stableEndpointReady := false
 	if bootstrap.enabled() {
@@ -301,11 +303,12 @@ func RunAgentWorkerJoin(ctx context.Context, request Request, workerName string,
 		result.addPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "failed")
 		return result, fmt.Errorf("worker join material for %s: %s", worker.Name, inventory.Redact(err.Error()))
 	}
-	if err := submitAndWaitWorkerJoin(ctx, worker, plan, statuses[worker.Name], material, deps); err != nil {
-		result.addPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "failed")
+	operationRef, err := submitAndWaitWorkerJoin(ctx, worker, plan, statuses[worker.Name], material, deps)
+	if err != nil {
+		result.addOperationPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "failed", operationRef)
 		return result, fmt.Errorf("worker join operation on %s: %s", worker.Name, inventory.Redact(err.Error()))
 	}
-	result.addPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "passed")
+	result.addOperationPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "passed", operationRef)
 	return result, nil
 }
 
@@ -377,8 +380,13 @@ func readinessFromStatuses(plan inventory.Plan, statuses map[string]*agentapi.No
 }
 
 type bootstrapInitResult struct {
-	OperationID string
+	Operation   operationReference
 	Credentials AdminCredentials
+}
+
+type operationReference struct {
+	ID            string
+	RequestDigest string
 }
 
 type workerJoinMaterial struct {
@@ -397,15 +405,16 @@ func submitAndWaitBootstrapInit(ctx context.Context, node inventory.PlannedNode,
 	if err != nil {
 		return bootstrapInitResult{}, fmt.Errorf("submit operation: %w", err)
 	}
+	result := bootstrapInitResult{Operation: operationReference{ID: accepted.GetOperationId(), RequestDigest: accepted.GetRequestDigest()}}
 	final, err := waitOperationTerminal(ctx, conn.Client, accepted, deps)
 	if err != nil {
-		return bootstrapInitResult{}, err
+		return result, err
 	}
 	if !final.GetTerminal() {
-		return bootstrapInitResult{}, fmt.Errorf("operation %s did not reach terminal status", accepted.GetOperationId())
+		return result, fmt.Errorf("operation %s did not reach terminal status", accepted.GetOperationId())
 	}
 	if final.GetResult() != "" && final.GetResult() != operation.ResultSucceeded {
-		return bootstrapInitResult{}, fmt.Errorf("operation %s finished with result %s: %s", accepted.GetOperationId(), final.GetResult(), final.GetFailureReason())
+		return result, fmt.Errorf("operation %s finished with result %s: %s", accepted.GetOperationId(), final.GetResult(), final.GetFailureReason())
 	}
 	output, err := conn.Client.GetOperation(ctx, &agentapi.GetOperationRequest{
 		OperationId:           accepted.GetOperationId(),
@@ -413,13 +422,14 @@ func submitAndWaitBootstrapInit(ctx context.Context, node inventory.PlannedNode,
 		IncludeDiagnostics:    "bootstrap-output",
 	})
 	if err != nil {
-		return bootstrapInitResult{}, fmt.Errorf("get bootstrap output for operation %s: %w", accepted.GetOperationId(), err)
+		return result, fmt.Errorf("get bootstrap output for operation %s: %w", accepted.GetOperationId(), err)
 	}
 	credentials, err := parseAdminCredentials([]byte(output.GetAdminKubeconfig()))
 	if err != nil {
-		return bootstrapInitResult{}, err
+		return result, err
 	}
-	return bootstrapInitResult{OperationID: accepted.GetOperationId(), Credentials: credentials}, nil
+	result.Credentials = credentials
+	return result, nil
 }
 
 func createControlPlaneJoinMaterial(ctx context.Context, initNode, controlPlane inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
@@ -464,18 +474,18 @@ func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.Planne
 	return workerJoinMaterial{Ref: ref, Material: material}, nil
 }
 
-func submitAndWaitControlPlaneJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) error {
+func submitAndWaitControlPlaneJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) (operationReference, error) {
 	return submitAndWaitJoin(ctx, node, plan, status, material, deps, "bootstrap-join-control-plane")
 }
 
-func submitAndWaitWorkerJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) error {
+func submitAndWaitWorkerJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) (operationReference, error) {
 	return submitAndWaitJoin(ctx, node, plan, status, material, deps, "bootstrap-join-worker")
 }
 
-func submitAndWaitJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies, kind string) error {
+func submitAndWaitJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies, kind string) (operationReference, error) {
 	conn, err := deps.Connector.Connect(ctx, node)
 	if err != nil {
-		return fmt.Errorf("connect to katlc agent: %w", err)
+		return operationReference{}, fmt.Errorf("connect to katlc agent: %w", err)
 	}
 	defer closeAgent(conn)
 	req := bootstrapOperationRequest(node, plan, status, deps, kind)
@@ -483,19 +493,20 @@ func submitAndWaitJoin(ctx context.Context, node inventory.PlannedNode, plan inv
 	req.Bootstrap.WorkerJoinMaterial = material.Material
 	accepted, err := conn.Client.SubmitOperation(ctx, req)
 	if err != nil {
-		return fmt.Errorf("submit operation: %w", err)
+		return operationReference{}, fmt.Errorf("submit operation: %w", err)
 	}
+	operationRef := operationReference{ID: accepted.GetOperationId(), RequestDigest: accepted.GetRequestDigest()}
 	final, err := waitOperationTerminal(ctx, conn.Client, accepted, deps)
 	if err != nil {
-		return err
+		return operationRef, err
 	}
 	if !final.GetTerminal() {
-		return fmt.Errorf("operation %s did not reach terminal status", accepted.GetOperationId())
+		return operationRef, fmt.Errorf("operation %s did not reach terminal status", accepted.GetOperationId())
 	}
 	if final.GetResult() != "" && final.GetResult() != operation.ResultSucceeded {
-		return fmt.Errorf("operation %s finished with result %s: %s", accepted.GetOperationId(), final.GetResult(), final.GetFailureReason())
+		return operationRef, fmt.Errorf("operation %s finished with result %s: %s", accepted.GetOperationId(), final.GetResult(), final.GetFailureReason())
 	}
-	return nil
+	return operationRef, nil
 }
 
 func bootstrapInitRequest(node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, deps AgentBootstrapDependencies) *agentapi.SubmitOperationRequest {

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -111,6 +111,9 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "bootstrap-init", "control-plane-join", "kubeconfig"}) {
 		t.Fatalf("phases = %#v", got)
 	}
+	if result.Phases[2].OperationID != "bootstrap-init-1" || result.Phases[2].RequestDigest != "digest-init" || result.Phases[3].OperationID != "bootstrap-join-control-plane-1" || result.Phases[3].RequestDigest != "digest-cp-join" {
+		t.Fatalf("operation phases = %#v", result.Phases)
+	}
 	if len(cpClient.createMaterialRequests) != 1 {
 		t.Fatalf("CreateWorkerJoinMaterial requests = %d, want 1", len(cpClient.createMaterialRequests))
 	}
@@ -126,6 +129,25 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	}
 	if cp2Req.Bootstrap.JoinMaterialRef != "operation:bootstrap-init-1/control-plane:cp-2" {
 		t.Fatalf("join material ref = %q", cp2Req.Bootstrap.JoinMaterialRef)
+	}
+}
+
+func TestRunAgentBootstrapPreservesFailedOperationReference(t *testing.T) {
+	client := &fakeAgentClient{
+		status: readyAgentStatus("machine-cp-1"),
+		accepted: &agentapi.OperationAccepted{
+			OperationId:   "bootstrap-init-failed",
+			RequestDigest: "digest-failed",
+			InitialStatus: &agentapi.OperationStatus{OperationId: "bootstrap-init-failed", Terminal: true, Result: "failed", FailureReason: "kubeadm refused input"},
+		},
+	}
+	result, err := RunAgentBootstrap(context.Background(), Request{Inventory: validSingleNodeInventory()}, AgentBootstrapDependencies{Connector: newFakeAgentConnector(map[string]*fakeAgentClient{"cp-1": client})})
+	if err == nil || !strings.Contains(err.Error(), "kubeadm refused input") {
+		t.Fatalf("RunAgentBootstrap() error = %v", err)
+	}
+	failed := result.Phases[len(result.Phases)-1]
+	if failed.Status != "failed" || failed.OperationID != "bootstrap-init-failed" || failed.RequestDigest != "digest-failed" {
+		t.Fatalf("failed phase = %#v", failed)
 	}
 }
 

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -131,10 +131,12 @@ type Result struct {
 }
 
 type Phase struct {
-	Name   string                    `json:"name"`
-	Node   string                    `json:"node,omitempty"`
-	Action inventory.BootstrapAction `json:"action,omitempty"`
-	Status string                    `json:"status"`
+	Name          string                    `json:"name"`
+	Node          string                    `json:"node,omitempty"`
+	Action        inventory.BootstrapAction `json:"action,omitempty"`
+	Status        string                    `json:"status"`
+	OperationID   string                    `json:"operationID,omitempty"`
+	RequestDigest string                    `json:"requestDigest,omitempty"`
 }
 
 const (
@@ -615,6 +617,17 @@ func validateEndpointLike(endpoint string) error {
 
 func (r *Result) addPhase(name, node string, action inventory.BootstrapAction, status string) {
 	r.Phases = append(r.Phases, Phase{Name: name, Node: node, Action: action, Status: status})
+}
+
+func (r *Result) addOperationPhase(name, node string, action inventory.BootstrapAction, status string, operation operationReference) {
+	r.Phases = append(r.Phases, Phase{
+		Name:          name,
+		Node:          node,
+		Action:        action,
+		Status:        status,
+		OperationID:   operation.ID,
+		RequestDigest: operation.RequestDigest,
+	})
 }
 
 func controlPlaneJoinNodes(plan inventory.Plan) []inventory.PlannedNode {


### PR DESCRIPTION
## Summary

- add digest-bound operation snapshot and watch commands with polling fallback
- authenticate streaming RPCs and preserve bootstrap operation references
- update lifecycle runbooks to use the supported status path