### PR TITLE
ux: hide config integrity digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,10 @@ bundle for all nodes:
 ```sh
 katlctl config validate ./cluster.yaml
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
-sha256sum ./katl-lab.katlcfg
 ```
 
-Keep both the printed `bundleDigest` and the archive SHA-256. They protect
-different layers and are not interchangeable.
+Katl verifies the bundle's content-addressed structure whenever it reads the
+file; operators do not need to copy or pass its internal digests.
 
 ### 3. Install each node
 
@@ -157,7 +156,6 @@ node by name:
 
 ```sh
 INSTALLER_ENDPOINT=http://192.0.2.10:8080
-BUNDLE_DIGEST='sha256:...'
 umask 077
 read -rsp 'Installer token: ' INSTALL_TOKEN; printf '\n'
 printf '%s\n' "$INSTALL_TOKEN" > ./installer.token
@@ -167,7 +165,6 @@ katlctl install apply \
   --endpoint "$INSTALLER_ENDPOINT" \
   --token-file ./installer.token \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --node cp-1
 ```
 
@@ -186,15 +183,13 @@ activation. Kubernetes bootstrap is a separate operator action.
 ### 4. Bootstrap Kubernetes
 
 Once all installed nodes are reachable through their `katlc` endpoints, use the
-same config bundle and its internal digest. First retrieve each node's distinct
+same config bundle. First retrieve each node's distinct
 agent token over SSH and populate the per-node `file:` credential references as
 described in [Access installed nodes](docs/operations/access.md):
 
 ```sh
-BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig
@@ -246,21 +241,19 @@ Remove `--plan` only after reviewing the response. Automated fleet rollout and
 Kubernetes version upgrade execution are not supported alpha workflows.
 
 Every accepted config, host-upgrade, bootstrap, and destructive-reset response
-includes an `operationId` and `requestDigest`. Query a snapshot or follow it to
-terminal state through the same node agent:
+includes an `operationId`. Query a snapshot or follow it to terminal state
+through the same node agent:
 
 ```sh
 katlctl operation status \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --watch
 ```
 
-The digest binds the query to the exact accepted request. Watch streams are an
-optimization; `katlctl` falls back to the node's authoritative persisted status
-if a stream is interrupted.
+Watch streams are an optimization; `katlctl` falls back to the node's
+authoritative persisted status if a stream is interrupted.
 
 ## Release artifacts
 

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -25,15 +25,14 @@ const (
 )
 
 type installApplyOptions struct {
-	endpoint     string
-	token        string
-	tokenFile    string
-	bundlePath   string
-	bundleDigest string
-	nodeName     string
-	noWait       bool
-	timeout      time.Duration
-	output       string
+	endpoint   string
+	token      string
+	tokenFile  string
+	bundlePath string
+	nodeName   string
+	noWait     bool
+	timeout    time.Duration
+	output     string
 }
 
 type installStatusOptions struct {
@@ -47,7 +46,6 @@ type installHandoffReport struct {
 	Kind         string                `json:"kind"`
 	Endpoint     string                `json:"endpoint"`
 	SelectedNode string                `json:"selectedNode,omitempty"`
-	BundleDigest string                `json:"bundleDigest,omitempty"`
 	Handoff      handoff.HandoffStatus `json:"handoff"`
 }
 
@@ -72,7 +70,6 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	cmd.Flags().StringVar(&opts.token, "token", "", "one-time installer token; --token-file avoids shell history exposure")
 	cmd.Flags().StringVar(&opts.tokenFile, "token-file", "", "protected file containing the one-time installer token")
 	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "verified Katl config bundle")
-	cmd.Flags().StringVar(&opts.bundleDigest, "config-bundle-digest", "", "expected internal config bundle manifest digest")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the config bundle")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
@@ -114,9 +111,6 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if strings.TrimSpace(opts.bundlePath) == "" {
 		return fmt.Errorf("--config-bundle is required")
 	}
-	if strings.TrimSpace(opts.bundleDigest) == "" {
-		return fmt.Errorf("--config-bundle-digest is required")
-	}
 	if strings.TrimSpace(opts.nodeName) == "" {
 		return fmt.Errorf("--node is required")
 	}
@@ -124,7 +118,6 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 		return err
 	}
 	selected, err := configbundle.ReadSelectedNodeFile(opts.bundlePath, configbundle.ReadOptions{
-		ExpectedDigest:          opts.bundleDigest,
 		NodeName:                opts.nodeName,
 		AllowMissingKatlosImage: true,
 	})
@@ -147,7 +140,7 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if err != nil {
 		return redactInstallError(err, token)
 	}
-	report := newInstallHandoffReport(endpoint, selected.Node.Name, selected.BundleDigest, accepted)
+	report := newInstallHandoffReport(endpoint, selected.Node.Name, accepted)
 	if opts.noWait {
 		return writeInstallReport(stdout, report)
 	}
@@ -183,7 +176,7 @@ func runInstallStatus(ctx context.Context, opts installStatusOptions, stdout, st
 	if err != nil {
 		return err
 	}
-	return writeInstallReport(stdout, newInstallHandoffReport(endpoint, status.SelectedNode, status.InstallStatus.BundleDigest, status))
+	return writeInstallReport(stdout, newInstallHandoffReport(endpoint, status.SelectedNode, status))
 }
 
 func normalizeInstallerEndpoint(value string) (string, error) {
@@ -397,18 +390,21 @@ func requestTimeout(overall time.Duration) time.Duration {
 	return maximum
 }
 
-func newInstallHandoffReport(endpoint, node, digest string, status handoff.HandoffStatus) installHandoffReport {
+func newInstallHandoffReport(endpoint, node string, status handoff.HandoffStatus) installHandoffReport {
 	return installHandoffReport{
 		APIVersion:   installstatus.APIVersion,
 		Kind:         "InstallHandoffReport",
 		Endpoint:     endpoint,
 		SelectedNode: node,
-		BundleDigest: digest,
 		Handoff:      status,
 	}
 }
 
 func writeInstallReport(stdout io.Writer, report installHandoffReport) error {
+	report.Handoff.InstallStatus.BundleDigest = ""
+	report.Handoff.InstallStatus.SourceDigest = ""
+	report.Handoff.InstallStatus.NodeMaterialDigest = ""
+	report.Handoff.InstallStatus.InstallMaterialDigest = ""
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal installer handoff report: %w", err)

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -42,7 +42,7 @@ func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
 }
 
 func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	server, err := handoff.NewHandoffServer("install-token", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +56,6 @@ func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
 		"--endpoint", ts.URL,
 		"--token", "install-token",
 		"--config-bundle", bundlePath,
-		"--config-bundle-digest", bundleDigest,
 		"--node", "cp-1",
 		"--no-wait",
 	}, &stdout, &stderr)
@@ -67,7 +66,7 @@ func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode report: %v\n%s", err, stdout.String())
 	}
-	if report.SelectedNode != "cp-1" || report.BundleDigest != bundleDigest || report.Handoff.State != handoff.HandoffAccepted || !report.Handoff.BundleAccepted {
+	if report.SelectedNode != "cp-1" || report.Handoff.State != handoff.HandoffAccepted || !report.Handoff.BundleAccepted || strings.Contains(stdout.String(), "bundleDigest") {
 		t.Fatalf("report = %#v", report)
 	}
 	payload := server.Bundle()
@@ -77,7 +76,7 @@ func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
 }
 
 func TestInstallApplyReadsProtectedTokenFile(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	server, err := handoff.NewHandoffServer("file-token", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +94,6 @@ func TestInstallApplyReadsProtectedTokenFile(t *testing.T) {
 		"--endpoint", ts.URL,
 		"--token-file", tokenPath,
 		"--config-bundle", bundlePath,
-		"--config-bundle-digest", bundleDigest,
 		"--node", "cp-1",
 		"--no-wait",
 	}, &stdout, &stderr)
@@ -138,7 +136,6 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 		"--endpoint", ts.URL,
 		"--token", "wait-token",
 		"--config-bundle", bundlePath,
-		"--config-bundle-digest", bundleDigest,
 		"--node", "cp-1",
 		"--timeout", "5s",
 	}, &stdout, &stderr)
@@ -155,7 +152,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 }
 
 func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	var statusRequests atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/status", func(w http.ResponseWriter, _ *http.Request) {
@@ -175,7 +172,7 @@ func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "apply", "--endpoint", ts.URL, "--token", "failure-token",
-		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest,
+		"--config-bundle", bundlePath,
 		"--node", "cp-1", "--timeout", "5s",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "failed-before-mutation") || !strings.Contains(err.Error(), "target disk was not found") {
@@ -198,10 +195,10 @@ func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "apply", "--endpoint", ts.URL, "--token", "local-token",
-		"--config-bundle", bundlePath, "--config-bundle-digest", "sha256:" + strings.Repeat("0", 64),
-		"--node", "cp-1", "--no-wait",
+		"--config-bundle", bundlePath,
+		"--node", "missing-node", "--no-wait",
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+	if err == nil || !strings.Contains(err.Error(), "missing-node") {
 		t.Fatalf("run() error = %v", err)
 	}
 	if requests.Load() != 0 {
@@ -210,7 +207,7 @@ func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
 }
 
 func TestInstallApplyRedactsTokenFromHTTPFailure(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	const token = "secret-install-token"
 	var requests atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -226,7 +223,7 @@ func TestInstallApplyRedactsTokenFromHTTPFailure(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "apply", "--endpoint", ts.URL, "--token", token,
-		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest,
+		"--config-bundle", bundlePath,
 		"--node", "cp-1", "--no-wait",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "<redacted>") || strings.Contains(err.Error(), token) {
@@ -260,7 +257,7 @@ func TestInstallApplyRejectsInvalidEndpointAndOversizedBundle(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err = run(context.Background(), []string{
 		"install", "apply", "--endpoint", "http://installer.test:8080", "--token", "token",
-		"--config-bundle", path, "--config-bundle-digest", "sha256:" + strings.Repeat("0", 64), "--node", "cp-1",
+		"--config-bundle", path, "--node", "cp-1",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("oversized bundle error = %v", err)
@@ -281,7 +278,7 @@ func installTestStatus(handoffState handoff.HandoffState, state, step string) ha
 }
 
 func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	var submitted atomic.Bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
@@ -300,7 +297,7 @@ func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "apply", "--endpoint", ts.URL, "--token", "token",
-		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest,
+		"--config-bundle", bundlePath,
 		"--node", "cp-1", "--timeout", "3s",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "became unavailable") || !strings.Contains(err.Error(), "Partition") {
@@ -309,12 +306,12 @@ func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
 }
 
 func TestInstallTokenFlagsAreExclusive(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	for _, args := range [][]string{
 		{"--token", "a", "--token-file", "token-file"},
 		{},
 	} {
-		base := []string{"install", "apply", "--endpoint", "http://installer.test:8080", "--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest, "--node", "cp-1", "--no-wait"}
+		base := []string{"install", "apply", "--endpoint", "http://installer.test:8080", "--config-bundle", bundlePath, "--node", "cp-1", "--no-wait"}
 		base = append(base, args...)
 		var stdout, stderr bytes.Buffer
 		err := run(context.Background(), base, &stdout, &stderr)
@@ -325,7 +322,7 @@ func TestInstallTokenFlagsAreExclusive(t *testing.T) {
 }
 
 func TestInstallTokenFileMustBePrivate(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	tokenPath := filepath.Join(t.TempDir(), "installer.token")
 	if err := os.WriteFile(tokenPath, []byte("token\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -333,7 +330,7 @@ func TestInstallTokenFileMustBePrivate(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "apply", "--endpoint", "http://installer.test:8080", "--token-file", tokenPath,
-		"--config-bundle", bundlePath, "--config-bundle-digest", bundleDigest, "--node", "cp-1", "--no-wait",
+		"--config-bundle", bundlePath, "--node", "cp-1", "--no-wait",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "permissions") {
 		t.Fatalf("run() error = %v", err)

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -141,7 +141,7 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 		if terminal.Result != operation.ResultSucceeded {
 			return fmt.Errorf("node %s stopped rollout: %s: %s", t.node.Name, terminal.Phase, terminal.FailureReason)
 		}
-		summary = append(summary, map[string]string{"node": t.node.Name, "operationID": accepted.OperationId, "requestDigest": accepted.RequestDigest, "result": terminal.Result})
+		summary = append(summary, map[string]string{"node": t.node.Name, "operationID": accepted.OperationId, "result": terminal.Result})
 	}
 	return json.NewEncoder(stdout).Encode(map[string]any{"rolloutID": opts.rolloutID, "coordinator": opts.coordinator, "nodes": summary, "automaticRollback": false})
 }

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -53,6 +53,9 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 	if err := runKubeadmControlPlaneConfig(context.Background(), opts, &stdout); err != nil {
 		t.Fatal(err)
 	}
+	if strings.Contains(stdout.String(), "requestDigest") {
+		t.Fatalf("stdout exposed request digest: %s", stdout.String())
+	}
 	for index, name := range []string{"cp-1", "cp-2", "cp-3"} {
 		requests := clients[name].submitRequests
 		if len(requests) != 2 || !requests[0].DryRun || requests[1].DryRun {

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
 
@@ -218,12 +219,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
-	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(accepted)
-	if err != nil {
-		return fmt.Errorf("marshal operation accepted: %w", err)
-	}
-	_, err = stdout.Write(append(data, '\n'))
-	return err
+	return writeOperationAccepted(stdout, accepted)
 }
 
 type wipeClusterOptions struct {
@@ -499,7 +495,6 @@ type wipeClusterNodeResult struct {
 	Accepted      bool     `json:"accepted"`
 	OperationID   string   `json:"operationID,omitempty"`
 	OperationKind string   `json:"operationKind,omitempty"`
-	RequestDigest string   `json:"requestDigest,omitempty"`
 	Phase         string   `json:"phase,omitempty"`
 	Terminal      bool     `json:"terminal,omitempty"`
 	Result        string   `json:"result,omitempty"`
@@ -721,7 +716,6 @@ func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, re
 			result.Accepted = true
 			result.OperationID = accepted.GetOperationId()
 			result.OperationKind = accepted.GetOperationKind()
-			result.RequestDigest = accepted.GetRequestDigest()
 			if status := accepted.GetInitialStatus(); status != nil {
 				result.Phase = status.GetPhase()
 				result.Terminal = status.GetTerminal()
@@ -915,7 +909,6 @@ type configBundleOptions struct {
 type nodeConfigInputOptions struct {
 	sourcePath     string
 	bundlePath     string
-	bundleDigest   string
 	nodeName       string
 	sourceID       string
 	desiredVersion string
@@ -927,14 +920,11 @@ type configValidationNode struct {
 }
 
 type configValidationReport struct {
-	APIVersion      string                 `json:"apiVersion"`
-	Kind            string                 `json:"kind"`
-	Source          string                 `json:"source"`
-	ClusterName     string                 `json:"clusterName"`
-	SourceDigest    string                 `json:"sourceDigest"`
-	BundleDigest    string                 `json:"bundleDigest"`
-	ArtifactVersion string                 `json:"artifactVersion"`
-	Nodes           []configValidationNode `json:"nodes"`
+	APIVersion  string                 `json:"apiVersion"`
+	Kind        string                 `json:"kind"`
+	Source      string                 `json:"source"`
+	ClusterName string                 `json:"clusterName"`
+	Nodes       []configValidationNode `json:"nodes"`
 }
 
 func newConfigValidateCommand(stdout, stderr io.Writer) *cobra.Command {
@@ -964,14 +954,11 @@ func runConfigValidate(sourcePath string, stdout, stderr io.Writer) error {
 		nodes = append(nodes, configValidationNode{Name: node.Name, SystemRole: node.SystemRole})
 	}
 	report := configValidationReport{
-		APIVersion:      configbundle.APIVersion,
-		Kind:            "ClusterConfigValidation",
-		Source:          sourcePath,
-		ClusterName:     result.Manifest.ClusterName,
-		SourceDigest:    result.Manifest.Source.SourceDigest,
-		BundleDigest:    result.Digest,
-		ArtifactVersion: result.Manifest.ArtifactVersion,
-		Nodes:           nodes,
+		APIVersion:  configbundle.APIVersion,
+		Kind:        "ClusterConfigValidation",
+		Source:      sourcePath,
+		ClusterName: result.Manifest.ClusterName,
+		Nodes:       nodes,
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
@@ -999,11 +986,10 @@ func newConfigSchemaCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 type configBundleReport struct {
-	APIVersion   string `json:"apiVersion"`
-	Kind         string `json:"kind"`
-	Output       string `json:"output"`
-	BundleDigest string `json:"bundleDigest"`
-	ArchiveSize  int64  `json:"archiveSizeBytes"`
+	APIVersion  string `json:"apiVersion"`
+	Kind        string `json:"kind"`
+	Output      string `json:"output"`
+	ArchiveSize int64  `json:"archiveSizeBytes"`
 }
 
 func newConfigBundleCommand(stdout, stderr io.Writer) *cobra.Command {
@@ -1041,11 +1027,10 @@ func runConfigBundle(opts configBundleOptions, stdout, stderr io.Writer) error {
 		return err
 	}
 	report := configBundleReport{
-		APIVersion:   configbundle.APIVersion,
-		Kind:         "ConfigBundleReport",
-		Output:       opts.outputPath,
-		BundleDigest: result.Digest,
-		ArchiveSize:  result.ArchiveSize,
+		APIVersion:  configbundle.APIVersion,
+		Kind:        "ConfigBundleReport",
+		Output:      opts.outputPath,
+		ArchiveSize: result.ArchiveSize,
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
@@ -1080,7 +1065,6 @@ func newConfigRenderNodeCommand(stdout, stderr io.Writer) *cobra.Command {
 func addNodeConfigInputFlags(cmd *cobra.Command, opts *nodeConfigInputOptions) {
 	cmd.Flags().StringVar(&opts.sourcePath, "source", "", "ClusterConfig source YAML")
 	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "verified Katl config bundle")
-	cmd.Flags().StringVar(&opts.bundleDigest, "config-bundle-digest", "", "expected internal config bundle manifest digest")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from cluster intent")
 	cmd.Flags().StringVar(&opts.sourceID, "source-id", "", "runtime configuration source id; defaults to the cluster name")
 	cmd.Flags().StringVar(&opts.desiredVersion, "desired-version", "", "monotonic unsigned runtime configuration version")
@@ -1098,15 +1082,7 @@ func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) 
 	if strings.TrimSpace(opts.desiredVersion) == "" {
 		return nil, fmt.Errorf("--desired-version is required")
 	}
-	if fromSource && strings.TrimSpace(opts.bundleDigest) != "" {
-		return nil, fmt.Errorf("--config-bundle-digest requires --config-bundle")
-	}
-	if fromBundle && strings.TrimSpace(opts.bundleDigest) == "" {
-		return nil, fmt.Errorf("--config-bundle-digest is required with --config-bundle")
-	}
-
 	readOptions := configbundle.ReadOptions{
-		ExpectedDigest:          opts.bundleDigest,
 		NodeName:                opts.nodeName,
 		AllowMissingKatlosImage: true,
 	}
@@ -1217,8 +1193,8 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	var configYAML []byte
 	var err error
 	if fileInput {
-		if strings.TrimSpace(opts.nodeConfig.bundleDigest) != "" || strings.TrimSpace(opts.nodeConfig.sourceID) != "" || strings.TrimSpace(opts.nodeConfig.desiredVersion) != "" {
-			return fmt.Errorf("--config-bundle-digest, --source-id, and --desired-version require --source or --config-bundle")
+		if strings.TrimSpace(opts.nodeConfig.sourceID) != "" || strings.TrimSpace(opts.nodeConfig.desiredVersion) != "" {
+			return fmt.Errorf("--source-id and --desired-version require --source or --config-bundle")
 		}
 		configYAML, err = os.ReadFile(opts.configPath)
 		if err != nil {
@@ -1256,7 +1232,9 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		if err != nil {
 			return err
 		}
-		data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(result)
+		publicResult := proto.Clone(result).(*agentapi.ConfigValidationResult)
+		publicResult.RequestDigest = ""
+		data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(publicResult)
 		if err != nil {
 			return fmt.Errorf("marshal validation result: %w", err)
 		}
@@ -1325,12 +1303,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
-	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(accepted)
-	if err != nil {
-		return fmt.Errorf("marshal operation accepted: %w", err)
-	}
-	_, err = stdout.Write(append(data, '\n'))
-	return err
+	return writeOperationAccepted(stdout, accepted)
 }
 
 func configApplyOperationKind(acceptedMode string) (string, error) {
@@ -1556,7 +1529,6 @@ type clusterBootstrapOptions struct {
 	addresses                              addressOverrides
 	inventoryPath                          string
 	configBundlePath                       string
-	configBundleDigest                     string
 	initNode                               string
 	joinWorker                             string
 	controlPlaneEndpoint                   string
@@ -1585,7 +1557,6 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster bootstrap inventory")
 	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to verified Katl config bundle")
-	cmd.Flags().StringVar(&opts.configBundleDigest, "config-bundle-digest", "", "expected internal config bundle manifest digest")
 	cmd.Flags().StringVar(&opts.initNode, "init-node", "", "first control-plane node for kubeadm init")
 	cmd.Flags().StringVar(&opts.joinWorker, "join-worker", "", "join one fresh worker to an already initialized cluster without rerunning kubeadm init")
 	cmd.Flags().StringVar(&opts.controlPlaneEndpoint, "control-plane-endpoint", "", "control-plane endpoint host:port")
@@ -1670,9 +1641,6 @@ func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, erro
 		return inventory.Inventory{}, fmt.Errorf("--config-bundle and --inventory are mutually exclusive")
 	}
 	if bundlePath == "" {
-		if strings.TrimSpace(opts.configBundleDigest) != "" {
-			return inventory.Inventory{}, fmt.Errorf("--config-bundle-digest requires --config-bundle")
-		}
 		return loadInventory(inventoryPath)
 	}
 	if strings.TrimSpace(opts.kubernetesBundle) != "" {
@@ -1681,7 +1649,7 @@ func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, erro
 	if strings.TrimSpace(opts.controlPlaneEndpoint) != "" {
 		return inventory.Inventory{}, fmt.Errorf("--control-plane-endpoint conflicts with the endpoint embedded in --config-bundle")
 	}
-	bundle, err := configbundle.ReadBundleFile(bundlePath, opts.configBundleDigest)
+	bundle, err := configbundle.ReadBundleFile(bundlePath, "")
 	if err != nil {
 		return inventory.Inventory{}, err
 	}
@@ -1781,7 +1749,7 @@ func printBootstrapResult(stdout io.Writer, result cluster.Result) {
 	for _, phase := range result.Phases {
 		operationFields := ""
 		if phase.OperationID != "" {
-			operationFields = fmt.Sprintf(" operation-id=%s request-digest=%s", phase.OperationID, phase.RequestDigest)
+			operationFields = fmt.Sprintf(" operation-id=%s", phase.OperationID)
 		}
 		if phase.Node != "" {
 			fmt.Fprintf(stdout, "phase=%s node=%s status=%s%s\n", phase.Name, phase.Node, phase.Status, operationFields)

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -188,14 +188,13 @@ func TestConfigBundleCommandWritesBundle(t *testing.T) {
 		t.Fatalf("output bundle is empty")
 	}
 	var report struct {
-		Kind         string `json:"kind"`
-		Output       string `json:"output"`
-		BundleDigest string `json:"bundleDigest"`
+		Kind   string `json:"kind"`
+		Output string `json:"output"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
 	}
-	if report.Kind != "ConfigBundleReport" || report.Output != outputPath || !strings.HasPrefix(report.BundleDigest, "sha256:") {
+	if report.Kind != "ConfigBundleReport" || report.Output != outputPath || strings.Contains(stdout.String(), "Digest") {
 		t.Fatalf("report = %#v", report)
 	}
 }
@@ -243,7 +242,7 @@ func TestConfigRenderNodeFromMediaBundle(t *testing.T) {
 	if err := os.WriteFile(sourcePath, []byte(source[:imageStart]+source[defaultsStart:]), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{SourcePath: sourcePath})
+	archive, _, err := configbundle.BuildArchive(configbundle.BuildRequest{SourcePath: sourcePath})
 	if err != nil {
 		t.Fatalf("BuildArchive() error = %v", err)
 	}
@@ -256,7 +255,6 @@ func TestConfigRenderNodeFromMediaBundle(t *testing.T) {
 	if err := run(context.Background(), []string{
 		"config", "render-node",
 		"--config-bundle", bundlePath,
-		"--config-bundle-digest", result.Digest,
 		"--node", "cp-1",
 		"--desired-version", "2",
 	}, &stdout, &stderr); err != nil {
@@ -300,8 +298,8 @@ func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	if report.Kind != "ClusterConfigValidation" || report.ClusterName != "lab" || report.Source != sourcePath {
 		t.Fatalf("report = %#v", report)
 	}
-	if !strings.HasPrefix(report.SourceDigest, "sha256:") || !strings.HasPrefix(report.BundleDigest, "sha256:") || !strings.HasPrefix(report.ArtifactVersion, "sha256:") {
-		t.Fatalf("report digests = %#v", report)
+	if strings.Contains(stdout.String(), "Digest") || strings.Contains(stdout.String(), "artifactVersion") {
+		t.Fatalf("report exposes integrity plumbing = %s", stdout.String())
 	}
 	if len(report.Nodes) != 1 || report.Nodes[0] != (configValidationNode{Name: "cp-1", SystemRole: "control-plane"}) {
 		t.Fatalf("resolved nodes = %#v", report.Nodes)
@@ -315,8 +313,8 @@ func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &bundleReport); err != nil {
 		t.Fatalf("decode bundle stdout: %v\n%s", err, stdout.String())
 	}
-	if bundleReport.BundleDigest != report.BundleDigest {
-		t.Fatalf("bundle digest = %q, validation predicted %q", bundleReport.BundleDigest, report.BundleDigest)
+	if bundleReport.Output != outputPath || strings.Contains(stdout.String(), "Digest") {
+		t.Fatalf("bundle report = %#v\n%s", bundleReport, stdout.String())
 	}
 }
 
@@ -694,7 +692,7 @@ func TestClusterBootstrapRequiresInventory(t *testing.T) {
 }
 
 func TestClusterBootstrapUsesConfigBundleInventory(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	var got cluster.Request
 	old := runAgentBootstrap
 	runAgentBootstrap = func(_ context.Context, request cluster.Request, _ cluster.AgentBootstrapDependencies) (cluster.Result, error) {
@@ -707,7 +705,6 @@ func TestClusterBootstrapUsesConfigBundleInventory(t *testing.T) {
 	err := run(context.Background(), []string{
 		"cluster", "bootstrap",
 		"--config-bundle", bundlePath,
-		"--config-bundle-digest", bundleDigest,
 		"--init-node", "cp-1",
 		"--dry-run",
 	}, &stdout, &stderr)
@@ -1371,7 +1368,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 	if fake.stageRequest == nil || fake.stageRequest.CandidateGenerationId != "generation-1" || fake.stageRequest.ClientRequestId != "req-stage" || fake.stageRequest.Actor != "katlctl config apply" {
 		t.Fatalf("stage request = %+v", fake.stageRequest)
 	}
-	if !strings.Contains(stdout.String(), `"operationId"`) || !strings.Contains(stdout.String(), `"generation-stage-01"`) {
+	if !strings.Contains(stdout.String(), `"operationId"`) || !strings.Contains(stdout.String(), `"generation-stage-01"`) || strings.Contains(stdout.String(), "requestDigest") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }
@@ -1413,7 +1410,7 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 	if request.HostUpgrade.ImageUrl != "https://updates.example.test/katlos-upgrade.squashfs" || request.HostUpgrade.ImageSha256 != strings.Repeat("b", 64) || request.HostUpgrade.CandidateGenerationId != "generation-upgrade-1" {
 		t.Fatalf("host upgrade request = %+v", request.HostUpgrade)
 	}
-	if !strings.Contains(stdout.String(), "host-upgrade-01") {
+	if !strings.Contains(stdout.String(), "host-upgrade-01") || strings.Contains(stdout.String(), "requestDigest") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }
@@ -1467,7 +1464,7 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 	if fake.stageRequest != nil || fake.applyRequest != nil {
 		t.Fatalf("direct mutation request was sent: stage=%+v apply=%+v", fake.stageRequest, fake.applyRequest)
 	}
-	if !strings.Contains(stdout.String(), `"operationId"`) || !strings.Contains(stdout.String(), `"generation-apply-auto-01"`) {
+	if !strings.Contains(stdout.String(), `"operationId"`) || !strings.Contains(stdout.String(), `"generation-apply-auto-01"`) || strings.Contains(stdout.String(), "requestDigest") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }
@@ -1516,13 +1513,13 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
 		t.Fatalf("decode stdout = %v: %s", err, stdout.String())
 	}
-	if output["accepted"] != true || output["candidateGenerationId"] != "generation-plan" || !strings.Contains(stdout.String(), `"networkd"`) {
+	if output["accepted"] != true || output["candidateGenerationId"] != "generation-plan" || !strings.Contains(stdout.String(), `"networkd"`) || strings.Contains(stdout.String(), "requestDigest") {
 		t.Fatalf("stdout = %s", stdout.String())
 	}
 }
 
 func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	bundlePath, _ := writeConfigBundle(t)
 	fake := &fakeKatlcAgentClient{
 		validateResult: &agentapi.ConfigValidationResult{
 			Accepted:              true,
@@ -1551,7 +1548,6 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 		"config", "apply",
 		"--endpoint", "node-a.example.test:9443",
 		"--config-bundle", bundlePath,
-		"--config-bundle-digest", bundleDigest,
 		"--node", "cp-1",
 		"--desired-version", "2",
 		"--candidate-generation", "generation-bundle",
@@ -1687,14 +1683,31 @@ func TestAddressOverrideValidation(t *testing.T) {
 func TestPrintBootstrapResultIncludesOperationReference(t *testing.T) {
 	var stdout bytes.Buffer
 	printBootstrapResult(&stdout, cluster.Result{Phases: []cluster.Phase{{
-		Name:          "bootstrap-init",
-		Node:          "cp-1",
-		Status:        "failed",
-		OperationID:   "bootstrap-init-1",
-		RequestDigest: "digest-1",
+		Name:        "bootstrap-init",
+		Node:        "cp-1",
+		Status:      "failed",
+		OperationID: "bootstrap-init-1",
 	}}})
-	if got := stdout.String(); !strings.Contains(got, "operation-id=bootstrap-init-1 request-digest=digest-1") {
+	if got := stdout.String(); !strings.Contains(got, "operation-id=bootstrap-init-1") || strings.Contains(got, "digest") {
 		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestOperatorCommandsHideIntegrityDigestFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"install", "apply", "--help"},
+		{"config", "render-node", "--help"},
+		{"config", "apply", "--help"},
+		{"cluster", "bootstrap", "--help"},
+		{"operation", "status", "--help"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
+			t.Fatalf("run(%v) error = %v", args, err)
+		}
+		if strings.Contains(stdout.String(), "config-bundle-digest") || strings.Contains(stdout.String(), "request-digest") {
+			t.Fatalf("run(%v) exposed digest plumbing:\n%s", args, stdout.String())
+		}
 	}
 }
 

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const operationWatchRPCDuration = 5 * time.Second
@@ -27,7 +28,6 @@ type operationStatusOptions struct {
 	endpoint       string
 	agentTokenFile string
 	operationID    string
-	requestDigest  string
 	diagnostics    string
 	watch          bool
 	timeout        time.Duration
@@ -53,7 +53,6 @@ func newOperationStatusCommand(ctx context.Context, stdout, stderr io.Writer) *c
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
 	cmd.Flags().StringVar(&opts.operationID, "operation-id", "", "accepted operation id")
-	cmd.Flags().StringVar(&opts.requestDigest, "request-digest", "", "expected request digest returned at acceptance")
 	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
 	cmd.Flags().BoolVar(&opts.watch, "watch", false, "follow the operation until it reaches terminal state")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall status or watch timeout")
@@ -90,9 +89,8 @@ func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout
 	defer conn.Close()
 
 	request := &agentapi.GetOperationRequest{
-		OperationId:           strings.TrimSpace(opts.operationID),
-		ExpectedRequestDigest: strings.TrimSpace(opts.requestDigest),
-		IncludeDiagnostics:    opts.diagnostics,
+		OperationId:        strings.TrimSpace(opts.operationID),
+		IncludeDiagnostics: opts.diagnostics,
 	}
 	status, err := conn.Client.GetOperation(requestCtx, request)
 	if err != nil {
@@ -200,9 +198,28 @@ func writeOperationStatus(stdout io.Writer, status *agentapi.OperationStatus) er
 	if status == nil {
 		return fmt.Errorf("agent returned an empty operation status")
 	}
-	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(status)
+	publicStatus := proto.Clone(status).(*agentapi.OperationStatus)
+	publicStatus.RequestDigest = ""
+	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(publicStatus)
 	if err != nil {
 		return fmt.Errorf("marshal operation status: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func writeOperationAccepted(stdout io.Writer, accepted *agentapi.OperationAccepted) error {
+	if accepted == nil {
+		return fmt.Errorf("agent returned an empty operation acceptance")
+	}
+	publicAccepted := proto.Clone(accepted).(*agentapi.OperationAccepted)
+	publicAccepted.RequestDigest = ""
+	if publicAccepted.InitialStatus != nil {
+		publicAccepted.InitialStatus.RequestDigest = ""
+	}
+	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(publicAccepted)
+	if err != nil {
+		return fmt.Errorf("marshal operation accepted: %w", err)
 	}
 	_, err = stdout.Write(append(data, '\n'))
 	return err

--- a/cmd/katlctl/operation_test.go
+++ b/cmd/katlctl/operation_test.go
@@ -48,7 +48,6 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 				"--endpoint", "node.test:9443",
 				"--agent-token-file", tokenPath,
 				"--operation-id", "operation-1",
-				"--request-digest", strings.Repeat("a", 64),
 				"--diagnostics", "verbose",
 			}, &stdout, &stderr)
 			if err != nil {
@@ -61,7 +60,10 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 			if got.GetOperationKind() != kind || !got.GetRecoveryRequired() || got.GetFailureReason() != "operator recovery is required" {
 				t.Fatalf("status = %#v", &got)
 			}
-			if client.operationRequest.GetExpectedRequestDigest() != strings.Repeat("a", 64) || client.operationRequest.GetIncludeDiagnostics() != "verbose" {
+			if got.GetRequestDigest() != "" || strings.Contains(stdout.String(), "requestDigest") {
+				t.Fatalf("status exposed request digest: %s", stdout.String())
+			}
+			if client.operationRequest.GetExpectedRequestDigest() != "" || client.operationRequest.GetIncludeDiagnostics() != "verbose" {
 				t.Fatalf("request = %#v", client.operationRequest)
 			}
 		})

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -229,12 +229,10 @@ Validate the complete source without writing output, then compile it:
 ```sh
 katlctl config validate ./cluster.yaml
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
-sha256sum ./katl-lab.katlcfg
 ```
 
-Save both values printed by these commands. `bundleDigest` identifies the
-verified bundle manifest inside the archive; the `sha256sum` value protects the
-archive bytes while a PXE node downloads them. They are different digests.
+Katl derives and verifies the bundle's content-addressed integrity metadata
+whenever it reads the file. Operators do not need to retain or pass it.
 
 The destructive guard has two parts: the resolved node must set
 `install.wipeTarget: true`, and boot input must set `katl.install.mode=auto`.
@@ -265,7 +263,6 @@ Current bundle-oriented kernel arguments are:
 ```text
 katl.bundle.url=<config bundle URL>
 katl.bundle.sha256=<config bundle archive SHA-256>
-katl.bundle.digest=<internal bundle manifest digest>
 katl.bundle=<local config bundle path>
 katl.node=<node name>
 katl.install.mode=auto
@@ -276,8 +273,8 @@ ip=...
 ```
 
 A URL bundle must have `katl.bundle.sha256`; otherwise it cannot authorize disk
-mutation. Supplying `katl.bundle.digest` is strongly recommended and detects a
-valid archive that contains the wrong compiled cluster. Without input, or with
+mutation. The installer derives the internal bundle identity after verifying
+the downloaded archive. Without input, or with
 `katl.wait-for-config=1`, the installer waits for handoff. Debug mode never
 starts an install.
 
@@ -288,13 +285,12 @@ Illustrative iPXE entry for `cp-1`:
 set base https://boot.example.invalid/katl/2026.7.0
 set node cp-1
 set bundle_sha <config-bundle-archive-sha256>
-set bundle_digest sha256:<internal-bundle-manifest-digest>
-kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.bundle.sha256=${bundle_sha} katl.bundle.digest=${bundle_digest} katl.install.mode=auto
+kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.bundle.sha256=${bundle_sha} katl.install.mode=auto
 initrd ${base}/katl-installer.initrd
 boot
 ```
 
-Matchbox profiles carry the same five `katl.*` arguments. Groups should select
+Matchbox profiles carry the same four `katl.*` arguments. Groups should select
 only `katl.node`; they do not need a different bundle URL or archive digest per
 node. Katl does not create or operate DHCP, iPXE, or matchbox configuration.
 
@@ -319,7 +315,6 @@ Copy the one-time token from the console into a protected temporary file, then
 submit the verified bundle:
 
 ```sh
-BUNDLE_DIGEST='sha256:...'
 umask 077
 read -rsp 'Installer token: ' INSTALL_TOKEN; printf '\n'
 printf '%s\n' "$INSTALL_TOKEN" > ./installer.token
@@ -329,15 +324,14 @@ katlctl install apply \
   --endpoint "$INSTALLER_ENDPOINT" \
   --token-file ./installer.token \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --node cp-1
 
 rm -f ./installer.token
 ```
 
 For the worker, boot the same ISO and submit the same file with
-`--node worker-1`. `katlctl install apply` validates the archive, internal
-bundle digest, and selected node before contacting the installer. The installer
+`--node worker-1`. `katlctl install apply` validates the archive integrity and
+selected node before contacting the installer. The installer
 then validates the compiled install material and embedded KatlOS image before
 it can mutate the selected disk. The endpoint refuses later submissions.
 
@@ -366,7 +360,7 @@ unless you are deliberately integrating at that lower-level boundary.
 `katlos-install` validates before destructive disk mutation:
 
 ```text
-config bundle archive and internal manifest digests
+config bundle archive integrity and content descriptors
 selected node and compiled install manifest schema
 destructive install guard
 target disk selector and size
@@ -441,14 +435,11 @@ patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.
 
 After all nodes are installed and reachable through their node-local `katlc`
-management endpoints, bootstrap directly from the same verified bundle. Use the
-`bundleDigest` printed by `katlctl config bundle`, not the archive SHA-256:
+management endpoints, bootstrap directly from the same verified bundle:
 
 ```text
-BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --config-bundle katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
   --kubeconfig-out kubeconfig \
   --overwrite-kubeconfig
@@ -516,12 +507,10 @@ If the source has already been compiled, use the verified bundle instead of
 recompiling it:
 
 ```text
-BUNDLE_DIGEST='sha256:...'
 katlctl config apply validate \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --node cp-1 \
   --desired-version 2 \
   --candidate-generation config-2 \
@@ -587,7 +576,7 @@ installer console output
 journalctl -b
 journalctl -b -u katlos-install.service
 /var/lib/katl/install status and copied manifest files
-the config bundle, selected node name, and both bundle digests
+the config bundle and selected node name
 the KatlOS image metadata and SHA-256 file
 systemctl status katlc-agent.service
 systemctl status katl-boot-complete.target
@@ -597,8 +586,8 @@ Common failures:
 
 ```text
 bundle or selected node rejected
-  Run katlctl config validate again. Check the selected node name, internal
-  bundleDigest, archive SHA-256, SSH authorized keys, system role, kubeadm
+  Run katlctl config validate again. Check the selected node name, SSH
+  authorized keys, system role, kubeadm
   config reference, and target disk. PXE sources must include spec.katlosImage;
   ISO installs derive it from the embedded media descriptor.
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -34,7 +34,6 @@ Keep these artifacts together for the life of an evaluation:
 
 - the exact KatlOS release URL, assets, checksums, and provenance result;
 - the source `ClusterConfig` and compiled `.katlcfg` bundle;
-- both the config bundle archive SHA-256 and its internal `bundleDigest`;
 - the digest-pinned Kubernetes OCI reference;
 - one protected agent token file per node;
 - the kubeconfig, operation IDs, generation IDs, and relevant timestamps; and
@@ -52,8 +51,8 @@ Treat command outcomes precisely:
 Use a unique, stable `--client-request-id` for each intended mutation. Reuse it
 only when retrying the exact same request. Changing inputs requires a new ID.
 
-For every accepted mutation, retain both `operationId` and `requestDigest`.
-Use the generic status path for config apply, host upgrade, bootstrap, and
+For every accepted mutation, retain its `operationId`. Use the generic status
+path for config apply, host upgrade, bootstrap, and
 destructive reset:
 
 ```sh
@@ -61,7 +60,6 @@ katlctl operation status \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --watch
 ```
 

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -7,7 +7,6 @@ an explicit mutation of node-local kubeadm state and the Kubernetes API.
 
 - every intended node completed [generation 0 handoff](access.md);
 - the same verified `.katlcfg` bundle used for installation is available;
-- its internal `bundleDigest` is recorded;
 - each node has a reachable address and protected per-node token file;
 - the Kubernetes bundle reference is digest-pinned and compatible with the
   KatlOS runtime;
@@ -26,11 +25,10 @@ been installed. Do not silently replace the bundle after installation:
 ```sh
 katlctl config validate ./cluster.yaml
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
-sha256sum ./katl-lab.katlcfg
 ```
 
-Use the `bundleDigest` printed by `config bundle`, not the archive SHA-256, in
-the bootstrap command.
+Katl derives and verifies the bundle's integrity metadata when it reads the
+file; it is not an operator input.
 
 ## Dry Run
 
@@ -38,11 +36,9 @@ Validate topology, node access, bundle selection, and bootstrap ordering without
 running kubeadm:
 
 ```sh
-BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --dry-run \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig
 ```
@@ -61,10 +57,8 @@ Kubernetes version, and bundle reference. A dry run must not create generation
 Run the same command without `--dry-run`:
 
 ```sh
-BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig
@@ -77,14 +71,13 @@ Save the command output and returned operation IDs.
 
 Bootstrap waits for its submitted operations, but their node-local records
 remain queryable afterward. If the workstation disconnects or a result is
-unclear, query the affected node with the returned ID and digest:
+unclear, query the affected node with the returned operation ID:
 
 ```sh
 katlctl operation status \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --watch
 ```
 
@@ -96,10 +89,8 @@ management workflow, or explicitly include reviewed manifests and readiness
 conditions:
 
 ```sh
-BUNDLE_DIGEST='sha256:...'
 katlctl cluster bootstrap \
   --config-bundle ./katl-lab.katlcfg \
-  --config-bundle-digest "$BUNDLE_DIGEST" \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --bootstrap-manifest ./cni.yaml \

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -52,10 +52,9 @@ If the source has already been compiled, replace `--source` with:
 
 ```text
 --config-bundle ./katl-lab.katlcfg
---config-bundle-digest "$BUNDLE_DIGEST"
 ```
 
-Set `BUNDLE_DIGEST` to the printed internal digest before using those arguments.
+Katl derives and verifies the bundle's integrity metadata from the file.
 
 ## Apply the Reviewed Request
 
@@ -73,8 +72,8 @@ katlctl config apply \
 ```
 
 Keep the inputs and client request ID identical to the reviewed plan. The JSON
-response records the operation ID, request digest, and initial status. Accepted
-does not mean complete.
+response records the operation ID and initial status. Accepted does not mean
+complete.
 
 Follow the accepted operation before evaluating generation health:
 
@@ -83,7 +82,6 @@ katlctl operation status \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --watch
 ```
 

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -9,7 +9,7 @@ known.
 | Symptom | Primary evidence |
 | --- | --- |
 | Installer never becomes ready | installer console; `katlos-install.service` journal |
-| Config bundle rejected | bundle command output; selected node; both bundle digests |
+| Config bundle rejected | bundle command output; selected node; validation error |
 | Installed node does not complete boot | boot console; boot-health and handoff services |
 | Agent cannot be reached | network path to TCP 9443; `katlc-agent.service`; token file mapping |
 | Bootstrap or join fails | `katlctl` phase output; node operation record; kubelet/containerd/kubeadm journals |
@@ -40,7 +40,6 @@ katlctl operation status \
   --endpoint affected-node.example.test:9443 \
   --agent-token-file ./tokens/affected-node.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --diagnostics verbose
 ```
 
@@ -65,7 +64,7 @@ find /var/lib/katl/install -maxdepth 2 -type f -print
 ```
 
 Also retain the installer console, exact release filename and SHA-256, config
-bundle, selected node, archive SHA-256, internal `bundleDigest`, and disk
+bundle, selected node, and disk
 identity. A failure before validation completes must not repartition the disk;
 record disk state before attempting anything else.
 

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -45,18 +45,16 @@ candidate generation, resource locks, and refusal diagnostics.
 
 ## Stage the Trial
 
-Run the identical command without `--plan`. Save the returned `operationId` and
-`requestDigest`. The response means accepted, not staged successfully.
+Run the identical command without `--plan`. Save the returned `operationId`.
+The response means accepted, not staged successfully.
 
-Follow the accepted operation through the node agent, binding the query to the
-returned request digest:
+Follow the accepted operation through the node agent:
 
 ```sh
 katlctl operation status \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --watch
 ```
 

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -81,9 +81,9 @@ wiped surface, preserved surface, and refusal.
 
 Run the identical command without `--plan` only when the cluster is intentionally
 being discarded. The command submits node-local destructive-reset operations
-and reports their operation IDs, request digests, and initial status.
+and reports their operation IDs and initial status.
 
-For each reported node endpoint, operation ID, and request digest, follow the
+For each reported node endpoint and operation ID, follow the
 node-local reset to terminal state:
 
 ```sh
@@ -91,7 +91,6 @@ katlctl operation status \
   --endpoint worker-1.example.test:9443 \
   --agent-token-file ./tokens/worker-1.token \
   --operation-id "$OPERATION_ID" \
-  --request-digest "$REQUEST_DIGEST" \
   --watch
 ```
 

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -385,8 +385,7 @@ type bootstrapInitResult struct {
 }
 
 type operationReference struct {
-	ID            string
-	RequestDigest string
+	ID string
 }
 
 type workerJoinMaterial struct {
@@ -405,7 +404,7 @@ func submitAndWaitBootstrapInit(ctx context.Context, node inventory.PlannedNode,
 	if err != nil {
 		return bootstrapInitResult{}, fmt.Errorf("submit operation: %w", err)
 	}
-	result := bootstrapInitResult{Operation: operationReference{ID: accepted.GetOperationId(), RequestDigest: accepted.GetRequestDigest()}}
+	result := bootstrapInitResult{Operation: operationReference{ID: accepted.GetOperationId()}}
 	final, err := waitOperationTerminal(ctx, conn.Client, accepted, deps)
 	if err != nil {
 		return result, err
@@ -495,7 +494,7 @@ func submitAndWaitJoin(ctx context.Context, node inventory.PlannedNode, plan inv
 	if err != nil {
 		return operationReference{}, fmt.Errorf("submit operation: %w", err)
 	}
-	operationRef := operationReference{ID: accepted.GetOperationId(), RequestDigest: accepted.GetRequestDigest()}
+	operationRef := operationReference{ID: accepted.GetOperationId()}
 	final, err := waitOperationTerminal(ctx, conn.Client, accepted, deps)
 	if err != nil {
 		return operationRef, err

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -111,7 +111,7 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "bootstrap-init", "control-plane-join", "kubeconfig"}) {
 		t.Fatalf("phases = %#v", got)
 	}
-	if result.Phases[2].OperationID != "bootstrap-init-1" || result.Phases[2].RequestDigest != "digest-init" || result.Phases[3].OperationID != "bootstrap-join-control-plane-1" || result.Phases[3].RequestDigest != "digest-cp-join" {
+	if result.Phases[2].OperationID != "bootstrap-init-1" || result.Phases[3].OperationID != "bootstrap-join-control-plane-1" {
 		t.Fatalf("operation phases = %#v", result.Phases)
 	}
 	if len(cpClient.createMaterialRequests) != 1 {
@@ -146,7 +146,7 @@ func TestRunAgentBootstrapPreservesFailedOperationReference(t *testing.T) {
 		t.Fatalf("RunAgentBootstrap() error = %v", err)
 	}
 	failed := result.Phases[len(result.Phases)-1]
-	if failed.Status != "failed" || failed.OperationID != "bootstrap-init-failed" || failed.RequestDigest != "digest-failed" {
+	if failed.Status != "failed" || failed.OperationID != "bootstrap-init-failed" {
 		t.Fatalf("failed phase = %#v", failed)
 	}
 }

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -131,12 +131,11 @@ type Result struct {
 }
 
 type Phase struct {
-	Name          string                    `json:"name"`
-	Node          string                    `json:"node,omitempty"`
-	Action        inventory.BootstrapAction `json:"action,omitempty"`
-	Status        string                    `json:"status"`
-	OperationID   string                    `json:"operationID,omitempty"`
-	RequestDigest string                    `json:"requestDigest,omitempty"`
+	Name        string                    `json:"name"`
+	Node        string                    `json:"node,omitempty"`
+	Action      inventory.BootstrapAction `json:"action,omitempty"`
+	Status      string                    `json:"status"`
+	OperationID string                    `json:"operationID,omitempty"`
 }
 
 const (
@@ -621,12 +620,11 @@ func (r *Result) addPhase(name, node string, action inventory.BootstrapAction, s
 
 func (r *Result) addOperationPhase(name, node string, action inventory.BootstrapAction, status string, operation operationReference) {
 	r.Phases = append(r.Phases, Phase{
-		Name:          name,
-		Node:          node,
-		Action:        action,
-		Status:        status,
-		OperationID:   operation.ID,
-		RequestDigest: operation.RequestDigest,
+		Name:        name,
+		Node:        node,
+		Action:      action,
+		Status:      status,
+		OperationID: operation.ID,
 	})
 }
 


### PR DESCRIPTION
## Summary

- derive and verify config bundle integrity inside katlctl
- remove config/request digest flags and output from operator workflows
- simplify install, bootstrap, config, operation, PXE, and troubleshooting docs