### PR TITLE
installer: show boot progress on VGA

### DIFF
--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -50,6 +50,13 @@ jobs:
             run: ^TestFirstInstallTargetDiskSerialSmoke$
             go_timeout: 35m
             timeout_minutes: 70
+          - id: installer-iso-boot
+            name: Installer ISO Boot VM
+            artifact_set: default
+            package: ./internal/vmtest/scenarios
+            run: ^TestInstallerISOBootSmoke$
+            go_timeout: 15m
+            timeout_minutes: 45
           - id: installed-runtime
             name: Installed Runtime VM
             artifact_set: default

--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ file; operators do not need to copy or pass its internal digests.
 ### 3. Install each node
 
 Attach or write `katl-installer.iso` using your normal UEFI virtual-media or USB
-workflow, then boot it. Without preseed input, the installer waits safely and
-prints an HTTP handoff URL and one-time token. Store the token in a protected
-temporary file, then submit the same bundle to every node while selecting that
-node by name:
+workflow, then boot it. The installer reports progress on both a local VGA
+console and a 115200-baud serial console. Secure Boot must remain disabled until
+Katl publishes signed boot artifacts. Without preseed input, the installer waits
+safely and prints an HTTP handoff URL and one-time token. Store the token in a
+protected temporary file, then submit the same bundle to every node while
+selecting that node by name:
 
 ```sh
 INSTALLER_ENDPOINT=http://192.0.2.10:8080

--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -1163,7 +1163,7 @@ func writeBootMetadata(role, format, artifactPath, created string, cfg config) e
 		SHA256:                   digest,
 		CreatedAt:                created,
 		InstallerInterface:       cfg.InstallerInterface,
-		DefaultKernelCommandLine: []string{"console=ttyS0,115200n8", "systemd.log_target=console", "loglevel=6"},
+		DefaultKernelCommandLine: []string{"console=ttyS0,115200n8", "console=tty0", "systemd.log_target=console", "loglevel=6"},
 		SupportedInputModes:      []string{"pxe-preseed", "local-handoff", "offline-media"},
 	}
 	data, err := json.MarshalIndent(metadata, "", "  ")

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -38,9 +38,10 @@ build/boot/test loop.
 - Required smoke path: `scripts/vmtest-run` with libvirt system VM execution
   and deterministic serial capture.
 - Firmware expectation: the runner is given readable OVMF/edk2 pflash images.
-- Serial settings: the guest kernel command line includes
-  `console=ttyS0,115200n8`; libvirt exposes that serial device to the runner's
-  captured console log.
+- Console settings: the guest kernel command line includes both
+  `console=ttyS0,115200n8` and `console=tty0`. VGA remains the interactive
+  display console while the installer journal is mirrored to ttyS0 for the
+  runner's deterministic captured console log.
 - Stable boot signal: `Katl hello`.
 - Generated VM logs and scratch state belong under `build/`.
 

--- a/internal/scriptstest/installer_iso_scripts_test.go
+++ b/internal/scriptstest/installer_iso_scripts_test.go
@@ -145,6 +145,29 @@ exit 1
 	}
 }
 
+func TestInstallerConsoleAndVMGateContract(t *testing.T) {
+	repo := repoRoot(t)
+	profile := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles/installer-image/mkosi.conf")))
+	journal := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles/installer-image/mkosi.extra/etc/systemd/journald.conf.d/10-katl-installer-console.conf")))
+	workflow := string(mustReadFile(t, filepath.Join(repo, ".github/workflows/vmtest.yml")))
+
+	for _, value := range []string{"console=tty0", "console=ttyS0,115200n8"} {
+		if !strings.Contains(profile, value) {
+			t.Fatalf("installer profile missing console %q", value)
+		}
+	}
+	for _, value := range []string{"ForwardToConsole=yes", "TTYPath=/dev/ttyS0"} {
+		if !strings.Contains(journal, value) {
+			t.Fatalf("installer dual-console journal routing missing %q", value)
+		}
+	}
+	for _, value := range []string{"Installer ISO Boot VM", "^TestInstallerISOBootSmoke$"} {
+		if !strings.Contains(workflow, value) {
+			t.Fatalf("installer ISO VM workflow missing %q", value)
+		}
+	}
+}
+
 func TestMkosiInstallerISOUsesBuilder(t *testing.T) {
 	repo := repoRoot(t)
 	tmp := t.TempDir()

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -46,7 +46,7 @@ RemoveFiles=
         /usr/share/dnf5
         /usr/share/licenses/pkgconf
         /var/lib/rpm-state
-KernelCommandLine=console=ttyS0,115200n8 systemd.log_target=console loglevel=6
+KernelCommandLine=console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6
 Hostname=katl-installer
 Autologin=yes
 MakeInitrd=yes

--- a/mkosi.profiles/installer-image/mkosi.extra/etc/systemd/journald.conf.d/10-katl-installer-console.conf
+++ b/mkosi.profiles/installer-image/mkosi.extra/etc/systemd/journald.conf.d/10-katl-installer-console.conf
@@ -1,0 +1,6 @@
+[Journal]
+# Keep the local VGA terminal as /dev/console for virtual media users while
+# mirroring the installer journal to ttyS0 for deterministic automation.
+ForwardToConsole=yes
+TTYPath=/dev/ttyS0
+MaxLevelConsole=info

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,7 +11,7 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "1d03efec807d91c4b6a23e7ad49d86c7c11f02de951337d72b46050bf4a5f2e9",
+      "configSHA256": "e2e78ad2d9a620abec2f840705e0e8623d8604e3e53259e613705fd964b3b25a",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -25,7 +25,7 @@ inspect="$(ukify inspect "$artifact")" || fail "inspect installer UKI failed"
 grep -Fq '.linux:' <<<"$inspect" || fail "installer UKI missing .linux section"
 grep -Fq '.initrd:' <<<"$inspect" || fail "installer UKI missing .initrd section"
 grep -Fq '.cmdline:' <<<"$inspect" || fail "installer UKI missing .cmdline section"
-grep -Fq 'console=ttyS0,115200n8 systemd.log_target=console loglevel=6' <<<"$inspect" ||
+grep -Fq 'console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6' <<<"$inspect" ||
     fail "installer UKI command line mismatch"
 
 initrd_list="$(cpio -it <"$initrd" 2>/dev/null)" || fail "list installer initrd failed"
@@ -79,6 +79,7 @@ for path in \
     /usr/lib/systemd/system/systemd-resolved.service \
     /usr/lib/systemd/system/sshd.service \
     /etc/systemd/system/sshd.service.d/10-katl-disabled.conf \
+    /etc/systemd/journald.conf.d/10-katl-installer-console.conf \
     /usr/lib/systemd/network/80-katl-installer-dhcp.network
 do
     has_path "$path"
@@ -88,6 +89,8 @@ file_has /usr/lib/systemd/system/katlos-install.service "ExecStart=/usr/bin/katl
 file_has /usr/lib/systemd/system/katl-input-apply.service "ExecStart=/usr/bin/katlos-install --apply-input"
 file_has /usr/lib/systemd/system/katl-installer-smoke.service "Katl installer ready"
 file_has /etc/systemd/system/sshd.service.d/10-katl-disabled.conf "ConditionPathExists=/etc/katl/installer-ssh.enabled"
+file_has /etc/systemd/journald.conf.d/10-katl-installer-console.conf "ForwardToConsole=yes"
+file_has /etc/systemd/journald.conf.d/10-katl-installer-console.conf "TTYPath=/dev/ttyS0"
 
 for path in \
     /usr/bin/mkosi \


### PR DESCRIPTION
Fix the Proxmox q35/OVMF installer appearing frozen after UEFI handoff by making VGA the display console while mirroring installer output to serial. Add the dedicated installer ISO boot smoke to capable-host CI.