### PR TITLE
vmtest: prove published Kubernetes bundle upgrades

### DIFF
--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -64,6 +64,15 @@ jobs:
             run: ^TestInstalledRuntimeTwoNodeKubeadmJoinSmoke$
             go_timeout: 60m
             timeout_minutes: 110
+          - id: kubernetes-upgrade
+            name: Kubernetes Bundle Upgrade VM
+            artifact_set: default
+            package: ./internal/vmtest/scenarios
+            run: ^TestKubeadmUpgradeOperationSmoke$
+            go_timeout: 75m
+            timeout_minutes: 140
+            source_bundle: ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b
+            target_bundle: ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537
 
     env:
       GOTOOLCHAIN: auto
@@ -72,6 +81,8 @@ jobs:
       KATL_VMTEST_DEBUG_ON_FAILURE: "0"
       KATL_VMTEST_REQUIRE_SCENARIO_RESULT: "1"
       KATL_VMTEST_RUN_ID: gha-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.gate.id }}
+      KATL_VMTEST_KUBERNETES_BUNDLE: ${{ matrix.gate.source_bundle || '' }}
+      KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE: ${{ matrix.gate.target_bundle || '' }}
 
     steps:
       - name: Check out repository
@@ -167,6 +178,8 @@ jobs:
             KATL_VMTEST_KEEP="$KATL_VMTEST_KEEP" \
             KATL_VMTEST_DEBUG_ON_FAILURE="$KATL_VMTEST_DEBUG_ON_FAILURE" \
             KATL_VMTEST_REQUIRE_SCENARIO_RESULT="$KATL_VMTEST_REQUIRE_SCENARIO_RESULT" \
+            KATL_VMTEST_KUBERNETES_BUNDLE="$KATL_VMTEST_KUBERNETES_BUNDLE" \
+            KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE="$KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE" \
             KATL_OVMF_CODE="${KATL_OVMF_CODE:-}" \
             KATL_OVMF_VARS="${KATL_OVMF_VARS:-}" \
             KATL_VMTEST_LIBVIRT_URI="${KATL_VMTEST_LIBVIRT_URI:-}" \

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -148,6 +148,18 @@ scripts/vmtest-run ./internal/vmtest/scenarios \
   -timeout 60m -count=1
 ```
 
+To exercise the release boundary rather than locally built Kubernetes
+artifacts, provide digest-pinned source and target OCI bundles. The upgrade
+scenario fetches and verifies both bundles through the product bundle path:
+
+```sh
+KATL_VMTEST_KUBERNETES_BUNDLE='ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b' \
+KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE='ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537' \
+scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
+  -run '^TestKubeadmUpgradeOperationSmoke$' \
+  -count=1 -failfast -timeout 75m
+```
+
 The runner creates a temporary world under `${TMPDIR:-/tmp}/katl-vmtest/`, probes
 host capabilities, records `world.json`, `host-capabilities.json`, `run.json`,
 and `go-test.log`, exports the world environment, and then executes `go test`
@@ -327,7 +339,18 @@ scripts/vmtest-run --artifact-set=default ./internal/vmtest \
 scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
   -run '^TestInstalledRuntimeTwoNodeKubeadmJoinSmoke$' \
   -count=1 -failfast -timeout 60m
+KATL_VMTEST_KUBERNETES_BUNDLE='<digest-pinned-source-bundle>' \
+KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE='<digest-pinned-target-bundle>' \
+scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
+  -run '^TestKubeadmUpgradeOperationSmoke$' \
+  -count=1 -failfast -timeout 75m
 ```
+
+The upgrade row pins the published source and target OCI references in the
+workflow matrix. It proves etcd snapshot capture, control-plane-first kubeadm
+upgrade, generation selection across reboot, worker upgrade, and final cluster
+health. Update those pins deliberately when promoting a newly published bundle
+pair into the compatibility gate.
 
 The runtime artifact set is intentionally limited to direct-runtime tests.
 Installed-runtime tests consume the KatlOS install image and reject

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -560,11 +560,13 @@ that image and validates component compatibility before selection.
 
 Kubernetes version upgrades remain separate from day-one install. They require a
 kubeadm-aware operation that can make the target `kubeadm` available before the
-target kubelet starts. Until that path is implemented and tested, treat
-Kubernetes upgrades as unsupported operational work. Producing and publishing a
-new sysext such as `v1.36.1` is useful immediately for fresh installs and
-future upgrade planning, but it does not by itself make `v1.36.0` to `v1.36.1`
-mutation safe on an existing cluster.
+target kubelet starts. Katl's node-side operation and VM proof now exercise a
+control-plane-first `v1.36.0` to `v1.36.1` upgrade, including an etcd snapshot,
+reboots, worker upgrade, and final cluster health. There is not yet a supported
+`katlctl` command that coordinates that operation across an operator's cluster,
+so continue to treat Kubernetes upgrades as unsupported operational work. A
+published sysext alone is not sufficient authorization to perform the mutation
+manually.
 
 ## Troubleshooting
 

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -185,3 +185,41 @@ func TestKubernetesBundleRenovateContract(t *testing.T) {
 		}
 	}
 }
+
+func TestKubernetesUpgradeVMTestArtifactContract(t *testing.T) {
+	repo := repoRoot(t)
+	runner := string(mustReadFile(t, repo+"/scripts/vmtest-run"))
+	for _, value := range []string{
+		"verify_kubernetes_upgrade_artifacts",
+		`scripts/check-kubernetes-sysext`,
+		`katl-kubernetes-upgrade.raw`,
+		`KATL_KUBERNETES_UPGRADE_PAYLOAD_VERSION`,
+		`published Kubernetes upgrade proof requires both KATL_VMTEST_KUBERNETES_BUNDLE and KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE`,
+		`-package-set installer-image`,
+		`-package-set runtime`,
+		`-package-set katlos-install-image`,
+		`sha256sum katl-kubernetes-upgrade.raw > katl-kubernetes-upgrade.raw.sha256`,
+	} {
+		source := runner
+		if strings.HasPrefix(value, "sha256sum ") {
+			source = string(mustReadFile(t, repo+"/scripts/mkosi"))
+		}
+		if !strings.Contains(source, value) {
+			t.Fatalf("Kubernetes upgrade vmtest contract missing %q", value)
+		}
+	}
+
+	workflow := string(mustReadFile(t, repo+"/.github/workflows/vmtest.yml"))
+	for _, value := range []string{
+		"Kubernetes Bundle Upgrade VM",
+		"^TestKubeadmUpgradeOperationSmoke$",
+		"KATL_VMTEST_KUBERNETES_BUNDLE",
+		"KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE",
+		"ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b",
+		"ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537",
+	} {
+		if !strings.Contains(workflow, value) {
+			t.Fatalf("Kubernetes upgrade vmtest workflow missing %q", value)
+		}
+	}
+}

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -1025,6 +1025,9 @@ func kubernetesBundleServerCertificate(gateway string) (tls.Certificate, []byte,
 }
 
 func installKubernetesBundleCA(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, bundle threeControlPlaneKubernetesPayloadBundle) error {
+	if len(bundle.CACertPEM) == 0 {
+		return nil
+	}
 	if err := writeNodeFile(ctx, node, bundle.CACertGuestPath, bundle.CACertPEM, 0o644, false); err != nil {
 		return err
 	}

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/artifact"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	"github.com/katl-dev/katl/internal/installer/persistedrecord"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -125,6 +126,13 @@ func operationBackedFreshFixtureWorld(world vmtest.World) vmtest.World {
 
 func operationBackedKubernetesVersion(t *testing.T, repo string) string {
 	t.Helper()
+	if value := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_BUNDLE")); value != "" {
+		image, err := kubernetesbundle.ParseImageReference(value)
+		if err != nil {
+			t.Fatalf("parse published Kubernetes bundle: %v", err)
+		}
+		return image.PayloadVersion
+	}
 	if version := firstString(os.Getenv("KATL_KUBERNETES_VERSION"), os.Getenv("KATL_KUBERNETES_PAYLOAD_VERSION")); version != "" {
 		return version
 	}
@@ -605,6 +613,27 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 	}
 	targetHost := filepath.Join(katlRepoRoot(t), "_build/mkosi/katl-kubernetes-upgrade.raw")
 	metadataHost := targetHost + ".json"
+	if value := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE")); value != "" {
+		image, err := kubernetesbundle.ParseImageReference(value)
+		if err != nil {
+			return fmt.Errorf("parse published target Kubernetes bundle: %w", err)
+		}
+		staged, err := kubernetesbundle.FetchAndStage(ctx, kubernetesbundle.Request{
+			Source:           image.Source,
+			Ref:              image.Value,
+			CacheDir:         filepath.Join(smoke.Result.ManifestDir, "published-kubernetes-upgrade"),
+			RuntimeInterface: "katl-runtime-1",
+			Architecture:     "x86_64",
+		})
+		if err != nil {
+			return fmt.Errorf("fetch published target Kubernetes bundle: %w", err)
+		}
+		if staged.PayloadVersion != targetVersion {
+			return fmt.Errorf("published target Kubernetes bundle payload is %s, want %s", staged.PayloadVersion, targetVersion)
+		}
+		targetHost = staged.SysextPath
+		metadataHost = staged.MetadataPath
+	}
 	target, err := os.ReadFile(targetHost)
 	if err != nil {
 		return fmt.Errorf("read target Kubernetes sysext: %w", err)
@@ -828,6 +857,25 @@ func operationBackedVMConfigForRun(run operationBackedSmokeRun, mac string, cid 
 }
 
 func stageOperationBackedKubernetesPayloadBundle(repo string, result vmtest.Result, gateway, kubernetesVersion string) (threeControlPlaneKubernetesPayloadBundle, guestReachableBundleServer, error) {
+	if value := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_BUNDLE")); value != "" {
+		image, err := kubernetesbundle.ParseImageReference(value)
+		if err != nil {
+			return threeControlPlaneKubernetesPayloadBundle{}, guestReachableBundleServer{}, err
+		}
+		if image.PayloadVersion != kubernetesVersion {
+			return threeControlPlaneKubernetesPayloadBundle{}, guestReachableBundleServer{}, fmt.Errorf("published Kubernetes bundle payload is %s, want %s", image.PayloadVersion, kubernetesVersion)
+		}
+		bundle := threeControlPlaneKubernetesPayloadBundle{
+			Source:         image.Source,
+			Ref:            image.Value,
+			PayloadVersion: image.PayloadVersion,
+			LogPath:        filepath.Join(result.RunDir, "kubernetes-payload-bundle.log"),
+		}
+		if err := writeKubernetesBundleSourceLog(bundle.LogPath, bundle); err != nil {
+			return threeControlPlaneKubernetesPayloadBundle{}, guestReachableBundleServer{}, err
+		}
+		return bundle, guestReachableBundleServer{}, nil
+	}
 	bundle, err := stageThreeControlPlaneKubernetesPayloadBundles(repo, result, kubernetesVersion)
 	if err != nil {
 		return threeControlPlaneKubernetesPayloadBundle{}, guestReachableBundleServer{}, err

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -600,9 +600,13 @@ else
 				KATL_KUBERNETES_KUBELET_VERSION="${KATL_KUBERNETES_UPGRADE_KUBELET_VERSION:-0:1.36.1-150500.1.1}" \
 				KATL_KUBERNETES_KUBECTL_VERSION="${KATL_KUBERNETES_UPGRADE_KUBECTL_VERSION:-0:1.36.1-150500.1.1}" \
 				"$repo_root/scripts/mkosi" build-kubernetes-sysext
-			for suffix in raw raw.json raw.sha256; do
+			for suffix in raw raw.json; do
 				cp "$build_dir/katl-kubernetes.$suffix" "$build_dir/katl-kubernetes-upgrade.$suffix"
 			done
+			(
+				cd "$build_dir"
+				sha256sum katl-kubernetes-upgrade.raw > katl-kubernetes-upgrade.raw.sha256
+			)
 			exit 0
 			;;
         build-katlos-install-image)

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -90,6 +90,10 @@ vmtest_requests_kubernetes_upgrade() {
     return 1
 }
 
+vmtest_uses_published_kubernetes_upgrade_bundles() {
+	[[ -n "${KATL_VMTEST_KUBERNETES_BUNDLE:-}" && -n "${KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE:-}" ]]
+}
+
 usage() {
     cat <<'EOF'
 usage: scripts/vmtest-run [vmtest-run options] [go test args]
@@ -320,6 +324,15 @@ validate_current_artifact_inputs() {
     if has_explicit_artifact_index || has_explicit_installer_artifact || has_explicit_runtime_artifact || has_explicit_install_manifest; then
         setup_failures+=("explicit installer artifact inputs are not supported by scripts/vmtest-run; use current repo artifacts validated by katl-resource-lock")
     fi
+	if vmtest_requests_kubernetes_upgrade; then
+		local published_source_set=0
+		local published_target_set=0
+		[[ -n "${KATL_VMTEST_KUBERNETES_BUNDLE:-}" ]] && published_source_set=1
+		[[ -n "${KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE:-}" ]] && published_target_set=1
+		if [[ "$published_source_set" != "$published_target_set" ]]; then
+			setup_failures+=("published Kubernetes upgrade proof requires both KATL_VMTEST_KUBERNETES_BUNDLE and KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE")
+		fi
+	fi
 }
 
 build_default_artifacts() {
@@ -339,10 +352,12 @@ build_default_artifacts() {
             if ! has_explicit_install_manifest; then
                 targets+=("build-katlos-install-image")
 			targets+=("build-katlos-upgrade-image")
-				if vmtest_requests_kubernetes_upgrade; then
+				if vmtest_requests_kubernetes_upgrade && ! vmtest_uses_published_kubernetes_upgrade_bundles; then
 					targets+=("build-kubernetes-upgrade-sysext")
 				fi
-                targets+=("build-kubernetes-sysext")
+				if ! vmtest_requests_kubernetes_upgrade || ! vmtest_uses_published_kubernetes_upgrade_bundles; then
+					targets+=("build-kubernetes-sysext")
+				fi
             elif ! has_explicit_runtime_artifact; then
                 targets+=("build-runtime")
             fi
@@ -389,6 +404,22 @@ build_default_artifacts() {
         fi
         rm -f "$log"
 	done
+	if vmtest_requests_kubernetes_upgrade && ! vmtest_uses_published_kubernetes_upgrade_bundles; then
+		verify_kubernetes_upgrade_artifacts
+	fi
+}
+
+verify_kubernetes_upgrade_artifacts() {
+	local base="$repo_root/_build/mkosi/katl-kubernetes.raw"
+	local target="$repo_root/_build/mkosi/katl-kubernetes-upgrade.raw"
+	printf 'vmtest verifying source Kubernetes sysext independently: %s\n' "$base" >&2
+	"$repo_root/scripts/check-kubernetes-sysext" "$base"
+	printf 'vmtest verifying target Kubernetes sysext independently: %s\n' "$target" >&2
+	KATL_KUBERNETES_PAYLOAD_VERSION="${KATL_KUBERNETES_UPGRADE_PAYLOAD_VERSION:-v1.36.1}" \
+		KATL_KUBERNETES_KUBEADM_VERSION="${KATL_KUBERNETES_UPGRADE_KUBEADM_VERSION:-0:1.36.1-150500.1.1}" \
+		KATL_KUBERNETES_KUBELET_VERSION="${KATL_KUBERNETES_UPGRADE_KUBELET_VERSION:-0:1.36.1-150500.1.1}" \
+		KATL_KUBERNETES_KUBECTL_VERSION="${KATL_KUBERNETES_UPGRADE_KUBECTL_VERSION:-0:1.36.1-150500.1.1}" \
+		"$repo_root/scripts/check-kubernetes-sysext" "$target"
 }
 
 mkosi_cache_label_for_target() {
@@ -462,14 +493,26 @@ prepare_resource_manifest() {
     fi
 
     local revision
+	local -a lock_args
     revision="$(git_revision)"
     printf 'vmtest validating current repo artifacts: katl-resource-lock prepare-mkosi --mode strict\n' >&2
-    if ! run_resource_lock prepare-mkosi \
+	lock_args=(prepare-mkosi \
         -manifest "$resource_manifest" \
         -lock "$package_lock" \
         -mode strict \
         -run-id "$run_id" \
-        -git-revision "$revision"; then
+		-git-revision "$revision")
+	if vmtest_requests_kubernetes_upgrade; then
+		# The committed lock names the selected release payload. Upgrade tests
+		# deliberately build a different source payload, so validate the KatlOS
+		# package sets here and validate both Kubernetes sysexts independently.
+		lock_args+=(
+			-package-set installer-image
+			-package-set runtime
+			-package-set katlos-install-image
+		)
+	fi
+	if ! run_resource_lock "${lock_args[@]}"; then
         setup_failures+=("strict vmtest resource manifest validation failed")
         return 1
     fi


### PR DESCRIPTION
Prove the two-node v1.36.0 to v1.36.1 upgrade using the published digest-pinned GHCR bundles. Promote the control-plane-first upgrade and recovery scenario into capable-host CI, and keep the unsupported katlctl orchestration boundary explicit.