### PR TITLE
vmtest: retain runtime artifact provenance

### DIFF
--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -60,6 +60,19 @@ func run(args []string, stdout, stderr io.Writer, environ []string) error {
 		}
 		fmt.Fprintf(stdout, "artifact index: %s\n", relPath(repoRoot, indexPath))
 		return nil
+	case "write-runtime-index":
+		indexPath := cfg.DefaultIndex
+		if len(args) > 1 {
+			return fmt.Errorf("write-runtime-index accepts at most one INDEX argument")
+		}
+		if len(args) == 1 {
+			indexPath = absPath(repoRoot, args[0])
+		}
+		if err := writeRuntimeIndex(indexPath, cfg); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "runtime artifact index: %s\n", relPath(repoRoot, indexPath))
+		return nil
 	case "path":
 		if len(args) < 1 {
 			return fmt.Errorf("path requires KIND")
@@ -100,6 +113,7 @@ func run(args []string, stdout, stderr io.Writer, environ []string) error {
 }
 
 const usage = `Usage: katl-mkosi-artifacts [write [INDEX]]
+	   katl-mkosi-artifacts write-runtime-index [INDEX]
        katl-mkosi-artifacts path KIND [INDEX]
        katl-mkosi-artifacts write-runtime-root --artifact PATH
        katl-mkosi-artifacts write-runtime-uki --artifact PATH --runtime-artifact PATH --runtime-sha256 SHA --kernel-version VERSION
@@ -1069,6 +1083,62 @@ func writeIndex(indexPath string, cfg config) error {
 		return fmt.Errorf("write artifact index %s: %w", relPath(cfg.RepoRoot, indexPath), err)
 	}
 	return nil
+}
+
+func writeRuntimeIndex(indexPath string, cfg config) error {
+	for _, input := range []struct {
+		label string
+		path  string
+	}{
+		{"runtime UKI", cfg.RuntimeUKI},
+		{"runtime UKI metadata", cfg.RuntimeUKIMetadata},
+		{"runtime UKI checksum", cfg.RuntimeUKIChecksum},
+		{"runtime SquashFS", cfg.RuntimeRoot},
+		{"runtime metadata", cfg.RuntimeMetadata},
+		{"runtime checksum", cfg.RuntimeChecksum},
+	} {
+		if err := requireFile(input.label, input.path, cfg.RepoRoot); err != nil {
+			return err
+		}
+	}
+	runtimeEntries := make([]artifactEntry, 0, 2)
+	for _, artifact := range []struct {
+		kind     string
+		format   string
+		path     string
+		metadata string
+		checksum string
+	}{
+		{"runtime-uki", "uki", cfg.RuntimeUKI, cfg.RuntimeUKIMetadata, cfg.RuntimeUKIChecksum},
+		{"runtime-root", "squashfs", cfg.RuntimeRoot, cfg.RuntimeMetadata, cfg.RuntimeChecksum},
+	} {
+		entry, err := newEntry(artifact.kind, artifact.format, artifact.path, artifact.metadata, artifact.checksum, cfg.RepoRoot)
+		if err != nil {
+			return err
+		}
+		runtimeEntries = append(runtimeEntries, entry)
+	}
+	index := artifactIndex{SchemaVersion: 1}
+	if data, err := os.ReadFile(indexPath); err == nil {
+		if err := json.Unmarshal(data, &index); err != nil {
+			return fmt.Errorf("decode artifact index %s: %w", relPath(cfg.RepoRoot, indexPath), err)
+		}
+		if index.SchemaVersion != 1 {
+			return fmt.Errorf("artifact index %s has unsupported schemaVersion %d", relPath(cfg.RepoRoot, indexPath), index.SchemaVersion)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read artifact index %s: %w", relPath(cfg.RepoRoot, indexPath), err)
+	}
+	entries := make([]artifactEntry, 0, len(index.Artifacts)+2)
+	for _, entry := range index.Artifacts {
+		if entry.Kind != "runtime-uki" && entry.Kind != "runtime-root" {
+			entries = append(entries, entry)
+		}
+	}
+	index.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	index.Generation = cfg.Generation
+	index.Artifacts = append(entries, runtimeEntries...)
+	return writeJSON(indexPath, index, cfg.RepoRoot)
 }
 
 func writeBootMetadata(role, format, artifactPath, created string, cfg config) error {

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -152,6 +152,54 @@ func TestWriteIncludesExistingInstallerISO(t *testing.T) {
 	t.Fatalf("existing installer ISO omitted from index: %#v", index.Artifacts)
 }
 
+func TestWriteRuntimeIndexReplacesRuntimeAndPreservesInstaller(t *testing.T) {
+	repo := testRepoRoot(t)
+	workDir := testWorkDir(t, repo)
+	runtimeUKI := writeTestFile(t, workDir, "runtime.efi", "new runtime uki")
+	runtimeRoot := writeTestFile(t, workDir, "runtime-root.squashfs", "new runtime root")
+	for _, path := range []string{runtimeUKI, runtimeRoot} {
+		writeTestChecksum(t, path)
+		writeTestJSON(t, path+".json", map[string]any{"path": filepath.Base(path)})
+	}
+	indexPath := filepath.Join(workDir, "artifacts.json")
+	writeTestJSON(t, indexPath, artifactIndex{
+		SchemaVersion: 1,
+		Generation:    "old-build",
+		Artifacts: []artifactEntry{
+			{Kind: "installer-uki", Path: "installer.efi", SHA256: strings.Repeat("a", 64)},
+			{Kind: "runtime-root", Path: "old-runtime.squashfs", SHA256: strings.Repeat("b", 64)},
+		},
+	})
+	cfg := config{
+		RepoRoot:           repo,
+		RuntimeUKI:         runtimeUKI,
+		RuntimeUKIMetadata: runtimeUKI + ".json",
+		RuntimeUKIChecksum: runtimeUKI + ".sha256",
+		RuntimeRoot:        runtimeRoot,
+		RuntimeMetadata:    runtimeRoot + ".json",
+		RuntimeChecksum:    runtimeRoot + ".sha256",
+		Generation:         "new-build",
+	}
+	if err := writeRuntimeIndex(indexPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	var index artifactIndex
+	readTestJSON(t, indexPath, &index)
+	if index.Generation != "new-build" || len(index.Artifacts) != 3 {
+		t.Fatalf("index = %#v", index)
+	}
+	byKind := make(map[string]artifactEntry, len(index.Artifacts))
+	for _, entry := range index.Artifacts {
+		byKind[entry.Kind] = entry
+	}
+	if byKind["installer-uki"].Path != "installer.efi" {
+		t.Fatalf("installer entry = %#v", byKind["installer-uki"])
+	}
+	if byKind["runtime-root"].Path != relPath(repo, runtimeRoot) || byKind["runtime-root"].SHA256 != testFileSHA256(t, runtimeRoot) {
+		t.Fatalf("runtime root entry = %#v", byKind["runtime-root"])
+	}
+}
+
 func TestPathForKindRejectsDuplicate(t *testing.T) {
 	repo := testRepoRoot(t)
 	indexPath := filepath.Join(testWorkDir(t, repo), "artifacts.json")

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -307,6 +307,11 @@ scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
   -count=1 -failfast -timeout 60m
 ```
 
+The runtime artifact set is intentionally limited to direct-runtime tests.
+Installed-runtime tests consume the KatlOS install image and reject
+`--artifact-set=runtime`; run them with `--artifact-set=default` or
+`--artifact-set=install` so fixture invalidation follows the installed payload.
+
 CI sets `KATL_VMTEST_KEEP=always` only long enough to upload the run directory
 as a workflow artifact, excluding large VM disk images, then removes the local
 run directory. Live-domain debug preservation is disabled in CI; local debugging

--- a/internal/vmtest/installed_world.go
+++ b/internal/vmtest/installed_world.go
@@ -97,6 +97,13 @@ func WorldFixtureCacheDir(world World) string {
 	return filepath.Join(world.RunDir, "_build")
 }
 
+func validateInstalledRuntimeArtifactSet(world World) error {
+	if world.ArtifactSet == "runtime" {
+		return errors.New("installed-runtime VM tests require --artifact-set=default or --artifact-set=install; --artifact-set=runtime is only for direct-runtime tests")
+	}
+	return nil
+}
+
 func FindPublishedFirstInstallRuntimeFixtureInBuildRoots(buildRoots []string, spec NodeSpec) (PublishedFirstInstallRuntimeFixture, error) {
 	return findPublishedFirstInstallRuntimeFixtureInBuildRoots(buildRoots, spec, "")
 }

--- a/internal/vmtest/installed_world_test.go
+++ b/internal/vmtest/installed_world_test.go
@@ -24,6 +24,9 @@ func installedRuntimeWorldRunFor(t *testing.T, name string, spec NodeSpec) (inst
 		return installedRuntimeWorldRun{}, false
 	}
 	world := RequireWorld(t)
+	if err := validateInstalledRuntimeArtifactSet(world); err != nil {
+		failInstalledRuntimeWorldFixtureSetup(t, world, name, err)
+	}
 	repo := repoRoot(t)
 	options := DefaultOptions()
 	input := DefaultFirstInstallWorldInputFromEnv(FirstInstallWorldPreseed, envBool("KATL_FIRST_INSTALL_USE_INSTALLED_ESP"))
@@ -41,6 +44,16 @@ func installedRuntimeWorldRunFor(t *testing.T, name string, spec NodeSpec) (inst
 		failWorldSetup(t, run.Scenario, err)
 	}
 	return run, true
+}
+
+func TestInstalledRuntimeArtifactSetRejectsRuntimeOnly(t *testing.T) {
+	err := validateInstalledRuntimeArtifactSet(World{ArtifactSet: "runtime"})
+	if err == nil || !strings.Contains(err.Error(), "only for direct-runtime tests") {
+		t.Fatalf("validateInstalledRuntimeArtifactSet() error = %v", err)
+	}
+	if err := validateInstalledRuntimeArtifactSet(World{ArtifactSet: "install"}); err != nil {
+		t.Fatalf("validateInstalledRuntimeArtifactSet(install) error = %v", err)
+	}
 }
 
 func failInstalledRuntimeWorldFixtureSetup(t *testing.T, world World, name string, err error) {

--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -506,7 +506,7 @@ exec "$@"
 	}
 }
 
-func TestVMTestRunBuildsRuntimeOnlyArtifacts(t *testing.T) {
+func TestVMTestRunRecordsRuntimeOnlyCacheProvenance(t *testing.T) {
 	realRepo := scriptTestRepoRoot(t)
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, "scripts"), 0o755); err != nil {
@@ -516,6 +516,7 @@ func TestVMTestRunBuildsRuntimeOnlyArtifacts(t *testing.T) {
 	writeExecutable(t, filepath.Join(repo, "scripts", "mkosi"), `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$KATL_FAKE_MKOSI_ARGS"
+printf 'mkosi cache hit: runtime artifacts match the current repo\n'
 `)
 	writeExecutable(t, filepath.Join(repo, "scripts", "vmtest-exec"), `#!/usr/bin/env bash
 set -euo pipefail
@@ -523,6 +524,29 @@ export KATL_VMTEST_RUN=1
 export KATL_VMTEST_WORLD_STRICT=1
 exec "$@"
 `)
+	runtimePath := filepath.Join(repo, "_build", "mkosi", "katl-runtime-root.squashfs")
+	if err := os.MkdirAll(filepath.Dir(runtimePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimePath, []byte("current runtime"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runtimeSHA := strings.Repeat("a", 64)
+	artifactIndex := map[string]any{
+		"schemaVersion": 1,
+		"artifacts": []map[string]any{{
+			"kind": "runtime-root", "path": "_build/mkosi/katl-runtime-root.squashfs",
+			"sha256": runtimeSHA, "sizeBytes": len("current runtime"),
+		}},
+	}
+	indexData, err := json.Marshal(artifactIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexPath := filepath.Join(repo, "_build", "mkosi", "artifacts.json")
+	if err := os.WriteFile(indexPath, indexData, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	tmp := t.TempDir()
 	fakeGo, fakeChild := writeFakeGoTools(t, tmp)
@@ -572,9 +596,18 @@ exec "$@"
 	if world.ArtifactSet != "runtime" {
 		t.Fatalf("world artifact set = %q", world.ArtifactSet)
 	}
+	if len(world.Artifacts) != 1 || world.Artifacts[0].Kind != "runtime-root" || world.Artifacts[0].Digest != runtimeSHA || world.Artifacts[0].Action != "cache-resolved" {
+		t.Fatalf("world artifacts = %#v", world.Artifacts)
+	}
+	if world.ArtifactInputs == nil || len(world.ArtifactInputs.Tools) != 1 || world.ArtifactInputs.Tools[0].Name != "mkosi-artifact-index" || world.ArtifactInputs.Tools[0].SHA256 == "" {
+		t.Fatalf("world artifact inputs = %#v", world.ArtifactInputs)
+	}
 	runIndex := readRunIndex(t, filepath.Join(runDir, "run.json"))
 	if runIndex.ArtifactSet != "runtime" {
 		t.Fatalf("run index artifact set = %q", runIndex.ArtifactSet)
+	}
+	if len(runIndex.Artifacts) != 1 || runIndex.Artifacts[0].Action != "cache-resolved" || runIndex.ArtifactInputs == nil {
+		t.Fatalf("run index provenance = artifacts=%#v inputs=%#v", runIndex.Artifacts, runIndex.ArtifactInputs)
 	}
 }
 

--- a/internal/vmtest/world.go
+++ b/internal/vmtest/world.go
@@ -212,6 +212,17 @@ func ValidateWorld(world World) error {
 		}
 	}
 	if world.ArtifactInputs != nil {
+		for i, tool := range world.ArtifactInputs.Tools {
+			if strings.TrimSpace(tool.Name) == "" {
+				return fmt.Errorf("vmtestArtifactInputs.tools[%d].name is required", i)
+			}
+			if strings.TrimSpace(tool.Path) != "" && !filepath.IsAbs(tool.Path) {
+				return fmt.Errorf("vmtestArtifactInputs.tools[%d].path must be an absolute path", i)
+			}
+			if strings.TrimSpace(tool.SHA256) != "" && !validWorldSHA256(tool.SHA256) {
+				return fmt.Errorf("vmtestArtifactInputs.tools[%d].sha256 must be lowercase SHA-256", i)
+			}
+		}
 		for i, profile := range world.ArtifactInputs.MkosiProfiles {
 			if strings.TrimSpace(profile.Name) == "" {
 				return fmt.Errorf("vmtestArtifactInputs.mkosiProfiles[%d].name is required", i)

--- a/internal/vmtest/world_test.go
+++ b/internal/vmtest/world_test.go
@@ -372,6 +372,11 @@ func TestDecodeWorldArtifactProvenance(t *testing.T) {
 		Action:    "cache-resolved",
 	}}
 	world.ArtifactInputs = &WorldArtifactInputs{
+		Tools: []WorldToolInput{{
+			Name:   "mkosi-artifact-index",
+			Path:   "/repo/_build/mkosi/artifacts.json",
+			SHA256: strings.Repeat("d", 64),
+		}},
 		MkosiProfiles: []WorldMkosiProfile{{
 			Name:         "installer-image",
 			Path:         "mkosi.profiles/installer-image",
@@ -408,6 +413,11 @@ func TestDecodeWorldArtifactProvenance(t *testing.T) {
 			want:   "vmtestArtifacts[0].action must be built, cache-resolved, or validated",
 		},
 		{
+			name:   "tool digest",
+			mutate: func(world *World) { world.ArtifactInputs.Tools[0].SHA256 = "bad" },
+			want:   "vmtestArtifactInputs.tools[0].sha256 must be lowercase SHA-256",
+		},
+		{
 			name:   "profile digest",
 			mutate: func(world *World) { world.ArtifactInputs.MkosiProfiles[0].ConfigSHA256 = "bad" },
 			want:   "vmtestArtifactInputs.mkosiProfiles[0].configSHA256 must be lowercase SHA-256",
@@ -424,6 +434,7 @@ func TestDecodeWorldArtifactProvenance(t *testing.T) {
 			mutated := world
 			mutated.Artifacts = append([]WorldArtifact(nil), world.Artifacts...)
 			inputs := *world.ArtifactInputs
+			inputs.Tools = append([]WorldToolInput(nil), world.ArtifactInputs.Tools...)
 			inputs.MkosiProfiles = append([]WorldMkosiProfile(nil), world.ArtifactInputs.MkosiProfiles...)
 			inputs.PackageSets = append([]WorldPackageSetInput(nil), world.ArtifactInputs.PackageSets...)
 			mutated.ArtifactInputs = &inputs

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -854,6 +854,11 @@ set +e
             fi
         fi
     fi
+    if [[ "$status" -eq 0 && "${KATL_EMIT_RUNTIME_ARTIFACT:-0}" == 1 ]]; then
+        if ! mkosi_artifacts write-runtime-index >/dev/null; then
+            status=1
+        fi
+    fi
     if [[ "$status" -eq 0 && "${KATL_EMIT_KUBERNETES_SYSEXT:-0}" == 1 ]]; then
         artifact=_build/mkosi/katl-kubernetes.raw
         runtime_meta=_build/mkosi/katl-runtime-root.squashfs.json

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -453,6 +453,10 @@ file_sha256() {
 }
 
 prepare_resource_manifest() {
+    if [[ "$artifact_set" == "runtime" ]]; then
+        prepare_runtime_artifact_provenance
+        return
+    fi
     if ! uses_installer_artifacts; then
         return 0
     fi
@@ -510,6 +514,66 @@ prepare_resource_manifest() {
           }
         ' "$resource_manifest"
 	)"
+}
+
+prepare_runtime_artifact_provenance() {
+    local index="${KATL_MKOSI_ARTIFACT_INDEX:-$repo_root/_build/mkosi/artifacts.json}"
+    if [[ ! -f "$index" ]]; then
+        setup_failures+=("runtime artifact index is missing after build-runtime: $index")
+        return 1
+    fi
+    local action="${artifact_build_actions[build-runtime]:-validated}"
+    vmtest_artifacts_json="$(
+        jq -ce '
+          def abs_path($repo):
+            if (.path | startswith("/")) then .path else ($repo + "/" + .path) end;
+          [.artifacts[]
+            | select(.kind == "runtime-root" or .kind == "runtime-uki")
+            | {
+                name: .kind,
+                kind,
+                path: abs_path($repoRoot),
+                repoPath: .path,
+                sha256,
+                sizeBytes,
+                source: "mkosi-artifact-index",
+                action: $action
+              }]
+          | if any(.[]; .kind == "runtime-root") then .
+            else error("runtime-root is missing from mkosi artifact index") end
+        ' --arg repoRoot "$repo_root" --arg action "$action" "$index"
+    )" || {
+        setup_failures+=("runtime artifact index is invalid: $index")
+        return 1
+    }
+    local path expected_sha expected_size actual_sha actual_size
+    while IFS=$'\t' read -r path expected_sha expected_size; do
+        if [[ ! -f "$path" ]]; then
+            setup_failures+=("runtime artifact is missing: $path")
+            return 1
+        fi
+        actual_sha="$(file_sha256 "$path")"
+        actual_size="$(stat -c %s "$path")"
+        if [[ "$actual_sha" != "$expected_sha" || "$actual_size" != "$expected_size" ]]; then
+            setup_failures+=("runtime artifact does not match mkosi artifact index: $path (sha256 $actual_sha, size $actual_size; expected sha256 $expected_sha, size $expected_size)")
+            return 1
+        fi
+    done < <(jq -r '.[] | [.path, .sha256, (.sizeBytes | tostring)] | @tsv' <<<"$vmtest_artifacts_json")
+    local index_sha revision
+    index_sha="$(file_sha256 "$index")"
+    revision="$(git_revision)"
+    vmtest_artifact_inputs_json="$(
+        jq -nc \
+            --arg revision "$revision" \
+            --arg path "$index" \
+            --arg sha256 "$index_sha" \
+            '{
+              resourceManifestGitRevision: $revision,
+              tools: [{name: "mkosi-artifact-index", path: $path, sha256: $sha256}],
+              mkosiProfiles: [],
+              packageSets: []
+            }'
+    )"
 }
 
 probe_vm_capabilities() {


### PR DESCRIPTION
Refresh and verify runtime artifact index entries before publishing VM worlds. Record runtime cache-hit identity and reject installed-runtime scenarios that select the runtime-only artifact set.