### PR TITLE
release: automate Kubernetes bundle preparation

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -9,14 +9,12 @@ on:
   workflow_dispatch:
     inputs:
       payload_version:
-        description: Exact Kubernetes payload version, for example v1.36.1
-        required: true
-        default: v1.36.1
+        description: Exact Kubernetes payload version; empty uses the committed release manifest
+        required: false
         type: string
       artifact_version:
-        description: Immutable Katl bundle build version, for example v1.36.1-katl.1
-        required: true
-        default: v1.36.1-katl.1
+        description: Immutable Katl bundle build version; empty derives it from the committed release manifest
+        required: false
         type: string
       publish:
         description: Publish the verified OCI artifact to ghcr.io/katl-dev/kubernetes
@@ -83,15 +81,21 @@ jobs:
       - name: Resolve and validate release identity
         shell: bash
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            # shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
-            source mkosi.profiles/kubernetes-sysext/kubernetes.env
+          # shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
+          source mkosi.profiles/kubernetes-sysext/kubernetes.env
+          if [[ "$GITHUB_EVENT_NAME" == "push" || -z "$DISPATCH_PAYLOAD_VERSION" ]]; then
             PAYLOAD_VERSION="$KATL_KUBERNETES_PAYLOAD_VERSION"
-            ARTIFACT_VERSION="${PAYLOAD_VERSION}-katl.${KATL_KUBERNETES_ARTIFACT_REVISION}"
-            PUBLISH=true
           else
             PAYLOAD_VERSION="$DISPATCH_PAYLOAD_VERSION"
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "push" || -z "$DISPATCH_ARTIFACT_VERSION" ]]; then
+            ARTIFACT_VERSION="${PAYLOAD_VERSION}-katl.${KATL_KUBERNETES_ARTIFACT_REVISION}"
+          else
             ARTIFACT_VERSION="$DISPATCH_ARTIFACT_VERSION"
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            PUBLISH=true
+          else
             PUBLISH="$DISPATCH_PUBLISH"
           fi
 

--- a/.github/workflows/public-kubernetes-bundle.yml
+++ b/.github/workflows/public-kubernetes-bundle.yml
@@ -18,11 +18,23 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      - name: Fetch and verify selected alpha bundle anonymously
+      - name: Resolve and verify selected bundle anonymously
+        id: bundle
+        shell: bash
         run: |
-          scripts/check-public-kubernetes-bundle \
-            ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3 \
-            sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
+          # shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
+          source mkosi.profiles/kubernetes-sysext/kubernetes.env
+          artifact_version="${KATL_KUBERNETES_PAYLOAD_VERSION}-katl.${KATL_KUBERNETES_ARTIFACT_REVISION}"
+          image="ghcr.io/katl-dev/kubernetes:${artifact_version}"
+          verification="$(scripts/check-public-kubernetes-bundle "$image")"
+          printf '%s\n' "$verification"
+          digest="${verification##*@}"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "error: public bundle check returned invalid digest: $digest" >&2
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate provenance client to GHCR
         env:
@@ -34,7 +46,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh attestation verify \
-            oci://ghcr.io/katl-dev/kubernetes@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b \
+            "oci://ghcr.io/katl-dev/kubernetes@${{ steps.bundle.outputs.digest }}" \
             --repo katl-dev/katl \
             --signer-workflow katl-dev/katl/.github/workflows/kubernetes-bundles.yml \
             --source-ref refs/heads/main

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ metadata:
 spec:
   controlPlaneEndpoint: api.katl.test:6443
   kubernetes:
-    version: v1.36.0
+    version: v1.36.1
     bundle: ghcr.io/katl-dev/kubernetes:<version>
   # defaults, kubeadmConfigs, and nodes omitted here; use the complete example
   # in docs/installing.md.

--- a/cmd/katl-kubernetes-release/main.go
+++ b/cmd/katl-kubernetes-release/main.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const defaultManifest = "mkosi.profiles/kubernetes-sysext/kubernetes.env"
+
+var payloadPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+
+type releaseIdentity struct {
+	PayloadVersion  string `json:"payloadVersion"`
+	ArtifactVersion string `json:"artifactVersion"`
+	Image           string `json:"image"`
+}
+
+type packageQuery func(name, selector, baseURL, command string) (string, error)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr, queryPackage); err != nil {
+		fmt.Fprintf(os.Stderr, "katl-kubernetes-release: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer, query packageQuery) error {
+	if len(args) == 0 {
+		return errors.New("command is required: identity or prepare")
+	}
+	switch args[0] {
+	case "identity":
+		return runIdentity(args[1:], stdout, stderr)
+	case "prepare":
+		return runPrepare(args[1:], stdout, stderr, query)
+	default:
+		return fmt.Errorf("unsupported command %q", args[0])
+	}
+}
+
+func runIdentity(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release identity", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	manifest := flags.String("manifest", defaultManifest, "Kubernetes release manifest")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	state, _, err := readState(*manifest)
+	if err != nil {
+		return err
+	}
+	identity := releaseIdentity{
+		PayloadVersion:  state.payload,
+		ArtifactVersion: fmt.Sprintf("%s-katl.%d", state.payload, state.revision),
+	}
+	identity.Image = "ghcr.io/katl-dev/kubernetes:" + identity.ArtifactVersion
+	data, err := json.Marshal(identity)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, string(data))
+	return nil
+}
+
+func runPrepare(args []string, stdout, stderr io.Writer, query packageQuery) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	manifest := flags.String("manifest", defaultManifest, "Kubernetes release manifest to update")
+	payload := flags.String("payload-version", "", "exact Kubernetes payload version, for example v1.36.1")
+	repoquery := flags.String("repoquery", "dnf", "dnf-compatible repository query command")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	match := payloadPattern.FindStringSubmatch(strings.TrimSpace(*payload))
+	if match == nil {
+		return fmt.Errorf("--payload-version must look like v1.36.1")
+	}
+	state, data, err := readState(*manifest)
+	if err != nil {
+		return err
+	}
+	minor := "v" + match[1] + "." + match[2]
+	if minor != state.minor {
+		return fmt.Errorf("payload minor %s does not match selected release line %s", minor, state.minor)
+	}
+	baseURL := "https://pkgs.k8s.io/core:/stable:/" + minor + "/rpm/"
+	upstream := strings.TrimPrefix(*payload, "v")
+	versions := make(map[string]string, 4)
+	for _, name := range []string{"kubeadm", "kubelet", "kubectl"} {
+		version, err := query(name, name+"-"+upstream, baseURL, *repoquery)
+		if err != nil {
+			return err
+		}
+		if packageUpstream(version) != upstream {
+			return fmt.Errorf("%s resolved to %s, want Kubernetes %s", name, version, upstream)
+		}
+		versions[name] = version
+	}
+	cri, err := query("cri-tools", "cri-tools-"+match[1]+"."+match[2]+".*", baseURL, *repoquery)
+	if err != nil {
+		return err
+	}
+	if err := validateCRITools(cri, match); err != nil {
+		return err
+	}
+	versions["cri-tools"] = cri
+
+	replacements := map[string]string{
+		"KATL_KUBERNETES_PAYLOAD_DEFAULT":           *payload,
+		"KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT": "1",
+		"KATL_KUBERNETES_KUBEADM_VERSION":           versions["kubeadm"],
+		"KATL_KUBERNETES_KUBELET_VERSION":           versions["kubelet"],
+		"KATL_KUBERNETES_KUBECTL_VERSION":           versions["kubectl"],
+		"KATL_KUBERNETES_CRITOOLS_VERSION":          versions["cri-tools"],
+	}
+	updated, err := replaceManifestValues(data, replacements)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(*manifest)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(*manifest), ".kubernetes-release-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(updated); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, *manifest); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "prepared %s-katl.1\n", *payload)
+	for _, name := range []string{"kubeadm", "kubelet", "kubectl", "cri-tools"} {
+		fmt.Fprintf(stdout, "%s=%s\n", name, versions[name])
+	}
+	return nil
+}
+
+type releaseState struct {
+	minor    string
+	payload  string
+	revision int
+}
+
+func readState(path string) (releaseState, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return releaseState{}, nil, fmt.Errorf("read release manifest: %w", err)
+	}
+	values := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		if key, value, ok := manifestAssignment(line); ok {
+			values[key] = value
+		}
+	}
+	state := releaseState{minor: values["KATL_KUBERNETES_MINOR"], payload: values["KATL_KUBERNETES_PAYLOAD_DEFAULT"]}
+	state.revision, err = strconv.Atoi(values["KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT"])
+	if err != nil || state.revision < 1 {
+		return releaseState{}, nil, errors.New("release manifest has invalid artifact revision")
+	}
+	if !regexp.MustCompile(`^v[0-9]+\.[0-9]+$`).MatchString(state.minor) {
+		return releaseState{}, nil, errors.New("release manifest has invalid Kubernetes minor")
+	}
+	if match := payloadPattern.FindStringSubmatch(state.payload); match == nil || "v"+match[1]+"."+match[2] != state.minor {
+		return releaseState{}, nil, errors.New("release manifest payload does not match its Kubernetes minor")
+	}
+	return state, data, nil
+}
+
+func manifestAssignment(line string) (string, string, bool) {
+	line = strings.TrimSpace(line)
+	if strings.HasPrefix(line, `: "${`) && strings.HasSuffix(line, `}"`) {
+		line = strings.TrimSuffix(strings.TrimPrefix(line, `: "${`), `}"`)
+		parts := strings.SplitN(line, ":=", 2)
+		if len(parts) == 2 {
+			return parts[0], parts[1], true
+		}
+	}
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) == 2 && strings.HasPrefix(parts[0], "KATL_KUBERNETES_") && !strings.Contains(parts[1], "${") {
+		return parts[0], strings.Trim(parts[1], `"`), true
+	}
+	return "", "", false
+}
+
+func replaceManifestValues(data []byte, replacements map[string]string) ([]byte, error) {
+	lines := strings.Split(string(data), "\n")
+	seen := make(map[string]bool, len(replacements))
+	for i, line := range lines {
+		key, _, ok := manifestAssignment(line)
+		value, wanted := replacements[key]
+		if !ok || !wanted {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), `: "${`) {
+			lines[i] = `: "${` + key + `:=` + value + `}"`
+		} else {
+			lines[i] = key + "=" + value
+		}
+		seen[key] = true
+	}
+	for key := range replacements {
+		if !seen[key] {
+			return nil, fmt.Errorf("release manifest is missing %s", key)
+		}
+	}
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+func queryPackage(name, selector, baseURL, command string) (string, error) {
+	cmd := exec.Command(command,
+		"repoquery",
+		"--repofrompath=kubernetes,"+baseURL,
+		"--repo=kubernetes",
+		"--arch=x86_64",
+		"--latest-limit=1",
+		"--qf", "%{epoch}:%{version}-%{release}",
+		selector,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("query %s: %w: %s", name, err, strings.TrimSpace(stderr.String()))
+	}
+	lines := strings.Fields(stdout.String())
+	if len(lines) != 1 || !regexp.MustCompile(`^[0-9]+:[0-9]+\.[0-9]+\.[0-9]+-[A-Za-z0-9._+~-]+$`).MatchString(lines[0]) {
+		return "", fmt.Errorf("query %s returned invalid version %q", name, strings.TrimSpace(stdout.String()))
+	}
+	return lines[0], nil
+}
+
+func packageUpstream(version string) string {
+	version = strings.TrimPrefix(version, "0:")
+	return strings.SplitN(version, "-", 2)[0]
+}
+
+func validateCRITools(version string, payload []string) error {
+	match := payloadPattern.FindStringSubmatch("v" + packageUpstream(version))
+	if match == nil || match[1] != payload[1] || match[2] != payload[2] {
+		return fmt.Errorf("cri-tools resolved to incompatible version %s", version)
+	}
+	criPatch, _ := strconv.Atoi(match[3])
+	payloadPatch, _ := strconv.Atoi(payload[3])
+	if criPatch > payloadPatch {
+		return fmt.Errorf("cri-tools %s is newer than payload v%s.%s.%s", version, payload[1], payload[2], payload[3])
+	}
+	return nil
+}

--- a/cmd/katl-kubernetes-release/main_test.go
+++ b/cmd/katl-kubernetes-release/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testManifest = `: "${KATL_KUBERNETES_MINOR:=v1.36}"
+KATL_KUBERNETES_PAYLOAD_DEFAULT=v1.36.0
+KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=4
+: "${KATL_KUBERNETES_KUBEADM_VERSION:=0:1.36.0-1}"
+: "${KATL_KUBERNETES_KUBELET_VERSION:=0:1.36.0-1}"
+: "${KATL_KUBERNETES_KUBECTL_VERSION:=0:1.36.0-1}"
+: "${KATL_KUBERNETES_CRITOOLS_VERSION:=0:1.36.0-1}"
+`
+
+func TestPrepare(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubernetes.env")
+	if err := os.WriteFile(path, []byte(testManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	versions := map[string]string{
+		"kubeadm":   "0:1.36.1-150500.1.1",
+		"kubelet":   "0:1.36.1-150500.1.1",
+		"kubectl":   "0:1.36.1-150500.1.1",
+		"cri-tools": "0:1.36.0-150500.1.1",
+	}
+	query := func(name, selector, baseURL, command string) (string, error) {
+		if baseURL != "https://pkgs.k8s.io/core:/stable:/v1.36/rpm/" || command != "dnf" {
+			t.Fatalf("query %s baseURL=%q command=%q", name, baseURL, command)
+		}
+		return versions[name], nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"prepare", "--manifest", path, "--payload-version", "v1.36.1"}, &stdout, &stderr, query); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"KATL_KUBERNETES_PAYLOAD_DEFAULT=v1.36.1",
+		"KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=1",
+		"KATL_KUBERNETES_KUBEADM_VERSION:=0:1.36.1-150500.1.1",
+		"KATL_KUBERNETES_CRITOOLS_VERSION:=0:1.36.0-150500.1.1",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("updated manifest missing %q:\n%s", want, data)
+		}
+	}
+}
+
+func TestIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubernetes.env")
+	if err := os.WriteFile(path, []byte(testManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"identity", "--manifest", path}, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	want := `{"payloadVersion":"v1.36.0","artifactVersion":"v1.36.0-katl.4","image":"ghcr.io/katl-dev/kubernetes:v1.36.0-katl.4"}`
+	if strings.TrimSpace(stdout.String()) != want {
+		t.Fatalf("identity = %s, want %s", stdout.String(), want)
+	}
+}
+
+func TestPrepareRejectsPackageMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubernetes.env")
+	if err := os.WriteFile(path, []byte(testManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	query := func(name, selector, baseURL, command string) (string, error) {
+		return "0:1.36.0-1", nil
+	}
+	if err := run([]string{"prepare", "--manifest", path, "--payload-version", "v1.36.1"}, &bytes.Buffer{}, &bytes.Buffer{}, query); err == nil || !strings.Contains(err.Error(), "want Kubernetes 1.36.1") {
+		t.Fatalf("run() error = %v", err)
+	}
+}

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -254,11 +254,27 @@ kubelet, kubectl, and cri-tools RPM NEVRAs in
 `vMAJOR.MINOR.PATCH-katl.1` GHCR artifact. Earlier patch releases and digests
 remain addressable.
 
+Prepare or complete that reviewed update with one command on a capable build
+host:
+
+```sh
+scripts/prepare-kubernetes-release v1.36.2
+```
+
+The command resolves the exact x86_64 RPMs from the selected official
+Kubernetes repository, requires kubeadm, kubelet, and kubectl to match the
+payload patch, selects the newest compatible cri-tools patch, resets the Katl
+artifact revision to `1`, builds the runtime and sysext, refreshes the resource
+lock, and runs the producer checks. Review the resulting release manifest and
+resource-lock diff, then submit them as a normal ready pull request. The merge
+is the release event; no tag or manual workflow dispatch is required.
+
 Manual dispatch remains the explicit rebuild and dry-run path. Dispatch it with
-an exact Kubernetes payload such as
-`v1.36.0`, an immutable Katl build identity such as `v1.36.0-katl.1`, and
-`publish: false` for a build-only verification run. A successful build uploads
-the complete staged bundle as a GitHub Actions artifact.
+empty version inputs to rebuild the committed release manifest, or provide an
+exact Kubernetes payload and immutable Katl build identity to inspect another
+candidate. Keep `publish: false` for a build-only verification run. A
+successful build uploads the complete staged bundle as a GitHub Actions
+artifact.
 
 Set `publish: true` only for a reviewed bundle identity. The workflow refuses
 to replace either immutable GHCR tag, publishes the Katl custom bundle manifest
@@ -278,6 +294,12 @@ namespace operation. The workflow summary prints the readable and digest-pinned
 OCI bundle references for install/bootstrap manifests. Published development
 bundles remain unsigned until the signing policy lands; the GitHub attestation
 records build provenance but is not yet a trust decision enforced by `katlc`.
+
+The scheduled public-bundle workflow derives the selected readable tag from
+the same committed release manifest, resolves its immutable digest
+anonymously, verifies every OCI blob, and verifies the GitHub attestation. A
+patch release therefore does not require a second commit just to update a
+hard-coded verifier digest.
 
 ## GitHub VM Tests
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -149,8 +149,8 @@ metadata:
 spec:
   controlPlaneEndpoint: api.katl.test:6443
   kubernetes:
-    version: v1.36.0
-    bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3
+    version: v1.36.1
+    bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1
   defaults:
     install:
       wipeTarget: true
@@ -188,7 +188,7 @@ spec:
         ---
         apiVersion: kubeadm.k8s.io/v1beta4
         kind: ClusterConfiguration
-        kubernetesVersion: v1.36.0
+        kubernetesVersion: v1.36.1
     worker:
       config: |
         apiVersion: kubeadm.k8s.io/v1beta4
@@ -409,7 +409,7 @@ later explicit operator action.
 The Kubernetes bundle is one ordinary OCI image reference. During the explicit
 bootstrap operation, `katlc` resolves and fetches that bundle, checks its
 contents internally, stages the sysext locally, and selects it for generation
-1. The selected alpha reference above supplies the `v1.36.0`
+1. The selected alpha reference above supplies the `v1.36.1`
 payload; a different Kubernetes version requires its matching bundle reference
 and a KatlOS runtime compatible with that bundle.
 
@@ -417,20 +417,20 @@ Katl publishes development Kubernetes bundles as custom OCI artifacts in the
 public `ghcr.io/katl-dev/kubernetes` package. A tag-only reference is accepted:
 
 ```text
-ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3
+ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1
 ```
 
 An immutable OCI manifest pin is optional when exact byte-for-byte
 reproducibility matters:
 
 ```text
-ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
+ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537
 ```
 
 `katlc` verifies the resolved OCI manifest, the Katl bundle config, every layer
 digest and size, and
 Katl runtime compatibility, and only then stages the sysext. The readable
-`ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3` tag is suitable for Renovate's
+`ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1` tag is suitable for Renovate's
 Docker datasource; the full patch precision lets Renovate propose Kubernetes
 patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.
@@ -538,7 +538,7 @@ spec:
       config: |
         apiVersion: kubeadm.k8s.io/v1beta4
         kind: ClusterConfiguration
-        kubernetesVersion: v1.36.0
+        kubernetesVersion: v1.36.1
   clusterDefaults:
     kubernetes:
       kubeadm:

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -1,6 +1,7 @@
 package scriptstest
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -95,8 +96,10 @@ func TestPublicKubernetesBundleWorkflowContract(t *testing.T) {
 		"workflow_dispatch:",
 		"packages: read",
 		"scripts/check-public-kubernetes-bundle",
-		"ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3",
-		"sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b",
+		"source mkosi.profiles/kubernetes-sysext/kubernetes.env",
+		`artifact_version="${KATL_KUBERNETES_PAYLOAD_VERSION}-katl.${KATL_KUBERNETES_ARTIFACT_REVISION}"`,
+		`verification="$(scripts/check-public-kubernetes-bundle "$image")"`,
+		`digest="${verification##*@}"`,
 		"gh attestation verify",
 		"docker login ghcr.io",
 		"--repo katl-dev/katl",
@@ -111,6 +114,7 @@ func TestPublicKubernetesBundleWorkflowContract(t *testing.T) {
 	for _, value := range []string{
 		"https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull",
 		`fetch_manifest "$tag"`,
+		`resolved_digest="sha256:$(sha256sum "$work/tag.json"`,
 		`fetch_manifest "$expected_digest"`,
 		`cmp --silent "$work/tag.json" "$work/digest.json"`,
 		`sha256sum "$blob"`,
@@ -146,15 +150,38 @@ func TestKubernetesBundleRenovateContract(t *testing.T) {
 
 	for _, value := range []string{
 		`https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/`,
-		`KATL_KUBERNETES_PAYLOAD_DEFAULT=v1.36.1`,
 		`KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=1`,
-		`KATL_KUBERNETES_KUBEADM_VERSION:=0:1.36.1-150500.1.1`,
-		`KATL_KUBERNETES_KUBELET_VERSION:=0:1.36.1-150500.1.1`,
-		`KATL_KUBERNETES_KUBECTL_VERSION:=0:1.36.1-150500.1.1`,
-		`KATL_KUBERNETES_CRITOOLS_VERSION:=0:1.36.0-150500.1.1`,
+		`KATL_KUBERNETES_PAYLOAD_DEFAULT=`,
+		`KATL_KUBERNETES_KUBEADM_VERSION:=`,
+		`KATL_KUBERNETES_KUBELET_VERSION:=`,
+		`KATL_KUBERNETES_KUBECTL_VERSION:=`,
+		`KATL_KUBERNETES_CRITOOLS_VERSION:=`,
 	} {
 		if !strings.Contains(manifest, value) {
 			t.Fatalf("Kubernetes release lock missing %q", value)
+		}
+	}
+	payload := regexp.MustCompile(`KATL_KUBERNETES_PAYLOAD_DEFAULT=v([0-9]+\.[0-9]+\.[0-9]+)`).FindStringSubmatch(manifest)
+	if payload == nil {
+		t.Fatal("Kubernetes release lock has no exact payload version")
+	}
+	for _, name := range []string{"KUBEADM", "KUBELET", "KUBECTL"} {
+		match := regexp.MustCompile(`KATL_KUBERNETES_` + name + `_VERSION:=0:([0-9]+\.[0-9]+\.[0-9]+)-`).FindStringSubmatch(manifest)
+		if match == nil || match[1] != payload[1] {
+			t.Fatalf("%s package version does not match payload %s", name, payload[1])
+		}
+	}
+
+	prepare := string(mustReadFile(t, repo+"/scripts/prepare-kubernetes-release"))
+	for _, value := range []string{
+		"go run ./cmd/katl-kubernetes-release prepare",
+		"scripts/mkosi build-runtime",
+		"scripts/mkosi build-kubernetes-sysext",
+		"scripts/check-kubernetes-sysext",
+		"go run ./cmd/katl-kubernetes-release identity",
+	} {
+		if !strings.Contains(prepare, value) {
+			t.Fatalf("Kubernetes release preparation missing %q", value)
 		}
 	}
 }

--- a/scripts/check-public-kubernetes-bundle
+++ b/scripts/check-public-kubernetes-bundle
@@ -4,12 +4,12 @@ set -euo pipefail
 image="${1:-}"
 expected_digest="${2:-}"
 if [[ ! "$image" =~ ^ghcr\.io/katl-dev/kubernetes:([A-Za-z0-9._-]+)$ ]]; then
-    echo "usage: scripts/check-public-kubernetes-bundle ghcr.io/katl-dev/kubernetes:TAG sha256:DIGEST" >&2
+    echo "usage: scripts/check-public-kubernetes-bundle ghcr.io/katl-dev/kubernetes:TAG [sha256:DIGEST]" >&2
     exit 2
 fi
 tag="${BASH_REMATCH[1]}"
 payload_version="${tag%-katl.*}"
-if [[ ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+if [[ -n "$expected_digest" && ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
     echo "error: expected OCI manifest digest must be sha256 followed by 64 lowercase hex characters" >&2
     exit 2
 fi
@@ -36,6 +36,13 @@ fetch_manifest() {
 }
 
 fetch_manifest "$tag" "$work/tag.json"
+resolved_digest="sha256:$(sha256sum "$work/tag.json" | cut -d ' ' -f 1)"
+if [[ -z "$expected_digest" ]]; then
+    expected_digest="$resolved_digest"
+elif [[ "$resolved_digest" != "$expected_digest" ]]; then
+    echo "error: tag resolved to $resolved_digest, want $expected_digest" >&2
+    exit 1
+fi
 fetch_manifest "$expected_digest" "$work/digest.json"
 if ! cmp --silent "$work/tag.json" "$work/digest.json"; then
     echo "error: tag and expected digest resolved to different OCI manifests" >&2

--- a/scripts/prepare-kubernetes-release
+++ b/scripts/prepare-kubernetes-release
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${KATL_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+payload_version="${1:-}"
+
+if [[ ! "$payload_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ || $# -ne 1 ]]; then
+    echo "usage: scripts/prepare-kubernetes-release vMAJOR.MINOR.PATCH" >&2
+    exit 2
+fi
+
+cd "$repo_root"
+go run ./cmd/katl-kubernetes-release prepare --payload-version "$payload_version"
+scripts/mkosi build-runtime
+scripts/mkosi build-kubernetes-sysext
+scripts/check-kubernetes-sysext
+go test \
+    ./cmd/katl-kubernetes-release \
+    ./cmd/katl-publish-kubernetes-sysext \
+    ./internal/installer/kubernetesbundle \
+    ./internal/installer/sysextcatalog \
+    ./internal/scriptstest \
+    -count=1
+
+go run ./cmd/katl-kubernetes-release identity
+echo "Kubernetes release preparation passed; review and submit the manifest and resource-lock changes."


### PR DESCRIPTION
Adds a one-command Kubernetes patch release preparation flow and removes hard-coded selected versions from workflow inputs and tests. Public verification now derives the committed immutable tag, resolves its GHCR digest, verifies every blob, and checks its build provenance.