### PR TITLE
ux: keep operation tracking inside katlctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ katlctl host upgrade \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --candidate-generation "katlos-$VERSION" \
-  --client-request-id "cp-1-katlos-$VERSION" \
   --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE"
 ```
 
@@ -221,20 +220,19 @@ the inactive root slot.
 Remove `--plan` only after reviewing the response. Automated fleet rollout and
 Kubernetes version upgrade execution are not supported alpha workflows.
 
-Every accepted config, host-upgrade, bootstrap, and destructive-reset response
-includes an `operationId`. Query a snapshot or follow it to terminal state
-through the same node agent:
+Mutating commands follow the node's durable operation to completion by default.
+Progress is written to stderr and the final structured result to stdout. A lost
+watch automatically falls back to polling the durable node record.
+
+Use `--no-wait` only for deliberately detached work. The detached response
+includes an operation reference. Current and recent operations remain
+discoverable afterward:
 
 ```sh
-katlctl operation status \
+katlctl operations list \
   --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --operation-id "$OPERATION_ID" \
-  --watch
+  --agent-token-file ./tokens/cp-1.token
 ```
-
-Watch streams are an optimization; `katlctl` falls back to the node's
-authoritative persisted status if a stream is interrupted.
 
 ## Release artifacts
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
@@ -142,11 +143,13 @@ type hostUpgradeOptions struct {
 	clientRequestID     string
 	actor               string
 	plan                bool
+	noWait              bool
+	waitTimeout         time.Duration
 	output              string
 }
 
 func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := hostUpgradeOptions{actor: "katlctl host upgrade", output: "json"}
+	opts := hostUpgradeOptions{actor: "katlctl host upgrade", waitTimeout: 30 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Stage one KatlOS image for bounded next-boot activation",
@@ -160,9 +163,12 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	cmd.Flags().StringVar(&opts.imageURL, "image-url", "", "HTTPS KatlOS upgrade image URL")
 	cmd.Flags().StringVar(&opts.imageLocalRef, "image-local-ref", "", "relative KatlOS image reference under the node artifact store")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
-	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "idempotency key")
+	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
+	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
 	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate without accepting an operation")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
+	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
 	return cmd
 }
@@ -175,8 +181,12 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if strings.TrimSpace(opts.endpoint) == "" {
 		return fmt.Errorf("--endpoint is required")
 	}
-	if strings.TrimSpace(opts.clientRequestID) == "" {
-		return fmt.Errorf("--client-request-id is required")
+	if opts.waitTimeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	requestID, err := clientRequestID(opts.clientRequestID)
+	if err != nil {
+		return err
 	}
 	request := operation.HostUpgrade{
 		ImageURL:              strings.TrimSpace(opts.imageURL),
@@ -198,7 +208,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 		ApiVersion:      operation.APIVersion,
 		Kind:            "SubmitOperationRequest",
-		ClientRequestId: opts.clientRequestID,
+		ClientRequestId: requestID,
 		OperationKind:   "host-upgrade",
 		Actor:           strings.TrimSpace(opts.actor),
 		DryRun:          opts.plan,
@@ -211,7 +221,10 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
-	return writeOperationAccepted(stdout, accepted)
+	if opts.plan || opts.noWait {
+		return writeOperationAccepted(stdout, accepted)
+	}
+	return waitAcceptedOperation(ctx, conn.Client, accepted, opts.waitTimeout, stdout, stderr)
 }
 
 type wipeClusterOptions struct {
@@ -225,6 +238,7 @@ type wipeClusterOptions struct {
 	clientRequestID string
 	agentTokenFile  string
 	planOnly        bool
+	noWait          bool
 	timeout         string
 	output          string
 }
@@ -244,10 +258,12 @@ func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, comman
 	cmd.Flags().BoolVar(&opts.allowPartial, "allow-partial-cluster", false, "allow a partial cluster target set")
 	cmd.Flags().BoolVar(&opts.confirm, "confirm-destructive-wipe", false, "confirm destructive wipe")
 	cmd.Flags().StringVar(&opts.acknowledgement, "acknowledge", "", "required destructive acknowledgement text")
-	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "idempotency key")
+	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
+	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
 	cmd.Flags().BoolVar(&opts.planOnly, "plan", false, "print the destructive wipe plan without accepting node-local operations")
-	cmd.Flags().StringVar(&opts.timeout, "timeout", "", "operation timeout duration")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after nodes accept their operations")
+	cmd.Flags().StringVar(&opts.timeout, "timeout", "30m", "operation and wait timeout duration")
 	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
 	cmd.Flags().Var(&opts.selectedNodes, "node", "inventory node name to wipe; may be repeated")
 	return cmd
@@ -267,8 +283,13 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 	if opts.acknowledgement != wipeAcknowledgementText {
 		return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
 	}
-	if strings.TrimSpace(opts.clientRequestID) == "" {
-		return fmt.Errorf("--client-request-id is required")
+	requestID, err := clientRequestID(opts.clientRequestID)
+	if err != nil {
+		return err
+	}
+	waitTimeout, err := time.ParseDuration(opts.timeout)
+	if err != nil || waitTimeout <= 0 {
+		return fmt.Errorf("--timeout must be a positive duration")
 	}
 	if opts.all && len(opts.selectedNodes.values) > 0 {
 		return fmt.Errorf("--all and --node cannot be combined")
@@ -314,7 +335,7 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 		report.NodeLocalOperations = plannedWipeClusterOperations(targets)
 		return printWipeClusterReport(stdout, report)
 	}
-	submitErr := submitWipeCluster(ctx, connector, &report, targets, strings.TrimSpace(opts.clientRequestID), strings.TrimSpace(opts.timeout))
+	submitErr := submitWipeCluster(ctx, connector, &report, targets, requestID, strings.TrimSpace(opts.timeout), opts.noWait, waitTimeout, stderr)
 	if printErr := printWipeClusterReport(stdout, report); printErr != nil {
 		return printErr
 	}
@@ -331,6 +352,7 @@ type wipeNodeOptions struct {
 	clientRequestID string
 	agentTokenFile  string
 	planOnly        bool
+	noWait          bool
 	timeout         string
 	output          string
 }
@@ -349,10 +371,12 @@ func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandNa
 	cmd.Flags().StringVar(&opts.kubeconfigPath, "kubeconfig", "", "path to operator kubeconfig")
 	cmd.Flags().BoolVar(&opts.confirm, "confirm-destructive-wipe", false, "confirm destructive wipe")
 	cmd.Flags().StringVar(&opts.acknowledgement, "acknowledge", "", "required destructive acknowledgement text")
-	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "idempotency key")
+	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
+	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
 	cmd.Flags().BoolVar(&opts.planOnly, "plan", false, "print the destructive wipe plan without accepting node-local operation")
-	cmd.Flags().StringVar(&opts.timeout, "timeout", "", "operation timeout duration")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
+	cmd.Flags().StringVar(&opts.timeout, "timeout", "30m", "operation and wait timeout duration")
 	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
 	cmd.Flags().Var(&opts.selectedNodes, "node", "inventory node name to wipe")
 	return cmd
@@ -378,8 +402,13 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 	if opts.acknowledgement != wipeAcknowledgementText {
 		return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
 	}
-	if strings.TrimSpace(opts.clientRequestID) == "" {
-		return fmt.Errorf("--client-request-id is required")
+	requestID, err := clientRequestID(opts.clientRequestID)
+	if err != nil {
+		return err
+	}
+	waitTimeout, err := time.ParseDuration(opts.timeout)
+	if err != nil || waitTimeout <= 0 {
+		return fmt.Errorf("--timeout must be a positive duration")
 	}
 
 	inv, err := loadInventory(opts.inventoryPath)
@@ -438,7 +467,7 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return fmt.Errorf("Kubernetes cleanup failed before node-local wipe")
 	}
 
-	submitErr := submitWipeCluster(ctx, connector, &report.wipeClusterReport, []inventory.PlannedNode{target}, strings.TrimSpace(opts.clientRequestID), strings.TrimSpace(opts.timeout))
+	submitErr := submitWipeCluster(ctx, connector, &report.wipeClusterReport, []inventory.PlannedNode{target}, requestID, strings.TrimSpace(opts.timeout), opts.noWait, waitTimeout, stderr)
 	if printErr := printWipeNodeReport(stdout, report); printErr != nil {
 		return printErr
 	}
@@ -662,7 +691,7 @@ func wipeNodeOperation(node inventory.PlannedNode) wipeClusterNodeLocalOperation
 	return operation
 }
 
-func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, report *wipeClusterReport, targets []inventory.PlannedNode, clientRequestID string, timeout string) error {
+func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, report *wipeClusterReport, targets []inventory.PlannedNode, clientRequestID string, timeout string, noWait bool, waitTimeout time.Duration, stderr io.Writer) error {
 	var failures []string
 	for _, node := range targets {
 		result := wipeClusterNodeResult{Node: node.Name}
@@ -697,7 +726,6 @@ func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, re
 				WipeSurfaces:           operationSpec.WipeSurfaces,
 			},
 		})
-		closeErr := closeAgentConnection(conn)
 		if err != nil {
 			result.Diagnostics = append(result.Diagnostics, inventory.Redact(err.Error()))
 			failures = append(failures, node.Name)
@@ -706,7 +734,9 @@ func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, re
 			failures = append(failures, node.Name)
 		} else {
 			result.Accepted = true
-			result.OperationID = accepted.GetOperationId()
+			if noWait {
+				result.OperationID = accepted.GetOperationId()
+			}
 			result.OperationKind = accepted.GetOperationKind()
 			if status := accepted.GetInitialStatus(); status != nil {
 				result.Phase = status.GetPhase()
@@ -716,7 +746,34 @@ func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, re
 					result.Diagnostics = append(result.Diagnostics, inventory.Redact(status.GetFailureReason()))
 				}
 			}
+			if !noWait {
+				waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+				status := accepted.GetInitialStatus()
+				if status == nil {
+					status, err = conn.Client.GetOperation(waitCtx, &agentapi.GetOperationRequest{OperationId: accepted.GetOperationId(), IncludeDiagnostics: "normal"})
+				}
+				if err == nil && status != nil && !status.GetTerminal() {
+					status, err = followOperation(waitCtx, conn.Client, &agentapi.GetOperationRequest{OperationId: accepted.GetOperationId(), IncludeDiagnostics: "normal"}, status, stderr)
+				}
+				cancel()
+				if err != nil {
+					result.Diagnostics = append(result.Diagnostics, inventory.Redact(err.Error()))
+					failures = append(failures, node.Name)
+				} else if status == nil {
+					result.Diagnostics = append(result.Diagnostics, "agent returned an empty operation status")
+					failures = append(failures, node.Name)
+				} else {
+					result.Phase = status.GetPhase()
+					result.Terminal = status.GetTerminal()
+					result.Result = status.GetResult()
+					if resultErr := operationResultError(status); resultErr != nil {
+						result.Diagnostics = append(result.Diagnostics, inventory.Redact(resultErr.Error()))
+						failures = append(failures, node.Name)
+					}
+				}
+			}
 		}
+		closeErr := closeAgentConnection(conn)
 		if closeErr != nil {
 			result.Diagnostics = append(result.Diagnostics, inventory.Redact(closeErr.Error()))
 			failures = append(failures, node.Name)
@@ -1120,6 +1177,8 @@ type configApplyOptions struct {
 	clientRequestID     string
 	actor               string
 	plan                bool
+	noWait              bool
+	waitTimeout         time.Duration
 	output              string
 }
 
@@ -1145,8 +1204,10 @@ func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 		},
 	}
 	addConfigApplyFlags(validateCmd, &validateOpts)
-	if flag := validateCmd.Flags().Lookup("plan"); flag != nil {
-		flag.Hidden = true
+	for _, name := range []string{"plan", "no-wait", "timeout", "client-request-id"} {
+		if flag := validateCmd.Flags().Lookup(name); flag != nil {
+			flag.Hidden = true
+		}
 	}
 	cmd.AddCommand(validateCmd)
 	cmd.AddCommand(newConfigApplyStatusCommand(ctx, stdout, stderr))
@@ -1154,28 +1215,37 @@ func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 }
 
 func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
+	if opts.waitTimeout == 0 {
+		opts.waitTimeout = 30 * time.Minute
+	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
 	cmd.Flags().StringVar(&opts.configPath, "file", "", "pre-rendered NodeConfigurationChange YAML")
 	addNodeConfigInputFlags(cmd, &opts.nodeConfig)
 	cmd.Flags().StringVar(&opts.mode, "mode", opts.mode, "apply mode: auto, live, or next-boot")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
-	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "idempotency key for this apply request")
+	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
+	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
 	cmd.Flags().BoolVar(&opts.plan, "plan", opts.plan, "validate and plan without accepting an operation")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
+	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
 	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
 }
 
 func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr io.Writer) error {
-	_ = stderr
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
 	if strings.TrimSpace(opts.endpoint) == "" {
 		return fmt.Errorf("--endpoint is required")
 	}
-	if strings.TrimSpace(opts.clientRequestID) == "" {
-		return fmt.Errorf("--client-request-id is required")
+	if opts.waitTimeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	requestID, err := clientRequestID(opts.clientRequestID)
+	if err != nil {
+		return err
 	}
 	fileInput := strings.TrimSpace(opts.configPath) != ""
 	intentInput := strings.TrimSpace(opts.nodeConfig.sourcePath) != "" || strings.TrimSpace(opts.nodeConfig.bundlePath) != ""
@@ -1183,7 +1253,6 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		return fmt.Errorf("exactly one of --file, --source, or --config-bundle is required")
 	}
 	var configYAML []byte
-	var err error
 	if fileInput {
 		if strings.TrimSpace(opts.nodeConfig.sourceID) != "" || strings.TrimSpace(opts.nodeConfig.desiredVersion) != "" {
 			return fmt.Errorf("--source-id and --desired-version require --source or --config-bundle")
@@ -1214,7 +1283,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion:            operation.APIVersion,
 			Kind:                  "ValidateConfigRequest",
-			ClientRequestId:       opts.clientRequestID,
+			ClientRequestId:       requestID,
 			Actor:                 opts.actor,
 			ApplyMode:             opts.mode,
 			CandidateGenerationId: opts.candidateGeneration,
@@ -1237,7 +1306,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	req := &agentapi.GenerationApplyRequest{
 		ApiVersion:            operation.APIVersion,
 		Kind:                  "GenerationApplyRequest",
-		ClientRequestId:       opts.clientRequestID,
+		ClientRequestId:       requestID,
 		Actor:                 opts.actor,
 		CandidateGenerationId: opts.candidateGeneration,
 		NodeName:              opts.nodeConfig.nodeName,
@@ -1256,7 +1325,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion:            operation.APIVersion,
 			Kind:                  "ValidateConfigRequest",
-			ClientRequestId:       opts.clientRequestID,
+			ClientRequestId:       requestID,
 			Actor:                 opts.actor,
 			ApplyMode:             requestedMode,
 			CandidateGenerationId: opts.candidateGeneration,
@@ -1279,7 +1348,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		accepted, err = conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 			ApiVersion:      operation.APIVersion,
 			Kind:            "SubmitOperationRequest",
-			ClientRequestId: opts.clientRequestID,
+			ClientRequestId: requestID,
 			OperationKind:   operationKind,
 			Actor:           opts.actor,
 			ConfigApply: &agentapi.ConfigApplyOperationRequest{
@@ -1295,7 +1364,10 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
-	return writeOperationAccepted(stdout, accepted)
+	if opts.noWait {
+		return writeOperationAccepted(stdout, accepted)
+	}
+	return waitAcceptedOperation(ctx, conn.Client, accepted, opts.waitTimeout, stdout, stderr)
 }
 
 func configApplyOperationKind(acceptedMode string) (string, error) {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/katl-dev/katl/internal/vmtest"
 	vmtestpb "github.com/katl-dev/katl/internal/vmtest/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestVersion(t *testing.T) {
@@ -972,7 +973,7 @@ func TestWipeClusterSubmitsDestructiveResetToAllNodes(t *testing.T) {
 		}
 	}
 	for _, node := range report.Nodes {
-		if !node.Accepted || node.OperationKind != wipeClusterOperationKind || node.OperationID == "" {
+		if !node.Accepted || node.OperationKind != wipeClusterOperationKind || node.OperationID != "" || !node.Terminal || node.Result != "succeeded" {
 			t.Fatalf("node result = %#v", node)
 		}
 	}
@@ -1368,9 +1369,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 	if fake.stageRequest == nil || fake.stageRequest.CandidateGenerationId != "generation-1" || fake.stageRequest.ClientRequestId != "req-stage" || fake.stageRequest.Actor != "katlctl config apply" {
 		t.Fatalf("stage request = %+v", fake.stageRequest)
 	}
-	if !strings.Contains(stdout.String(), `"operationId"`) || !strings.Contains(stdout.String(), `"generation-stage-01"`) || strings.Contains(stdout.String(), "requestDigest") {
-		t.Fatalf("stdout = %s", stdout.String())
-	}
+	assertSuccessfulMutationOutput(t, stdout.Bytes())
 }
 
 func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
@@ -1396,7 +1395,6 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 		"--endpoint", "node-a.example.test:9443",
 		"--image-url", "https://updates.example.test/katlos-upgrade.squashfs",
 		"--candidate-generation", "generation-upgrade-1",
-		"--client-request-id", "req-host-upgrade",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
@@ -1405,12 +1403,13 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 	if request == nil || request.OperationKind != "host-upgrade" || request.GetHostUpgrade() == nil {
 		t.Fatalf("submit request = %+v", request)
 	}
+	if !strings.HasPrefix(request.ClientRequestId, "katlctl-") {
+		t.Fatalf("generated client request id = %q", request.ClientRequestId)
+	}
 	if request.HostUpgrade.ImageUrl != "https://updates.example.test/katlos-upgrade.squashfs" || request.HostUpgrade.ImageSha256 != "" || request.HostUpgrade.ImageSizeBytes != 0 || request.HostUpgrade.CandidateGenerationId != "generation-upgrade-1" {
 		t.Fatalf("host upgrade request = %+v", request.HostUpgrade)
 	}
-	if !strings.Contains(stdout.String(), "host-upgrade-01") || strings.Contains(stdout.String(), "requestDigest") {
-		t.Fatalf("stdout = %s", stdout.String())
-	}
+	assertSuccessfulMutationOutput(t, stdout.Bytes())
 }
 
 func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
@@ -1462,9 +1461,7 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 	if fake.stageRequest != nil || fake.applyRequest != nil {
 		t.Fatalf("direct mutation request was sent: stage=%+v apply=%+v", fake.stageRequest, fake.applyRequest)
 	}
-	if !strings.Contains(stdout.String(), `"operationId"`) || !strings.Contains(stdout.String(), `"generation-apply-auto-01"`) || strings.Contains(stdout.String(), "requestDigest") {
-		t.Fatalf("stdout = %s", stdout.String())
-	}
+	assertSuccessfulMutationOutput(t, stdout.Bytes())
 }
 
 func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
@@ -1567,8 +1564,17 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 	if request.SourceID != "lab" || request.DesiredVersion != "2" || request.NodeOverrides["cp-1"].Identity == nil {
 		t.Fatalf("rendered request = %#v", request)
 	}
-	if !strings.Contains(stdout.String(), "generation-bundle-apply") {
-		t.Fatalf("stdout = %s", stdout.String())
+	assertSuccessfulMutationOutput(t, stdout.Bytes())
+}
+
+func assertSuccessfulMutationOutput(t *testing.T, data []byte) {
+	t.Helper()
+	var status agentapi.OperationStatus
+	if err := protojson.Unmarshal(data, &status); err != nil {
+		t.Fatalf("decode mutation result: %v\n%s", err, data)
+	}
+	if !status.Terminal || status.Result != operation.ResultSucceeded || status.OperationId != "" || status.RequestDigest != "" {
+		t.Fatalf("mutation result = %+v", &status)
 	}
 }
 
@@ -1740,6 +1746,8 @@ type fakeKatlcAgentClient struct {
 	generationRequest *agentapi.GetGenerationRequest
 	operationStatus   *agentapi.OperationStatus
 	operationRequest  *agentapi.GetOperationRequest
+	operations        *agentapi.ListOperationsResponse
+	operationsRequest *agentapi.ListOperationsRequest
 }
 
 type fakeWipeClusterConnector struct {
@@ -1794,7 +1802,7 @@ func readyWipeClusterClient(machineID string) *fakeKatlcAgentClient {
 			OperationId:   "wipe-" + machineID,
 			OperationKind: wipeClusterOperationKind,
 			RequestDigest: strings.Repeat("a", 64),
-			InitialStatus: &agentapi.OperationStatus{Phase: "accepted"},
+			InitialStatus: &agentapi.OperationStatus{Phase: "completed", Terminal: true, Result: "succeeded"},
 		},
 	}
 }
@@ -1840,7 +1848,26 @@ func (c *fakeKatlcAgentClient) CreateWorkerJoinMaterial(context.Context, *agenta
 
 func (c *fakeKatlcAgentClient) GetOperation(_ context.Context, req *agentapi.GetOperationRequest, _ ...grpc.CallOption) (*agentapi.OperationStatus, error) {
 	c.operationRequest = req
+	if c.operationStatus == nil {
+		accepted := c.stageAccepted
+		if c.submitAccepted != nil {
+			accepted = c.submitAccepted
+		}
+		status := &agentapi.OperationStatus{OperationId: req.OperationId, Phase: "completed", Terminal: true, Result: "succeeded"}
+		if accepted != nil {
+			status.OperationKind = accepted.GetOperationKind()
+		}
+		return status, nil
+	}
 	return c.operationStatus, nil
+}
+
+func (c *fakeKatlcAgentClient) ListOperations(_ context.Context, req *agentapi.ListOperationsRequest, _ ...grpc.CallOption) (*agentapi.ListOperationsResponse, error) {
+	c.operationsRequest = req
+	if c.operations == nil {
+		return &agentapi.ListOperationsResponse{}, nil
+	}
+	return c.operations, nil
 }
 
 func (c *fakeKatlcAgentClient) WatchOperation(context.Context, *agentapi.WatchOperationRequest, ...grpc.CallOption) (agentapi.KatlcAgent_WatchOperationClient, error) {

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +21,17 @@ const operationWatchRPCDuration = 5 * time.Second
 
 const operationPollInterval = 500 * time.Millisecond
 
+func clientRequestID(value string) (string, error) {
+	if value = strings.TrimSpace(value); value != "" {
+		return value, nil
+	}
+	var random [12]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", fmt.Errorf("generate request id: %w", err)
+	}
+	return "katlctl-" + hex.EncodeToString(random[:]), nil
+}
+
 type operationClient interface {
 	GetOperation(context.Context, *agentapi.GetOperationRequest, ...grpc.CallOption) (*agentapi.OperationStatus, error)
 	WatchOperation(context.Context, *agentapi.WatchOperationRequest, ...grpc.CallOption) (agentapi.KatlcAgent_WatchOperationClient, error)
@@ -34,9 +47,20 @@ type operationStatusOptions struct {
 	output         string
 }
 
+type operationListOptions struct {
+	endpoint       string
+	agentTokenFile string
+	activeOnly     bool
+	limit          int32
+	diagnostics    string
+	timeout        time.Duration
+	output         string
+}
+
 func newOperationCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{Use: "operation", Short: "KatlOS operation status"}
+	cmd := &cobra.Command{Use: "operations", Aliases: []string{"operation"}, Short: "Inspect KatlOS operations"}
 	cmd.AddCommand(newOperationStatusCommand(ctx, stdout, stderr))
+	cmd.AddCommand(newOperationListCommand(ctx, stdout, stderr))
 	return cmd
 }
 
@@ -58,6 +82,73 @@ func newOperationStatusCommand(ctx context.Context, stdout, stderr io.Writer) *c
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall status or watch timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
 	return cmd
+}
+
+func newOperationListCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := operationListOptions{limit: 20, diagnostics: "normal", timeout: 15 * time.Second, output: "json"}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List current and recent KatlOS operations",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runOperationList(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
+	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().BoolVar(&opts.activeOnly, "active", false, "show only non-terminal operations")
+	cmd.Flags().Int32Var(&opts.limit, "limit", opts.limit, "maximum operations to return")
+	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "list request timeout")
+	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	return cmd
+}
+
+func runOperationList(ctx context.Context, opts operationListOptions, stdout, stderr io.Writer) error {
+	_ = stderr
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want json", opts.output)
+	}
+	if strings.TrimSpace(opts.endpoint) == "" {
+		return fmt.Errorf("--endpoint is required")
+	}
+	if opts.limit < 1 || opts.limit > 100 {
+		return fmt.Errorf("--limit must be between 1 and 100")
+	}
+	if opts.diagnostics != "normal" && opts.diagnostics != "verbose" {
+		return fmt.Errorf("--diagnostics must be %q or %q", "normal", "verbose")
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	token, err := readAgentToken(opts.agentTokenFile)
+	if err != nil {
+		return err
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	conn, err := dialKatlcAgent(requestCtx, opts.endpoint, token)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	response, err := conn.Client.ListOperations(requestCtx, &agentapi.ListOperationsRequest{
+		ActiveOnly:         opts.activeOnly,
+		Limit:              opts.limit,
+		IncludeDiagnostics: opts.diagnostics,
+	})
+	if err != nil {
+		return err
+	}
+	for _, status := range response.GetOperations() {
+		status.RequestDigest = ""
+	}
+	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("marshal operations: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
 }
 
 func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout, stderr io.Writer) error {
@@ -128,7 +219,7 @@ func followOperation(ctx context.Context, client operationClient, request *agent
 	for {
 		progress := fmt.Sprintf("%s/%s/%t/%s", status.GetOperationKind(), status.GetPhase(), status.GetTerminal(), status.GetResult())
 		if progress != lastProgress {
-			fmt.Fprintf(stderr, "katlctl operation id=%s kind=%s phase=%s terminal=%t result=%s\n", status.GetOperationId(), status.GetOperationKind(), status.GetPhase(), status.GetTerminal(), status.GetResult())
+			fmt.Fprintf(stderr, "katlctl operation kind=%s phase=%s terminal=%t result=%s\n", status.GetOperationKind(), status.GetPhase(), status.GetTerminal(), status.GetResult())
 			lastProgress = progress
 		}
 		if status.GetTerminal() {
@@ -208,12 +299,63 @@ func writeOperationStatus(stdout io.Writer, status *agentapi.OperationStatus) er
 	return err
 }
 
+func writeMutationOperationStatus(stdout io.Writer, status *agentapi.OperationStatus) error {
+	if status == nil {
+		return fmt.Errorf("agent returned an empty operation status")
+	}
+	publicStatus := proto.Clone(status).(*agentapi.OperationStatus)
+	publicStatus.OperationId = ""
+	publicStatus.RequestDigest = ""
+	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(publicStatus)
+	if err != nil {
+		return fmt.Errorf("marshal operation result: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func waitAcceptedOperation(ctx context.Context, client operationClient, accepted *agentapi.OperationAccepted, timeout time.Duration, stdout, stderr io.Writer) error {
+	if accepted == nil || strings.TrimSpace(accepted.GetOperationId()) == "" {
+		return fmt.Errorf("agent returned an empty operation acceptance")
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	request := &agentapi.GetOperationRequest{OperationId: accepted.GetOperationId(), IncludeDiagnostics: "normal"}
+	status := accepted.GetInitialStatus()
+	if status == nil {
+		var err error
+		status, err = client.GetOperation(waitCtx, request)
+		if err != nil {
+			return fmt.Errorf("get accepted operation %s: %w", accepted.GetOperationId(), err)
+		}
+	}
+	status = proto.Clone(status).(*agentapi.OperationStatus)
+	if status.OperationId == "" {
+		status.OperationId = accepted.GetOperationId()
+	}
+	if status.OperationKind == "" {
+		status.OperationKind = accepted.GetOperationKind()
+	}
+	var err error
+	if !status.GetTerminal() {
+		status, err = followOperation(waitCtx, client, request, status, stderr)
+	}
+	if writeErr := writeMutationOperationStatus(stdout, status); writeErr != nil {
+		return writeErr
+	}
+	if err != nil {
+		return err
+	}
+	return operationResultError(status)
+}
+
 func writeOperationAccepted(stdout io.Writer, accepted *agentapi.OperationAccepted) error {
 	if accepted == nil {
 		return fmt.Errorf("agent returned an empty operation acceptance")
 	}
 	publicAccepted := proto.Clone(accepted).(*agentapi.OperationAccepted)
 	publicAccepted.RequestDigest = ""
+	publicAccepted.RecordPath = ""
 	if publicAccepted.InitialStatus != nil {
 		publicAccepted.InitialStatus.RequestDigest = ""
 	}

--- a/cmd/katlctl/operation_test.go
+++ b/cmd/katlctl/operation_test.go
@@ -70,6 +70,50 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 	}
 }
 
+func TestOperationsListDiscoversRecentWork(t *testing.T) {
+	client := &fakeKatlcAgentClient{operations: &agentapi.ListOperationsResponse{Operations: []*agentapi.OperationStatus{
+		{OperationId: "active-1", OperationKind: "host-upgrade", RequestDigest: strings.Repeat("a", 64), Phase: "download"},
+		{OperationId: "done-1", OperationKind: "generation-apply", RequestDigest: strings.Repeat("b", 64), Phase: "complete", Terminal: true, Result: "succeeded"},
+	}}}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(context.Context, string, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"operations", "list", "--endpoint", "node:9443", "--active", "--limit", "5"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got agentapi.ListOperationsResponse
+	if err := protojson.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode operations: %v\n%s", err, stdout.String())
+	}
+	if len(got.Operations) != 2 || got.Operations[0].OperationId != "active-1" {
+		t.Fatalf("operations = %#v", got.Operations)
+	}
+	if strings.Contains(stdout.String(), "requestDigest") {
+		t.Fatalf("operations exposed request digest: %s", stdout.String())
+	}
+	if client.operationsRequest == nil || !client.operationsRequest.ActiveOnly || client.operationsRequest.Limit != 5 {
+		t.Fatalf("list request = %#v", client.operationsRequest)
+	}
+}
+
+func TestDetachedAcceptanceHidesNodeRecordPath(t *testing.T) {
+	var stdout bytes.Buffer
+	err := writeOperationAccepted(&stdout, &agentapi.OperationAccepted{
+		OperationId: "op-1", OperationKind: "host-upgrade", RecordPath: "/var/lib/katl/operations/op-1/record.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "op-1") || strings.Contains(stdout.String(), "recordPath") || strings.Contains(stdout.String(), "/var/lib/katl") {
+		t.Fatalf("detached output = %s", stdout.String())
+	}
+}
+
 func TestFollowOperationUsesWatchSequence(t *testing.T) {
 	terminal := &agentapi.OperationStatus{OperationId: "operation-1", OperationKind: "host-upgrade", Phase: "complete", LatestJournalSeq: 4, Terminal: true, Result: "succeeded"}
 	client := &fakeOperationClient{streams: []*fakeOperationStream{{events: []*agentapi.OperationEvent{{OperationId: "operation-1", JournalSeq: 4, Terminal: true, Status: terminal}}}}}

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -500,8 +500,7 @@ katlctl config apply validate \
   --source ./cluster.yaml \
   --node cp-1 \
   --desired-version 2 \
-  --candidate-generation config-2 \
-  --client-request-id cp-1-config-2
+  --candidate-generation config-2
 ```
 
 If the source has already been compiled, use the bundle instead of
@@ -514,15 +513,14 @@ katlctl config apply validate \
   --config-bundle ./katl-lab.katlcfg \
   --node cp-1 \
   --desired-version 2 \
-  --candidate-generation config-2 \
-  --client-request-id cp-1-config-2
+  --candidate-generation config-2
 ```
 
 Remove `validate` to submit the accepted plan. The default `--mode auto` uses
 the agent's domain matrix to choose live apply or next boot; `--mode live` and
 `--mode next-boot` request an explicit policy and are rejected when unsafe.
-Keep the same inputs when submitting; the client request id becomes the
-idempotency key for the accepted operation.
+Keep the same configuration inputs when submitting. `katlctl` generates the
+idempotency key and follows the accepted operation to its terminal result.
 
 The renderer currently carries hostname, SSH authorized keys, and systemd-
 networkd files from the selected node. It deliberately excludes disk/install

--- a/docs/internal/katlc-agent-architecture.md
+++ b/docs/internal/katlc-agent-architecture.md
@@ -46,7 +46,8 @@ redacted diagnostics and status projections
 loading inventory or compiled plans
 selecting the bootstrap init node
 sequencing requests across nodes
-polling or watching returned operation IDs
+polling or watching accepted operations internally
+discovering current and recent durable operations after client interruption
 writing disposable client summaries
 writing explicit client-side output such as kubeconfig files
 ```
@@ -115,10 +116,12 @@ katlctl bootstrap init
 katlctl bootstrap join-control-plane
 katlctl bootstrap join-worker
 katlctl kubeconfig get
+katlctl operations list
+katlctl operations status
 ```
 
 These commands load operator config, select target nodes, call the node-local
-agent APIs, poll or watch operation IDs, and write client-side output. They do
+agent APIs, track operation IDs internally, and write client-side output. They do
 not create node-local state directly. Existing greenfield scaffolding may still
 use older command names such as `katlctl cluster bootstrap`; move that surface
 toward the target shape instead of preserving both names.

--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -29,9 +29,6 @@ Required common flags:
 --acknowledge TEXT
   Must exactly match the acknowledgement text above after shell parsing.
 
---client-request-id ID
-  Idempotency key recorded in every accepted node-local operation request.
-
 --output json
   v0.1 status and plan output format. Other formats are unsupported.
 ```
@@ -46,6 +43,13 @@ Optional common flags:
 --timeout DURATION
   Upper bound for client-side waits. Timeout stops waiting but does not cancel an
   accepted node-local wipe operation.
+
+--no-wait
+  Return after every selected node accepts its durable operation. The detached
+  result includes operation IDs for exact later lookup.
+
+--client-request-id ID
+  Optional advanced override for the automatically generated idempotency key.
 ```
 
 Authentication and authorization:
@@ -63,9 +67,9 @@ Plan and status output:
 - `--plan` prints JSON with `command`, `targets`, `acknowledgementAccepted`,
   `kubernetesCleanup`, `nodeLocalOperations`, `wipedState`, `preservedState`,
   and `refusals`.
-- Executing commands print JSON with one entry per selected node, including the
-  accepted node-local operation ID, current phase, terminal status when known,
-  and the evidence paths or redacted diagnostics available to the client.
+- Executing commands wait by default and print JSON with one entry per selected
+  node, including the final phase, terminal status, and redacted diagnostics.
+  Opaque operation IDs appear only for detached execution or exact diagnostics.
 - Aggregate success means every selected node has had its Katl-owned disk boot
   path disabled so a reboot must use installer media or PXE. Partial success
   exits non-zero and reports each node's terminal or last observed status.
@@ -103,10 +107,10 @@ Requests are refused before node-local mutation when:
 Failure behavior:
 
 - After a node-local operation is accepted, `katlctl` may lose connectivity
-  without changing the operation's authority. Operators must use status polling
-  against node-local `katlc` to resume observation.
+  without changing the operation's authority. Operators discover durable work
+  with `katlctl operations list` and may resume exact observation by ID.
 - If mutation may have started, retry is not automatic. A later command must use
-  the same `--client-request-id` or an explicit recovery flow once one exists.
+  operation discovery rather than blindly submitting another destructive reset.
 - Diagnostics must redact bearer tokens, kubeconfigs, bootstrap tokens,
   certificate private keys, and etcd secrets.
 
@@ -116,7 +120,7 @@ Command:
 
 ```text
 katlctl wipe node --inventory PATH --node NAME --kubeconfig PATH \
-  --confirm-destructive-wipe --acknowledge TEXT --client-request-id ID
+  --confirm-destructive-wipe --acknowledge TEXT
 ```
 
 Target selection:
@@ -165,7 +169,7 @@ Command:
 
 ```text
 katlctl cluster wipe --inventory PATH --all \
-  --confirm-destructive-wipe --acknowledge TEXT --client-request-id ID
+  --confirm-destructive-wipe --acknowledge TEXT
 ```
 
 The old `katlctl wipe cluster` spelling is a temporary compatibility alias. It

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -36,7 +36,7 @@ Keep these artifacts together for the life of an evaluation:
 - the source `ClusterConfig` and compiled `.katlcfg` bundle;
 - the Kubernetes OCI reference;
 - one protected agent token file per node;
-- the kubeconfig, operation IDs, generation IDs, and relevant timestamps; and
+- the kubeconfig, command results, generation IDs, and relevant timestamps; and
 - independent etcd, application, and persistent-data backups.
 
 Treat command outcomes precisely:
@@ -48,26 +48,23 @@ Treat command outcomes precisely:
 - **failed-needs-repair** means do not blindly retry or assume host rollback
   reverted Kubernetes state.
 
-Use a unique, stable `--client-request-id` for each intended mutation. Reuse it
-only when retrying the exact same request. Changing inputs requires a new ID.
+`katlctl` generates mutation idempotency keys and follows durable operations to
+their terminal result. Operators do not need to create request IDs or retain
+operation IDs. Progress is written to stderr and final structured status to
+stdout.
 
-For every accepted mutation, retain its `operationId`. Use the generic status
-path for config apply, host upgrade, bootstrap, and
-destructive reset:
+Use `--no-wait` only when intentionally detaching a command. Discover current
+or recent node work later with:
 
 ```sh
-katlctl operation status \
+katlctl operations list \
   --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --operation-id "$OPERATION_ID" \
-  --watch
+  --agent-token-file ./tokens/cp-1.token
 ```
 
-Without `--watch`, the command returns one authoritative snapshot. With it,
-progress is written to stderr and final structured status to stdout. A lost
-watch automatically falls back to polling the durable node record. Use
-`--diagnostics verbose` when the normal redacted status is insufficient. A
-watched terminal failure still prints its final JSON status and exits nonzero.
+`katlctl operation status --operation-id ID` remains an advanced diagnostic
+path for one exact record. Use `--diagnostics verbose` when normal redacted
+status is insufficient.
 
 ## Boundaries That Matter During Operations
 

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -66,18 +66,16 @@ katlctl cluster bootstrap \
 The normal sequence verifies and stages the Kubernetes sysext, initializes the
 first control plane, creates join material, joins remaining nodes, checks
 post-kubeadm health, commits generation 1, and writes the operator kubeconfig.
-Save the command output and returned operation IDs.
+Save the command output and resulting kubeconfig.
 
-Bootstrap waits for its submitted operations, but their node-local records
+Bootstrap waits for its submitted operations, and their node-local records
 remain queryable afterward. If the workstation disconnects or a result is
-unclear, query the affected node with the returned operation ID:
+unclear, discover the affected node's current and recent operations:
 
 ```sh
-katlctl operation status \
+katlctl operations list \
   --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --operation-id "$OPERATION_ID" \
-  --watch
+  --agent-token-file ./tokens/cp-1.token
 ```
 
 ## Establish Cluster Networking
@@ -121,7 +119,7 @@ endpoint, and node readiness matches the chosen CNI stage.
 ## Failure Boundary
 
 Do not assume rerunning bootstrap is safe. If kubeadm or API mutation began,
-host generation rollback does not erase it. Preserve operation IDs and follow
+host generation rollback does not erase it. Preserve the command result and follow
 [Troubleshoot KatlOS](troubleshoot.md). Additional-control-plane repair,
 Kubernetes version upgrade, and general reconciliation are not supported alpha
 operations.

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -39,8 +39,7 @@ katlctl config apply validate \
   --source ./cluster.yaml \
   --node cp-1 \
   --desired-version 2 \
-  --candidate-generation config-2 \
-  --client-request-id cp-1-config-2
+  --candidate-generation config-2
 ```
 
 Validation reports the changed domains and accepted apply mode without
@@ -67,27 +66,13 @@ katlctl config apply \
   --source ./cluster.yaml \
   --node cp-1 \
   --desired-version 2 \
-  --candidate-generation config-2 \
-  --client-request-id cp-1-config-2
+  --candidate-generation config-2
 ```
 
-Keep the inputs and client request ID identical to the reviewed plan. The JSON
-response records the operation ID and initial status. Accepted does not mean
-complete.
-
-Follow the accepted operation before evaluating generation health:
-
-```sh
-katlctl operation status \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --operation-id "$OPERATION_ID" \
-  --watch
-```
-
-Require `terminal: true` and `result: succeeded`. If `recoveryRequired` is
-true, stop and follow `failureReason` and `nextAction`; do not submit a new
-apply merely because the watch disconnected.
+Keep the configuration inputs identical to the reviewed plan. `katlctl`
+generates the retry identity, follows the durable apply, and exits only after a
+terminal result. Require `terminal: true` and `result: succeeded`. If
+`recoveryRequired` is true, stop and follow `failureReason` and `nextAction`.
 
 ## Check Generation Status
 

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -32,16 +32,16 @@ find /var/lib/katl/generations -maxdepth 2 -type f -print
 find /var/lib/katl/operations -maxdepth 3 -type f -print
 ```
 
-For one accepted operation, first query its redacted durable status through the
-agent:
+First discover current and recent durable operations through the agent:
 
 ```sh
-katlctl operation status \
+katlctl operations list \
   --endpoint affected-node.example.test:9443 \
-  --agent-token-file ./tokens/affected-node.token \
-  --operation-id "$OPERATION_ID" \
-  --diagnostics verbose
+  --agent-token-file ./tokens/affected-node.token
 ```
+
+Use `katlctl operation status --operation-id ID --diagnostics verbose` when an
+exact record needs deeper inspection.
 
 If the agent is unavailable, use SSH as a break-glass evidence path and read
 the record without editing it. The journal directory is authoritative when a

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -31,7 +31,6 @@ katlctl host upgrade \
   --endpoint cp-1.example.test:9443 \
   --agent-token-file ./tokens/cp-1.token \
   --candidate-generation "katlos-$VERSION" \
-  --client-request-id "cp-1-katlos-$VERSION" \
   --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE"
 ```
 
@@ -44,18 +43,8 @@ component metadata before changing the inactive slot.
 
 ## Stage the Trial
 
-Run the identical command without `--plan`. Save the returned `operationId`.
-The response means accepted, not staged successfully.
-
-Follow the accepted operation through the node agent:
-
-```sh
-katlctl operation status \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --operation-id "$OPERATION_ID" \
-  --watch
-```
+Run the identical command without `--plan`. `katlctl` follows the durable stage
+operation and returns its terminal result.
 
 Do not reboot until the operation is terminal with `result: succeeded` and
 `nextAction` says to reboot into the bounded candidate trial. A terminal staging

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -71,8 +71,7 @@ katlctl cluster wipe \
   --inventory ./cluster-inventory.yaml \
   --all \
   --confirm-destructive-wipe \
-  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.' \
-  --client-request-id discard-katl-lab-1
+  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.'
 ```
 
 Even a plan requires the acknowledgement so automation cannot casually turn a
@@ -80,19 +79,8 @@ review command into a destructive one. Review every target, address, role,
 wiped surface, preserved surface, and refusal.
 
 Run the identical command without `--plan` only when the cluster is intentionally
-being discarded. The command submits node-local destructive-reset operations
-and reports their operation IDs and initial status.
-
-For each reported node endpoint and operation ID, follow the
-node-local reset to terminal state:
-
-```sh
-katlctl operation status \
-  --endpoint worker-1.example.test:9443 \
-  --agent-token-file ./tokens/worker-1.token \
-  --operation-id "$OPERATION_ID" \
-  --watch
-```
+being discarded. The command follows every node-local destructive reset and
+reports each terminal result.
 
 Do not proceed to reinstall until every intended reset reports `terminal: true`
 and `result: succeeded`. Treat `recoveryRequired: true` as a stop condition.
@@ -107,8 +95,7 @@ katlctl cluster wipe node \
   --inventory ./cluster-inventory.yaml \
   --node worker-1 \
   --confirm-destructive-wipe \
-  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.' \
-  --client-request-id replace-worker-1-1
+  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.'
 ```
 
 Execution additionally requires `--kubeconfig ./kubeconfig`. If Kubernetes

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -598,6 +598,35 @@ func (s Store) Read(operationID string) (OperationRecord, error) {
 	return record, nil
 }
 
+// List returns durable operation records with the most recently updated first.
+func (s Store) List() ([]OperationRecord, error) {
+	entries, err := os.ReadDir(s.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read operation store: %w", err)
+	}
+	records := make([]OperationRecord, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		record, err := s.Read(entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read operation %q: %w", entry.Name(), err)
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].UpdatedAt.Equal(records[j].UpdatedAt) {
+			return records[i].OperationID < records[j].OperationID
+		}
+		return records[i].UpdatedAt.After(records[j].UpdatedAt)
+	})
+	return records, nil
+}
+
 func (s Store) EventsAfter(operationID string, afterSeq int) ([]JournalEvent, error) {
 	dir, err := s.operationDir(operationID)
 	if err != nil {

--- a/internal/installer/operation/store_test.go
+++ b/internal/installer/operation/store_test.go
@@ -46,6 +46,22 @@ func TestStoreCreatesAndUpdatesJournalFirstRecord(t *testing.T) {
 	}
 }
 
+func TestStoreListsMostRecentlyUpdatedFirst(t *testing.T) {
+	store := testStore(t)
+	older := mustCreate(t, store, "op-older")
+	newer := baseRecord("op-newer")
+	if _, err := store.Create(newer, "accepted", older.UpdatedAt.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	records, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 || records[0].OperationID != "op-newer" || records[1].OperationID != "op-older" {
+		t.Fatalf("records = %#v", records)
+	}
+}
+
 func TestValidateHostUpgrade(t *testing.T) {
 	valid := HostUpgrade{
 		ImageLocalRef:         "updates/katlos-upgrade.squashfs",

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -452,6 +452,41 @@ func (s *Server) GetOperation(ctx context.Context, req *agentapi.GetOperationReq
 	return status, nil
 }
 
+func (s *Server) ListOperations(ctx context.Context, req *agentapi.ListOperationsRequest) (*agentapi.ListOperationsResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if req == nil {
+		req = &agentapi.ListOperationsRequest{}
+	}
+	if req.Limit < 0 || req.Limit > 100 {
+		return nil, status.Error(codes.InvalidArgument, "limit must be between 0 and 100")
+	}
+	options, err := responseOptions(req.IncludeDiagnostics)
+	if err != nil {
+		return nil, err
+	}
+	records, err := s.Store.List()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list operations: %v", err)
+	}
+	limit := int(req.Limit)
+	if limit == 0 {
+		limit = 20
+	}
+	response := &agentapi.ListOperationsResponse{}
+	for _, record := range records {
+		if req.ActiveOnly && record.Terminal {
+			continue
+		}
+		response.Operations = append(response.Operations, operationStatus(record, options.Diagnostics))
+		if len(response.Operations) == limit {
+			break
+		}
+	}
+	return response, nil
+}
+
 func (s *Server) WatchOperation(req *agentapi.WatchOperationRequest, stream agentapi.KatlcAgent_WatchOperationServer) error {
 	if req == nil || strings.TrimSpace(req.OperationId) == "" {
 		return status.Error(codes.InvalidArgument, "operationID is required")

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -71,6 +71,29 @@ func TestSubmitOperationCreatesRecord(t *testing.T) {
 	}
 }
 
+func TestListOperationsFiltersActiveRecords(t *testing.T) {
+	server := newTestServer(t)
+	active := createAgentOperation(t, server.Store, "op-active")
+	terminal := createAgentOperation(t, server.Store, "op-terminal")
+	if _, err := server.Store.Update(terminal.OperationID, "complete", "complete", func(record operation.OperationRecord) (operation.OperationRecord, error) {
+		completedAt := time.Now().UTC()
+		record.Terminal = true
+		record.Result = operation.ResultSucceeded
+		record.CompletedAt = &completedAt
+		return record, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := server.ListOperations(context.Background(), &agentapi.ListOperationsRequest{ActiveOnly: true, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Operations) != 1 || response.Operations[0].OperationId != active.OperationID {
+		t.Fatalf("operations = %#v", response.Operations)
+	}
+}
+
 func TestSubmitOperationRecordsDestructiveReset(t *testing.T) {
 	server := newTestServer(t)
 	var dispatched atomic.Int32

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -1753,6 +1753,110 @@ func (x *GetOperationRequest) GetIncludeDiagnostics() string {
 	return ""
 }
 
+type ListOperationsRequest struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	ActiveOnly         bool                   `protobuf:"varint,1,opt,name=active_only,json=activeOnly,proto3" json:"active_only,omitempty"`
+	Limit              int32                  `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	IncludeDiagnostics string                 `protobuf:"bytes,3,opt,name=include_diagnostics,json=includeDiagnostics,proto3" json:"include_diagnostics,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *ListOperationsRequest) Reset() {
+	*x = ListOperationsRequest{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListOperationsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOperationsRequest) ProtoMessage() {}
+
+func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOperationsRequest.ProtoReflect.Descriptor instead.
+func (*ListOperationsRequest) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *ListOperationsRequest) GetActiveOnly() bool {
+	if x != nil {
+		return x.ActiveOnly
+	}
+	return false
+}
+
+func (x *ListOperationsRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListOperationsRequest) GetIncludeDiagnostics() string {
+	if x != nil {
+		return x.IncludeDiagnostics
+	}
+	return ""
+}
+
+type ListOperationsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Operations    []*OperationStatus     `protobuf:"bytes,1,rep,name=operations,proto3" json:"operations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListOperationsResponse) Reset() {
+	*x = ListOperationsResponse{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListOperationsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOperationsResponse) ProtoMessage() {}
+
+func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOperationsResponse.ProtoReflect.Descriptor instead.
+func (*ListOperationsResponse) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ListOperationsResponse) GetOperations() []*OperationStatus {
+	if x != nil {
+		return x.Operations
+	}
+	return nil
+}
+
 type OperationStatus struct {
 	state                   protoimpl.MessageState `protogen:"open.v1"`
 	OperationId             string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
@@ -1789,7 +1893,7 @@ type OperationStatus struct {
 
 func (x *OperationStatus) Reset() {
 	*x = OperationStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1801,7 +1905,7 @@ func (x *OperationStatus) String() string {
 func (*OperationStatus) ProtoMessage() {}
 
 func (x *OperationStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1814,7 +1918,7 @@ func (x *OperationStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationStatus.ProtoReflect.Descriptor instead.
 func (*OperationStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *OperationStatus) GetOperationId() string {
@@ -2026,7 +2130,7 @@ type DiagnosticArtifact struct {
 
 func (x *DiagnosticArtifact) Reset() {
 	*x = DiagnosticArtifact{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2038,7 +2142,7 @@ func (x *DiagnosticArtifact) String() string {
 func (*DiagnosticArtifact) ProtoMessage() {}
 
 func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2051,7 +2155,7 @@ func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiagnosticArtifact.ProtoReflect.Descriptor instead.
 func (*DiagnosticArtifact) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DiagnosticArtifact) GetArtifactId() string {
@@ -2106,7 +2210,7 @@ type OperationInvocation struct {
 
 func (x *OperationInvocation) Reset() {
 	*x = OperationInvocation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2118,7 +2222,7 @@ func (x *OperationInvocation) String() string {
 func (*OperationInvocation) ProtoMessage() {}
 
 func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2131,7 +2235,7 @@ func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationInvocation.ProtoReflect.Descriptor instead.
 func (*OperationInvocation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *OperationInvocation) GetInvocationId() string {
@@ -2210,7 +2314,7 @@ type WatchOperationRequest struct {
 
 func (x *WatchOperationRequest) Reset() {
 	*x = WatchOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2222,7 +2326,7 @@ func (x *WatchOperationRequest) String() string {
 func (*WatchOperationRequest) ProtoMessage() {}
 
 func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2235,7 +2339,7 @@ func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchOperationRequest.ProtoReflect.Descriptor instead.
 func (*WatchOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *WatchOperationRequest) GetOperationId() string {
@@ -2288,7 +2392,7 @@ type OperationEvent struct {
 
 func (x *OperationEvent) Reset() {
 	*x = OperationEvent{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2300,7 +2404,7 @@ func (x *OperationEvent) String() string {
 func (*OperationEvent) ProtoMessage() {}
 
 func (x *OperationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2313,7 +2417,7 @@ func (x *OperationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationEvent.ProtoReflect.Descriptor instead.
 func (*OperationEvent) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *OperationEvent) GetOperationId() string {
@@ -2374,7 +2478,7 @@ type ListGenerationsRequest struct {
 
 func (x *ListGenerationsRequest) Reset() {
 	*x = ListGenerationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2386,7 +2490,7 @@ func (x *ListGenerationsRequest) String() string {
 func (*ListGenerationsRequest) ProtoMessage() {}
 
 func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2399,7 +2503,7 @@ func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsRequest.ProtoReflect.Descriptor instead.
 func (*ListGenerationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ListGenerationsRequest) GetIncludeConfigApply() bool {
@@ -2418,7 +2522,7 @@ type ListGenerationsResponse struct {
 
 func (x *ListGenerationsResponse) Reset() {
 	*x = ListGenerationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2430,7 +2534,7 @@ func (x *ListGenerationsResponse) String() string {
 func (*ListGenerationsResponse) ProtoMessage() {}
 
 func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2443,7 +2547,7 @@ func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsResponse.ProtoReflect.Descriptor instead.
 func (*ListGenerationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ListGenerationsResponse) GetGenerations() []*Generation {
@@ -2463,7 +2567,7 @@ type GetGenerationRequest struct {
 
 func (x *GetGenerationRequest) Reset() {
 	*x = GetGenerationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2475,7 +2579,7 @@ func (x *GetGenerationRequest) String() string {
 func (*GetGenerationRequest) ProtoMessage() {}
 
 func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2488,7 +2592,7 @@ func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGenerationRequest.ProtoReflect.Descriptor instead.
 func (*GetGenerationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetGenerationRequest) GetGenerationId() string {
@@ -2525,7 +2629,7 @@ type Generation struct {
 
 func (x *Generation) Reset() {
 	*x = Generation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2537,7 +2641,7 @@ func (x *Generation) String() string {
 func (*Generation) ProtoMessage() {}
 
 func (x *Generation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2550,7 +2654,7 @@ func (x *Generation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Generation.ProtoReflect.Descriptor instead.
 func (*Generation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Generation) GetGenerationId() string {
@@ -2652,7 +2756,7 @@ type ExtensionRef struct {
 
 func (x *ExtensionRef) Reset() {
 	*x = ExtensionRef{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2664,7 +2768,7 @@ func (x *ExtensionRef) String() string {
 func (*ExtensionRef) ProtoMessage() {}
 
 func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2677,7 +2781,7 @@ func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionRef.ProtoReflect.Descriptor instead.
 func (*ExtensionRef) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExtensionRef) GetName() string {
@@ -2741,7 +2845,7 @@ type GeneratedConfext struct {
 
 func (x *GeneratedConfext) Reset() {
 	*x = GeneratedConfext{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2753,7 +2857,7 @@ func (x *GeneratedConfext) String() string {
 func (*GeneratedConfext) ProtoMessage() {}
 
 func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2766,7 +2870,7 @@ func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeneratedConfext.ProtoReflect.Descriptor instead.
 func (*GeneratedConfext) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GeneratedConfext) GetName() string {
@@ -2813,7 +2917,7 @@ type ConfigApplyStatus struct {
 
 func (x *ConfigApplyStatus) Reset() {
 	*x = ConfigApplyStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2825,7 +2929,7 @@ func (x *ConfigApplyStatus) String() string {
 func (*ConfigApplyStatus) ProtoMessage() {}
 
 func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2838,7 +2942,7 @@ func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyStatus.ProtoReflect.Descriptor instead.
 func (*ConfigApplyStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ConfigApplyStatus) GetPhase() string {
@@ -3088,7 +3192,16 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x13GetOperationRequest\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\x126\n" +
 	"\x17expected_request_digest\x18\x02 \x01(\tR\x15expectedRequestDigest\x12/\n" +
-	"\x13include_diagnostics\x18\x03 \x01(\tR\x12includeDiagnostics\"\xd8\t\n" +
+	"\x13include_diagnostics\x18\x03 \x01(\tR\x12includeDiagnostics\"\x7f\n" +
+	"\x15ListOperationsRequest\x12\x1f\n" +
+	"\vactive_only\x18\x01 \x01(\bR\n" +
+	"activeOnly\x12\x14\n" +
+	"\x05limit\x18\x02 \x01(\x05R\x05limit\x12/\n" +
+	"\x13include_diagnostics\x18\x03 \x01(\tR\x12includeDiagnostics\"X\n" +
+	"\x16ListOperationsResponse\x12>\n" +
+	"\n" +
+	"operations\x18\x01 \x03(\v2\x1e.katl.agent.v1.OperationStatusR\n" +
+	"operations\"\xd8\t\n" +
 	"\x0fOperationStatus\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\x12%\n" +
 	"\x0eoperation_kind\x18\x02 \x01(\tR\roperationKind\x12%\n" +
@@ -3205,7 +3318,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0efailure_reason\x18\x05 \x01(\tR\rfailureReason\x126\n" +
 	"\x17kubeadm_action_required\x18\x06 \x01(\bR\x15kubeadmActionRequired\x12?\n" +
 	"\x1cprevious_kubeadm_config_name\x18\a \x01(\tR\x19previousKubeadmConfigName\x12?\n" +
-	"\x1cselected_kubeadm_config_name\x18\b \x01(\tR\x19selectedKubeadmConfigName2\xad\a\n" +
+	"\x1cselected_kubeadm_config_name\x18\b \x01(\tR\x19selectedKubeadmConfigName2\x8c\b\n" +
 	"\n" +
 	"KatlcAgent\x12O\n" +
 	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12]\n" +
@@ -3214,7 +3327,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0fStageGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
 	"\x0fSubmitOperation\x12%.katl.agent.v1.SubmitOperationRequest\x1a .katl.agent.v1.OperationAccepted\x12{\n" +
 	"\x18CreateWorkerJoinMaterial\x12..katl.agent.v1.CreateWorkerJoinMaterialRequest\x1a/.katl.agent.v1.CreateWorkerJoinMaterialResponse\x12R\n" +
-	"\fGetOperation\x12\".katl.agent.v1.GetOperationRequest\x1a\x1e.katl.agent.v1.OperationStatus\x12W\n" +
+	"\fGetOperation\x12\".katl.agent.v1.GetOperationRequest\x1a\x1e.katl.agent.v1.OperationStatus\x12]\n" +
+	"\x0eListOperations\x12$.katl.agent.v1.ListOperationsRequest\x1a%.katl.agent.v1.ListOperationsResponse\x12W\n" +
 	"\x0eWatchOperation\x12$.katl.agent.v1.WatchOperationRequest\x1a\x1d.katl.agent.v1.OperationEvent0\x01\x12`\n" +
 	"\x0fListGenerations\x12%.katl.agent.v1.ListGenerationsRequest\x1a&.katl.agent.v1.ListGenerationsResponse\x12O\n" +
 	"\rGetGeneration\x12#.katl.agent.v1.GetGenerationRequest\x1a\x19.katl.agent.v1.GenerationB;Z9github.com/katl-dev/katl/internal/katlc/agentapi;agentapib\x06proto3"
@@ -3231,7 +3345,7 @@ func file_internal_katlc_agentapi_agent_proto_rawDescGZIP() []byte {
 	return file_internal_katlc_agentapi_agent_proto_rawDescData
 }
 
-var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*GetNodeStatusRequest)(nil),                      // 0: katl.agent.v1.GetNodeStatusRequest
 	(*NodeStatus)(nil),                                // 1: katl.agent.v1.NodeStatus
@@ -3250,18 +3364,20 @@ var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*CreateWorkerJoinMaterialResponse)(nil),          // 14: katl.agent.v1.CreateWorkerJoinMaterialResponse
 	(*OperationAccepted)(nil),                         // 15: katl.agent.v1.OperationAccepted
 	(*GetOperationRequest)(nil),                       // 16: katl.agent.v1.GetOperationRequest
-	(*OperationStatus)(nil),                           // 17: katl.agent.v1.OperationStatus
-	(*DiagnosticArtifact)(nil),                        // 18: katl.agent.v1.DiagnosticArtifact
-	(*OperationInvocation)(nil),                       // 19: katl.agent.v1.OperationInvocation
-	(*WatchOperationRequest)(nil),                     // 20: katl.agent.v1.WatchOperationRequest
-	(*OperationEvent)(nil),                            // 21: katl.agent.v1.OperationEvent
-	(*ListGenerationsRequest)(nil),                    // 22: katl.agent.v1.ListGenerationsRequest
-	(*ListGenerationsResponse)(nil),                   // 23: katl.agent.v1.ListGenerationsResponse
-	(*GetGenerationRequest)(nil),                      // 24: katl.agent.v1.GetGenerationRequest
-	(*Generation)(nil),                                // 25: katl.agent.v1.Generation
-	(*ExtensionRef)(nil),                              // 26: katl.agent.v1.ExtensionRef
-	(*GeneratedConfext)(nil),                          // 27: katl.agent.v1.GeneratedConfext
-	(*ConfigApplyStatus)(nil),                         // 28: katl.agent.v1.ConfigApplyStatus
+	(*ListOperationsRequest)(nil),                     // 17: katl.agent.v1.ListOperationsRequest
+	(*ListOperationsResponse)(nil),                    // 18: katl.agent.v1.ListOperationsResponse
+	(*OperationStatus)(nil),                           // 19: katl.agent.v1.OperationStatus
+	(*DiagnosticArtifact)(nil),                        // 20: katl.agent.v1.DiagnosticArtifact
+	(*OperationInvocation)(nil),                       // 21: katl.agent.v1.OperationInvocation
+	(*WatchOperationRequest)(nil),                     // 22: katl.agent.v1.WatchOperationRequest
+	(*OperationEvent)(nil),                            // 23: katl.agent.v1.OperationEvent
+	(*ListGenerationsRequest)(nil),                    // 24: katl.agent.v1.ListGenerationsRequest
+	(*ListGenerationsResponse)(nil),                   // 25: katl.agent.v1.ListGenerationsResponse
+	(*GetGenerationRequest)(nil),                      // 26: katl.agent.v1.GetGenerationRequest
+	(*Generation)(nil),                                // 27: katl.agent.v1.Generation
+	(*ExtensionRef)(nil),                              // 28: katl.agent.v1.ExtensionRef
+	(*GeneratedConfext)(nil),                          // 29: katl.agent.v1.GeneratedConfext
+	(*ConfigApplyStatus)(nil),                         // 30: katl.agent.v1.ConfigApplyStatus
 }
 var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	3,  // 0: katl.agent.v1.SubmitOperationRequest.bootstrap:type_name -> katl.agent.v1.BootstrapOperationRequest
@@ -3272,40 +3388,43 @@ var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	9,  // 5: katl.agent.v1.SubmitOperationRequest.kubeadm_control_plane_config:type_name -> katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
 	4,  // 6: katl.agent.v1.BootstrapOperationRequest.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
 	4,  // 7: katl.agent.v1.CreateWorkerJoinMaterialResponse.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
-	17, // 8: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
-	18, // 9: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	19, // 10: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
-	17, // 11: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
-	18, // 12: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	25, // 13: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
-	26, // 14: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
-	27, // 15: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
-	28, // 16: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
-	0,  // 17: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
-	5,  // 18: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
-	7,  // 19: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	7,  // 20: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	2,  // 21: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
-	13, // 22: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
-	16, // 23: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
-	20, // 24: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
-	22, // 25: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
-	24, // 26: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
-	1,  // 27: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
-	6,  // 28: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
-	15, // 29: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
-	15, // 30: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
-	15, // 31: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
-	14, // 32: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
-	17, // 33: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
-	21, // 34: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
-	23, // 35: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
-	25, // 36: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
-	27, // [27:37] is the sub-list for method output_type
-	17, // [17:27] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	19, // 8: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
+	19, // 9: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
+	20, // 10: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	21, // 11: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
+	19, // 12: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
+	20, // 13: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	27, // 14: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
+	28, // 15: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
+	29, // 16: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
+	30, // 17: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
+	0,  // 18: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
+	5,  // 19: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
+	7,  // 20: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	7,  // 21: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	2,  // 22: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
+	13, // 23: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
+	16, // 24: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
+	17, // 25: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
+	22, // 26: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
+	24, // 27: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
+	26, // 28: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
+	1,  // 29: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
+	6,  // 30: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
+	15, // 31: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
+	15, // 32: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
+	15, // 33: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
+	14, // 34: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
+	19, // 35: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
+	18, // 36: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
+	23, // 37: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
+	25, // 38: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
+	27, // 39: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
+	29, // [29:40] is the sub-list for method output_type
+	18, // [18:29] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_internal_katlc_agentapi_agent_proto_init() }
@@ -3319,7 +3438,7 @@ func file_internal_katlc_agentapi_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_katlc_agentapi_agent_proto_rawDesc), len(file_internal_katlc_agentapi_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -12,6 +12,7 @@ service KatlcAgent {
   rpc SubmitOperation(SubmitOperationRequest) returns (OperationAccepted);
   rpc CreateWorkerJoinMaterial(CreateWorkerJoinMaterialRequest) returns (CreateWorkerJoinMaterialResponse);
   rpc GetOperation(GetOperationRequest) returns (OperationStatus);
+  rpc ListOperations(ListOperationsRequest) returns (ListOperationsResponse);
   rpc WatchOperation(WatchOperationRequest) returns (stream OperationEvent);
   rpc ListGenerations(ListGenerationsRequest) returns (ListGenerationsResponse);
   rpc GetGeneration(GetGenerationRequest) returns (Generation);
@@ -205,6 +206,16 @@ message GetOperationRequest {
   string operation_id = 1;
   string expected_request_digest = 2;
   string include_diagnostics = 3;
+}
+
+message ListOperationsRequest {
+  bool active_only = 1;
+  int32 limit = 2;
+  string include_diagnostics = 3;
+}
+
+message ListOperationsResponse {
+  repeated OperationStatus operations = 1;
 }
 
 message OperationStatus {

--- a/internal/katlc/agentapi/agent_grpc.pb.go
+++ b/internal/katlc/agentapi/agent_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	KatlcAgent_SubmitOperation_FullMethodName          = "/katl.agent.v1.KatlcAgent/SubmitOperation"
 	KatlcAgent_CreateWorkerJoinMaterial_FullMethodName = "/katl.agent.v1.KatlcAgent/CreateWorkerJoinMaterial"
 	KatlcAgent_GetOperation_FullMethodName             = "/katl.agent.v1.KatlcAgent/GetOperation"
+	KatlcAgent_ListOperations_FullMethodName           = "/katl.agent.v1.KatlcAgent/ListOperations"
 	KatlcAgent_WatchOperation_FullMethodName           = "/katl.agent.v1.KatlcAgent/WatchOperation"
 	KatlcAgent_ListGenerations_FullMethodName          = "/katl.agent.v1.KatlcAgent/ListGenerations"
 	KatlcAgent_GetGeneration_FullMethodName            = "/katl.agent.v1.KatlcAgent/GetGeneration"
@@ -42,6 +43,7 @@ type KatlcAgentClient interface {
 	SubmitOperation(ctx context.Context, in *SubmitOperationRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
 	CreateWorkerJoinMaterial(ctx context.Context, in *CreateWorkerJoinMaterialRequest, opts ...grpc.CallOption) (*CreateWorkerJoinMaterialResponse, error)
 	GetOperation(ctx context.Context, in *GetOperationRequest, opts ...grpc.CallOption) (*OperationStatus, error)
+	ListOperations(ctx context.Context, in *ListOperationsRequest, opts ...grpc.CallOption) (*ListOperationsResponse, error)
 	WatchOperation(ctx context.Context, in *WatchOperationRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[OperationEvent], error)
 	ListGenerations(ctx context.Context, in *ListGenerationsRequest, opts ...grpc.CallOption) (*ListGenerationsResponse, error)
 	GetGeneration(ctx context.Context, in *GetGenerationRequest, opts ...grpc.CallOption) (*Generation, error)
@@ -125,6 +127,16 @@ func (c *katlcAgentClient) GetOperation(ctx context.Context, in *GetOperationReq
 	return out, nil
 }
 
+func (c *katlcAgentClient) ListOperations(ctx context.Context, in *ListOperationsRequest, opts ...grpc.CallOption) (*ListOperationsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListOperationsResponse)
+	err := c.cc.Invoke(ctx, KatlcAgent_ListOperations_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *katlcAgentClient) WatchOperation(ctx context.Context, in *WatchOperationRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[OperationEvent], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &KatlcAgent_ServiceDesc.Streams[0], KatlcAgent_WatchOperation_FullMethodName, cOpts...)
@@ -175,6 +187,7 @@ type KatlcAgentServer interface {
 	SubmitOperation(context.Context, *SubmitOperationRequest) (*OperationAccepted, error)
 	CreateWorkerJoinMaterial(context.Context, *CreateWorkerJoinMaterialRequest) (*CreateWorkerJoinMaterialResponse, error)
 	GetOperation(context.Context, *GetOperationRequest) (*OperationStatus, error)
+	ListOperations(context.Context, *ListOperationsRequest) (*ListOperationsResponse, error)
 	WatchOperation(*WatchOperationRequest, grpc.ServerStreamingServer[OperationEvent]) error
 	ListGenerations(context.Context, *ListGenerationsRequest) (*ListGenerationsResponse, error)
 	GetGeneration(context.Context, *GetGenerationRequest) (*Generation, error)
@@ -208,6 +221,9 @@ func (UnimplementedKatlcAgentServer) CreateWorkerJoinMaterial(context.Context, *
 }
 func (UnimplementedKatlcAgentServer) GetOperation(context.Context, *GetOperationRequest) (*OperationStatus, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetOperation not implemented")
+}
+func (UnimplementedKatlcAgentServer) ListOperations(context.Context, *ListOperationsRequest) (*ListOperationsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListOperations not implemented")
 }
 func (UnimplementedKatlcAgentServer) WatchOperation(*WatchOperationRequest, grpc.ServerStreamingServer[OperationEvent]) error {
 	return status.Error(codes.Unimplemented, "method WatchOperation not implemented")
@@ -365,6 +381,24 @@ func _KatlcAgent_GetOperation_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _KatlcAgent_ListOperations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListOperationsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KatlcAgentServer).ListOperations(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KatlcAgent_ListOperations_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KatlcAgentServer).ListOperations(ctx, req.(*ListOperationsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _KatlcAgent_WatchOperation_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(WatchOperationRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -446,6 +480,10 @@ var KatlcAgent_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetOperation",
 			Handler:    _KatlcAgent_GetOperation_Handler,
+		},
+		{
+			MethodName: "ListOperations",
+			Handler:    _KatlcAgent_ListOperations_Handler,
 		},
 		{
 			MethodName: "ListGenerations",

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -299,7 +299,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	assertReadlink(t, ctx, guest, "/run/confexts/katl-node", beforeConfext)
 
 	rejectedApplyGeneration := "2026.06.06-vmtest-rejected-apply"
-	rejectedAccepted := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, tokenFile, "config-apply-rejected", "live", rejectedApplyGeneration, "vmtest-config-apply-rejected-submit", configApplyFixture(t, "rejected-live-without-preflight.yaml"))
+	rejectedAccepted := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, tokenFile, "config-apply-rejected", "live", rejectedApplyGeneration, configApplyFixture(t, "rejected-live-without-preflight.yaml"), true)
 	rejectedStatus := waitKatlcOperationTerminal(t, ctx, endpoint, token, rejectedAccepted.OperationId)
 	if rejectedStatus.Result == operation.ResultSucceeded ||
 		rejectedStatus.GetExternalMutationStarted() ||
@@ -312,7 +312,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	assertReadlink(t, ctx, guest, "/run/confexts/katl-node", beforeConfext)
 	assertGuestFileContains(t, ctx, guest, rejectedAccepted.RecordPath, `"operationKind": "generation-apply"`, `"result": "failed-needs-repair"`, "staged-only")
 
-	liveAccepted := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, tokenFile, "config-apply-live", "", liveGeneration, "vmtest-config-apply-live", configApplyFixture(t, "live-sysctl.yaml"))
+	liveAccepted := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, tokenFile, "config-apply-live", "", liveGeneration, configApplyFixture(t, "live-sysctl.yaml"), false)
 	liveStatus := waitKatlcOperationTerminal(t, ctx, endpoint, token, liveAccepted.OperationId)
 	if liveStatus.Result != operation.ResultSucceeded || liveStatus.ConfigApplyPhase != "active" {
 		t.Fatalf("live operation status = %+v, want succeeded active config apply", liveStatus)
@@ -333,7 +333,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 
 	liveConfext := readlink(t, ctx, guest, "/run/confexts/katl-node")
 	assertGuestNonLoopbackLink(t, ctx, guest)
-	stagedAccepted := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, tokenFile, "config-apply-staged-networkd", "next-boot", stagedGeneration, "vmtest-config-apply-staged-networkd", configApplyFixture(t, "next-boot-networkd.yaml"))
+	stagedAccepted := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, tokenFile, "config-apply-staged-networkd", "next-boot", stagedGeneration, configApplyFixture(t, "next-boot-networkd.yaml"), false)
 	stagedStatus := waitKatlcOperationTerminal(t, ctx, endpoint, token, stagedAccepted.OperationId)
 	if stagedStatus.Result != operation.ResultSucceeded || stagedStatus.ConfigApplyPhase != "next-boot" {
 		t.Fatalf("staged operation status = %+v, want succeeded next-boot config apply", stagedStatus)
@@ -372,7 +372,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	return guest, nil
 }
 
-func submitKatlctlConfigApply(t *testing.T, ctx context.Context, result Result, katlctl, endpoint, tokenFile, name, mode, generationID, clientRequestID, fixture string) agentapi.OperationAccepted {
+func submitKatlctlConfigApply(t *testing.T, ctx context.Context, result Result, katlctl, endpoint, tokenFile, name, mode, generationID, fixture string, wantFailure bool) agentapi.OperationAccepted {
 	t.Helper()
 	args := []string{
 		"config", "apply",
@@ -380,19 +380,38 @@ func submitKatlctlConfigApply(t *testing.T, ctx context.Context, result Result, 
 		"--agent-token-file", tokenFile,
 		"--file", fixture,
 		"--candidate-generation", generationID,
-		"--client-request-id", clientRequestID,
 		"--actor", "installed-runtime config apply vmtest",
 	}
 	if mode != "" {
 		args = append(args, "--mode", mode)
 	}
-	output := runKatlctl(t, ctx, result, katlctl, name, args...)
-	var accepted agentapi.OperationAccepted
-	mustUnmarshalProtoJSON(t, output, &accepted)
-	if strings.TrimSpace(accepted.OperationId) == "" || strings.TrimSpace(accepted.RecordPath) == "" {
-		t.Fatalf("%s accepted operation = %+v, want operation ID and record path", name, accepted)
+	output, commandErr := runKatlctlOutcome(t, ctx, result, katlctl, name, args...)
+	if wantFailure && commandErr == nil {
+		t.Fatalf("%s succeeded, want terminal operation failure\n%s", name, output)
 	}
-	return accepted
+	if !wantFailure && commandErr != nil {
+		t.Fatalf("%s: katlctl failed: %v\n%s", name, commandErr, output)
+	}
+	var terminal agentapi.OperationStatus
+	mustUnmarshalProtoJSON(t, output, &terminal)
+	if !terminal.Terminal || (wantFailure && terminal.Result == operation.ResultSucceeded) || (!wantFailure && terminal.Result != operation.ResultSucceeded) {
+		t.Fatalf("%s terminal result = %+v", name, &terminal)
+	}
+	listOutput := runKatlctl(t, ctx, result, katlctl, name+"-operations",
+		"operations", "list", "--endpoint", endpoint, "--agent-token-file", tokenFile, "--limit", "20")
+	var listed agentapi.ListOperationsResponse
+	mustUnmarshalProtoJSON(t, listOutput, &listed)
+	for _, status := range listed.Operations {
+		if status.CandidateGenerationId == generationID {
+			return agentapi.OperationAccepted{
+				OperationId:   status.OperationId,
+				OperationKind: status.OperationKind,
+				RecordPath:    "/var/lib/katl/operations/" + status.OperationId + "/record.json",
+			}
+		}
+	}
+	t.Fatalf("%s operation for generation %q not found in recent operations", name, generationID)
+	return agentapi.OperationAccepted{}
 }
 
 func katlctlGenerationStatus(t *testing.T, ctx context.Context, result Result, katlctl, endpoint, tokenFile, name, generationID string) agentapi.Generation {
@@ -535,6 +554,15 @@ func failIfRestartExited(t *testing.T, handle *VMHandle) {
 
 func runKatlctl(t *testing.T, ctx context.Context, result Result, katlctl, name string, args ...string) []byte {
 	t.Helper()
+	stdout, err := runKatlctlOutcome(t, ctx, result, katlctl, name, args...)
+	if err != nil {
+		t.Fatalf("%s: katlctl failed: %v\nstdout:\n%s", name, err, stdout)
+	}
+	return stdout
+}
+
+func runKatlctlOutcome(t *testing.T, ctx context.Context, result Result, katlctl, name string, args ...string) ([]byte, error) {
+	t.Helper()
 	dir := filepath.Join(result.RunDir, "katlctl", name)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("create katlctl artifact dir: %v", err)
@@ -563,9 +591,9 @@ func runKatlctl(t *testing.T, ctx context.Context, result Result, katlctl, name 
 	_ = os.WriteFile(filepath.Join(dir, "stdout"), stdout.Bytes(), 0o644)
 	_ = os.WriteFile(filepath.Join(dir, "stderr"), stderr.Bytes(), 0o644)
 	if err != nil {
-		t.Fatalf("%s: katlctl failed: %v\nstdout:\n%s\nstderr:\n%s", name, err, stdout.String(), stderr.String())
+		return stdout.Bytes(), fmt.Errorf("%w\nstderr:\n%s", err, stderr.String())
 	}
-	return stdout.Bytes()
+	return stdout.Bytes(), nil
 }
 
 func configApplyFixture(t *testing.T, name string) string {

--- a/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
+++ b/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
@@ -394,7 +394,7 @@ func runWipeNodeHandoff(t *testing.T, ctx context.Context, result vmtest.Result,
 		return err
 	}
 	var stdout, stderr bytes.Buffer
-	err := runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"cluster", "wipe", "node", "--inventory", initial.Inventory, "--node", "worker-1", "--kubeconfig", initial.Kubeconfig, "--confirm-destructive-wipe", "--acknowledge", wipeClusterAcknowledgement, "--client-request-id", "vmtest-wipe-node", "--timeout", "10m"}, &stdout, &stderr)
+	err := runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"cluster", "wipe", "node", "--inventory", initial.Inventory, "--node", "worker-1", "--kubeconfig", initial.Kubeconfig, "--confirm-destructive-wipe", "--acknowledge", wipeClusterAcknowledgement, "--timeout", "10m"}, &stdout, &stderr)
 	_ = os.WriteFile(filepath.Join(dir, "katlctl-wipe-node.stdout"), stdout.Bytes(), 0o644)
 	_ = os.WriteFile(filepath.Join(dir, "katlctl-wipe-node.stderr"), stderr.Bytes(), 0o644)
 	if err != nil {
@@ -441,7 +441,6 @@ func runWipeClusterHandoff(t *testing.T, ctx context.Context, run operationBacke
 		"--all",
 		"--confirm-destructive-wipe",
 		"--acknowledge", wipeClusterAcknowledgement,
-		"--client-request-id", "vmtest-wipe-cluster",
 		"--timeout", "10m",
 	}, &stdout, &stderr)
 	_ = os.WriteFile(stdoutPath, stdout.Bytes(), 0o644)
@@ -516,6 +515,8 @@ func assertWipeClusterReport(data []byte) error {
 			Accepted      bool   `json:"accepted"`
 			OperationKind string `json:"operationKind"`
 			OperationID   string `json:"operationID"`
+			Terminal      bool   `json:"terminal"`
+			Result        string `json:"result"`
 		} `json:"nodes"`
 	}
 	if err := json.Unmarshal(data, &report); err != nil {
@@ -534,7 +535,7 @@ func assertWipeClusterReport(data []byte) error {
 		return fmt.Errorf("cluster wipe report nodes = %#v", report.Nodes)
 	}
 	for _, node := range report.Nodes {
-		if !node.Accepted || node.OperationKind != "destructive-reset" || strings.TrimSpace(node.OperationID) == "" {
+		if !node.Accepted || node.OperationKind != "destructive-reset" || strings.TrimSpace(node.OperationID) != "" || !node.Terminal || node.Result != operation.ResultSucceeded {
 			return fmt.Errorf("cluster wipe report node = %#v", node)
 		}
 	}


### PR DESCRIPTION
Generate retry identities and follow node mutations to completion by default. Add durable recent-operation discovery for detached or interrupted workflows, while keeping opaque IDs and record paths out of normal results.