### PR TITLE
installer: prune duplicate kernel data from initrd

### DIFF
--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -44,6 +44,8 @@ RemoveFiles=
         /run/dnf
         /usr/bin/pkg-config
         /usr/bin/pkgconf
+        /usr/lib/modules/*/System.map
+        /usr/lib/modules/*/vmlinuz
         /usr/lib/rpm
         /usr/share/dnf5
         /usr/share/licenses/pkgconf

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,7 +11,7 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "79118c41a3f9aad725696b05ead15254d56e9866cb77bd8254a7b25f8fca7bf7",
+      "configSHA256": "7325d4a2b2a0475d12eb7461b8382658d3cdf770857b9e6cb6ba827f3a416896",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -38,6 +38,9 @@ initrd_list="$(cpio -it <"$initrd_cpio" 2>/dev/null)" || fail "list installer in
 if grep -Eiq '(^|/)[^/]*(vmtest|vm-test)[^/]*($|/)' <<<"$initrd_list"; then
     fail "installer image contains VM-test support"
 fi
+if grep -Eq '^usr/lib/modules/[^/]+/(System\.map|vmlinuz)$' <<<"$initrd_list"; then
+    fail "installer initrd contains duplicate kernel build artifacts"
+fi
 
 has_path() {
     local path="${1#/}"


### PR DESCRIPTION
Remove the duplicate vmlinuz and System.map from the completed installer initrd after mkosi has saved the kernel used for UKI generation. Preserve locales and the full supported driver set, and prevent either artifact from returning.