### PR TITLE
ux: make the supported path homelab first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@ Katl is a greenfield project that produces and maintains KatlOS: an installable,
 
 ## Project Direction
 
+- Optimize the supported KatlOS journey for a home-lab operator on a trusted
+  network. Install, configuration, bootstrap, upgrade, and routine management
+  must work without user-managed hashes, attestations, expected-state digests,
+  or redundant verification steps.
+- Keep structural checks, destructive-action safeguards, and integrity metadata
+  internal and automatic on the normal path. Give users clear errors for inputs
+  Katl cannot apply, but do not turn implementation invariants into operator
+  ceremony. Stricter provenance, pinning, and trust-policy workflows may be
+  available as optional expert paths for users who choose a different threat
+  model.
 - Treat `katlc` as the KatlOS state/configuration command. It accepts user-supplied Katl YAML or configuration, validates it, compiles it into generation-scoped sysext/confext payloads, and applies, stages, reports, or rolls back that runtime state.
 - Use Go for Katl product logic: `katlc`, installer state machines, node/update agents, config validation, disk/update planners, and reusable libraries that need unit tests.
 - Do not write Go just to wrap `mkosi`, `podman`, hypervisor binaries, or `virsh` during early scaffolding. Start with thin scripts for build/boot orchestration and promote to Go only when the wrapper has meaningful parsing, state, or testable behavior. The current supported VM test path is the libvirt-backed `scripts/vmtest-run` world.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ prepares kubeadm-ready nodes; users operate the cluster built on top.
 ClusterConfig YAML
         │
         ▼
-katlctl validate + bundle ───────► one verified .katlcfg for every node
+katlctl config bundle ───────────► one .katlcfg for every node
                                             │
 KatlOS installer ISO ── boot node ◄─────────┘ select node by name
         │
@@ -50,7 +50,7 @@ KatlOS installer ISO ── boot node ◄─────────┘ select n
 immutable generation 0 + node-local katlc agent
         │
         ▼
-katlctl cluster bootstrap ───────► verified Kubernetes OCI bundle
+katlctl cluster bootstrap ───────► Kubernetes OCI bundle
         │
         ▼
 kubeadm cluster handoff ─────────► user-managed CNI, GitOps, and workloads
@@ -67,36 +67,19 @@ arguments, disk safety rules, and troubleshooting, is in the
 [installation guide](docs/installing.md). The outline below shows the normal ISO
 path.
 
-### 1. Download and verify a release
+### 1. Download a release
 
 From the [Katl releases page](https://github.com/katl-dev/katl/releases),
 download these files from the same release:
 
 ```text
 katl-installer.iso
-katl-installer.iso.sha256
 katlctl-<version>-linux-amd64
-katlctl-<version>-linux-amd64.sha256
-SHA256SUMS
-PROVENANCE.md
 ```
 
-Verify transport integrity before using them:
-
-```sh
-sha256sum --ignore-missing --check SHA256SUMS
-```
-
-Authenticate the installer against the release workflow, replacing `<tag>`
-with the exact tag you downloaded:
-
-```sh
-TAG=v2026.7.0-alpha.2
-gh attestation verify katl-installer.iso \
-  --repo katl-dev/katl \
-  --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \
-  --source-ref "refs/tags/$TAG"
-```
+Checksums and GitHub build attestations are also published for operators who
+want to authenticate downloaded artifacts. They are optional on the normal
+trusted-home-network path; see [Verify release artifacts](docs/operations/verify-release.md).
 
 Install the matching operator CLI and confirm its embedded identity:
 
@@ -126,20 +109,19 @@ spec:
   controlPlaneEndpoint: api.katl.test:6443
   kubernetes:
     version: v1.36.0
-    bundle: ghcr.io/katl-dev/kubernetes:<version>@sha256:<oci-manifest-digest>
+    bundle: ghcr.io/katl-dev/kubernetes:<version>
   # defaults, kubeadmConfigs, and nodes omitted here; use the complete example
   # in docs/installing.md.
 ```
 
-Digest pins are strongly recommended. A readable tag is accepted and works
-with Renovate's Docker datasource, but a digest prevents the selected content
-from changing before the operation resolves it.
+Use the readable version tag on the normal path. Katl resolves the selected
+content once for the operation and checks what it downloads internally. An
+immutable digest pin remains available as an optional reproducibility control.
 
-Validate the source without writing output, then compile one content-addressed
-bundle for all nodes:
+Compile one bundle for all nodes. The command checks the source as part of
+building it:
 
 ```sh
-katlctl config validate ./cluster.yaml
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
 ```
 

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -60,7 +60,7 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	opts := installApplyOptions{timeout: 30 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
 		Use:   "apply",
-		Short: "Submit one verified config bundle to a waiting KatlOS installer",
+		Short: "Submit one config bundle to a waiting KatlOS installer",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runInstallApply(ctx, opts, stdout, stderr)
@@ -69,7 +69,7 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL such as http://192.0.2.10:8080")
 	cmd.Flags().StringVar(&opts.token, "token", "", "one-time installer token; --token-file avoids shell history exposure")
 	cmd.Flags().StringVar(&opts.tokenFile, "token-file", "", "protected file containing the one-time installer token")
-	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "verified Katl config bundle")
+	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "Katl config bundle")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the config bundle")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1064,7 +1064,7 @@ func newConfigRenderNodeCommand(stdout, stderr io.Writer) *cobra.Command {
 
 func addNodeConfigInputFlags(cmd *cobra.Command, opts *nodeConfigInputOptions) {
 	cmd.Flags().StringVar(&opts.sourcePath, "source", "", "ClusterConfig source YAML")
-	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "verified Katl config bundle")
+	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "Katl config bundle")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from cluster intent")
 	cmd.Flags().StringVar(&opts.sourceID, "source-id", "", "runtime configuration source id; defaults to the cluster name")
 	cmd.Flags().StringVar(&opts.desiredVersion, "desired-version", "", "monotonic unsigned runtime configuration version")
@@ -1556,11 +1556,11 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster bootstrap inventory")
-	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to verified Katl config bundle")
+	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
 	cmd.Flags().StringVar(&opts.initNode, "init-node", "", "first control-plane node for kubeadm init")
 	cmd.Flags().StringVar(&opts.joinWorker, "join-worker", "", "join one fresh worker to an already initialized cluster without rerunning kubeadm init")
 	cmd.Flags().StringVar(&opts.controlPlaneEndpoint, "control-plane-endpoint", "", "control-plane endpoint host:port")
-	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", "", "Kubernetes OCI bundle image reference; an @sha256 manifest pin is strongly recommended")
+	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", "", "Kubernetes OCI bundle image reference; an @sha256 manifest pin is optional")
 	cmd.Flags().StringVar(&opts.kubeconfigOut, "kubeconfig-out", "", "operator kubeconfig output path")
 	cmd.Flags().BoolVar(&opts.overwriteKubeconfig, "overwrite-kubeconfig", false, "overwrite different existing kubeconfig")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "validate and print the bootstrap plan without running kubeadm")

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -26,7 +26,7 @@ User-managed provisioning
   one compiled cluster config bundle, a selected node name, and credentials
 
 katlos-install
-  verifies the bundle and selects one node's compiled install plan
+  reads the bundle and selects one node's compiled install plan
   binds that plan to the embedded or explicitly supplied KatlOS image
   mutates the selected disk only after validation
   installs generation 0 and records installed-node handoff state
@@ -98,13 +98,16 @@ identity, disk selection, networkd snippets, SSH authorized keys, system role,
 and bootstrap intent in one `ClusterConfig`, then compile one bundle for all
 nodes.
 
-### Verify release provenance
+### Optional: authenticate release artifacts
 
-Each KatlOS tag release includes `SHA256SUMS`, adjacent checksum files, and
-`PROVENANCE.md`. It also includes `katl-installer.packages.tsv`, the resolved
-package inventory for the temporary installer environment used to produce the
-boot media. After downloading the required assets into one directory, verify
-their transport integrity:
+The ISO and matching `katlctl` binary are sufficient for the normal trusted
+home-lab path. Each KatlOS tag also includes `SHA256SUMS`, adjacent checksum
+files, `PROVENANCE.md`, and a resolved package inventory for operators who want
+to authenticate the downloaded bytes. Those checks are optional and do not
+change how KatlOS operates.
+
+To check transport integrity, download the checksum manifest alongside the
+artifacts and run:
 
 ```sh
 sha256sum --ignore-missing --check SHA256SUMS
@@ -135,7 +138,8 @@ and bootstrap inventory, and produces one content-addressed `.katlcfg` archive.
 The same archive is used for every node; boot input selects the node by name.
 
 This two-node example uses DHCP and the KatlOS image embedded in the release ISO.
-Replace the SSH key, Kubernetes OCI digest, node addresses, and stable disk IDs:
+Replace the SSH key, Kubernetes bundle version, node addresses, and stable disk
+IDs:
 
 ```yaml
 apiVersion: config.katl.dev/v1alpha1
@@ -146,7 +150,7 @@ spec:
   controlPlaneEndpoint: api.katl.test:6443
   kubernetes:
     version: v1.36.0
-    bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
+    bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3
   defaults:
     install:
       wipeTarget: true
@@ -224,15 +228,14 @@ The release ISO supplies `katlosImage`, so do not put an external KatlOS URL in
 this source for the ISO flow. PXE uses the same source but adds an explicit
 `spec.katlosImage` descriptor for the published loose SquashFS.
 
-Validate the complete source without writing output, then compile it:
+Compile the source. Katl checks it as part of building the bundle:
 
 ```sh
-katlctl config validate ./cluster.yaml
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
 ```
 
-Katl derives and verifies the bundle's content-addressed integrity metadata
-whenever it reads the file. Operators do not need to retain or pass it.
+Katl maintains the bundle's internal consistency metadata itself. Operators do
+not need to retain or pass it.
 
 The destructive guard has two parts: the resolved node must set
 `install.wipeTarget: true`, and boot input must set `katl.install.mode=auto`.
@@ -312,7 +315,7 @@ katlctl install status --endpoint "$INSTALLER_ENDPOINT"
 ```
 
 Copy the one-time token from the console into a protected temporary file, then
-submit the verified bundle:
+submit the bundle:
 
 ```sh
 umask 077
@@ -404,12 +407,10 @@ Installation does not run `kubeadm`, fetch Kubernetes payloads, or bundle a
 Kubernetes sysext. It stores the node role and bootstrap intent needed for a
 later explicit operator action.
 
-The Kubernetes bundle is one ordinary OCI image reference. For example,
-`spec.kubernetes.bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b`
-means bootstrap must select that exact OCI manifest. During the explicit
-bootstrap operation, `katlc` fetches that bundle, verifies the Katl bundle
-metadata and payload digests, stages the sysext locally, and selects it for
-generation 1. The selected alpha reference above supplies the `v1.36.0`
+The Kubernetes bundle is one ordinary OCI image reference. During the explicit
+bootstrap operation, `katlc` resolves and fetches that bundle, checks its
+contents internally, stages the sysext locally, and selects it for generation
+1. The selected alpha reference above supplies the `v1.36.0`
 payload; a different Kubernetes version requires its matching bundle reference
 and a KatlOS runtime compatible with that bundle.
 
@@ -420,7 +421,8 @@ public `ghcr.io/katl-dev/kubernetes` package. A tag-only reference is accepted:
 ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3
 ```
 
-Pinning the OCI manifest is strongly recommended for reproducible provisioning:
+An immutable OCI manifest pin is optional when exact byte-for-byte
+reproducibility matters:
 
 ```text
 ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
@@ -435,7 +437,7 @@ patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.
 
 After all nodes are installed and reachable through their node-local `katlc`
-management endpoints, bootstrap directly from the same verified bundle:
+management endpoints, bootstrap directly from the same bundle:
 
 ```text
 katlctl cluster bootstrap \
@@ -503,7 +505,7 @@ katlctl config apply validate \
   --client-request-id cp-1-config-2
 ```
 
-If the source has already been compiled, use the verified bundle instead of
+If the source has already been compiled, use the bundle instead of
 recompiling it:
 
 ```text

--- a/docs/internal/alpha-release-readiness.md
+++ b/docs/internal/alpha-release-readiness.md
@@ -26,14 +26,15 @@ One repository-controlled `config.katl.dev/v1alpha1` `ClusterConfig` is the
 operator source of truth:
 
 1. Download `katlctl` and the KatlOS installer ISO from one KatlOS release.
-2. Verify checksums and GitHub build provenance.
-3. Validate the `ClusterConfig` without writing output.
-4. Compile it into one content-addressed Katl config bundle.
-5. Boot the same ISO on every node and select a node from that bundle through
-   local handoff, seed media, or verified PXE URL input.
-6. Reboot installed generation-0 nodes and bootstrap Kubernetes directly from
-   the verified bundle's embedded inventory and Kubernetes selection.
-7. Plan and apply later node configuration through an explicit runtime-change
+2. Optionally authenticate the release with its checksums and GitHub build
+   provenance when that matches the operator's threat model.
+3. Compile the `ClusterConfig` into one Katl config bundle; Katl checks the
+   source and bundle structure as part of this command.
+4. Boot the same ISO on every node and select a node from that bundle through
+   local handoff, seed media, or PXE URL input.
+5. Reboot installed generation-0 nodes and bootstrap Kubernetes directly from
+   the bundle's embedded inventory and Kubernetes selection.
+6. Plan and apply later node configuration through an explicit runtime-change
    interface derived from the same source intent.
 
 The compiled `install.katl.dev/v1alpha1` `InstallManifest` remains an internal
@@ -93,8 +94,8 @@ summary, the alpha may ship with these explicit boundaries:
 - user-managed DHCP, PXE, DNS, CNI, GitOps, storage, ingress, and application
   workloads;
 - only hardware and VM paths named by retained release evidence;
-- tag-only Kubernetes bundle references accepted but immutable digest pins
-  strongly recommended.
+- readable Kubernetes bundle tags on the normal path, with immutable digest
+  pins available as an optional reproducibility control.
 
 ## Beta Blockers
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -13,7 +13,7 @@ evaluation networks.
 
 | Current state | Operator goal | Runbook |
 | --- | --- | --- |
-| No KatlOS media downloaded | Authenticate a release | [Verify release artifacts](verify-release.md) |
+| No KatlOS media downloaded | Download a release | [Install KatlOS](../installing.md) |
 | Bare or disposable machine | Install generation 0 | [Install KatlOS](../installing.md) |
 | Generation 0 booted | Establish node management access | [Access installed nodes](access.md) |
 | All intended nodes installed | Create the kubeadm cluster | [Bootstrap Kubernetes](bootstrap-kubernetes.md) |
@@ -25,16 +25,16 @@ evaluation networks.
 ## Operating Rules
 
 The operator workstation needs the `katlctl` binary from the matching release,
-`ssh`, `curl`, GNU `sha256sum`, and `jq`. Provenance verification additionally
-uses GitHub CLI `gh`; cluster handoff checks use a `kubectl` version compatible
-with the selected Kubernetes release. These tools run on the workstation, not
-inside the KatlOS image.
+`ssh`, `curl`, and `jq`. Optional checksum and provenance inspection uses GNU
+`sha256sum` and GitHub CLI `gh`; cluster handoff checks use a `kubectl` version
+compatible with the selected Kubernetes release. These tools run on the
+workstation, not inside the KatlOS image.
 
 Keep these artifacts together for the life of an evaluation:
 
-- the exact KatlOS release URL, assets, checksums, and provenance result;
+- the KatlOS release URL and assets used;
 - the source `ClusterConfig` and compiled `.katlcfg` bundle;
-- the digest-pinned Kubernetes OCI reference;
+- the Kubernetes OCI reference;
 - one protected agent token file per node;
 - the kubeconfig, operation IDs, generation IDs, and relevant timestamps; and
 - independent etcd, application, and persistent-data backups.

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -6,10 +6,10 @@ an explicit mutation of node-local kubeadm state and the Kubernetes API.
 ## Prerequisites
 
 - every intended node completed [generation 0 handoff](access.md);
-- the same verified `.katlcfg` bundle used for installation is available;
+- the same `.katlcfg` bundle used for installation is available;
 - each node has a reachable address and protected per-node token file;
-- the Kubernetes bundle reference is digest-pinned and compatible with the
-  KatlOS runtime;
+- the Kubernetes bundle reference names a version compatible with the KatlOS
+  runtime;
 - the control-plane endpoint resolves or routes as designed; and
 - independent recovery/backup expectations are understood.
 
@@ -17,18 +17,17 @@ Katl fetches the Kubernetes bundle during this operation. Nodes need registry
 and CA access to `ghcr.io` unless the bundle is supplied through an explicitly
 supported local mechanism.
 
-## Review the Compiled Intent
+## Rebuild Changed Intent
 
-Revalidate the source and, if needed, rebuild the bundle before any node has
-been installed. Do not silently replace the bundle after installation:
+If the source changed before any node was installed, rebuild the bundle. Do not
+silently replace the bundle after installation:
 
 ```sh
-katlctl config validate ./cluster.yaml
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
 ```
 
-Katl derives and verifies the bundle's integrity metadata when it reads the
-file; it is not an operator input.
+Katl maintains the bundle's internal consistency metadata; it is not an
+operator input.
 
 ## Dry Run
 

--- a/docs/operations/verify-release.md
+++ b/docs/operations/verify-release.md
@@ -1,8 +1,11 @@
 # Verify KatlOS Release Artifacts
 
-Use this procedure before booting installation media or staging an upgrade.
-Download every asset in a verification set from one GitHub release; never mix
-files from different tags.
+This is an optional expert workflow for operators who want to authenticate
+downloaded artifacts against the Katl release pipeline. It is not a prerequisite
+for installing or operating KatlOS on the normal trusted home-lab path.
+
+When using it, download every asset in a verification set from one GitHub
+release; never mix files from different tags.
 
 ## Inputs
 
@@ -81,8 +84,9 @@ workflow, source ref, and commit. They do not provide Secure Boot signatures,
 node-side signature enforcement, revocation, downgrade prevention, vulnerability
 scanning guarantees, or a production incident-response commitment.
 
-Kubernetes bundles have their own OCI digest and GitHub provenance. Prefer a
-reference containing both the readable tag and immutable manifest digest:
+Kubernetes bundles have their own OCI digest and GitHub provenance. An operator
+who wants exact byte identity can use a reference containing both the readable
+tag and immutable manifest digest:
 
 ```text
 ghcr.io/katl-dev/kubernetes:<version>@sha256:<oci-manifest-digest>

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -21,14 +21,14 @@ before accepting the operation.
 The current wipe commands accept a low-level bootstrap inventory, not the
 verified `.katlcfg` directly. This is an acknowledged alpha UX gap. The
 inventory must describe the same installed nodes, addresses, roles, per-node
-token references, Kubernetes version, and digest-pinned bundle recorded in the
+token references, Kubernetes version, and bundle reference recorded in the
 compiled cluster intent. Do not use an older inventory merely because its nodes
 are reachable. A two-node shape is:
 
 ```yaml
 controlPlaneEndpoint: api.katl.test:6443
 kubernetesVersion: v1.36.0
-kubernetesBundle: ghcr.io/katl-dev/kubernetes:<version>@sha256:<digest>
+kubernetesBundle: ghcr.io/katl-dev/kubernetes:<version>
 nodes:
   - name: cp-1
     address: 192.0.2.11

--- a/docs/support.md
+++ b/docs/support.md
@@ -34,8 +34,9 @@ application lifecycle.
 
 KatlOS release assets provide SHA-256 checksums and keyless GitHub build-
 provenance attestations. Kubernetes bundles are digest-addressable OCI
-artifacts with GitHub provenance. Verify both before use and prefer immutable
-digest-pinned bundle references.
+artifacts with GitHub provenance. These are optional tools for operators who
+want a stricter supply-chain policy; the normal home-lab path accepts readable
+release and bundle versions and performs its own internal consistency checks.
 
 The current `katlc` management API uses bearer authentication over unencrypted
 TCP. Restrict port 9443 to an isolated evaluation management network. It is not
@@ -101,14 +102,14 @@ using the bug report form. Remove tokens, private keys, kubeconfigs, join
 commands, and other secrets before attaching anything. Include:
 
 - the KatlOS version, release URL, and `katlctl version` output;
-- exact artifact filenames, SHA-256 values, Kubernetes OCI reference and
-  digest, and whether provenance verification passed;
+- exact artifact filenames and Kubernetes OCI reference, plus SHA-256 values
+  or provenance results when they are relevant and available;
 - hardware or hypervisor, firmware/UEFI mode, CPU, storage controller and disk
   identity, and network devices;
 - the smallest redacted `ClusterConfig` and exact command sequence that
   reproduces the problem;
-- relevant operation IDs, generation IDs, config bundle digest, selected node,
-  and failure timestamps; and
+- relevant operation IDs, generation IDs, selected node, and failure
+  timestamps; and
 - redacted installer output, `systemctl` status, `journalctl` output, or retained
   `scripts/vmtest-run` run directory named by the failure.
 


### PR DESCRIPTION
## Summary

- make trusted home-lab operation the explicit product default
- keep checksums, attestations, and digest pins as optional expert controls
- simplify normal install, configuration, bootstrap, and support guidance