### PR TITLE
installer: compress boot artifacts with zstd

### DIFF
--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -50,11 +50,11 @@ jobs:
             run: ^TestFirstInstallTargetDiskSerialSmoke$
             go_timeout: 35m
             timeout_minutes: 70
-          - id: installer-iso-boot
-            name: Installer ISO Boot VM
+          - id: installer-boot-media
+            name: Installer Boot Media VM
             artifact_set: default
             package: ./internal/vmtest/scenarios
-            run: ^TestInstallerISOBootSmoke$
+            run: ^(TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke)$
             go_timeout: 15m
             timeout_minutes: 45
           - id: installed-runtime

--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -222,6 +222,7 @@ type bootMetadata struct {
 	Path                     string   `json:"path"`
 	SizeBytes                int64    `json:"sizeBytes"`
 	SHA256                   string   `json:"sha256"`
+	Compression              string   `json:"compression,omitempty"`
 	CreatedAt                string   `json:"createdAt"`
 	InstallerInterface       string   `json:"installerInterface"`
 	DefaultKernelCommandLine []string `json:"defaultKernelCommandLine"`
@@ -1161,6 +1162,7 @@ func writeBootMetadata(role, format, artifactPath, created string, cfg config) e
 		Path:                     rel,
 		SizeBytes:                size,
 		SHA256:                   digest,
+		Compression:              installerBootCompression(role),
 		CreatedAt:                created,
 		InstallerInterface:       cfg.InstallerInterface,
 		DefaultKernelCommandLine: []string{"console=ttyS0,115200n8", "console=tty0", "systemd.log_target=console", "loglevel=6"},
@@ -1175,6 +1177,13 @@ func writeBootMetadata(role, format, artifactPath, created string, cfg config) e
 		return fmt.Errorf("write installer boot metadata %s: %w", relPath(cfg.RepoRoot, path), err)
 	}
 	return nil
+}
+
+func installerBootCompression(role string) string {
+	if role == "installer-initrd" {
+		return "zstd"
+	}
+	return ""
 }
 
 func writeJSON(path string, value any, repoRoot string) error {

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -90,6 +90,13 @@ func TestWriteAndPath(t *testing.T) {
 	if metadata.InstallerInterface != "katl-installer-test" {
 		t.Fatalf("installer interface = %q", metadata.InstallerInterface)
 	}
+	if metadata.Compression != "" {
+		t.Fatalf("installer UKI compression = %q, want empty outer compression", metadata.Compression)
+	}
+	readTestJSON(t, installerInitrd+".json", &metadata)
+	if metadata.ArtifactRole != "installer-initrd" || metadata.Compression != "zstd" {
+		t.Fatalf("installer initrd metadata = %#v", metadata)
+	}
 	readTestJSON(t, installerISO+".json", &metadata)
 	if metadata.ArtifactRole != "installer-iso" || metadata.Format != "iso" || metadata.BuildID != "test-build" {
 		t.Fatalf("installer ISO metadata = %#v", metadata)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -239,7 +239,9 @@ install and upgrade SquashFS images, and the installer UKI, kernel, initrd, and
 UEFI-bootable ISO variants, each with
 adjacent JSON metadata and SHA-256 files. The ISO embeds the matching KatlOS
 install image and its metadata, so it is the primary self-contained install
-artifact. It remains generic because node identity, disk selection, network,
+artifact. The installer initrd is zstd-compressed inside both the loose initrd
+and UKI; its metadata records that compression while filenames remain stable.
+It remains generic because node identity, disk selection, network,
 and bootstrap configuration are supplied separately at boot. The loose
 installer and install-image artifacts remain available for PXE deployments.
 Loose runtime root/UKI intermediates and Kubernetes payload bundles are not

--- a/internal/scriptstest/installer_iso_scripts_test.go
+++ b/internal/scriptstest/installer_iso_scripts_test.go
@@ -156,12 +156,23 @@ func TestInstallerConsoleAndVMGateContract(t *testing.T) {
 			t.Fatalf("installer profile missing console %q", value)
 		}
 	}
+	for _, value := range []string{"CompressOutput=zstd", "CompressLevel=19"} {
+		if !strings.Contains(profile, value) {
+			t.Fatalf("installer profile missing compression setting %q", value)
+		}
+	}
+	checker := string(mustReadFile(t, filepath.Join(repo, "scripts/check-installer-image")))
+	for _, value := range []string{"need zstd", `zstd -q -d -c "$initrd"`} {
+		if !strings.Contains(checker, value) {
+			t.Fatalf("installer verification missing compressed initrd handling %q", value)
+		}
+	}
 	for _, value := range []string{"ForwardToConsole=yes", "TTYPath=/dev/ttyS0"} {
 		if !strings.Contains(journal, value) {
 			t.Fatalf("installer dual-console journal routing missing %q", value)
 		}
 	}
-	for _, value := range []string{"Installer ISO Boot VM", "^TestInstallerISOBootSmoke$"} {
+	for _, value := range []string{"Installer Boot Media VM", "TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke"} {
 		if !strings.Contains(workflow, value) {
 			t.Fatalf("installer ISO VM workflow missing %q", value)
 		}

--- a/internal/vmtest/scenarios/installer_iso_vmtest_test.go
+++ b/internal/vmtest/scenarios/installer_iso_vmtest_test.go
@@ -58,6 +58,61 @@ func TestInstallerISOBootSmoke(t *testing.T) {
 	}
 }
 
+func TestInstallerPXEBootSmoke(t *testing.T) {
+	options := vmtest.DefaultOptions()
+	if !options.Enabled {
+		t.Skip("set -katl.vmtest.run or KATL_VMTEST_RUN=1 to run installer PXE boot smoke")
+	}
+	world := vmtest.RequireWorld(t)
+	worldScenario := world.NewScenario(t, "installer-pxe-boot")
+	options.StateRoot = filepath.Join(worldScenario.Dir, "vm-runs")
+	options.Keep = vmtest.KeepFailed
+	repo := katlRepoRoot(t)
+	kernel := os.Getenv("KATL_INSTALLER_KERNEL")
+	if kernel == "" {
+		kernel = filepath.Join(repo, "_build", "mkosi", "katl-installer.vmlinuz")
+	}
+	initrd := os.Getenv("KATL_INSTALLER_INITRD")
+	if initrd == "" {
+		initrd = filepath.Join(repo, "_build", "mkosi", "katl-installer.initrd")
+	}
+	result, err := vmtest.RunInstallerBoot(
+		context.Background(),
+		vmtest.NewRunner(options),
+		vmtest.Scenario{Name: "installer-pxe-boot"},
+		vmtest.InstallerBootConfig{
+			InstallerKernel: kernel,
+			InstallerInitrd: initrd,
+			CommandLine: []string{
+				"console=ttyS0,115200n8",
+				"systemd.log_target=console",
+				"loglevel=6",
+			},
+			Expect: "Katl installer ready",
+			VM: vmtest.VMConfig{
+				KVM:     options.KVM,
+				RAMMiB:  2048,
+				CPUs:    2,
+				Timeout: 3 * time.Minute,
+			},
+		},
+		vmtest.VMRunner{},
+	)
+	if err != nil {
+		_ = worldScenario.WriteSetupFailure(err)
+		t.Fatalf("RunInstallerBoot() error = %v", err)
+	}
+	if result.Status != vmtest.StatusPassed {
+		if err := worldScenario.WriteResult(vmtest.WorldStatusFailed, result.FailureSummary); err != nil {
+			t.Fatalf("write failed world result: %v", err)
+		}
+		t.Fatalf("installer PXE boot status = %q: %s", result.Status, result.FailureSummary)
+	}
+	if err := worldScenario.WriteResult(vmtest.WorldStatusPassed, ""); err != nil {
+		t.Fatalf("write passed world result: %v", err)
+	}
+}
+
 func TestInstallerISOFirstInstallSmoke(t *testing.T) {
 	options := vmtest.DefaultOptions()
 	if !options.Enabled {

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -2,6 +2,8 @@
 Format=uki
 Output=katl-installer
 ImageId=katl-installer
+CompressOutput=zstd
+CompressLevel=19
 
 [Content]
 Bootable=yes

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,7 +11,7 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "e2e78ad2d9a620abec2f840705e0e8623d8604e3e53259e613705fd964b3b25a",
+      "configSHA256": "79118c41a3f9aad725696b05ead15254d56e9866cb77bd8254a7b25f8fca7bf7",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -17,9 +17,15 @@ need() {
 need cpio
 need grep
 need ukify
+need zstd
 
 [[ -f "$artifact" ]] || fail "installer UKI not found: $artifact"
 [[ -f "$initrd" ]] || fail "installer initrd not found: $initrd"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/katl-installer-check.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+initrd_cpio="$work/installer.cpio"
+zstd -q -d -c "$initrd" >"$initrd_cpio" || fail "decompress installer initrd failed"
 
 inspect="$(ukify inspect "$artifact")" || fail "inspect installer UKI failed"
 grep -Fq '.linux:' <<<"$inspect" || fail "installer UKI missing .linux section"
@@ -28,7 +34,7 @@ grep -Fq '.cmdline:' <<<"$inspect" || fail "installer UKI missing .cmdline secti
 grep -Fq 'console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6' <<<"$inspect" ||
     fail "installer UKI command line mismatch"
 
-initrd_list="$(cpio -it <"$initrd" 2>/dev/null)" || fail "list installer initrd failed"
+initrd_list="$(cpio -it <"$initrd_cpio" 2>/dev/null)" || fail "list installer initrd failed"
 if grep -Eiq '(^|/)[^/]*(vmtest|vm-test)[^/]*($|/)' <<<"$initrd_list"; then
     fail "installer image contains VM-test support"
 fi
@@ -49,7 +55,7 @@ file_has() {
     local path="${1#/}"
     local pattern="$2"
     local output
-    output="$(cpio -i --to-stdout "$path" <"$initrd" 2>/dev/null)" ||
+    output="$(cpio -i --to-stdout "$path" <"$initrd_cpio" 2>/dev/null)" ||
         fail "read installer path failed: /$path"
     grep -Fq -- "$pattern" <<<"$output" || fail "/$path missing $pattern"
 }


### PR DESCRIPTION
Compress the installer initrd with zstd level 19, reducing the UKI by 36% and the self-contained ISO by 16% without pruning hardware support. Verify the compression contract and gate both ISO and loose PXE boot paths.