### PR TITLE
ux: derive integrity state internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,18 +206,17 @@ artifact. Plan before accepting a next-boot generation:
 TAG=v2026.7.0-alpha.2
 VERSION=${TAG#v}
 IMAGE="katlos-upgrade-$VERSION-x86_64.squashfs"
-IMAGE_SHA256=$(sha256sum "$IMAGE" | awk '{print $1}')
-IMAGE_SIZE=$(stat -c %s "$IMAGE")
 katlctl host upgrade \
   --plan \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --candidate-generation "katlos-$VERSION" \
   --client-request-id "cp-1-katlos-$VERSION" \
-  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE" \
-  --image-sha256 "$IMAGE_SHA256" \
-  --image-size-bytes "$IMAGE_SIZE"
+  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE"
 ```
+
+The node calculates and records the downloaded image identity before changing
+the inactive root slot.
 
 Remove `--plan` only after reviewing the response. Automated fleet rollout and
 Kubernetes version upgrade execution are not supported alpha workflows.

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -17,12 +17,8 @@ import (
 )
 
 type kubeadmControlPlaneConfigOptions struct {
-	inventoryPath, coordinator, generationID, configName               string
-	desiredDigest, liveDigest, payloadVersion, payloadDigest           string
-	rolloutID                                                          string
-	fieldDelta                                                         stringList
-	snapshotRef, snapshotDigest, snapshotRevision, memberDigest        string
-	etcdVersion, snapshotCreatedAt, snapshotLocation, snapshotOperator string
+	inventoryPath, coordinator, generationID, configName string
+	rolloutID                                            string
 }
 
 func newKubeadmControlPlaneConfigCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
@@ -33,20 +29,7 @@ func newKubeadmControlPlaneConfigCommand(ctx context.Context, stdout, stderr io.
 	f.StringVar(&opts.coordinator, "coordinator", "", "coordinator control-plane node changed last")
 	f.StringVar(&opts.generationID, "generation", "", "active desired generation ID")
 	f.StringVar(&opts.configName, "config-name", "", "selected KubeadmConfig name")
-	f.StringVar(&opts.desiredDigest, "desired-config-sha256", "", "canonical desired config SHA-256")
-	f.StringVar(&opts.liveDigest, "expected-live-sha256", "", "expected live kubeadm ConfigMap SHA-256")
-	f.StringVar(&opts.payloadVersion, "kubernetes-version", "", "active Kubernetes payload version")
-	f.StringVar(&opts.payloadDigest, "kubernetes-sha256", "", "active Kubernetes sysext SHA-256")
 	f.StringVar(&opts.rolloutID, "rollout-id", "", "rollout identity")
-	f.Var(&opts.fieldDelta, "field-delta", "supported profiling=false field delta")
-	f.StringVar(&opts.snapshotRef, "snapshot-ref", "", "etcd snapshot reference")
-	f.StringVar(&opts.snapshotDigest, "snapshot-sha256", "", "etcd snapshot SHA-256")
-	f.StringVar(&opts.snapshotRevision, "snapshot-revision", "", "etcd snapshot revision")
-	f.StringVar(&opts.memberDigest, "member-list-sha256", "", "captured etcd member-list SHA-256")
-	f.StringVar(&opts.etcdVersion, "source-etcd-version", "", "source etcd version")
-	f.StringVar(&opts.snapshotCreatedAt, "snapshot-created-at", "", "snapshot RFC3339 creation time")
-	f.StringVar(&opts.snapshotLocation, "snapshot-location", "", "snapshot storage location")
-	f.StringVar(&opts.snapshotOperator, "snapshot-operator", "", "snapshot operator identity")
 	_ = stderr
 	return cmd
 }
@@ -69,13 +52,12 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 	if err != nil {
 		return err
 	}
-	if len(opts.fieldDelta.values) == 0 {
-		return fmt.Errorf("at least one --field-delta is required")
-	}
 	type target struct {
-		node    inventory.Node
-		conn    katlcAgentConnection
-		machine string
+		node           inventory.Node
+		conn           katlcAgentConnection
+		machine        string
+		payloadVersion string
+		payloadSHA256  string
 	}
 	targets := make([]target, 0, 3)
 	defer func() {
@@ -106,16 +88,22 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 		if gen.ConfigApply == nil || !gen.ConfigApply.KubeadmActionRequired || gen.ConfigApply.SelectedKubeadmConfigName != opts.configName {
 			return fmt.Errorf("node %s generation %s does not select kubeadm config %q as action-required", node.Name, opts.generationID, opts.configName)
 		}
-		matched := false
+		payloadVersion := ""
+		payloadSHA256 := ""
 		for _, ref := range gen.Sysexts {
-			if ref.Name == "kubernetes" && ref.PayloadVersion == opts.payloadVersion && ref.Sha256 == opts.payloadDigest {
-				matched = true
+			if ref.Name == "kubernetes" && ref.PayloadVersion != "" && ref.Sha256 != "" {
+				payloadVersion = ref.PayloadVersion
+				payloadSHA256 = ref.Sha256
+				break
 			}
 		}
-		if !matched {
-			return fmt.Errorf("node %s Kubernetes payload does not match rollout", node.Name)
+		if payloadVersion == "" {
+			return fmt.Errorf("node %s generation %s has no active Kubernetes payload", node.Name, opts.generationID)
 		}
-		targets = append(targets, target{node: node, conn: conn, machine: status.MachineId})
+		if len(targets) > 0 && (payloadVersion != targets[0].payloadVersion || payloadSHA256 != targets[0].payloadSHA256) {
+			return fmt.Errorf("node %s active Kubernetes payload does not match %s", node.Name, targets[0].node.Name)
+		}
+		targets = append(targets, target{node: node, conn: conn, machine: status.MachineId, payloadVersion: payloadVersion, payloadSHA256: payloadSHA256})
 	}
 	var summary []map[string]string
 	for i, t := range targets {
@@ -147,7 +135,7 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 }
 
 func kubeadmControlPlaneConfigBody(opts kubeadmControlPlaneConfigOptions, node inventory.Node, position uint32) *agentapi.KubeadmControlPlaneConfigOperationRequest {
-	return &agentapi.KubeadmControlPlaneConfigOperationRequest{RolloutId: opts.rolloutID, NodePosition: position, NodeCount: 3, NodeName: node.Name, CoordinatorNode: opts.coordinator, CoordinatorUpload: node.Name == opts.coordinator, DesiredGenerationId: opts.generationID, ConfigName: opts.configName, DesiredConfigSha256: opts.desiredDigest, ExpectedLiveConfigSha256: opts.liveDigest, KubernetesPayloadVersion: opts.payloadVersion, KubernetesPayloadSha256: opts.payloadDigest, SupportedFieldDelta: append([]string(nil), opts.fieldDelta.values...), SnapshotRef: opts.snapshotRef, SnapshotDigest: opts.snapshotDigest, SnapshotRevision: opts.snapshotRevision, CapturedMemberListDigest: opts.memberDigest, SourceEtcdVersion: opts.etcdVersion, SnapshotCreatedAt: opts.snapshotCreatedAt, SnapshotStorageLocation: opts.snapshotLocation, SnapshotOperatorIdentity: opts.snapshotOperator}
+	return &agentapi.KubeadmControlPlaneConfigOperationRequest{RolloutId: opts.rolloutID, NodePosition: position, NodeCount: 3, NodeName: node.Name, CoordinatorNode: opts.coordinator, CoordinatorUpload: node.Name == opts.coordinator, DesiredGenerationId: opts.generationID, ConfigName: opts.configName}
 }
 
 func orderControlPlanes(nodes []inventory.Node, coordinator string) ([]inventory.Node, error) {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -47,8 +47,7 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 		}
 		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
 	}
-	opts := kubeadmControlPlaneConfigOptions{inventoryPath: inventoryPath, coordinator: "cp-3", generationID: "gen-2", configName: "control-plane", desiredDigest: strings.Repeat("a", 64), liveDigest: strings.Repeat("b", 64), payloadVersion: "v1.36.1", payloadDigest: strings.Repeat("c", 64), rolloutID: "rollout-1", snapshotRef: "snap", snapshotDigest: strings.Repeat("d", 64), snapshotRevision: "42", memberDigest: strings.Repeat("e", 64), etcdVersion: "3.6.5", snapshotCreatedAt: "2026-07-11T08:00:00Z", snapshotLocation: "/var/lib/katl/snap.db", snapshotOperator: "operator"}
-	opts.fieldDelta.values = []string{"ClusterConfiguration.apiServer.extraArgs.profiling=false"}
+	opts := kubeadmControlPlaneConfigOptions{inventoryPath: inventoryPath, coordinator: "cp-3", generationID: "gen-2", configName: "control-plane", rolloutID: "rollout-1"}
 	var stdout bytes.Buffer
 	if err := runKubeadmControlPlaneConfig(context.Background(), opts, &stdout); err != nil {
 		t.Fatal(err)
@@ -64,6 +63,10 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 		req := requests[1]
 		if req == nil || req.KubeadmControlPlaneConfig.NodePosition != uint32(index+1) || req.KubeadmControlPlaneConfig.CoordinatorUpload != (name == "cp-3") {
 			t.Fatalf("%s request=%#v", name, req)
+		}
+		body := req.KubeadmControlPlaneConfig
+		if body.DesiredConfigSha256 != "" || body.ExpectedLiveConfigSha256 != "" || body.KubernetesPayloadSha256 != "" || body.SnapshotDigest != "" || len(body.SupportedFieldDelta) != 0 {
+			t.Fatalf("%s request exposed operator-derived state: %#v", name, body)
 		}
 	}
 }

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -138,8 +138,6 @@ type hostUpgradeOptions struct {
 	agentTokenFile      string
 	imageURL            string
 	imageLocalRef       string
-	imageSHA256         string
-	imageSizeBytes      uint64
 	candidateGeneration string
 	clientRequestID     string
 	actor               string
@@ -151,7 +149,7 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	opts := hostUpgradeOptions{actor: "katlctl host upgrade", output: "json"}
 	cmd := &cobra.Command{
 		Use:   "upgrade",
-		Short: "Stage one verified KatlOS image for bounded next-boot activation",
+		Short: "Stage one KatlOS image for bounded next-boot activation",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runHostUpgrade(ctx, opts, stdout, stderr)
@@ -161,8 +159,6 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
 	cmd.Flags().StringVar(&opts.imageURL, "image-url", "", "HTTPS KatlOS upgrade image URL")
 	cmd.Flags().StringVar(&opts.imageLocalRef, "image-local-ref", "", "relative KatlOS image reference under the node artifact store")
-	cmd.Flags().StringVar(&opts.imageSHA256, "image-sha256", "", "expected KatlOS image SHA-256")
-	cmd.Flags().Uint64Var(&opts.imageSizeBytes, "image-size-bytes", 0, "expected KatlOS image size")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "idempotency key")
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
@@ -185,8 +181,6 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	request := operation.HostUpgrade{
 		ImageURL:              strings.TrimSpace(opts.imageURL),
 		ImageLocalRef:         strings.TrimSpace(opts.imageLocalRef),
-		ImageSHA256:           strings.TrimSpace(opts.imageSHA256),
-		ImageSizeBytes:        opts.imageSizeBytes,
 		CandidateGenerationID: strings.TrimSpace(opts.candidateGeneration),
 	}
 	if err := operation.ValidateHostUpgrade(request); err != nil {
@@ -211,8 +205,6 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
 			ImageUrl:              request.ImageURL,
 			ImageLocalRef:         request.ImageLocalRef,
-			ImageSha256:           request.ImageSHA256,
-			ImageSizeBytes:        request.ImageSizeBytes,
 			CandidateGenerationId: request.CandidateGenerationID,
 		},
 	})

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1395,8 +1395,6 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 		"host", "upgrade",
 		"--endpoint", "node-a.example.test:9443",
 		"--image-url", "https://updates.example.test/katlos-upgrade.squashfs",
-		"--image-sha256", strings.Repeat("b", 64),
-		"--image-size-bytes", "4096",
 		"--candidate-generation", "generation-upgrade-1",
 		"--client-request-id", "req-host-upgrade",
 	}, &stdout, &stderr)
@@ -1407,7 +1405,7 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 	if request == nil || request.OperationKind != "host-upgrade" || request.GetHostUpgrade() == nil {
 		t.Fatalf("submit request = %+v", request)
 	}
-	if request.HostUpgrade.ImageUrl != "https://updates.example.test/katlos-upgrade.squashfs" || request.HostUpgrade.ImageSha256 != strings.Repeat("b", 64) || request.HostUpgrade.CandidateGenerationId != "generation-upgrade-1" {
+	if request.HostUpgrade.ImageUrl != "https://updates.example.test/katlos-upgrade.squashfs" || request.HostUpgrade.ImageSha256 != "" || request.HostUpgrade.ImageSizeBytes != 0 || request.HostUpgrade.CandidateGenerationId != "generation-upgrade-1" {
 		t.Fatalf("host upgrade request = %+v", request.HostUpgrade)
 	}
 	if !strings.Contains(stdout.String(), "host-upgrade-01") || strings.Contains(stdout.String(), "requestDigest") {
@@ -1699,13 +1697,18 @@ func TestOperatorCommandsHideIntegrityDigestFlags(t *testing.T) {
 		{"config", "render-node", "--help"},
 		{"config", "apply", "--help"},
 		{"cluster", "bootstrap", "--help"},
+		{"cluster", "kubeadm-control-plane-config", "--help"},
+		{"host", "upgrade", "--help"},
 		{"operation", "status", "--help"},
 	} {
 		var stdout, stderr bytes.Buffer
 		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
 			t.Fatalf("run(%v) error = %v", args, err)
 		}
-		if strings.Contains(stdout.String(), "config-bundle-digest") || strings.Contains(stdout.String(), "request-digest") {
+		for _, hidden := range []string{"config-bundle-digest", "request-digest", "image-sha256", "image-size-bytes", "desired-config-sha256", "expected-live-sha256", "kubernetes-sha256", "snapshot-sha256", "member-list-sha256", "field-delta"} {
+			if !strings.Contains(stdout.String(), hidden) {
+				continue
+			}
 			t.Fatalf("run(%v) exposed digest plumbing:\n%s", args, stdout.String())
 		}
 	}

--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -317,7 +317,7 @@ func runBootWithHandoff(ctx context.Context, runDir, etcDir, handoffAddr string,
 }
 
 func fetchBundleURL(ctx context.Context, bundleURL, wantSHA256, runDir string) (string, error) {
-	body, err := fetchURLWithSHA256(ctx, bundleURL, wantSHA256, "bundle", 64<<20)
+	body, err := fetchURLWithSHA256(ctx, bundleURL, wantSHA256, "bundle", 64<<20, false)
 	if err != nil {
 		return "", err
 	}
@@ -349,7 +349,7 @@ func fetchBundleURL(ctx context.Context, bundleURL, wantSHA256, runDir string) (
 }
 
 func fetchManifestURL(ctx context.Context, manifestURL, wantSHA256, runDir string) (string, error) {
-	body, err := fetchURLWithSHA256(ctx, manifestURL, wantSHA256, "manifest", 1<<20)
+	body, err := fetchURLWithSHA256(ctx, manifestURL, wantSHA256, "manifest", 1<<20, true)
 	if err != nil {
 		return "", err
 	}
@@ -380,7 +380,7 @@ func fetchManifestURL(ctx context.Context, manifestURL, wantSHA256, runDir strin
 	return path, nil
 }
 
-func fetchURLWithSHA256(ctx context.Context, rawURL, wantSHA256, label string, limit int64) ([]byte, error) {
+func fetchURLWithSHA256(ctx context.Context, rawURL, wantSHA256, label string, limit int64, requireDigest bool) ([]byte, error) {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
 		return nil, fmt.Errorf("parse %s URL: invalid URL", label)
@@ -392,11 +392,16 @@ func fetchURLWithSHA256(ctx context.Context, rawURL, wantSHA256, label string, l
 		return nil, fmt.Errorf("%s URL missing host", label)
 	}
 	wantSHA256 = strings.ToLower(strings.TrimSpace(wantSHA256))
-	if len(wantSHA256) != 64 {
+	if requireDigest && wantSHA256 == "" {
 		return nil, fmt.Errorf("%s URL requires %sSHA256", label, label)
 	}
-	if _, err := hex.DecodeString(wantSHA256); err != nil {
-		return nil, fmt.Errorf("%sSHA256 is not valid hex: %w", label, err)
+	if wantSHA256 != "" {
+		if len(wantSHA256) != 64 {
+			return nil, fmt.Errorf("%sSHA256 must be 64 hexadecimal characters", label)
+		}
+		if _, err := hex.DecodeString(wantSHA256); err != nil {
+			return nil, fmt.Errorf("%sSHA256 is not valid hex: %w", label, err)
+		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 	if err != nil {
@@ -424,7 +429,7 @@ func fetchURLWithSHA256(ctx context.Context, rawURL, wantSHA256, label string, l
 		return nil, fmt.Errorf("%s URL response exceeds %d bytes", label, limit)
 	}
 	gotSHA256 := sha256.Sum256(body)
-	if got := hex.EncodeToString(gotSHA256[:]); got != wantSHA256 {
+	if got := hex.EncodeToString(gotSHA256[:]); wantSHA256 != "" && got != wantSHA256 {
 		return nil, fmt.Errorf("%s URL digest mismatch: got %s want %s", label, got, wantSHA256)
 	}
 	return body, nil

--- a/cmd/katlos-install/main_test.go
+++ b/cmd/katlos-install/main_test.go
@@ -244,6 +244,32 @@ func TestFetchBundleURL(t *testing.T) {
 	}
 }
 
+func TestFetchBundleURLDerivesDigestWhenNotSupplied(t *testing.T) {
+	bundle := []byte("bundle archive")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bundle)
+	}))
+	t.Cleanup(server.Close)
+
+	path, err := fetchBundleURL(context.Background(), server.URL+"/cluster.katlcfg", "", t.TempDir())
+	if err != nil {
+		t.Fatalf("fetchBundleURL() error = %v", err)
+	}
+	assertFile(t, path, "bundle archive")
+}
+
+func TestFetchBundleURLRejectsOptionalDigestMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("bundle archive"))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := fetchBundleURL(context.Background(), server.URL+"/cluster.katlcfg", strings.Repeat("a", 64), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("fetchBundleURL() error = %v, want optional digest mismatch", err)
+	}
+}
+
 func TestFetchManifestURL(t *testing.T) {
 	manifest := []byte(`{"apiVersion":"install.katl.dev/v1alpha1","kind":"InstallManifest"}`)
 	digest := sha256.Sum256(manifest)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -265,7 +265,7 @@ Current bundle-oriented kernel arguments are:
 
 ```text
 katl.bundle.url=<config bundle URL>
-katl.bundle.sha256=<config bundle archive SHA-256>
+katl.bundle.sha256=<optional expected config bundle archive SHA-256>
 katl.bundle=<local config bundle path>
 katl.node=<node name>
 katl.install.mode=auto
@@ -275,9 +275,9 @@ console=...
 ip=...
 ```
 
-A URL bundle must have `katl.bundle.sha256`; otherwise it cannot authorize disk
-mutation. The installer derives the internal bundle identity after verifying
-the downloaded archive. Without input, or with
+The installer calculates the downloaded archive identity and checks the bundle
+structure itself. `katl.bundle.sha256` is an optional expert control when an
+external expected checksum is already available. Without input, or with
 `katl.wait-for-config=1`, the installer waits for handoff. Debug mode never
 starts an install.
 
@@ -287,15 +287,14 @@ Illustrative iPXE entry for `cp-1`:
 #!ipxe
 set base https://boot.example.invalid/katl/2026.7.0
 set node cp-1
-set bundle_sha <config-bundle-archive-sha256>
-kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.bundle.sha256=${bundle_sha} katl.install.mode=auto
+kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.install.mode=auto
 initrd ${base}/katl-installer.initrd
 boot
 ```
 
-Matchbox profiles carry the same four `katl.*` arguments. Groups should select
-only `katl.node`; they do not need a different bundle URL or archive digest per
-node. Katl does not create or operate DHCP, iPXE, or matchbox configuration.
+Matchbox profiles carry the same `katl.*` arguments. Groups should select only
+`katl.node`; they do not need a different bundle URL per node. Katl does not
+create or operate DHCP, iPXE, or matchbox configuration.
 
 ## ISO Or Local Handoff
 
@@ -595,8 +594,8 @@ bundle or selected node rejected
 
 destructive install refused
   Confirm install.wipeTarget is true and boot input selected
-  katl.install.mode=auto. For URL bundles, confirm katl.bundle.sha256 is present
-  and matches the published archive bytes.
+  katl.install.mode=auto. Confirm the URL is reachable and returns the intended
+  .katlcfg archive.
 
 target disk not found
   Prefer /dev/disk/by-id, WWN, or serial selectors. Confirm firmware and HBA

--- a/docs/internal/adrs/adr-007-user-authored-cluster-config-and-compiled-install-material.md
+++ b/docs/internal/adrs/adr-007-user-authored-cluster-config-and-compiled-install-material.md
@@ -358,7 +358,7 @@ v0.1 config bundle trust is digest-only. Consumers verify:
 ```text
 the archive unpacks as one OCI image layout
 the OCI config descriptor media type is application/vnd.katl.config.bundle.v1+json
-the custom manifest digest matches the expected bundle digest
+the custom manifest digest is derived from its canonical bytes
 every descriptor digest and size matches the fetched member bytes
 compatibility metadata matches the installer/runtime interface and architecture
 the selected node material exists and matches the selected node
@@ -373,18 +373,18 @@ Delivery paths identify and verify the same bundle this way:
 
 ```text
 USB/offline media
-  media carries homelab.katlcfg plus expected sha256 digest metadata; the
-  installer receives or derives the selected node name and verifies the digest
-  before selecting nodes/<node>/install/material.json.
+  media carries homelab.katlcfg; the installer receives or derives the selected
+  node name and checks the bundle's internal descriptors before selecting
+  nodes/<node>/install/material.json.
 
 PXE/matchbox
-  boot input provides a bundle URL, expected bundle digest, and selected node.
-  The installer fetches the archive, verifies the digest, and rejects mutable
-  URL-only input.
+  boot input provides a bundle URL and selected node. The installer fetches the
+  archive, calculates its identity, and checks its internal descriptors. An
+  expected archive SHA-256 is an optional stricter transport control.
 
 local handoff
-  the operator posts the bundle archive, selected node, and expected digest to
-  the waiting installer. The installer verifies the posted bytes before
+  the operator posts the bundle archive and selected node to the waiting
+  installer. The installer derives identity and checks the posted bytes before
   mutation.
 
 VM tests
@@ -392,9 +392,9 @@ VM tests
   supplies each VM with the same archive plus selected node.
 
 runtime apply
-  katlctl submits bundle bytes or a bundle source plus expected digest to
-  katlc. katlc stages the bundle, verifies descriptors, and then applies only
-  the operation-allowed runtime domains.
+  katlctl submits bundle bytes or a bundle source to katlc. katlc stages the
+  bundle, checks descriptors, and then applies only the operation-allowed
+  runtime domains.
 
 future controllers
   controllers store desired bundle source/ref/digest and reconcile only after

--- a/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
+++ b/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
@@ -115,13 +115,13 @@ all nodes agree on cluster identity and stable control-plane endpoint
 all nodes run the same Kubernetes payload version and digest
 the desired generation is active and committed on every target node
 the selected KubeadmConfig name and cluster-wide digest agree on every node
-the live kubeadm ConfigMap digest matches the request's expected-live digest
-the only desired/live differences are supported profiling=false additions
+katlc derives the live kubeadm ConfigMap identity immediately before mutation
+the internally observed desired/live differences are supported profiling=false
+  additions only
 all three nodes are Ready and the stable API endpoint is healthy
 all three stacked-etcd members are healthy and voting
 no concurrent kubeadm-state operation owns a target node
-an etcd snapshot record names its path, SHA-256, revision, member-list digest,
-  creation time, source etcd version, and operator identity
+stacked-etcd and API health pass before and after each bounded node mutation
 ```
 
 The operation refuses:
@@ -138,8 +138,8 @@ InitConfiguration, JoinConfiguration, KubeletConfiguration, or
 adding, removing, or replacing a control-plane or etcd member
 combined Kubernetes payload and control-plane configuration changes
 one-node or two-node execution presented as the three-control-plane release path
-parallel node mutation, unknown quorum, an unhealthy API, or stale expected-live
-  evidence
+parallel node mutation, unknown quorum, an unhealthy API, or desired state that
+  changed after operation acceptance
 ```
 
 Katl may later expand the allowlist one field at a time with an explicit phase,
@@ -152,11 +152,11 @@ Planning is read-only. The explicit plan reports:
 
 ```text
 config name and desired generation
-desired and live canonical digests
-supported field-level delta
-Kubernetes payload version and digest
+internally derived desired and live canonical identities
+internally observed supported field-level delta
+active Kubernetes payload version and identity
 three-node order and coordinator
-etcd member and snapshot preconditions
+etcd member and API health preconditions
 static manifest digests before mutation
 commands that would run
 unsupported differences and required manual action
@@ -310,7 +310,8 @@ post-upload-health-complete
 ```
 
 `katlctl` retains a non-authoritative rollout summary that references every
-node-local operation ID and request digest. Node-local journals remain the
+node-local operation ID. Node-local journals retain internally derived request,
+desired-state, live-state, payload, and manifest identities and remain the
 mutation authority.
 
 ## Consequences

--- a/docs/internal/single-katlos-image-artifact.md
+++ b/docs/internal/single-katlos-image-artifact.md
@@ -264,7 +264,8 @@ Required order:
 
 ```text
 resolve the KatlOS image from the manifest or local media
-verify the top-level image SHA-256 against the manifest or trusted local metadata
+calculate the top-level image SHA-256 and compare it when optional expected
+  metadata was explicitly supplied
 mount the image read-only
 load /katlos/image.json with unknown fields rejected
 validate apiVersion, kind, imageRole, architecture, and runtimeInterface

--- a/docs/internal/systemd-sysupdate-update-decision.md
+++ b/docs/internal/systemd-sysupdate-update-decision.md
@@ -156,12 +156,13 @@ metadata as the single image. The single image remains the contract for
 installers and offline media. The component view is an implementation view for
 sysupdate transport.
 
-For local or offline updates, Katl may mount a verified KatlOS image and run
+For local or offline updates, Katl may mount a KatlOS image and run
 sysupdate with `regular-file` sources and `--definitions=` pointing at
 Katl-generated transfer definitions for the mounted component directory. Local
 regular-file sources do not provide sysupdate's remote signature verification,
-so Katl must verify the top-level image digest and embedded component digests
-before invoking sysupdate.
+so Katl calculates and records the top-level image identity and checks embedded
+component digests before invoking sysupdate. Operators do not supply that
+identity on the normal path.
 
 Because sysupdate source `MatchPattern=` values must contain `@v`, the mounted
 image layout must either include a sysupdate-compatible component directory or

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -1,29 +1,26 @@
 # Upgrade a KatlOS Host
 
 KatlOS host upgrades are explicit, one-node-at-a-time, next-boot operations.
-They stage a verified root and UKI into the inactive slot and arm a bounded trial
+They stage a root and UKI into the inactive slot and arm a bounded trial
 boot. They do not upgrade Kubernetes or orchestrate fleet availability.
 
 ## Preconditions
 
 - the node is healthy on a known-good generation;
 - no other mutating node operation is active;
-- the exact upgrade SquashFS, metadata, checksum, and provenance are verified;
+- the selected upgrade SquashFS is from the intended KatlOS release;
 - the upgrade declares a compatible architecture and runtime interface;
 - the node can fetch the HTTPS image URL, or the image is already in its local
   artifact store;
 - an operator controls the reboot window; and
 - Kubernetes and workload availability have been handled outside Katl.
 
-Follow [Verify release artifacts](verify-release.md) first. Record the exact
-image SHA-256 and size:
+Choose the release and image name:
 
 ```sh
 TAG=v2026.7.0-alpha.2
 VERSION=${TAG#v}
 IMAGE="katlos-upgrade-$VERSION-x86_64.squashfs"
-IMAGE_SHA256=$(sha256sum "$IMAGE" | awk '{print $1}')
-IMAGE_SIZE=$(stat -c %s "$IMAGE")
 ```
 
 ## Plan
@@ -35,13 +32,15 @@ katlctl host upgrade \
   --agent-token-file ./tokens/cp-1.token \
   --candidate-generation "katlos-$VERSION" \
   --client-request-id "cp-1-katlos-$VERSION" \
-  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE" \
-  --image-sha256 "$IMAGE_SHA256" \
-  --image-size-bytes "$IMAGE_SIZE"
+  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE"
 ```
 
 A plan response has dry-run status and no durable mutation. Review the image,
 candidate generation, resource locks, and refusal diagnostics.
+
+During staging, the node downloads or opens the image, calculates its SHA-256
+and size, records that resolved identity in the operation, and checks the image's
+component metadata before changing the inactive slot.
 
 ## Stage the Trial
 

--- a/internal/installer/input.go
+++ b/internal/installer/input.go
@@ -59,7 +59,7 @@ type BootInput struct {
 }
 
 func (i BootInput) CanMutateDisks() bool {
-	return i.Action == InstallActionRun && i.InstallMode == "auto" && (i.ManifestPath != "" || (i.ManifestURL != "" && i.ManifestSHA256 != "") || i.BundlePath != "" || (i.BundleURL != "" && i.BundleSHA256 != ""))
+	return i.Action == InstallActionRun && i.InstallMode == "auto" && (i.ManifestPath != "" || (i.ManifestURL != "" && i.ManifestSHA256 != "") || i.BundlePath != "" || i.BundleURL != "")
 }
 
 func DiscoverBootInput(request BootInputRequest) (BootInput, error) {

--- a/internal/installer/input_test.go
+++ b/internal/installer/input_test.go
@@ -91,7 +91,7 @@ func TestDiscoverBootInputBundleKernelArgs(t *testing.T) {
 	}
 }
 
-func TestDiscoverBootInputBundleURLWithoutDigestDoesNotMutateDisks(t *testing.T) {
+func TestDiscoverBootInputBundleURLWithoutDigestCanMutateDisks(t *testing.T) {
 	input, err := DiscoverBootInput(BootInputRequest{
 		KernelCmdline: "katl.bundle.url=https://kernel.example/cluster.katlcfg katl.install.mode=auto katl.node=cp-1",
 	})
@@ -101,8 +101,8 @@ func TestDiscoverBootInputBundleURLWithoutDigestDoesNotMutateDisks(t *testing.T)
 	if input.Action != InstallActionRun {
 		t.Fatalf("action = %q, want run", input.Action)
 	}
-	if input.CanMutateDisks() {
-		t.Fatalf("bundle URL without transport digest must not allow disk mutation")
+	if !input.CanMutateDisks() {
+		t.Fatalf("bundle URL must allow disk mutation without an operator-supplied transport digest")
 	}
 }
 

--- a/internal/installer/katlosimage/image.go
+++ b/internal/installer/katlosimage/image.go
@@ -32,11 +32,13 @@ const (
 )
 
 type Payload struct {
-	Root       string
-	Index      Index
-	Runtime    Component
-	Boot       Component
-	Kubernetes Component
+	Root           string
+	ImageSHA256    string
+	ImageSizeBytes uint64
+	Index          Index
+	Runtime        Component
+	Boot           Component
+	Kubernetes     Component
 }
 
 type DirectoryResolver struct {
@@ -109,17 +111,21 @@ func (r LocalResolver) ResolveKatlosImage(ctx context.Context, expected manifest
 	if !info.Mode().IsRegular() {
 		return Payload{}, fmt.Errorf("KatlOS image localRef %q is not a regular file", expected.LocalRef)
 	}
-	if expected.SizeBytes > 0 && uint64(info.Size()) != expected.SizeBytes {
-		return Payload{}, fmt.Errorf("KatlOS image size %d does not match manifest %d", info.Size(), expected.SizeBytes)
-	}
-	if err := verifyImageFile(imagePath, expected.SHA256); err != nil {
-		return Payload{}, err
-	}
-	mountPoint, err := mountImageFile(ctx, imagePath, expected.SHA256, r.WorkDir, r.Commands)
+	digest, size, err := imageFileIdentity(imagePath, expected.SHA256, expected.SizeBytes)
 	if err != nil {
 		return Payload{}, err
 	}
-	return ResolveDirectory(ctx, mountPoint, expected)
+	mountPoint, err := mountImageFile(ctx, imagePath, digest, r.WorkDir, r.Commands)
+	if err != nil {
+		return Payload{}, err
+	}
+	payload, err := ResolveDirectory(ctx, mountPoint, expected)
+	if err != nil {
+		return Payload{}, err
+	}
+	payload.ImageSHA256 = digest
+	payload.ImageSizeBytes = size
+	return payload, nil
 }
 
 type RemoteResolver struct {
@@ -136,15 +142,21 @@ func (r RemoteResolver) ResolveKatlosImage(ctx context.Context, expected manifes
 	if workDir == "" {
 		workDir = filepath.Join(os.TempDir(), "katlos-image")
 	}
-	imagePath, err := downloadImage(ctx, expected, workDir, r.Client)
+	imagePath, digest, size, err := downloadImage(ctx, expected, workDir, r.Client)
 	if err != nil {
 		return Payload{}, err
 	}
-	mountPoint, err := mountImageFile(ctx, imagePath, expected.SHA256, workDir, r.Commands)
+	mountPoint, err := mountImageFile(ctx, imagePath, digest, workDir, r.Commands)
 	if err != nil {
 		return Payload{}, err
 	}
-	return ResolveDirectory(ctx, mountPoint, expected)
+	payload, err := ResolveDirectory(ctx, mountPoint, expected)
+	if err != nil {
+		return Payload{}, err
+	}
+	payload.ImageSHA256 = digest
+	payload.ImageSizeBytes = size
+	return payload, nil
 }
 
 func (p Payload) RuntimeArtifact() artifact.ArtifactVerification {
@@ -243,77 +255,96 @@ func cleanLocalRef(root string, ref string) (string, error) {
 	return filepath.Join(filepath.Clean(root), filepath.FromSlash(clean)), nil
 }
 
-func verifyImageFile(imagePath string, expectedSHA256 string) error {
-	if err := validateSHA256(expectedSHA256); err != nil {
-		return fmt.Errorf("KatlOS image SHA-256 is invalid: %w", err)
+func imageFileIdentity(imagePath string, expectedSHA256 string, expectedSize uint64) (string, uint64, error) {
+	expectedSHA256 = strings.TrimSpace(expectedSHA256)
+	if expectedSHA256 != "" {
+		if err := validateSHA256(expectedSHA256); err != nil {
+			return "", 0, fmt.Errorf("KatlOS image SHA-256 is invalid: %w", err)
+		}
 	}
 	file, err := os.Open(imagePath)
 	if err != nil {
-		return fmt.Errorf("open KatlOS image: %w", err)
+		return "", 0, fmt.Errorf("open KatlOS image: %w", err)
 	}
 	defer file.Close()
 	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return fmt.Errorf("hash KatlOS image: %w", err)
+	size, err := io.Copy(hash, file)
+	if err != nil {
+		return "", 0, fmt.Errorf("hash KatlOS image: %w", err)
 	}
 	got := hex.EncodeToString(hash.Sum(nil))
-	if got != expectedSHA256 {
-		return fmt.Errorf("KatlOS image digest %s does not match manifest %s", got, expectedSHA256)
+	if expectedSize > 0 && uint64(size) != expectedSize {
+		return "", 0, fmt.Errorf("KatlOS image size %d does not match manifest %d", size, expectedSize)
 	}
-	return nil
+	if expectedSHA256 != "" && got != expectedSHA256 {
+		return "", 0, fmt.Errorf("KatlOS image digest %s does not match manifest %s", got, expectedSHA256)
+	}
+	return got, uint64(size), nil
 }
 
-func downloadImage(ctx context.Context, expected manifest.KatlosImage, workDir string, client HTTPClient) (string, error) {
-	if err := validateSHA256(expected.SHA256); err != nil {
-		return "", fmt.Errorf("KatlOS image SHA-256 is invalid: %w", err)
+func downloadImage(ctx context.Context, expected manifest.KatlosImage, workDir string, client HTTPClient) (string, string, uint64, error) {
+	expectedSHA256 := strings.TrimSpace(expected.SHA256)
+	if expectedSHA256 != "" {
+		if err := validateSHA256(expectedSHA256); err != nil {
+			return "", "", 0, fmt.Errorf("KatlOS image SHA-256 is invalid: %w", err)
+		}
 	}
 	if client == nil {
 		client = http.DefaultClient
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, expected.URL, nil)
 	if err != nil {
-		return "", fmt.Errorf("create KatlOS image request: %w", err)
+		return "", "", 0, fmt.Errorf("create KatlOS image request: %w", err)
 	}
 	response, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("fetch KatlOS image: %w", err)
+		return "", "", 0, fmt.Errorf("fetch KatlOS image: %w", err)
 	}
 	if response == nil {
-		return "", fmt.Errorf("fetch KatlOS image: empty response")
+		return "", "", 0, fmt.Errorf("fetch KatlOS image: empty response")
 	}
 	if response.Body == nil {
-		return "", fmt.Errorf("fetch KatlOS image: empty response body")
+		return "", "", 0, fmt.Errorf("fetch KatlOS image: empty response body")
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("fetch KatlOS image: status %s", response.Status)
+		return "", "", 0, fmt.Errorf("fetch KatlOS image: status %s", response.Status)
 	}
 	downloadDir := filepath.Join(workDir, "downloads")
 	if err := os.MkdirAll(downloadDir, 0o755); err != nil {
-		return "", fmt.Errorf("create KatlOS image download dir: %w", err)
+		return "", "", 0, fmt.Errorf("create KatlOS image download dir: %w", err)
 	}
-	imagePath := filepath.Join(downloadDir, expected.SHA256+".squashfs")
-	file, err := os.OpenFile(imagePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	file, err := os.CreateTemp(downloadDir, ".katlos-image-*.squashfs")
 	if err != nil {
-		return "", fmt.Errorf("create KatlOS image download: %w", err)
+		return "", "", 0, fmt.Errorf("create KatlOS image download: %w", err)
+	}
+	tmpPath := file.Name()
+	defer os.Remove(tmpPath)
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return "", "", 0, fmt.Errorf("protect KatlOS image download: %w", err)
 	}
 	hash := sha256.New()
 	written, copyErr := io.Copy(file, io.TeeReader(response.Body, hash))
 	closeErr := file.Close()
 	if copyErr != nil {
-		return "", fmt.Errorf("download KatlOS image: %w", copyErr)
+		return "", "", 0, fmt.Errorf("download KatlOS image: %w", copyErr)
 	}
 	if closeErr != nil {
-		return "", fmt.Errorf("close KatlOS image download: %w", closeErr)
+		return "", "", 0, fmt.Errorf("close KatlOS image download: %w", closeErr)
 	}
 	if expected.SizeBytes > 0 && uint64(written) != expected.SizeBytes {
-		return "", fmt.Errorf("KatlOS image size %d does not match manifest %d", written, expected.SizeBytes)
+		return "", "", 0, fmt.Errorf("KatlOS image size %d does not match manifest %d", written, expected.SizeBytes)
 	}
 	got := hex.EncodeToString(hash.Sum(nil))
-	if got != expected.SHA256 {
-		return "", fmt.Errorf("KatlOS image digest %s does not match manifest %s", got, expected.SHA256)
+	if expectedSHA256 != "" && got != expectedSHA256 {
+		return "", "", 0, fmt.Errorf("KatlOS image digest %s does not match manifest %s", got, expectedSHA256)
 	}
-	return imagePath, nil
+	imagePath := filepath.Join(downloadDir, got+".squashfs")
+	if err := os.Rename(tmpPath, imagePath); err != nil {
+		return "", "", 0, fmt.Errorf("store KatlOS image download: %w", err)
+	}
+	return imagePath, got, uint64(written), nil
 }
 
 func mountImageFile(ctx context.Context, imagePath string, digest string, workDir string, commands CommandRunner) (string, error) {

--- a/internal/installer/katlosimage/image_test.go
+++ b/internal/installer/katlosimage/image_test.go
@@ -389,8 +389,8 @@ func TestLocalResolverMountsFileRef(t *testing.T) {
 	}
 	sum := sha256.Sum256(imageBytes)
 	expected := expectedImage()
-	expected.SHA256 = hex.EncodeToString(sum[:])
-	expected.SizeBytes = uint64(len(imageBytes))
+	expected.SHA256 = ""
+	expected.SizeBytes = 0
 	mounter := &fixtureMountRunner{populate: func(root string) {
 		writeImagePayloadAt(t, root, func(*Index) {})
 	}}
@@ -410,6 +410,9 @@ func TestLocalResolverMountsFileRef(t *testing.T) {
 	}
 	if payload.Root != mounter.calls[0][4] {
 		t.Fatalf("payload root = %q, mountpoint = %q", payload.Root, mounter.calls[0][4])
+	}
+	if payload.ImageSHA256 != hex.EncodeToString(sum[:]) || payload.ImageSizeBytes != uint64(len(imageBytes)) {
+		t.Fatalf("derived image identity = %s/%d", payload.ImageSHA256, payload.ImageSizeBytes)
 	}
 }
 
@@ -441,8 +444,8 @@ func TestRemoteResolverDownloadsAndMountsURL(t *testing.T) {
 	expected := expectedImage()
 	expected.LocalRef = ""
 	expected.URL = "https://artifacts.example.invalid/katlos-install.squashfs"
-	expected.SHA256 = hex.EncodeToString(sum[:])
-	expected.SizeBytes = uint64(len(imageBytes))
+	expected.SHA256 = ""
+	expected.SizeBytes = 0
 	mounter := &fixtureMountRunner{populate: func(root string) {
 		writeImagePayloadAt(t, root, func(*Index) {})
 	}}
@@ -469,6 +472,9 @@ func TestRemoteResolverDownloadsAndMountsURL(t *testing.T) {
 	}
 	if payload.Root != mounter.calls[0][4] {
 		t.Fatalf("payload root = %q, mountpoint = %q", payload.Root, mounter.calls[0][4])
+	}
+	if payload.ImageSHA256 != hex.EncodeToString(sum[:]) || payload.ImageSizeBytes != uint64(len(imageBytes)) {
+		t.Fatalf("derived image identity = %s/%d", payload.ImageSHA256, payload.ImageSizeBytes)
 	}
 }
 

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -938,10 +938,25 @@ func ValidateTransition(previous OperationRecord, next OperationRecord) error {
 	if !reflect.DeepEqual(next.DestructiveResetRequest, previous.DestructiveResetRequest) {
 		return fmt.Errorf("operation destructiveResetRequest is immutable")
 	}
-	if !reflect.DeepEqual(next.HostUpgradeRequest, previous.HostUpgradeRequest) {
+	if !hostUpgradeTransitionAllowed(previous.HostUpgradeRequest, next.HostUpgradeRequest) {
 		return fmt.Errorf("operation hostUpgradeRequest is immutable")
 	}
 	return nil
+}
+
+func hostUpgradeTransitionAllowed(previous *HostUpgrade, next *HostUpgrade) bool {
+	if previous == nil || next == nil {
+		return previous == nil && next == nil
+	}
+	previousComparable := *previous
+	nextComparable := *next
+	previousComparable.ImageSHA256 = ""
+	nextComparable.ImageSHA256 = ""
+	previousComparable.ImageSizeBytes = 0
+	nextComparable.ImageSizeBytes = 0
+	return reflect.DeepEqual(previousComparable, nextComparable) &&
+		resolvedDigestTransitionAllowed(previous.ImageSHA256, next.ImageSHA256) &&
+		(previous.ImageSizeBytes == next.ImageSizeBytes || previous.ImageSizeBytes == 0 && next.ImageSizeBytes > 0)
 }
 
 func bootstrapRequestTransitionAllowed(previous *BootstrapRequest, next *BootstrapRequest) bool {
@@ -975,7 +990,13 @@ func kubeadmControlPlaneConfigTransitionAllowed(previous *KubeadmControlPlaneCon
 	nextComparable.AfterManifestSHA256 = nil
 	previousComparable.OriginalNodeUnschedulable = false
 	nextComparable.OriginalNodeUnschedulable = false
-	return reflect.DeepEqual(previousComparable, nextComparable)
+	previousComparable.ExpectedLiveConfigSHA256 = ""
+	nextComparable.ExpectedLiveConfigSHA256 = ""
+	previousComparable.SupportedFieldDelta = nil
+	nextComparable.SupportedFieldDelta = nil
+	return reflect.DeepEqual(previousComparable, nextComparable) &&
+		resolvedDigestTransitionAllowed(previous.ExpectedLiveConfigSHA256, next.ExpectedLiveConfigSHA256) &&
+		(previous.SupportedFieldDelta == nil || reflect.DeepEqual(previous.SupportedFieldDelta, next.SupportedFieldDelta))
 }
 
 func resolvedDigestTransitionAllowed(previous string, next string) bool {
@@ -1660,9 +1681,7 @@ func validateKubeadmControlPlaneConfig(request KubeadmControlPlaneConfig) error 
 		"rolloutID": request.RolloutID, "coordinatorNode": request.CoordinatorNode,
 		"nodeName": request.NodeName, "desiredGenerationID": request.DesiredGenerationID,
 		"configName": request.ConfigName, "configPath": request.ConfigPath,
-		"kubernetesPayloadVersion": request.KubernetesPayloadVersion, "snapshotRef": request.SnapshotRef,
-		"snapshotRevision": request.SnapshotRevision, "sourceEtcdVersion": request.SourceEtcdVersion,
-		"snapshotStorageLocation": request.SnapshotStorageLocation, "snapshotOperatorIdentity": request.SnapshotOperatorIdentity,
+		"kubernetesPayloadVersion": request.KubernetesPayloadVersion,
 	}
 	for name, value := range required {
 		if strings.TrimSpace(value) == "" {
@@ -1676,19 +1695,28 @@ func validateKubeadmControlPlaneConfig(request KubeadmControlPlaneConfig) error 
 		return fmt.Errorf("kubeadmControlPlaneConfig config path is invalid")
 	}
 	for name, value := range map[string]string{
-		"desired config": request.DesiredConfigSHA256, "expected live config": request.ExpectedLiveConfigSHA256,
-		"kubernetes payload": request.KubernetesPayloadSHA256, "snapshot": request.SnapshotDigest,
-		"captured member list": request.CapturedMemberListDigest,
+		"desired config":     request.DesiredConfigSHA256,
+		"kubernetes payload": request.KubernetesPayloadSHA256,
 	} {
 		if err := validateSHA256Hex("kubeadmControlPlaneConfig "+name, value); err != nil {
 			return err
 		}
 	}
-	if len(request.SupportedFieldDelta) == 0 {
-		return fmt.Errorf("kubeadmControlPlaneConfig supportedFieldDelta is required")
+	for name, value := range map[string]string{
+		"expected live config": request.ExpectedLiveConfigSHA256,
+		"snapshot":             request.SnapshotDigest,
+		"captured member list": request.CapturedMemberListDigest,
+	} {
+		if strings.TrimSpace(value) != "" {
+			if err := validateSHA256Hex("kubeadmControlPlaneConfig "+name, value); err != nil {
+				return err
+			}
+		}
 	}
-	if _, err := time.Parse(time.RFC3339, request.SnapshotCreatedAt); err != nil {
-		return fmt.Errorf("kubeadmControlPlaneConfig snapshotCreatedAt must be RFC3339: %w", err)
+	if strings.TrimSpace(request.SnapshotCreatedAt) != "" {
+		if _, err := time.Parse(time.RFC3339, request.SnapshotCreatedAt); err != nil {
+			return fmt.Errorf("kubeadmControlPlaneConfig snapshotCreatedAt must be RFC3339: %w", err)
+		}
 	}
 	for name, digest := range request.BeforeManifestSHA256 {
 		if err := validateSHA256Hex("kubeadmControlPlaneConfig before manifest "+name, digest); err != nil {
@@ -1810,8 +1838,10 @@ func ValidateHostUpgrade(request HostUpgrade) error {
 			return fmt.Errorf("hostUpgradeRequest imageLocalRef must be a clean relative path")
 		}
 	}
-	if err := validateSHA256Hex("hostUpgradeRequest image", strings.TrimSpace(request.ImageSHA256)); err != nil {
-		return err
+	if strings.TrimSpace(request.ImageSHA256) != "" {
+		if err := validateSHA256Hex("hostUpgradeRequest image", strings.TrimSpace(request.ImageSHA256)); err != nil {
+			return err
+		}
 	}
 	if _, err := cleanSegment("hostUpgradeRequest candidateGenerationID", request.CandidateGenerationID); err != nil {
 		return err

--- a/internal/installer/operation/store_test.go
+++ b/internal/installer/operation/store_test.go
@@ -49,8 +49,6 @@ func TestStoreCreatesAndUpdatesJournalFirstRecord(t *testing.T) {
 func TestValidateHostUpgrade(t *testing.T) {
 	valid := HostUpgrade{
 		ImageLocalRef:         "updates/katlos-upgrade.squashfs",
-		ImageSHA256:           strings.Repeat("a", 64),
-		ImageSizeBytes:        4096,
 		CandidateGenerationID: "gen-upgrade-1",
 	}
 	if err := ValidateHostUpgrade(valid); err != nil {
@@ -63,7 +61,7 @@ func TestValidateHostUpgrade(t *testing.T) {
 	}{
 		{name: "two refs", mutate: func(v *HostUpgrade) { v.ImageURL = "https://example.test/image" }, want: "exactly one"},
 		{name: "path escape", mutate: func(v *HostUpgrade) { v.ImageLocalRef = "../image" }, want: "clean relative"},
-		{name: "bad digest", mutate: func(v *HostUpgrade) { v.ImageSHA256 = "bad" }, want: "SHA-256"},
+		{name: "bad optional digest", mutate: func(v *HostUpgrade) { v.ImageSHA256 = "bad" }, want: "SHA-256"},
 		{name: "bad generation", mutate: func(v *HostUpgrade) { v.CandidateGenerationID = "../gen" }, want: "clean path segment"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -31,6 +31,21 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 		return e.failHostUpgrade(record, "verify-katlos-image", err)
 	}
 	defer e.cleanupHostUpgradeMount(payload)
+	if strings.TrimSpace(payload.ImageSHA256) == "" || payload.ImageSizeBytes == 0 {
+		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("resolved KatlOS image identity is incomplete"))
+	}
+	record, err = e.Store.Update(record.OperationID, "host-upgrade-image-resolved", "verify-katlos-image", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.HostUpgradeRequest.ImageSHA256 = payload.ImageSHA256
+		current.HostUpgradeRequest.ImageSizeBytes = payload.ImageSizeBytes
+		current.Phase = "verify-katlos-image"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "verify-katlos-image")
+		current.UpdatedAt = e.clock()
+		current.NextAction = "stage the internally identified root and UKI components through systemd-sysupdate"
+		return current, nil
+	})
+	if err != nil {
+		return err
+	}
 	currentID, err := currentGenerationID(e.Root)
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", err)
@@ -76,7 +91,7 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 		current.ExternalMutationStarted = true
 		current.MutationScopes = appendMissing(current.MutationScopes, "root-slot-labels", "runtime-root", "runtime-uki")
 		current.UpdatedAt = e.clock()
-		current.NextAction = "stage verified root and UKI components through systemd-sysupdate"
+		current.NextAction = "stage root and UKI components through systemd-sysupdate"
 		return current, nil
 	})
 	if err != nil {

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -78,10 +78,12 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 		t.Fatal(err)
 	}
 	payload := katlosimage.Payload{
-		Root:    payloadRoot,
-		Index:   katlosimage.Index{ImageRole: katlosimage.RoleUpgrade, Version: "2026.7.0-dev.1", Architecture: "x86_64", RuntimeInterface: "katl-runtime-1"},
-		Runtime: katlosimage.Component{Name: "runtime-root", Role: katlosimage.ComponentRuntimeRoot, Path: "components/runtime/root.squashfs", SizeBytes: int64(len(runtimeBytes)), SHA256: testSHA(runtimeBytes), Version: "2026.7.0-dev.1", Architecture: "x86_64"},
-		Boot:    katlosimage.Component{Name: "runtime-uki", Role: katlosimage.ComponentRuntimeUKI, Path: "components/boot/katl.efi", SizeBytes: int64(len(ukiBytes)), SHA256: testSHA(ukiBytes), Version: "2026.7.0-dev.1", Architecture: "x86_64"},
+		Root:           payloadRoot,
+		ImageSHA256:    strings.Repeat("e", 64),
+		ImageSizeBytes: 4096,
+		Index:          katlosimage.Index{ImageRole: katlosimage.RoleUpgrade, Version: "2026.7.0-dev.1", Architecture: "x86_64", RuntimeInterface: "katl-runtime-1"},
+		Runtime:        katlosimage.Component{Name: "runtime-root", Role: katlosimage.ComponentRuntimeRoot, Path: "components/runtime/root.squashfs", SizeBytes: int64(len(runtimeBytes)), SHA256: testSHA(runtimeBytes), Version: "2026.7.0-dev.1", Architecture: "x86_64"},
+		Boot:           katlosimage.Component{Name: "runtime-uki", Role: katlosimage.ComponentRuntimeUKI, Path: "components/boot/katl.efi", SizeBytes: int64(len(ukiBytes)), SHA256: testSHA(ukiBytes), Version: "2026.7.0-dev.1", Architecture: "x86_64"},
 	}
 	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
 	if err != nil {

--- a/internal/katlc/agent/kubeadm_control_plane_config.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config.go
@@ -48,15 +48,12 @@ func validateKubeadmControlPlaneConfigRequest(kind string, req *agentapi.Kubeadm
 	if name == "" || filepath.Base(name) != name {
 		return fmt.Errorf("configName is invalid")
 	}
-	for field, value := range map[string]string{
-		"desiredConfigSHA256": req.GetDesiredConfigSha256(), "expectedLiveConfigSHA256": req.GetExpectedLiveConfigSha256(), "kubernetesPayloadSHA256": req.GetKubernetesPayloadSha256(), "snapshotDigest": req.GetSnapshotDigest(), "capturedMemberListDigest": req.GetCapturedMemberListDigest(),
-	} {
-		if err := validateDigestValue(field, value); err != nil {
-			return err
+	for field, value := range map[string]string{"desiredConfigSHA256": req.GetDesiredConfigSha256(), "expectedLiveConfigSHA256": req.GetExpectedLiveConfigSha256(), "kubernetesPayloadSHA256": req.GetKubernetesPayloadSha256()} {
+		if strings.TrimSpace(value) != "" {
+			if err := validateDigestValue(field, value); err != nil {
+				return err
+			}
 		}
-	}
-	if strings.TrimSpace(req.GetKubernetesPayloadVersion()) == "" || len(req.GetSupportedFieldDelta()) == 0 {
-		return fmt.Errorf("kubernetesPayloadVersion and supportedFieldDelta are required")
 	}
 	seen := map[string]bool{}
 	for _, field := range req.GetSupportedFieldDelta() {
@@ -64,16 +61,6 @@ func validateKubeadmControlPlaneConfigRequest(kind string, req *agentapi.Kubeadm
 			return fmt.Errorf("unsupported or repeated field delta %q", field)
 		}
 		seen[field] = true
-	}
-	for field, value := range map[string]string{
-		"snapshotRef": req.GetSnapshotRef(), "snapshotRevision": req.GetSnapshotRevision(), "sourceEtcdVersion": req.GetSourceEtcdVersion(), "snapshotStorageLocation": req.GetSnapshotStorageLocation(), "snapshotOperatorIdentity": req.GetSnapshotOperatorIdentity(),
-	} {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("%s is required", field)
-		}
-	}
-	if _, err := time.Parse(time.RFC3339, req.GetSnapshotCreatedAt()); err != nil {
-		return fmt.Errorf("snapshotCreatedAt must be RFC3339")
 	}
 	return nil
 }
@@ -114,9 +101,13 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 		return body, fmt.Errorf("read selected kubeadm config: %w", err)
 	}
 	desiredDigest, err := kubeadmplan.CanonicalClusterConfigurationSHA256(data)
-	if err != nil || desiredDigest != body.DesiredConfigSHA256 {
+	if err != nil {
+		return body, fmt.Errorf("read selected kubeadm config identity: %w", err)
+	}
+	if body.DesiredConfigSHA256 != "" && desiredDigest != body.DesiredConfigSHA256 {
 		return body, fmt.Errorf("selected kubeadm config digest changed")
 	}
+	body.DesiredConfigSHA256 = desiredDigest
 	spec, _, err := generation.ReadGeneration(s.Root, body.DesiredGenerationID)
 	if err != nil {
 		return body, fmt.Errorf("read desired generation: %w", err)
@@ -129,15 +120,25 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 	if err != nil || applyStatus.Kubeadm.SelectedConfigName != body.ConfigName || !applyStatus.Kubeadm.Required {
 		return body, fmt.Errorf("active generation does not select kubeadm config %q as action-required", body.ConfigName)
 	}
-	matchedPayload := false
+	var matchedPayload *generation.ExtensionRef
 	for _, ref := range spec.Sysexts {
-		if ref.Name == "kubernetes" && ref.PayloadVersion == body.KubernetesPayloadVersion && ref.SHA256 == body.KubernetesPayloadSHA256 {
-			matchedPayload = true
+		if ref.Name == "kubernetes" {
+			copy := ref
+			matchedPayload = &copy
+			break
 		}
 	}
-	if !matchedPayload {
-		return body, fmt.Errorf("active Kubernetes payload version or digest does not match request")
+	if matchedPayload == nil || matchedPayload.PayloadVersion == "" || matchedPayload.SHA256 == "" {
+		return body, fmt.Errorf("active generation has no identified Kubernetes payload")
 	}
+	if body.KubernetesPayloadVersion != "" && body.KubernetesPayloadVersion != matchedPayload.PayloadVersion {
+		return body, fmt.Errorf("active Kubernetes payload version does not match request")
+	}
+	if body.KubernetesPayloadSHA256 != "" && body.KubernetesPayloadSHA256 != matchedPayload.SHA256 {
+		return body, fmt.Errorf("active Kubernetes payload digest does not match request")
+	}
+	body.KubernetesPayloadVersion = matchedPayload.PayloadVersion
+	body.KubernetesPayloadSHA256 = matchedPayload.SHA256
 	return body, nil
 }
 
@@ -147,6 +148,10 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 	if err != nil {
 		return e.failControlPlaneConfig(record, "preflight", err)
 	}
+	desiredDigest, err := kubeadmplan.CanonicalClusterConfigurationSHA256(desired)
+	if err != nil || desiredDigest != request.DesiredConfigSHA256 {
+		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("selected kubeadm config changed after operation acceptance"))
+	}
 	liveResult := e.toolRunner()(ctx, []string{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kubeadm-config", "-o", "jsonpath={.data.ClusterConfiguration}"}, nil)
 	if liveResult.Err != nil || liveResult.ExitStatus != 0 {
 		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("collect live kubeadm config: %s", toolFailure(liveResult)))
@@ -155,12 +160,16 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 	if err != nil {
 		return e.failControlPlaneConfig(record, "preflight", err)
 	}
-	sort.Strings(request.SupportedFieldDelta)
-	if !reflect.DeepEqual(delta, request.SupportedFieldDelta) {
+	requestedDelta := append([]string(nil), request.SupportedFieldDelta...)
+	sort.Strings(requestedDelta)
+	if len(requestedDelta) > 0 && !reflect.DeepEqual(delta, requestedDelta) {
 		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("observed supported delta %v does not match request %v", delta, request.SupportedFieldDelta))
 	}
 	liveDigest, err := kubeadmplan.CanonicalClusterConfigurationSHA256(liveResult.Stdout)
-	if err != nil || liveDigest != request.ExpectedLiveConfigSHA256 {
+	if err != nil {
+		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("identify live kubeadm config: %w", err))
+	}
+	if request.ExpectedLiveConfigSHA256 != "" && liveDigest != request.ExpectedLiveConfigSHA256 {
 		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("live kubeadm config digest is stale"))
 	}
 	if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-dry-run", []string{"/usr/bin/kubeadm", "init", "phase", "control-plane", "all", "--config", request.ConfigPath, "--dry-run"}, false); err != nil {
@@ -172,6 +181,8 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 	}
 	originalUnschedulable := strings.TrimSpace(string(schedResult.Stdout)) == "true"
 	if _, err := e.Store.Update(record.OperationID, "preflight-complete", "preflight-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.KubeadmControlPlaneConfig.ExpectedLiveConfigSHA256 = liveDigest
+		current.KubeadmControlPlaneConfig.SupportedFieldDelta = append([]string(nil), delta...)
 		current.KubeadmControlPlaneConfig.OriginalNodeUnschedulable = originalUnschedulable
 		current.Phase = "preflight-complete"
 		current.UpdatedAt = e.clock()

--- a/internal/katlc/agent/kubeadm_control_plane_config_test.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config_test.go
@@ -49,9 +49,6 @@ func TestAcceptKubeadmControlPlaneConfigBindsActiveGeneration(t *testing.T) {
 	}
 	body := validControlPlaneConfigRequest()
 	body.DesiredGenerationId = "generation-0"
-	body.KubernetesPayloadVersion = "v1.35.0"
-	body.KubernetesPayloadSha256 = digestBytesForAgentTest([]byte("current kubernetes sysext\n"))
-	body.DesiredConfigSha256, _ = kubeadmplan.CanonicalClusterConfigurationSHA256([]byte(config))
 	var dispatched atomic.Int32
 	server.Dispatcher = dispatchFunc(func(context.Context, operation.OperationRecord) error {
 		dispatched.Add(1)
@@ -66,7 +63,8 @@ func TestAcceptKubeadmControlPlaneConfigBindsActiveGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dispatched.Load() != 1 || record.KubeadmControlPlaneConfig.ConfigName != "control-plane" || record.PreviousGenerationID != "generation-0" {
+	wantDesired, _ := kubeadmplan.CanonicalClusterConfigurationSHA256([]byte(config))
+	if dispatched.Load() != 1 || record.KubeadmControlPlaneConfig.ConfigName != "control-plane" || record.PreviousGenerationID != "generation-0" || record.KubeadmControlPlaneConfig.DesiredConfigSHA256 != wantDesired || record.KubeadmControlPlaneConfig.KubernetesPayloadVersion != "v1.35.0" {
 		t.Fatalf("dispatches=%d record=%#v accepted=%#v", dispatched.Load(), record, accepted)
 	}
 }
@@ -80,6 +78,8 @@ func TestExecuteKubeadmControlPlaneConfigRunsBoundedPhases(t *testing.T) {
 	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
 	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
 	body.CoordinatorUpload = true
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
 	liveConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n"
 	desiredConfig := liveConfig + "apiServer:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\n"
 	desiredPath := filepath.Join(root, "etc/katl/kubeadm/control-plane/config.yaml")
@@ -135,6 +135,9 @@ func TestExecuteKubeadmControlPlaneConfigRunsBoundedPhases(t *testing.T) {
 	if err != nil || !completed.Terminal || completed.Result != operation.ResultSucceeded || !completed.MutatingToolRan {
 		t.Fatalf("completed = %#v, err = %v", completed, err)
 	}
+	if completed.KubeadmControlPlaneConfig.ExpectedLiveConfigSHA256 == "" || len(completed.KubeadmControlPlaneConfig.SupportedFieldDelta) != 1 {
+		t.Fatalf("operation did not persist internally observed state: %#v", completed.KubeadmControlPlaneConfig)
+	}
 }
 
 func TestExecuteKubeadmControlPlaneConfigStopsAfterMutationUncertainty(t *testing.T) {
@@ -144,6 +147,8 @@ func TestExecuteKubeadmControlPlaneConfigStopsAfterMutationUncertainty(t *testin
 		t.Fatal(err)
 	}
 	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
 	liveConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n"
 	desiredConfig := liveConfig + "apiServer:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\n"
 	path := filepath.Join(root, "etc/katl/kubeadm/control-plane/config.yaml")
@@ -185,6 +190,6 @@ func TestExecuteKubeadmControlPlaneConfigStopsAfterMutationUncertainty(t *testin
 
 func validControlPlaneConfigRequest() *agentapi.KubeadmControlPlaneConfigOperationRequest {
 	return &agentapi.KubeadmControlPlaneConfigOperationRequest{
-		RolloutId: "rollout-1", NodePosition: 1, NodeCount: 3, CoordinatorNode: "cp-3", NodeName: "cp-1", DesiredGenerationId: "gen-2", ConfigName: "control-plane", DesiredConfigSha256: strings.Repeat("a", 64), ExpectedLiveConfigSha256: strings.Repeat("b", 64), KubernetesPayloadVersion: "v1.36.1", KubernetesPayloadSha256: strings.Repeat("c", 64), SupportedFieldDelta: []string{"ClusterConfiguration.apiServer.extraArgs.profiling=false"}, SnapshotRef: "snapshot-1", SnapshotDigest: strings.Repeat("d", 64), SnapshotRevision: "42", CapturedMemberListDigest: strings.Repeat("e", 64), SourceEtcdVersion: "3.6.5", SnapshotCreatedAt: "2026-07-11T07:55:00Z", SnapshotStorageLocation: "/var/lib/katl/snapshots/snapshot-1.db", SnapshotOperatorIdentity: "operator@example.test",
+		RolloutId: "rollout-1", NodePosition: 1, NodeCount: 3, CoordinatorNode: "cp-3", NodeName: "cp-1", DesiredGenerationId: "gen-2", ConfigName: "control-plane",
 	}
 }

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -122,8 +122,6 @@ func TestSubmitOperationRecordsHostUpgrade(t *testing.T) {
 		Actor:           "test-actor",
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
 			ImageUrl:              "https://updates.example.test/katlos-upgrade.squashfs",
-			ImageSha256:           strings.Repeat("a", 64),
-			ImageSizeBytes:        4096,
 			CandidateGenerationId: "gen-upgrade-1",
 		},
 	}
@@ -138,7 +136,7 @@ func TestSubmitOperationRecordsHostUpgrade(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.HostUpgradeRequest == nil || record.HostUpgradeRequest.ImageURL != req.HostUpgrade.ImageUrl || record.HostUpgradeRequest.ImageSHA256 != req.HostUpgrade.ImageSha256 {
+	if record.HostUpgradeRequest == nil || record.HostUpgradeRequest.ImageURL != req.HostUpgrade.ImageUrl || record.HostUpgradeRequest.ImageSHA256 != "" {
 		t.Fatalf("host upgrade request = %+v", record.HostUpgradeRequest)
 	}
 	if record.ActivationMode != operation.ActivationModeNextBoot || !record.BootHealthPending || record.CandidateGenerationID != "gen-upgrade-1" {

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -462,11 +460,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	if err := os.WriteFile(filepath.Join(proofDir, "live-cluster-configuration.yaml"), liveConfig, 0o600); err != nil {
 		return err
 	}
-	desiredConfig, deltas, err := controlPlaneProfilingConfig(liveConfig)
-	if err != nil {
-		return err
-	}
-	liveDigest, err := kubeadmplan.CanonicalClusterConfigurationSHA256(liveConfig)
+	desiredConfig, _, err := controlPlaneProfilingConfig(liveConfig)
 	if err != nil {
 		return err
 	}
@@ -515,23 +509,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-before-operation.txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
 		return err
 	}
-	snapshotSHA, err := nodeFileSHA256(ctx, nodes[0], snapshot.Snapshot.Path)
-	if err != nil {
-		return err
-	}
-	membersJSON, err := json.Marshal(snapshot.Health.Members)
-	if err != nil {
-		return err
-	}
-	memberSum := sha256.Sum256(membersJSON)
-	etcdVersion := "unknown"
-	if len(snapshot.Health.EndpointStatuses) > 0 {
-		etcdVersion = snapshot.Health.EndpointStatuses[0].Version
-	}
-	args := []string{"cluster", "kubeadm-control-plane-config", "--inventory", inventoryPath, "--coordinator", "cp-3", "--generation", generationID, "--config-name", configName, "--desired-config-sha256", desiredDigest, "--expected-live-sha256", liveDigest, "--kubernetes-version", bundle.PayloadVersion, "--kubernetes-sha256", strings.TrimPrefix(bundle.SysextPayloadDigest, "sha256:"), "--rollout-id", "2026.07.11-vmtest-control-plane-config", "--snapshot-ref", filepath.Base(snapshot.Snapshot.Path), "--snapshot-sha256", snapshotSHA, "--snapshot-revision", snapshot.Snapshot.Revision, "--member-list-sha256", hex.EncodeToString(memberSum[:]), "--source-etcd-version", etcdVersion, "--snapshot-created-at", time.Now().UTC().Format(time.RFC3339), "--snapshot-location", snapshot.Snapshot.Path, "--snapshot-operator", "katl-vmtest"}
-	for _, delta := range deltas {
-		args = append(args, "--field-delta", delta)
-	}
+	args := []string{"cluster", "kubeadm-control-plane-config", "--inventory", inventoryPath, "--coordinator", "cp-3", "--generation", generationID, "--config-name", configName, "--rollout-id", "2026.07.11-vmtest-control-plane-config"}
 	stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "rollout", args...)
 	if err != nil {
 		return fmt.Errorf("run serial control-plane config rollout: %w: %s", err, stderr)

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -127,8 +126,6 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 		"--endpoint", endpoint,
 		"--agent-token-file", tokenFile,
 		"--image-local-ref", localRef,
-		"--image-sha256", upgrade.SHA256,
-		"--image-size-bytes", strconv.FormatUint(upgrade.SizeBytes, 10),
 		"--candidate-generation", candidateGeneration,
 		"--client-request-id", "vmtest-host-upgrade-"+candidateGeneration,
 		"--actor", "installed runtime host upgrade vmtest",
@@ -138,6 +135,19 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 	status := waitKatlcOperationTerminal(t, ctx, endpoint, token, accepted.OperationId)
 	if status.GetResult() != operation.ResultSucceeded || !status.GetBootHealthPending() || status.GetCandidateGenerationId() != candidateGeneration {
 		t.Fatalf("host upgrade operation status = %+v", status)
+	}
+	recordData := readGuestFile(t, ctx, guest, "/var/lib/katl/operations/"+accepted.OperationId+"/record.json")
+	envelope, err := persistedrecord.DecodeEnvelope([]byte(recordData))
+	if err != nil {
+		t.Fatalf("decode host upgrade operation envelope: %v", err)
+	}
+	persisted, err := persistedrecord.DecodePayload[operation.Snapshot](envelope)
+	if err != nil {
+		t.Fatalf("decode host upgrade operation snapshot: %v", err)
+	}
+	request := persisted.Record.HostUpgradeRequest
+	if request == nil || request.ImageSHA256 != upgrade.SHA256 || request.ImageSizeBytes != upgrade.SizeBytes {
+		t.Fatalf("host upgrade did not persist derived image identity: %#v", request)
 	}
 	trial := bootSelectionFromGuest(t, ctx, guest)
 	if trial.TrialGenerationID != candidateGeneration || trial.PreviousKnownGoodGenerationID != previousGeneration || !trial.PendingHealthValidation {


### PR DESCRIPTION
## Summary

- make PXE config-bundle checksums optional
- derive and persist host-upgrade image identity on the node
- derive kubeadm rollout desired, live, and payload state internally