### PR TITLE
katlctl: add Kubernetes upgrade workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,24 @@ katlctl host upgrade \
 The node calculates and records the downloaded image identity before changing
 the inactive root slot.
 
-Remove `--plan` only after reviewing the response. Automated fleet rollout and
-Kubernetes version upgrade execution are not supported alpha workflows.
+Kubernetes upgrades use the workstation cluster context and a readable bundle
+reference. Plan the whole control-plane-first rollout without supplying bundle
+digests, artifact paths, snapshot metadata, generation IDs, or operation IDs:
+
+```sh
+katlctl cluster upgrade kubernetes \
+  --bundle ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1 \
+  --plan
+```
+
+Remove `--plan` to upgrade the next eligible node. Reboot that node, verify
+cluster health, then rerun the same command to advance through control planes
+and workers one at a time. Each node fetches and verifies the selected bundle
+itself; control-plane nodes capture pre-mutation etcd snapshot evidence. See
+[Upgrade Kubernetes](docs/operations/upgrade-kubernetes.md).
+
+Remove `--plan` only after reviewing the response. Unattended fleet rollout is
+not a supported alpha workflow.
 
 Mutating commands follow the node's durable operation to completion by default.
 Progress is written to stderr and the final structured result to stdout. A lost

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+	"github.com/spf13/cobra"
+)
+
+type kubernetesUpgradeOptions struct {
+	configPath    string
+	contextName   string
+	inventoryPath string
+	bundle        string
+	plan          bool
+	timeout       time.Duration
+	output        string
+}
+
+type kubernetesUpgradeNodeReport struct {
+	Name             string `json:"name"`
+	Role             string `json:"role"`
+	SourceVersion    string `json:"sourceVersion"`
+	TargetVersion    string `json:"targetVersion"`
+	Result           string `json:"result"`
+	Phase            string `json:"phase,omitempty"`
+	RecoveryRequired bool   `json:"recoveryRequired,omitempty"`
+	NextAction       string `json:"nextAction,omitempty"`
+}
+
+type kubernetesUpgradeReport struct {
+	Cluster       string                        `json:"cluster"`
+	SourceVersion string                        `json:"sourceVersion"`
+	TargetVersion string                        `json:"targetVersion"`
+	Bundle        string                        `json:"bundle"`
+	Plan          bool                          `json:"plan"`
+	Nodes         []kubernetesUpgradeNodeReport `json:"nodes"`
+	NextAction    string                        `json:"nextAction,omitempty"`
+}
+
+type kubernetesUpgradeTarget struct {
+	node       workstation.TopologyNode
+	role       string
+	conn       katlcAgentConnection
+	machineID  string
+	generation string
+	source     string
+	candidate  string
+}
+
+var kubernetesUpgradeNow = func() time.Time { return time.Now().UTC() }
+
+func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := kubernetesUpgradeOptions{timeout: 25 * time.Minute, output: "json"}
+	cmd := &cobra.Command{
+		Use:   "kubernetes",
+		Short: "Upgrade Kubernetes control planes and workers serially",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return runKubernetesUpgrade(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl config path (defaults to the selected workstation context)")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl config context name")
+	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "cluster inventory instead of a workstation context")
+	cmd.Flags().StringVar(&opts.bundle, "bundle", "", "Kubernetes bundle image, for example ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1")
+	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate the complete rollout without accepting operations")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "per-node operation timeout")
+	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	_ = stderr
+	return cmd
+}
+
+func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, stdout, stderr io.Writer) error {
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want json", opts.output)
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	if opts.timeout > 25*time.Minute {
+		return fmt.Errorf("--timeout must not exceed 25m")
+	}
+	image, err := kubernetesbundle.ParseImageReference(opts.bundle)
+	if err != nil {
+		return fmt.Errorf("--bundle: %w", err)
+	}
+	topology, err := resolveKubernetesUpgradeTopology(opts)
+	if err != nil {
+		return err
+	}
+	targets, err := connectKubernetesUpgradeTargets(ctx, topology, image.PayloadVersion)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, target := range targets {
+			_ = target.conn.Close()
+		}
+	}()
+
+	report := kubernetesUpgradeReport{Cluster: topology.ClusterName, TargetVersion: image.PayloadVersion, Bundle: image.Value, Plan: opts.plan}
+	if len(targets) > 0 {
+		report.SourceVersion = targets[0].source
+	} else {
+		report.SourceVersion = image.PayloadVersion
+		report.NextAction = "every node already runs the selected Kubernetes version"
+		return writeKubernetesUpgradeReport(stdout, report)
+	}
+	for _, target := range targets {
+		body := kubernetesUpgradeBody(target, image)
+		accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
+			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
+			ClientRequestId: "katlctl-plan-" + target.candidate, OperationKind: "kubeadm-upgrade",
+			Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
+			ExpectedCurrentGenerationId: target.generation, DryRun: true, KubernetesSysextUpdate: body,
+		})
+		if err != nil {
+			return fmt.Errorf("plan node %s: %w", target.node.Name, err)
+		}
+		if accepted.InitialStatus == nil || accepted.InitialStatus.Phase != "accepted" && accepted.InitialStatus.Phase != "dry-run" {
+			return fmt.Errorf("node %s did not confirm the Kubernetes upgrade plan", target.node.Name)
+		}
+		report.Nodes = append(report.Nodes, kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: "planned"})
+	}
+	if opts.plan {
+		return writeKubernetesUpgradeReport(stdout, report)
+	}
+
+	report.Nodes = nil
+	for _, target := range targets[:1] {
+		accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
+			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
+			ClientRequestId: "katlctl-" + target.candidate, OperationKind: "kubeadm-upgrade",
+			Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
+			ExpectedCurrentGenerationId: target.generation, OperationTimeout: opts.timeout.String(),
+			KubernetesSysextUpdate: kubernetesUpgradeBody(target, image),
+		})
+		if err != nil {
+			return fmt.Errorf("submit node %s: %w", target.node.Name, err)
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+		terminal, err := waitKubernetesUpgrade(waitCtx, target.conn.Client, accepted.OperationId, target.node.Name, stderr)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("wait for node %s: %w", target.node.Name, err)
+		}
+		nodeReport := kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: terminal.Result, Phase: terminal.Phase, RecoveryRequired: terminal.RecoveryRequired, NextAction: terminal.NextAction}
+		report.Nodes = append(report.Nodes, nodeReport)
+		if terminal.Result != operation.ResultSucceeded {
+			_ = writeKubernetesUpgradeReport(stdout, report)
+			return fmt.Errorf("Kubernetes upgrade stopped at node %s: %s", target.node.Name, terminal.FailureReason)
+		}
+	}
+	report.NextAction = "reboot " + targets[0].node.Name + ", confirm boot health, then rerun this command to advance the rollout"
+	return writeKubernetesUpgradeReport(stdout, report)
+}
+
+func waitKubernetesUpgrade(ctx context.Context, client agentapi.KatlcAgentClient, operationID, nodeName string, stderr io.Writer) (*agentapi.OperationStatus, error) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	lastPhase := ""
+	for {
+		status, err := client.GetOperation(ctx, &agentapi.GetOperationRequest{OperationId: operationID, IncludeDiagnostics: "normal"})
+		if err != nil {
+			return nil, err
+		}
+		if status.Phase != lastPhase {
+			lastPhase = status.Phase
+			if _, err := fmt.Fprintf(stderr, "kubernetes upgrade node=%s phase=%s\n", nodeName, status.Phase); err != nil {
+				return nil, err
+			}
+		}
+		if status.Terminal {
+			return status, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func resolveKubernetesUpgradeTopology(opts kubernetesUpgradeOptions) (workstation.ResolvedTopology, error) {
+	request := workstation.ResolveRequest{ConfigPath: strings.TrimSpace(opts.configPath), ContextName: strings.TrimSpace(opts.contextName)}
+	if strings.TrimSpace(opts.inventoryPath) != "" {
+		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
+			return workstation.ResolvedTopology{}, fmt.Errorf("--inventory cannot be combined with --config or --context")
+		}
+		inv, err := loadInventory(opts.inventoryPath)
+		if err != nil {
+			return workstation.ResolvedTopology{}, err
+		}
+		request.ExplicitInventory = &inv
+	}
+	return workstation.ResolveTopology(request)
+}
+
+func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.ResolvedTopology, targetVersion string) ([]kubernetesUpgradeTarget, error) {
+	nodes := append([]workstation.TopologyNode(nil), topology.Nodes...)
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].SystemRole != nodes[j].SystemRole {
+			return nodes[i].SystemRole == inventory.RoleControlPlane
+		}
+		return nodes[i].Name < nodes[j].Name
+	})
+	controlPlanes := 0
+	for _, node := range nodes {
+		if node.SystemRole == inventory.RoleControlPlane {
+			controlPlanes++
+		}
+	}
+	if controlPlanes == 0 {
+		return nil, fmt.Errorf("cluster has no control-plane node")
+	}
+	runID := fmt.Sprintf("%d", kubernetesUpgradeNow().Unix())
+	inspected := make([]kubernetesUpgradeTarget, 0, len(nodes))
+	closeTargets := func() {
+		for _, target := range inspected {
+			_ = target.conn.Close()
+		}
+	}
+	for _, node := range nodes {
+		token, err := tokenForTopologyNode(node)
+		if err != nil {
+			closeTargets()
+			return nil, err
+		}
+		conn, err := dialKatlcAgent(ctx, node.ManagementEndpoint, token)
+		if err != nil {
+			closeTargets()
+			return nil, fmt.Errorf("connect node %s: %w", node.Name, err)
+		}
+		status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+		if err != nil {
+			_ = conn.Close()
+			closeTargets()
+			return nil, fmt.Errorf("status node %s: %w", node.Name, err)
+		}
+		generationID := strings.TrimSpace(status.CurrentGenerationId)
+		if generationID == "" {
+			_ = conn.Close()
+			closeTargets()
+			return nil, fmt.Errorf("node %s did not report its current generation", node.Name)
+		}
+		gen, err := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: generationID})
+		if err != nil {
+			_ = conn.Close()
+			closeTargets()
+			return nil, fmt.Errorf("current generation on node %s: %w", node.Name, err)
+		}
+		if gen.CommitState != "committed" || gen.HealthState != "healthy" {
+			_ = conn.Close()
+			closeTargets()
+			return nil, fmt.Errorf("node %s current generation %s is not committed and healthy", node.Name, generationID)
+		}
+		sourceVersion := ""
+		for _, ref := range gen.Sysexts {
+			if ref.Name == "kubernetes" {
+				sourceVersion = strings.TrimSpace(ref.PayloadVersion)
+				break
+			}
+		}
+		if sourceVersion == "" {
+			_ = conn.Close()
+			closeTargets()
+			return nil, fmt.Errorf("node %s current generation has no Kubernetes payload", node.Name)
+		}
+		candidate := kubernetesUpgradeCandidate(targetVersion, node.Name, runID)
+		inspected = append(inspected, kubernetesUpgradeTarget{node: node, conn: conn, machineID: status.MachineId, generation: generationID, source: sourceVersion, candidate: candidate})
+	}
+	baseVersion := ""
+	controlPlaneAtTarget := false
+	pendingControlPlanes := false
+	workerAtTarget := false
+	for _, target := range inspected {
+		if target.source == targetVersion {
+			if target.node.SystemRole == inventory.RoleControlPlane {
+				controlPlaneAtTarget = true
+			} else {
+				workerAtTarget = true
+			}
+			continue
+		}
+		if baseVersion == "" {
+			baseVersion = target.source
+		} else if target.source != baseVersion {
+			closeTargets()
+			return nil, fmt.Errorf("node %s runs Kubernetes %s while the pending rollout source is %s", target.node.Name, target.source, baseVersion)
+		}
+		if target.node.SystemRole == inventory.RoleControlPlane {
+			pendingControlPlanes = true
+		}
+	}
+	if workerAtTarget && pendingControlPlanes {
+		closeTargets()
+		return nil, fmt.Errorf("a worker already runs %s while a control plane is still pending", targetVersion)
+	}
+	targets := make([]kubernetesUpgradeTarget, 0, len(inspected))
+	applySelected := controlPlaneAtTarget
+	for _, target := range inspected {
+		if target.source == targetVersion {
+			_ = target.conn.Close()
+			continue
+		}
+		target.role = "worker"
+		if target.node.SystemRole == inventory.RoleControlPlane {
+			target.role = "control-plane"
+			if !applySelected {
+				target.role = "apply"
+				applySelected = true
+			}
+		}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+func kubernetesUpgradeBody(target kubernetesUpgradeTarget, image kubernetesbundle.ImageReference) *agentapi.KubernetesSysextUpdateOperationRequest {
+	return &agentapi.KubernetesSysextUpdateOperationRequest{
+		TargetPayloadVersion: targetVersion(image), CandidateGenerationId: target.candidate,
+		UpgradeRole: target.role, SourcePayloadVersion: target.source,
+		KubernetesBundleSource: image.Source, KubernetesBundleRef: image.Value,
+	}
+}
+
+func targetVersion(image kubernetesbundle.ImageReference) string { return image.PayloadVersion }
+
+func kubernetesUpgradeCandidate(version, node, runID string) string {
+	version = strings.NewReplacer("v", "", ".", "-").Replace(strings.TrimSpace(version))
+	return "kubernetes-" + version + "-" + node + "-" + runID
+}
+
+func tokenForTopologyNode(node workstation.TopologyNode) (string, error) {
+	ref := strings.TrimSpace(node.CredentialRef)
+	path, ok := strings.CutPrefix(ref, "file:")
+	if !ok || strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("node %s credentialRef must be a file reference", node.Name)
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("read node %s credential: %w", node.Name, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func writeKubernetesUpgradeReport(stdout io.Writer, report kubernetesUpgradeReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "katlctl.yaml")
+	var nodes strings.Builder
+	for _, node := range []struct{ name, endpoint, role string }{{"worker-1", "192.0.2.4:9443", "worker"}, {"cp-2", "192.0.2.2:9443", "control-plane"}, {"cp-1", "192.0.2.1:9443", "control-plane"}} {
+		token := filepath.Join(root, node.name+".token")
+		if err := os.WriteFile(token, []byte("token-"+node.name+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = nodes.WriteString("      - name: " + node.name + "\n        managementEndpoint: " + node.endpoint + "\n        systemRole: " + node.role + "\n        credentialRef: file:" + token + "\n")
+	}
+	config := "currentContext: lab\ncontexts:\n  - name: lab\n    cluster: home\nclusters:\n  - name: home\n    controlPlaneEndpoint: 192.0.2.10:6443\n    nodes:\n" + nodes.String()
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	clients := map[string]*fakeKatlcAgentClient{}
+	var executionOrder []string
+	for _, name := range []string{"cp-1", "cp-2", "worker-1"} {
+		name := name
+		client := &fakeKatlcAgentClient{
+			nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-" + name, CurrentGenerationId: "gen-1"},
+			generation:      &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0", Sha256: strings.Repeat("a", 64)}}},
+			submitAccepted:  &agentapi.OperationAccepted{OperationId: "internal-" + name},
+			operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "healthy", NextAction: "reboot for boot health"},
+		}
+		client.onSubmit = func(req *agentapi.SubmitOperationRequest) {
+			if !req.DryRun {
+				executionOrder = append(executionOrder, name)
+			}
+		}
+		clients[name] = client
+	}
+	byEndpoint := map[string]*fakeKatlcAgentClient{"192.0.2.1:9443": clients["cp-1"], "192.0.2.2:9443": clients["cp-2"], "192.0.2.4:9443": clients["worker-1"]}
+	previousDial := dialKatlcAgent
+	previousNow := kubernetesUpgradeNow
+	defer func() { dialKatlcAgent = previousDial; kubernetesUpgradeNow = previousNow }()
+	dialKatlcAgent = func(_ context.Context, endpoint, token string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: byEndpoint[endpoint], Close: func() error { return nil }}, nil
+	}
+	kubernetesUpgradeNow = func() time.Time { return time.Unix(42, 0).UTC() }
+	run := func() kubernetesUpgradeReport {
+		t.Helper()
+		var stdout bytes.Buffer
+		if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{configPath: configPath, bundle: "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1", timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(stdout.String(), "internal-") || strings.Contains(strings.ToLower(stdout.String()), "digest") {
+			t.Fatalf("output exposed internal operation data: %s", stdout.String())
+		}
+		var report kubernetesUpgradeReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		return report
+	}
+
+	roles := []string{"apply", "control-plane", "worker"}
+	for i, name := range []string{"cp-1", "cp-2", "worker-1"} {
+		report := run()
+		if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 1 || report.Nodes[0].Name != name || report.NextAction == "" {
+			t.Fatalf("run %d report = %#v", i+1, report)
+		}
+		requests := clients[name].submitRequests
+		if len(requests) == 0 || requests[len(requests)-1].DryRun {
+			t.Fatalf("%s requests = %#v", name, requests)
+		}
+		body := requests[len(requests)-1].KubernetesSysextUpdate
+		if body.UpgradeRole != roles[i] || body.SourcePayloadVersion != "v1.36.0" || body.TargetPayloadVersion != "v1.36.1" {
+			t.Fatalf("%s body = %#v", name, body)
+		}
+		if body.TargetSysextPath != "" || body.TargetSysextSha256 != "" || body.SnapshotDigest != "" || body.CandidateGenerationId == "" {
+			t.Fatalf("%s request exposed internal artifact or snapshot inputs: %#v", name, body)
+		}
+		clients[name].generation.Sysexts[0].PayloadVersion = "v1.36.1"
+	}
+	if want := []string{"cp-1", "cp-2", "worker-1"}; !reflect.DeepEqual(executionOrder, want) {
+		t.Fatalf("execution order = %v, want %v", executionOrder, want)
+	}
+	report := run()
+	if len(report.Nodes) != 0 || !strings.Contains(report.NextAction, "already") {
+		t.Fatalf("completed report = %#v", report)
+	}
+}
+
+func TestKubernetesUpgradePlanDoesNotExecute(t *testing.T) {
+	root := t.TempDir()
+	token := filepath.Join(root, "token")
+	if err := os.WriteFile(token, []byte("token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inv := filepath.Join(root, "inventory.yaml")
+	if err := os.WriteFile(inv, []byte("nodes:\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n    access:\n      method: agent\n      credentialRef: file:"+token+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine", CurrentGenerationId: "gen-1"}, generation: &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0"}}}}
+	previous := dialKatlcAgent
+	defer func() { dialKatlcAgent = previous }()
+	dialKatlcAgent = func(context.Context, string, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	var stdout bytes.Buffer
+	if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{inventoryPath: inv, bundle: "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1", plan: true, timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.submitRequests) != 1 || !client.submitRequests[0].DryRun || !strings.Contains(stdout.String(), `"result": "planned"`) {
+		t.Fatalf("requests=%#v output=%s", client.submitRequests, stdout.String())
+	}
+}

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -98,6 +98,9 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 
 	clusterCmd := &cobra.Command{Use: "cluster", Short: "Cluster lifecycle operations"}
 	clusterCmd.AddCommand(newClusterBootstrapCommand(ctx, stdout, stderr))
+	clusterUpgradeCmd := &cobra.Command{Use: "upgrade", Short: "Cluster upgrade operations"}
+	clusterUpgradeCmd.AddCommand(newKubernetesUpgradeCommand(ctx, stdout, stderr))
+	clusterCmd.AddCommand(clusterUpgradeCmd)
 	clusterCmd.AddCommand(newKubeadmControlPlaneConfigCommand(ctx, stdout, stderr))
 	clusterWipeCmd := newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe")
 	clusterWipeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl cluster wipe node"))

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1748,6 +1748,7 @@ type fakeKatlcAgentClient struct {
 	operationRequest  *agentapi.GetOperationRequest
 	operations        *agentapi.ListOperationsResponse
 	operationsRequest *agentapi.ListOperationsRequest
+	onSubmit          func(*agentapi.SubmitOperationRequest)
 }
 
 type fakeWipeClusterConnector struct {
@@ -1827,6 +1828,9 @@ func (c *fakeKatlcAgentClient) StageGeneration(_ context.Context, req *agentapi.
 }
 
 func (c *fakeKatlcAgentClient) SubmitOperation(_ context.Context, req *agentapi.SubmitOperationRequest, _ ...grpc.CallOption) (*agentapi.OperationAccepted, error) {
+	if c.onSubmit != nil {
+		c.onSubmit(req)
+	}
 	c.submitRequest = req
 	c.submitRequests = append(c.submitRequests, req)
 	if req.DryRun {

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -558,15 +558,15 @@ runtime root, boot assets, versions, architecture, runtime
 interface, and digests. An upgrade operation creates a candidate generation from
 that image and validates component compatibility before selection.
 
-Kubernetes version upgrades remain separate from day-one install. They require a
-kubeadm-aware operation that can make the target `kubeadm` available before the
-target kubelet starts. Katl's node-side operation and VM proof now exercise a
-control-plane-first `v1.36.0` to `v1.36.1` upgrade, including an etcd snapshot,
-reboots, worker upgrade, and final cluster health. There is not yet a supported
-`katlctl` command that coordinates that operation across an operator's cluster,
-so continue to treat Kubernetes upgrades as unsupported operational work. A
-published sysext alone is not sufficient authorization to perform the mutation
-manually.
+Kubernetes version upgrades remain separate from day-one install. Use
+`katlctl cluster upgrade kubernetes` to plan and execute the kubeadm-aware,
+control-plane-first rollout from a published bundle. Katl resolves the bundle
+identity, captures control-plane etcd snapshot evidence, stages the target
+`kubeadm` privately before releasing the target kubelet, and reports recovery
+requirements without asking operators for digests, artifact paths, snapshot
+metadata, generation IDs, or operation IDs. Follow
+[Upgrade Kubernetes](operations/upgrade-kubernetes.md); activating a published
+sysext manually is not a supported upgrade.
 
 ## Troubleshooting
 
@@ -619,7 +619,6 @@ Current day-one docs intentionally do not cover:
 Katl-managed DHCP, TFTP, iPXE, or matchbox services
 automatic cluster reconciliation after bootstrap
 control-plane join through operation-backed bootstrap
-Kubernetes version upgrade execution
 optional node application sysexts such as BIRD, gVisor, or Kata
 hardware extension catalogs or per-node installer artifact rebuilds
 secret distribution beyond protected install input or local handoff

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -120,6 +120,6 @@ endpoint, and node readiness matches the chosen CNI stage.
 
 Do not assume rerunning bootstrap is safe. If kubeadm or API mutation began,
 host generation rollback does not erase it. Preserve the command result and follow
-[Troubleshoot KatlOS](troubleshoot.md). Additional-control-plane repair,
-Kubernetes version upgrade, and general reconciliation are not supported alpha
-operations.
+[Troubleshoot KatlOS](troubleshoot.md). Kubernetes upgrades use the separate
+[Upgrade Kubernetes](upgrade-kubernetes.md) workflow. Additional-control-plane
+repair and general reconciliation remain unsupported alpha operations.

--- a/docs/operations/upgrade-kubernetes.md
+++ b/docs/operations/upgrade-kubernetes.md
@@ -1,0 +1,89 @@
+# Upgrade Kubernetes
+
+Katl upgrades Kubernetes as an explicit cluster operation. `katlctl` validates
+every pending node, then upgrades one node per invocation. Rerunning the same
+command advances control planes before workers. The first control plane runs
+`kubeadm upgrade apply`; remaining control planes and workers run `kubeadm
+upgrade node`.
+
+## Preconditions
+
+- every node is reachable through the selected `katlctl` workstation context;
+- every node reports either the common source version or the selected target
+  version on a committed, healthy generation;
+- per-node `credentialRef` values point to protected token files;
+- no other mutating Katl operation is active;
+- workloads tolerate a serial control-plane-first rollout; and
+- the selected bundle represents a newer patch or the next Kubernetes minor.
+
+Nodes fetch the bundle directly. They need registry and CA access to `ghcr.io`.
+An immutable `@sha256:` suffix is recommended but not required.
+
+## Plan
+
+```sh
+katlctl cluster upgrade kubernetes \
+  --bundle ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1 \
+  --plan
+```
+
+By default, `katlctl` uses the current context in its workstation configuration.
+Use `--context NAME`, `--config PATH`, or `--inventory PATH` when needed.
+
+The plan connects to every node, reads its current healthy generation and
+Kubernetes payload, derives the control-plane/worker order, and asks every
+pending node to validate its operation. It does not fetch a bundle, create a
+candidate generation, take a snapshot, or run kubeadm.
+
+Operators provide only the cluster selection and bundle reference. Katl derives
+and records bundle digests, sysext paths and sizes, candidate generation IDs,
+operation IDs, and snapshot evidence internally.
+
+## Execute
+
+Run the same command without `--plan`:
+
+```sh
+katlctl cluster upgrade kubernetes \
+  --bundle ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1
+```
+
+The command validates every pending operation but executes only the next
+eligible node. That node fetches and verifies the OCI bundle before mutation.
+Control-plane nodes capture a local pre-upgrade etcd snapshot and member-list
+digest. The target sysext is mounted privately so target `kubeadm` runs while
+the source kubelet remains active. Katl releases the target kubelet only after
+kubeadm succeeds, performs local health checks, and commits the candidate
+generation.
+
+The command stops immediately on the first failed or recovery-required node. It
+does not continue through the remaining cluster.
+
+## Reboot and verify
+
+After the node operation succeeds, reboot the named node. Wait for the node and
+its workloads to become healthy:
+
+```sh
+ssh root@cp-1.example.test systemctl reboot
+kubectl --kubeconfig ./kubeconfig get nodes -o wide
+kubectl --kubeconfig ./kubeconfig get pods -A
+```
+
+Also require `katl-boot-complete.target` to be active on the rebooted node. The
+upgrade is not fully proven until the committed candidate has passed boot
+health. Then rerun the same `katlctl cluster upgrade kubernetes` command. It
+recognizes nodes already on the target version and advances the next control
+plane or worker. Repeat the execute, reboot, and verify loop until the command
+reports that every node already runs the selected version.
+
+## Failure boundary
+
+A failure before kubeadm mutation abandons the candidate and permits a corrected
+retry. A failure after kubeadm or Kubernetes API mutation reports
+`recoveryRequired: true` and stops the rollout. Host generation rollback does
+not reverse etcd, kubeadm, Kubernetes API, or workload changes.
+
+Preserve the command output and node diagnostics. Do not retry blindly. Follow
+[Troubleshoot KatlOS](troubleshoot.md) and use the snapshot path recorded on the
+affected control plane when planning manual recovery.

--- a/docs/support.md
+++ b/docs/support.md
@@ -76,11 +76,13 @@ objects, persistent volumes, application data, or external infrastructure.
 After a partial kubeadm or Kubernetes mutation, the node may report that manual
 recovery is required.
 
-Kubernetes version upgrade execution, automated fleet rollout, etcd disaster
-recovery, failed control-plane replacement, and general cluster reconciliation
-are not supported alpha workflows. Wipe/reinstall is destructive recovery, not
-backup or same-cluster disaster recovery. Keep independent etcd, workload, and
-data backups; do not rely on Katl generation rollback as a cluster backup.
+Kubernetes upgrades support an explicit serial rollout to a newer patch or the
+next minor using a published Katl bundle. They do not provide automatic fleet
+rollout, automatic post-mutation repair, etcd disaster recovery, failed
+control-plane replacement, or general cluster reconciliation. Wipe/reinstall is
+destructive recovery, not backup or same-cluster disaster recovery. Keep
+independent etcd, workload, and data backups; do not rely on Katl generation
+rollback as a cluster backup.
 
 ## Explicitly Unsupported
 

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -207,6 +207,9 @@ type KubernetesSysextUpdate struct {
 	SourceEtcdVersion        string `json:"sourceEtcdVersion,omitempty"`
 	SnapshotStorageLocation  string `json:"snapshotStorageLocation,omitempty"`
 	SnapshotOperatorIdentity string `json:"snapshotOperatorIdentity,omitempty"`
+	KubernetesBundleSource   string `json:"kubernetesBundleSource,omitempty"`
+	KubernetesBundleRef      string `json:"kubernetesBundleRef,omitempty"`
+	BundleManifestDigest     string `json:"bundleManifestDigest,omitempty"`
 }
 
 type KubeadmUpgradeEvidence struct {
@@ -953,7 +956,7 @@ func ValidateTransition(previous OperationRecord, next OperationRecord) error {
 	if !reflect.DeepEqual(next.ConfigApplyRequest, previous.ConfigApplyRequest) {
 		return fmt.Errorf("operation configApplyRequest is immutable")
 	}
-	if !reflect.DeepEqual(next.KubernetesSysextUpdate, previous.KubernetesSysextUpdate) {
+	if !kubernetesSysextUpdateTransitionAllowed(previous.KubernetesSysextUpdate, next.KubernetesSysextUpdate) {
 		return fmt.Errorf("operation kubernetesSysextUpdate is immutable")
 	}
 	if !kubeadmControlPlaneConfigTransitionAllowed(previous.KubeadmControlPlaneConfig, next.KubeadmControlPlaneConfig) {
@@ -1003,6 +1006,44 @@ func bootstrapRequestTransitionAllowed(previous *BootstrapRequest, next *Bootstr
 	}
 	return resolvedDigestTransitionAllowed(previous.KubernetesBundleManifestDigest, next.KubernetesBundleManifestDigest) &&
 		resolvedDigestTransitionAllowed(previous.KubernetesSysextPayloadDigest, next.KubernetesSysextPayloadDigest)
+}
+
+func kubernetesSysextUpdateTransitionAllowed(previous *KubernetesSysextUpdate, next *KubernetesSysextUpdate) bool {
+	if previous == nil || next == nil {
+		return previous == nil && next == nil
+	}
+	previousComparable := *previous
+	nextComparable := *next
+	for _, clear := range []func(*KubernetesSysextUpdate){
+		func(v *KubernetesSysextUpdate) { v.TargetSysextPath = "" },
+		func(v *KubernetesSysextUpdate) { v.TargetSysextSHA256 = "" },
+		func(v *KubernetesSysextUpdate) { v.TargetSysextSize = 0 },
+		func(v *KubernetesSysextUpdate) { v.BundleManifestDigest = "" },
+		func(v *KubernetesSysextUpdate) { v.SnapshotRef = "" },
+		func(v *KubernetesSysextUpdate) { v.SnapshotDigest = "" },
+		func(v *KubernetesSysextUpdate) { v.SnapshotRevision = "" },
+		func(v *KubernetesSysextUpdate) { v.SnapshotCreatedAt = "" },
+		func(v *KubernetesSysextUpdate) { v.CapturedMemberListDigest = "" },
+		func(v *KubernetesSysextUpdate) { v.SourceEtcdVersion = "" },
+		func(v *KubernetesSysextUpdate) { v.SnapshotStorageLocation = "" },
+		func(v *KubernetesSysextUpdate) { v.SnapshotOperatorIdentity = "" },
+	} {
+		clear(&previousComparable)
+		clear(&nextComparable)
+	}
+	return reflect.DeepEqual(previousComparable, nextComparable) &&
+		resolvedDigestTransitionAllowed(previous.TargetSysextPath, next.TargetSysextPath) &&
+		resolvedDigestTransitionAllowed(previous.TargetSysextSHA256, next.TargetSysextSHA256) &&
+		(previous.TargetSysextSize == next.TargetSysextSize || previous.TargetSysextSize == 0 && next.TargetSysextSize > 0) &&
+		resolvedDigestTransitionAllowed(previous.BundleManifestDigest, next.BundleManifestDigest) &&
+		resolvedDigestTransitionAllowed(previous.SnapshotRef, next.SnapshotRef) &&
+		resolvedDigestTransitionAllowed(previous.SnapshotDigest, next.SnapshotDigest) &&
+		resolvedDigestTransitionAllowed(previous.SnapshotRevision, next.SnapshotRevision) &&
+		resolvedDigestTransitionAllowed(previous.SnapshotCreatedAt, next.SnapshotCreatedAt) &&
+		resolvedDigestTransitionAllowed(previous.CapturedMemberListDigest, next.CapturedMemberListDigest) &&
+		resolvedDigestTransitionAllowed(previous.SourceEtcdVersion, next.SourceEtcdVersion) &&
+		resolvedDigestTransitionAllowed(previous.SnapshotStorageLocation, next.SnapshotStorageLocation) &&
+		resolvedDigestTransitionAllowed(previous.SnapshotOperatorIdentity, next.SnapshotOperatorIdentity)
 }
 
 func kubeadmControlPlaneConfigTransitionAllowed(previous *KubeadmControlPlaneConfig, next *KubeadmControlPlaneConfig) bool {
@@ -1764,11 +1805,31 @@ func validateKubernetesSysextUpdate(request KubernetesSysextUpdate) error {
 	if strings.TrimSpace(request.TargetPayloadVersion) == "" {
 		return fmt.Errorf("kubernetesSysextUpdate targetPayloadVersion is required")
 	}
-	if strings.TrimSpace(request.TargetSysextPath) == "" {
-		return fmt.Errorf("kubernetesSysextUpdate targetSysextPath is required")
+	hasBundleSource := strings.TrimSpace(request.KubernetesBundleSource) != ""
+	hasBundleRef := strings.TrimSpace(request.KubernetesBundleRef) != ""
+	if hasBundleSource != hasBundleRef {
+		return fmt.Errorf("kubernetesSysextUpdate bundle source and ref must be provided together")
 	}
-	if err := validateSHA256Hex("kubernetesSysextUpdate targetSysext", strings.TrimSpace(request.TargetSysextSHA256)); err != nil {
-		return err
+	if hasBundleSource {
+		parsed, err := url.Parse(request.KubernetesBundleSource)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return fmt.Errorf("kubernetesSysextUpdate bundle source must be an HTTPS URL")
+		}
+	}
+	hasTargetPath := strings.TrimSpace(request.TargetSysextPath) != ""
+	hasTargetDigest := strings.TrimSpace(request.TargetSysextSHA256) != ""
+	if hasTargetPath != hasTargetDigest || !hasBundleSource && !hasTargetPath {
+		return fmt.Errorf("kubernetesSysextUpdate requires a bundle reference or a target sysext path and digest")
+	}
+	if hasTargetDigest {
+		if err := validateSHA256Hex("kubernetesSysextUpdate targetSysext", strings.TrimSpace(request.TargetSysextSHA256)); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(request.BundleManifestDigest) != "" {
+		if err := validateSHA256Digest("kubernetesSysextUpdate bundle manifest", request.BundleManifestDigest); err != nil {
+			return err
+		}
 	}
 	if strings.TrimSpace(request.UpgradeRole) == "" {
 		return nil
@@ -1781,22 +1842,27 @@ func validateKubernetesSysextUpdate(request KubernetesSysextUpdate) error {
 	default:
 		return fmt.Errorf("kubernetesSysextUpdate upgradeRole must be apply, control-plane, or worker")
 	}
-	required := map[string]string{"sourcePayloadVersion": request.SourcePayloadVersion, "snapshotRef": request.SnapshotRef}
-	if request.UpgradeRole != "worker" {
-		required["snapshotCreatedAt"] = request.SnapshotCreatedAt
-		required["capturedMemberListDigest"] = request.CapturedMemberListDigest
-		required["snapshotStorageLocation"] = request.SnapshotStorageLocation
-		required["snapshotOperatorIdentity"] = request.SnapshotOperatorIdentity
-	}
+	required := map[string]string{"sourcePayloadVersion": request.SourcePayloadVersion}
 	for name, value := range required {
 		if strings.TrimSpace(value) == "" {
 			return fmt.Errorf("kubernetesSysextUpdate %s is required", name)
 		}
 	}
-	if err := validateSHA256Hex("kubernetesSysextUpdate snapshot", request.SnapshotDigest); err != nil {
-		return err
+	hasSnapshot := strings.TrimSpace(request.SnapshotRef) != "" || strings.TrimSpace(request.SnapshotDigest) != "" || strings.TrimSpace(request.SnapshotStorageLocation) != ""
+	if hasSnapshot {
+		if strings.TrimSpace(request.SnapshotRef) == "" || strings.TrimSpace(request.SnapshotDigest) == "" {
+			return fmt.Errorf("kubernetesSysextUpdate snapshot ref and digest must be provided together")
+		}
+		if err := validateSHA256Hex("kubernetesSysextUpdate snapshot", request.SnapshotDigest); err != nil {
+			return err
+		}
 	}
-	if request.UpgradeRole != "worker" {
+	if request.UpgradeRole != "worker" && hasSnapshot {
+		for name, value := range map[string]string{"snapshotCreatedAt": request.SnapshotCreatedAt, "capturedMemberListDigest": request.CapturedMemberListDigest, "snapshotStorageLocation": request.SnapshotStorageLocation, "snapshotOperatorIdentity": request.SnapshotOperatorIdentity} {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("kubernetesSysextUpdate %s is required with snapshot evidence", name)
+			}
+		}
 		if err := validateSHA256Hex("kubernetesSysextUpdate member list", request.CapturedMemberListDigest); err != nil {
 			return err
 		}

--- a/internal/katlc/agent/kubeadm_upgrade_executor.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor.go
@@ -14,12 +14,22 @@ import (
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
 	"github.com/katl-dev/katl/internal/installer/operation"
 )
 
 const kubeadmUpgradeTimeout = 30 * time.Minute
 
 func (e *Executor) executeKubeadmUpgrade(ctx context.Context, record operation.OperationRecord) error {
+	var err error
+	record, err = e.resolveKubernetesUpgradePayload(ctx, record)
+	if err != nil {
+		return e.failKubeadmUpgrade(record, "resolve-target", err, false)
+	}
+	record, err = e.prepareKubeadmUpgradeSnapshot(ctx, record)
+	if err != nil {
+		return e.failKubeadmUpgrade(record, "snapshot", err, false)
+	}
 	request := record.KubernetesSysextUpdate
 	if request == nil || request.UpgradeRole == "" {
 		return fmt.Errorf("executable kubeadm upgrade request is required")
@@ -153,6 +163,108 @@ func (e *Executor) executeKubeadmUpgrade(ctx context.Context, record operation.O
 	}
 	retainToolView = false
 	return nil
+}
+
+func (e *Executor) resolveKubernetesUpgradePayload(ctx context.Context, record operation.OperationRecord) (operation.OperationRecord, error) {
+	request := record.KubernetesSysextUpdate
+	if request == nil {
+		return record, fmt.Errorf("Kubernetes upgrade request is missing")
+	}
+	if strings.TrimSpace(request.TargetSysextPath) != "" && strings.TrimSpace(request.TargetSysextSHA256) != "" {
+		return record, nil
+	}
+	if strings.TrimSpace(request.KubernetesBundleSource) == "" || strings.TrimSpace(request.KubernetesBundleRef) == "" {
+		return record, fmt.Errorf("Kubernetes bundle reference is missing")
+	}
+	cacheDir := rootedRuntimePath(e.Root, filepath.ToSlash(filepath.Join("/var/lib/katl/artifacts/kubernetes-upgrades", record.OperationID)))
+	staged, err := kubernetesbundle.FetchAndStage(ctx, kubernetesbundle.Request{
+		Source:           request.KubernetesBundleSource,
+		Ref:              request.KubernetesBundleRef,
+		CacheDir:         cacheDir,
+		RuntimeInterface: "katl-runtime-1",
+		Architecture:     "x86_64",
+		Client:           e.BundleClient,
+	})
+	if err != nil {
+		return record, fmt.Errorf("fetch Kubernetes bundle: %w", err)
+	}
+	if staged.PayloadVersion != request.TargetPayloadVersion {
+		return record, fmt.Errorf("fetched Kubernetes payload %s does not match requested target %s", staged.PayloadVersion, request.TargetPayloadVersion)
+	}
+	logicalPath, err := runtimeLogicalPath(e.Root, staged.SysextPath)
+	if err != nil {
+		return record, err
+	}
+	info, err := os.Stat(staged.SysextPath)
+	if err != nil {
+		return record, fmt.Errorf("stat fetched Kubernetes sysext: %w", err)
+	}
+	return e.Store.Update(record.OperationID, "kubernetes-upgrade-target-resolved", "target-resolved", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.KubernetesSysextUpdate.TargetSysextPath = logicalPath
+		current.KubernetesSysextUpdate.TargetSysextSHA256 = strings.TrimPrefix(staged.SysextPayloadDigest, "sha256:")
+		current.KubernetesSysextUpdate.TargetSysextSize = uint64(info.Size())
+		current.KubernetesSysextUpdate.BundleManifestDigest = staged.BundleManifestDigest
+		current.Phase = "target-resolved"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "accepted", "target-resolved")
+		current.PhaseIndex = len(current.CompletedPhases)
+		current.UpdatedAt = e.clock()
+		current.NextAction = "capture pre-upgrade etcd evidence when required"
+		return current, nil
+	})
+}
+
+func (e *Executor) prepareKubeadmUpgradeSnapshot(ctx context.Context, record operation.OperationRecord) (operation.OperationRecord, error) {
+	request := record.KubernetesSysextUpdate
+	if request == nil || request.UpgradeRole == "worker" || strings.TrimSpace(request.SnapshotStorageLocation) != "" {
+		return record, nil
+	}
+	containerResult := e.toolRunner()(ctx, []string{"crictl", "ps", "--state", "Running", "--name", "etcd", "-q"}, nil)
+	if containerResult.Err != nil || containerResult.ExitStatus != 0 {
+		return record, fmt.Errorf("locate running etcd container: %s", toolFailure(containerResult))
+	}
+	containers := strings.Fields(string(containerResult.Stdout))
+	if len(containers) != 1 {
+		return record, fmt.Errorf("expected one running etcd container, got %d", len(containers))
+	}
+	location := filepath.ToSlash(filepath.Join("/var/lib/etcd", "katl-upgrade-"+record.OperationID+".db"))
+	etcdctl := []string{"crictl", "exec", containers[0], "etcdctl", "--endpoints=https://127.0.0.1:2379", "--cacert=/etc/kubernetes/pki/etcd/ca.crt", "--cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt", "--key=/etc/kubernetes/pki/etcd/healthcheck-client.key"}
+	saveResult := e.toolRunner()(ctx, append(append([]string(nil), etcdctl...), "snapshot", "save", location), nil)
+	if saveResult.Err != nil || saveResult.ExitStatus != 0 {
+		return record, fmt.Errorf("save pre-upgrade etcd snapshot: %s", toolFailure(saveResult))
+	}
+	digest, _, err := fileDigest(rootedRuntimePath(e.Root, location))
+	if err != nil {
+		return record, fmt.Errorf("hash pre-upgrade etcd snapshot: %w", err)
+	}
+	membersResult := e.toolRunner()(ctx, append(append([]string(nil), etcdctl...), "member", "list"), nil)
+	if membersResult.Err != nil || membersResult.ExitStatus != 0 {
+		return record, fmt.Errorf("capture pre-upgrade etcd member list: %s", toolFailure(membersResult))
+	}
+	membersHash := sha256.Sum256(membersResult.Stdout)
+	now := e.clock()
+	return e.Store.Update(record.OperationID, "kubernetes-upgrade-snapshot-prepared", "snapshot-prepared", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		update := current.KubernetesSysextUpdate
+		update.SnapshotRef = "pre-" + update.SourcePayloadVersion + "-to-" + update.TargetPayloadVersion
+		update.SnapshotDigest = digest
+		update.SnapshotCreatedAt = now.Format(time.RFC3339)
+		update.CapturedMemberListDigest = hex.EncodeToString(membersHash[:])
+		update.SnapshotStorageLocation = location
+		update.SnapshotOperatorIdentity = inventory.Redact(current.Actor)
+		current.Phase = "snapshot-prepared"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "snapshot-prepared")
+		current.PhaseIndex = len(current.CompletedPhases)
+		current.UpdatedAt = now
+		current.NextAction = "stage the verified target Kubernetes payload"
+		return current, nil
+	})
+}
+
+func runtimeLogicalPath(root, hostPath string) (string, error) {
+	rel, err := filepath.Rel(runtimeRoot(root), hostPath)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("resolved Kubernetes sysext is outside the runtime root")
+	}
+	return "/" + filepath.ToSlash(rel), nil
 }
 
 func (e *Executor) runKubeadmUpgradeCommand(ctx context.Context, record operation.OperationRecord, phase string, argv []string, mutating bool) error {
@@ -495,24 +607,30 @@ func rootedRuntimePath(root, path string) string {
 	return filepath.Join(runtimeRoot(root), strings.TrimPrefix(filepath.Clean(path), string(filepath.Separator)))
 }
 func verifyFileDigest(path, want string, size uint64) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	hash := sha256.New()
-	n, err := io.Copy(hash, file)
+	got, n, err := fileDigest(path)
 	if err != nil {
 		return err
 	}
 	if size > 0 && uint64(n) != size {
 		return fmt.Errorf("size %d, want %d", n, size)
 	}
-	got := hex.EncodeToString(hash.Sum(nil))
 	if got != want {
 		return fmt.Errorf("sha256 %s, want %s", got, want)
 	}
 	return nil
+}
+func fileDigest(path string) (string, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	n, err := io.Copy(hash, file)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), n, nil
 }
 func copyVerifiedFile(source, target, want string) error {
 	in, err := os.Open(source)

--- a/internal/katlc/agent/kubeadm_upgrade_executor_test.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor_test.go
@@ -144,6 +144,26 @@ func TestValidateKubeadmUpgradeExecutionSafetyInputs(t *testing.T) {
 	if err := validateKubernetesSysextUpdateRequest(OperationKindKubeadmUpgrade, base); err != nil {
 		t.Fatalf("valid request: %v", err)
 	}
+	bundle := *base
+	bundle.TargetSysextPath = ""
+	bundle.TargetSysextSha256 = ""
+	bundle.TargetSysextSizeBytes = 0
+	bundle.SnapshotRef = ""
+	bundle.SnapshotDigest = ""
+	bundle.SnapshotCreatedAt = ""
+	bundle.CapturedMemberListDigest = ""
+	bundle.SnapshotStorageLocation = ""
+	bundle.SnapshotOperatorIdentity = ""
+	bundle.KubernetesBundleSource = "https://ghcr.io/v2/katl-dev/kubernetes"
+	bundle.KubernetesBundleRef = "ghcr.io/katl-dev/kubernetes:v1.36.2-katl.1"
+	if err := validateKubernetesSysextUpdateRequest(OperationKindKubeadmUpgrade, &bundle); err != nil {
+		t.Fatalf("valid bundle request: %v", err)
+	}
+	bundle.TargetSysextPath = base.TargetSysextPath
+	bundle.TargetSysextSha256 = base.TargetSysextSha256
+	if err := validateKubernetesSysextUpdateRequest(OperationKindKubeadmUpgrade, &bundle); err == nil || !strings.Contains(err.Error(), "resolved by the node") {
+		t.Fatalf("operator-resolved target error = %v", err)
+	}
 	missing := *base
 	missing.SnapshotDigest = ""
 	if err := validateKubernetesSysextUpdateRequest(OperationKindKubeadmUpgrade, &missing); err == nil || !strings.Contains(err.Error(), "snapshotDigest is required") {
@@ -154,6 +174,84 @@ func TestValidateKubeadmUpgradeExecutionSafetyInputs(t *testing.T) {
 	if err := validateKubernetesSysextUpdateRequest(OperationKindKubeadmUpgrade, &skip); err == nil || !strings.Contains(err.Error(), "only a newer patch or the next minor") {
 		t.Fatalf("skip error = %v", err)
 	}
+}
+
+func TestExecutorResolvesUpgradeBundleInsideNode(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	executor := NewExecutor(root, store, "agent-test")
+	source, ref := configureExecutorBundle(t, executor, "v1.35.1", "target-payload")
+	record := createUnresolvedUpgradeRecord(t, store, "resolve-upgrade", &operation.KubernetesSysextUpdate{TargetPayloadVersion: "v1.35.1", CandidateGenerationID: "gen1", UpgradeRole: "worker", SourcePayloadVersion: "v1.35.0", KubernetesBundleSource: source, KubernetesBundleRef: ref})
+	resolved, err := executor.resolveKubernetesUpgradePayload(context.Background(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := resolved.KubernetesSysextUpdate
+	if request.TargetSysextPath == "" || request.TargetSysextSHA256 == "" || request.TargetSysextSize == 0 || request.BundleManifestDigest == "" {
+		t.Fatalf("resolved request = %#v", request)
+	}
+	if strings.HasPrefix(request.TargetSysextPath, root) {
+		t.Fatalf("resolved path leaked host root: %s", request.TargetSysextPath)
+	}
+	if err := verifyFileDigest(rootedRuntimePath(root, request.TargetSysextPath), request.TargetSysextSHA256, request.TargetSysextSize); err != nil {
+		t.Fatalf("resolved payload: %v", err)
+	}
+}
+
+func TestExecutorCapturesUpgradeSnapshotInsideNode(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := createUnresolvedUpgradeRecord(t, store, "snapshot-upgrade", &operation.KubernetesSysextUpdate{TargetPayloadVersion: "v1.36.2", TargetSysextPath: "/var/lib/katl/artifacts/kubernetes.raw", TargetSysextSHA256: strings.Repeat("a", 64), CandidateGenerationID: "gen1", UpgradeRole: "apply", SourcePayloadVersion: "v1.36.1"})
+	executor := NewExecutor(root, store, "agent-test")
+	executor.Now = func() time.Time { return time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC) }
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		joined := strings.Join(argv, " ")
+		switch {
+		case joined == "crictl ps --state Running --name etcd -q":
+			return ToolResult{Stdout: []byte("etcd-container\n")}
+		case strings.Contains(joined, "snapshot save"):
+			location := argv[len(argv)-1]
+			path := rootedRuntimePath(root, location)
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return ToolResult{Err: err, ExitStatus: 1}
+			}
+			if err := os.WriteFile(path, []byte("snapshot"), 0o600); err != nil {
+				return ToolResult{Err: err, ExitStatus: 1}
+			}
+			return ToolResult{}
+		case strings.Contains(joined, "member list"):
+			return ToolResult{Stdout: []byte("member-a\n")}
+		default:
+			return ToolResult{Err: errors.New("unexpected command: " + joined), ExitStatus: 1}
+		}
+	}
+	resolved, err := executor.prepareKubeadmUpgradeSnapshot(context.Background(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := resolved.KubernetesSysextUpdate
+	if request.SnapshotRef == "" || request.SnapshotDigest == "" || request.SnapshotCreatedAt == "" || request.CapturedMemberListDigest == "" || request.SnapshotStorageLocation == "" || request.SnapshotOperatorIdentity != "katlctl" {
+		t.Fatalf("snapshot request = %#v", request)
+	}
+	if err := verifyFileDigest(rootedRuntimePath(root, request.SnapshotStorageLocation), request.SnapshotDigest, 0); err != nil {
+		t.Fatalf("snapshot evidence: %v", err)
+	}
+}
+
+func createUnresolvedUpgradeRecord(t *testing.T, store operation.Store, id string, request *operation.KubernetesSysextUpdate) operation.OperationRecord {
+	t.Helper()
+	now := time.Date(2026, 7, 12, 11, 0, 0, 0, time.UTC)
+	record, err := store.Create(operation.OperationRecord{OperationID: id, OperationKind: OperationKindKubeadmUpgrade, Scope: "kubeadm-state", Actor: "katlctl", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", PhasePlan: kubeadmUpgradePhasePlan(request.UpgradeRole), CompletedPhases: []string{"accepted"}, PhaseIndex: 1, CandidateGenerationID: request.CandidateGenerationID, KubernetesSysextUpdate: request, KubeadmUpgradeEvidence: &operation.KubeadmUpgradeEvidence{TargetKubeadmAccessMode: kubeadmAccessOperationPrivate, KubeletActivationGate: kubeletGateOperationReleased, KubeletGateState: "locked", SourceKubeletPolicy: "keep-running"}, ActivationMode: operation.ActivationModeNextBoot, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCandidate, PostKubeadmHealthState: operation.PostKubeadmHealthNotRun, ResourceLocks: []string{"generation-state.lock", "kubeadm-state.lock"}}, "accepted", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record
 }
 
 func TestExecutorRefusesUpgradeBeforeMutationWhenSafetyGateFails(t *testing.T) {

--- a/internal/katlc/agent/kubernetes_sysext_update.go
+++ b/internal/katlc/agent/kubernetes_sysext_update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"google.golang.org/grpc/codes"
@@ -177,6 +178,9 @@ func kubernetesSysextUpdateFromProto(req *agentapi.KubernetesSysextUpdateOperati
 		SourceEtcdVersion:        strings.TrimSpace(req.SourceEtcdVersion),
 		SnapshotStorageLocation:  strings.TrimSpace(req.SnapshotStorageLocation),
 		SnapshotOperatorIdentity: inventory.Redact(strings.TrimSpace(req.SnapshotOperatorIdentity)),
+		KubernetesBundleSource:   strings.TrimSpace(req.KubernetesBundleSource),
+		KubernetesBundleRef:      strings.TrimSpace(req.KubernetesBundleRef),
+		BundleManifestDigest:     strings.TrimSpace(req.KubernetesBundleManifestDigest),
 	}
 }
 
@@ -190,14 +194,41 @@ func validateKubernetesSysextUpdateRequest(operationKind string, req *agentapi.K
 	if strings.TrimSpace(req.TargetPayloadVersion) == "" {
 		return fmt.Errorf("targetPayloadVersion is required")
 	}
-	if strings.TrimSpace(req.TargetSysextPath) == "" {
-		return fmt.Errorf("targetSysextPath is required")
+	hasBundleSource := strings.TrimSpace(req.KubernetesBundleSource) != ""
+	hasBundleRef := strings.TrimSpace(req.KubernetesBundleRef) != ""
+	if hasBundleSource != hasBundleRef {
+		return fmt.Errorf("kubernetesBundleSource and kubernetesBundleRef must be provided together")
 	}
-	if strings.TrimSpace(req.TargetSysextSha256) == "" {
-		return fmt.Errorf("targetSysextSHA256 is required")
+	hasTargetPath := strings.TrimSpace(req.TargetSysextPath) != ""
+	hasTargetDigest := strings.TrimSpace(req.TargetSysextSha256) != ""
+	if hasTargetPath != hasTargetDigest {
+		return fmt.Errorf("targetSysextPath and targetSysextSHA256 must be provided together")
 	}
-	if err := validateLowercaseSHA256("targetSysextSHA256", strings.TrimSpace(req.TargetSysextSha256)); err != nil {
-		return err
+	if !hasBundleSource && !hasTargetPath {
+		return fmt.Errorf("kubernetes bundle reference is required")
+	}
+	if hasBundleSource && hasTargetPath {
+		return fmt.Errorf("target sysext path and digest are resolved by the node when a Kubernetes bundle reference is supplied")
+	}
+	if strings.TrimSpace(req.KubernetesBundleManifestDigest) != "" {
+		return fmt.Errorf("kubernetesBundleManifestDigest is resolved by the node")
+	}
+	if hasBundleSource {
+		image, err := kubernetesbundle.ParseImageReference(req.KubernetesBundleRef)
+		if err != nil {
+			return fmt.Errorf("kubernetesBundleRef: %w", err)
+		}
+		if strings.TrimRight(strings.TrimSpace(req.KubernetesBundleSource), "/") != image.Source {
+			return fmt.Errorf("kubernetesBundleSource does not match kubernetesBundleRef repository")
+		}
+		if image.PayloadVersion != strings.TrimSpace(req.TargetPayloadVersion) {
+			return fmt.Errorf("kubernetesBundleRef payload %s does not match targetPayloadVersion %s", image.PayloadVersion, req.TargetPayloadVersion)
+		}
+	}
+	if hasTargetDigest {
+		if err := validateLowercaseSHA256("targetSysextSHA256", strings.TrimSpace(req.TargetSysextSha256)); err != nil {
+			return err
+		}
 	}
 	if strings.TrimSpace(req.TargetActivationPath) != "" {
 		return fmt.Errorf("raw Kubernetes sysext activation paths are unsupported before the kubelet activation gate exists")
@@ -215,22 +246,25 @@ func validateKubernetesSysextUpdateRequest(operationKind string, req *agentapi.K
 	if err := validateKubernetesUpgradeVersions(req.SourcePayloadVersion, req.TargetPayloadVersion); err != nil {
 		return err
 	}
-	required := map[string]string{"snapshotRef": req.SnapshotRef, "snapshotDigest": req.SnapshotDigest}
-	if role != "worker" {
-		required["snapshotCreatedAt"] = req.SnapshotCreatedAt
-		required["capturedMemberListDigest"] = req.CapturedMemberListDigest
-		required["snapshotStorageLocation"] = req.SnapshotStorageLocation
-		required["snapshotOperatorIdentity"] = req.SnapshotOperatorIdentity
-	}
-	for name, value := range required {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("%s is required for Kubernetes upgrade execution", name)
+	hasSnapshot := strings.TrimSpace(req.SnapshotRef) != "" || strings.TrimSpace(req.SnapshotDigest) != "" || strings.TrimSpace(req.SnapshotStorageLocation) != ""
+	if hasSnapshot {
+		required := map[string]string{"snapshotRef": req.SnapshotRef, "snapshotDigest": req.SnapshotDigest}
+		if role != "worker" {
+			required["snapshotCreatedAt"] = req.SnapshotCreatedAt
+			required["capturedMemberListDigest"] = req.CapturedMemberListDigest
+			required["snapshotStorageLocation"] = req.SnapshotStorageLocation
+			required["snapshotOperatorIdentity"] = req.SnapshotOperatorIdentity
+		}
+		for name, value := range required {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("%s is required when snapshot evidence is supplied", name)
+			}
+		}
+		if err := validateLowercaseSHA256("snapshotDigest", strings.TrimSpace(req.SnapshotDigest)); err != nil {
+			return err
 		}
 	}
-	if err := validateLowercaseSHA256("snapshotDigest", strings.TrimSpace(req.SnapshotDigest)); err != nil {
-		return err
-	}
-	if role != "worker" {
+	if role != "worker" && hasSnapshot {
 		if err := validateLowercaseSHA256("capturedMemberListDigest", strings.TrimSpace(req.CapturedMemberListDigest)); err != nil {
 			return err
 		}

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -101,6 +101,7 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
 	}
+	currentGenerationID, _ := currentGenerationID(s.Root)
 	return &agentapi.NodeStatus{
 		ApiVersion:              APIVersion,
 		MachineId:               machineID,
@@ -110,6 +111,7 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 		SupportedOperationKinds: append([]string(nil), s.supportedOperationKinds()...),
 		OperationLockHeld:       len(ids) > 0,
 		ActiveOperationIds:      ids,
+		CurrentGenerationId:     currentGenerationID,
 	}, nil
 }
 

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -67,6 +67,7 @@ type NodeStatus struct {
 	SupportedOperationKinds []string               `protobuf:"bytes,6,rep,name=supported_operation_kinds,json=supportedOperationKinds,proto3" json:"supported_operation_kinds,omitempty"`
 	OperationLockHeld       bool                   `protobuf:"varint,7,opt,name=operation_lock_held,json=operationLockHeld,proto3" json:"operation_lock_held,omitempty"`
 	ActiveOperationIds      []string               `protobuf:"bytes,8,rep,name=active_operation_ids,json=activeOperationIds,proto3" json:"active_operation_ids,omitempty"`
+	CurrentGenerationId     string                 `protobuf:"bytes,9,opt,name=current_generation_id,json=currentGenerationId,proto3" json:"current_generation_id,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -155,6 +156,13 @@ func (x *NodeStatus) GetActiveOperationIds() []string {
 		return x.ActiveOperationIds
 	}
 	return nil
+}
+
+func (x *NodeStatus) GetCurrentGenerationId() string {
+	if x != nil {
+		return x.CurrentGenerationId
+	}
+	return ""
 }
 
 type SubmitOperationRequest struct {
@@ -1150,25 +1158,28 @@ func (x *KubeadmControlPlaneConfigOperationRequest) GetNodeName() string {
 }
 
 type KubernetesSysextUpdateOperationRequest struct {
-	state                    protoimpl.MessageState `protogen:"open.v1"`
-	TargetPayloadVersion     string                 `protobuf:"bytes,1,opt,name=target_payload_version,json=targetPayloadVersion,proto3" json:"target_payload_version,omitempty"`
-	TargetSysextPath         string                 `protobuf:"bytes,2,opt,name=target_sysext_path,json=targetSysextPath,proto3" json:"target_sysext_path,omitempty"`
-	TargetSysextSha256       string                 `protobuf:"bytes,3,opt,name=target_sysext_sha256,json=targetSysextSha256,proto3" json:"target_sysext_sha256,omitempty"`
-	TargetSysextSizeBytes    uint64                 `protobuf:"varint,4,opt,name=target_sysext_size_bytes,json=targetSysextSizeBytes,proto3" json:"target_sysext_size_bytes,omitempty"`
-	TargetActivationPath     string                 `protobuf:"bytes,5,opt,name=target_activation_path,json=targetActivationPath,proto3" json:"target_activation_path,omitempty"`
-	CandidateGenerationId    string                 `protobuf:"bytes,6,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
-	UpgradeRole              string                 `protobuf:"bytes,7,opt,name=upgrade_role,json=upgradeRole,proto3" json:"upgrade_role,omitempty"`
-	SourcePayloadVersion     string                 `protobuf:"bytes,8,opt,name=source_payload_version,json=sourcePayloadVersion,proto3" json:"source_payload_version,omitempty"`
-	SnapshotRef              string                 `protobuf:"bytes,9,opt,name=snapshot_ref,json=snapshotRef,proto3" json:"snapshot_ref,omitempty"`
-	SnapshotDigest           string                 `protobuf:"bytes,10,opt,name=snapshot_digest,json=snapshotDigest,proto3" json:"snapshot_digest,omitempty"`
-	SnapshotRevision         string                 `protobuf:"bytes,11,opt,name=snapshot_revision,json=snapshotRevision,proto3" json:"snapshot_revision,omitempty"`
-	SnapshotCreatedAt        string                 `protobuf:"bytes,12,opt,name=snapshot_created_at,json=snapshotCreatedAt,proto3" json:"snapshot_created_at,omitempty"`
-	CapturedMemberListDigest string                 `protobuf:"bytes,13,opt,name=captured_member_list_digest,json=capturedMemberListDigest,proto3" json:"captured_member_list_digest,omitempty"`
-	SourceEtcdVersion        string                 `protobuf:"bytes,14,opt,name=source_etcd_version,json=sourceEtcdVersion,proto3" json:"source_etcd_version,omitempty"`
-	SnapshotStorageLocation  string                 `protobuf:"bytes,15,opt,name=snapshot_storage_location,json=snapshotStorageLocation,proto3" json:"snapshot_storage_location,omitempty"`
-	SnapshotOperatorIdentity string                 `protobuf:"bytes,16,opt,name=snapshot_operator_identity,json=snapshotOperatorIdentity,proto3" json:"snapshot_operator_identity,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state                          protoimpl.MessageState `protogen:"open.v1"`
+	TargetPayloadVersion           string                 `protobuf:"bytes,1,opt,name=target_payload_version,json=targetPayloadVersion,proto3" json:"target_payload_version,omitempty"`
+	TargetSysextPath               string                 `protobuf:"bytes,2,opt,name=target_sysext_path,json=targetSysextPath,proto3" json:"target_sysext_path,omitempty"`
+	TargetSysextSha256             string                 `protobuf:"bytes,3,opt,name=target_sysext_sha256,json=targetSysextSha256,proto3" json:"target_sysext_sha256,omitempty"`
+	TargetSysextSizeBytes          uint64                 `protobuf:"varint,4,opt,name=target_sysext_size_bytes,json=targetSysextSizeBytes,proto3" json:"target_sysext_size_bytes,omitempty"`
+	TargetActivationPath           string                 `protobuf:"bytes,5,opt,name=target_activation_path,json=targetActivationPath,proto3" json:"target_activation_path,omitempty"`
+	CandidateGenerationId          string                 `protobuf:"bytes,6,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
+	UpgradeRole                    string                 `protobuf:"bytes,7,opt,name=upgrade_role,json=upgradeRole,proto3" json:"upgrade_role,omitempty"`
+	SourcePayloadVersion           string                 `protobuf:"bytes,8,opt,name=source_payload_version,json=sourcePayloadVersion,proto3" json:"source_payload_version,omitempty"`
+	SnapshotRef                    string                 `protobuf:"bytes,9,opt,name=snapshot_ref,json=snapshotRef,proto3" json:"snapshot_ref,omitempty"`
+	SnapshotDigest                 string                 `protobuf:"bytes,10,opt,name=snapshot_digest,json=snapshotDigest,proto3" json:"snapshot_digest,omitempty"`
+	SnapshotRevision               string                 `protobuf:"bytes,11,opt,name=snapshot_revision,json=snapshotRevision,proto3" json:"snapshot_revision,omitempty"`
+	SnapshotCreatedAt              string                 `protobuf:"bytes,12,opt,name=snapshot_created_at,json=snapshotCreatedAt,proto3" json:"snapshot_created_at,omitempty"`
+	CapturedMemberListDigest       string                 `protobuf:"bytes,13,opt,name=captured_member_list_digest,json=capturedMemberListDigest,proto3" json:"captured_member_list_digest,omitempty"`
+	SourceEtcdVersion              string                 `protobuf:"bytes,14,opt,name=source_etcd_version,json=sourceEtcdVersion,proto3" json:"source_etcd_version,omitempty"`
+	SnapshotStorageLocation        string                 `protobuf:"bytes,15,opt,name=snapshot_storage_location,json=snapshotStorageLocation,proto3" json:"snapshot_storage_location,omitempty"`
+	SnapshotOperatorIdentity       string                 `protobuf:"bytes,16,opt,name=snapshot_operator_identity,json=snapshotOperatorIdentity,proto3" json:"snapshot_operator_identity,omitempty"`
+	KubernetesBundleSource         string                 `protobuf:"bytes,17,opt,name=kubernetes_bundle_source,json=kubernetesBundleSource,proto3" json:"kubernetes_bundle_source,omitempty"`
+	KubernetesBundleRef            string                 `protobuf:"bytes,18,opt,name=kubernetes_bundle_ref,json=kubernetesBundleRef,proto3" json:"kubernetes_bundle_ref,omitempty"`
+	KubernetesBundleManifestDigest string                 `protobuf:"bytes,19,opt,name=kubernetes_bundle_manifest_digest,json=kubernetesBundleManifestDigest,proto3" json:"kubernetes_bundle_manifest_digest,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
 }
 
 func (x *KubernetesSysextUpdateOperationRequest) Reset() {
@@ -1309,6 +1320,27 @@ func (x *KubernetesSysextUpdateOperationRequest) GetSnapshotStorageLocation() st
 func (x *KubernetesSysextUpdateOperationRequest) GetSnapshotOperatorIdentity() string {
 	if x != nil {
 		return x.SnapshotOperatorIdentity
+	}
+	return ""
+}
+
+func (x *KubernetesSysextUpdateOperationRequest) GetKubernetesBundleSource() string {
+	if x != nil {
+		return x.KubernetesBundleSource
+	}
+	return ""
+}
+
+func (x *KubernetesSysextUpdateOperationRequest) GetKubernetesBundleRef() string {
+	if x != nil {
+		return x.KubernetesBundleRef
+	}
+	return ""
+}
+
+func (x *KubernetesSysextUpdateOperationRequest) GetKubernetesBundleManifestDigest() string {
+	if x != nil {
+		return x.KubernetesBundleManifestDigest
 	}
 	return ""
 }
@@ -3006,7 +3038,7 @@ var File_internal_katlc_agentapi_agent_proto protoreflect.FileDescriptor
 const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\n" +
 	"#internal/katlc/agentapi/agent.proto\x12\rkatl.agent.v1\"\x16\n" +
-	"\x14GetNodeStatusRequest\"\xf0\x02\n" +
+	"\x14GetNodeStatusRequest\"\xa4\x03\n" +
 	"\n" +
 	"NodeStatus\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
@@ -3018,7 +3050,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x16supported_api_versions\x18\x05 \x03(\tR\x14supportedApiVersions\x12:\n" +
 	"\x19supported_operation_kinds\x18\x06 \x03(\tR\x17supportedOperationKinds\x12.\n" +
 	"\x13operation_lock_held\x18\a \x01(\bR\x11operationLockHeld\x120\n" +
-	"\x14active_operation_ids\x18\b \x03(\tR\x12activeOperationIds\"\x8d\b\n" +
+	"\x14active_operation_ids\x18\b \x03(\tR\x12activeOperationIds\x122\n" +
+	"\x15current_generation_id\x18\t \x01(\tR\x13currentGenerationId\"\x8d\b\n" +
 	"\x16SubmitOperationRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -3134,7 +3167,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x13snapshot_created_at\x18\x12 \x01(\tR\x11snapshotCreatedAt\x12:\n" +
 	"\x19snapshot_storage_location\x18\x13 \x01(\tR\x17snapshotStorageLocation\x12<\n" +
 	"\x1asnapshot_operator_identity\x18\x14 \x01(\tR\x18snapshotOperatorIdentity\x12\x1b\n" +
-	"\tnode_name\x18\x15 \x01(\tR\bnodeName\"\xd0\x06\n" +
+	"\tnode_name\x18\x15 \x01(\tR\bnodeName\"\x89\b\n" +
 	"&KubernetesSysextUpdateOperationRequest\x124\n" +
 	"\x16target_payload_version\x18\x01 \x01(\tR\x14targetPayloadVersion\x12,\n" +
 	"\x12target_sysext_path\x18\x02 \x01(\tR\x10targetSysextPath\x120\n" +
@@ -3152,7 +3185,10 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x1bcaptured_member_list_digest\x18\r \x01(\tR\x18capturedMemberListDigest\x12.\n" +
 	"\x13source_etcd_version\x18\x0e \x01(\tR\x11sourceEtcdVersion\x12:\n" +
 	"\x19snapshot_storage_location\x18\x0f \x01(\tR\x17snapshotStorageLocation\x12<\n" +
-	"\x1asnapshot_operator_identity\x18\x10 \x01(\tR\x18snapshotOperatorIdentity\"\x84\x02\n" +
+	"\x1asnapshot_operator_identity\x18\x10 \x01(\tR\x18snapshotOperatorIdentity\x128\n" +
+	"\x18kubernetes_bundle_source\x18\x11 \x01(\tR\x16kubernetesBundleSource\x122\n" +
+	"\x15kubernetes_bundle_ref\x18\x12 \x01(\tR\x13kubernetesBundleRef\x12I\n" +
+	"!kubernetes_bundle_manifest_digest\x18\x13 \x01(\tR\x1ekubernetesBundleManifestDigest\"\x84\x02\n" +
 	" DestructiveResetOperationRequest\x12.\n" +
 	"\x13inventory_node_name\x18\x01 \x01(\tR\x11inventoryNodeName\x12\x1f\n" +
 	"\vreset_scope\x18\x02 \x01(\tR\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -29,6 +29,7 @@ message NodeStatus {
   repeated string supported_operation_kinds = 6;
   bool operation_lock_held = 7;
   repeated string active_operation_ids = 8;
+  string current_generation_id = 9;
 }
 
 message SubmitOperationRequest {
@@ -160,6 +161,9 @@ message KubernetesSysextUpdateOperationRequest {
   string source_etcd_version = 14;
   string snapshot_storage_location = 15;
   string snapshot_operator_identity = 16;
+  string kubernetes_bundle_source = 17;
+  string kubernetes_bundle_ref = 18;
+  string kubernetes_bundle_manifest_digest = 19;
 }
 
 message DestructiveResetOperationRequest {

--- a/internal/scriptstest/support_boundary_test.go
+++ b/internal/scriptstest/support_boundary_test.go
@@ -26,7 +26,7 @@ func TestPublishedSupportBoundaryContract(t *testing.T) {
 		"persisted-state formats",
 		"Reinstall may be required",
 		"do not roll back etcd",
-		"Kubernetes version upgrade execution",
+		"Kubernetes upgrades support an explicit serial rollout",
 		"support SLA",
 		"Katl GitHub issue",
 		"private vulnerability",

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -611,6 +611,9 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-before-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
 		return fmt.Errorf("wait for cluster readiness after bootstrap generation reboot: %w", err)
 	}
+	if bundle := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE")); bundle != "" {
+		return runPublishedKubernetesUpgradeCLIProof(ctx, katlRepoRoot(t), bundle, cpNode, workerNode, cpAddress, workerAddress, cpTokenPath, workerTokenPath, cniFixtures, kubeconfigPath, evidenceDir)
+	}
 	targetHost := filepath.Join(katlRepoRoot(t), "_build/mkosi/katl-kubernetes-upgrade.raw")
 	metadataHost := targetHost + ".json"
 	if value := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE")); value != "" {
@@ -726,6 +729,79 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 		}
 		if generationRecord.Status.CommitState != generation.CommitStateCommitted {
 			return fmt.Errorf("%s upgrade candidate is %s", item.node.Name, generationRecord.Status.CommitState)
+		}
+	}
+	return nil
+}
+
+func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle string, cpNode, workerNode vmtest.RunningInstalledRuntimeNode, cpAddress, workerAddress, cpTokenPath, workerTokenPath string, cniFixtures map[string]nodeCNIFixture, kubeconfigPath, evidenceDir string) error {
+	configPath := filepath.Join(evidenceDir, "katlctl-upgrade.yaml")
+	config := fmt.Sprintf("currentContext: vmtest\ncontexts:\n  - name: vmtest\n    cluster: upgrade\nclusters:\n  - name: upgrade\n    controlPlaneEndpoint: %s:6443\n    nodes:\n      - name: cp-1\n        managementEndpoint: %s:9443\n        systemRole: control-plane\n        credentialRef: file:%s\n      - name: worker-1\n        managementEndpoint: %s:9443\n        systemRole: worker\n        credentialRef: file:%s\n", cpAddress, cpAddress, cpTokenPath, workerAddress, workerTokenPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		return fmt.Errorf("write katlctl upgrade context: %w", err)
+	}
+	for i, item := range []struct {
+		name string
+		node vmtest.RunningInstalledRuntimeNode
+	}{{"cp-1", cpNode}, {"worker-1", workerNode}} {
+		command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "cluster", "upgrade", "kubernetes", "--config", configPath, "--bundle", bundle, "--timeout", "25m")
+		command.Dir = repoRoot
+		stdout, err := command.Output()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				_ = os.WriteFile(filepath.Join(evidenceDir, fmt.Sprintf("katlctl-kubernetes-upgrade-%d.stderr", i+1)), exitErr.Stderr, 0o600)
+			}
+			return fmt.Errorf("katlctl Kubernetes upgrade step %d: %w", i+1, err)
+		}
+		if err := os.WriteFile(filepath.Join(evidenceDir, fmt.Sprintf("katlctl-kubernetes-upgrade-%d.json", i+1)), stdout, 0o600); err != nil {
+			return err
+		}
+		var report struct {
+			SourceVersion string `json:"sourceVersion"`
+			TargetVersion string `json:"targetVersion"`
+			Nodes         []struct {
+				Name   string `json:"name"`
+				Result string `json:"result"`
+			} `json:"nodes"`
+		}
+		if err := json.Unmarshal(stdout, &report); err != nil {
+			return fmt.Errorf("decode katlctl Kubernetes upgrade report step %d: %w", i+1, err)
+		}
+		if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 1 || report.Nodes[0].Name != item.name || report.Nodes[0].Result != operation.ResultSucceeded {
+			return fmt.Errorf("unexpected katlctl Kubernetes upgrade report step %d: %+v", i+1, report)
+		}
+		_, record, err := collectOperationEvidence(ctx, item.node, filepath.Join(evidenceDir, item.name, "upgrade-pre-reboot"), "kubeadm-upgrade")
+		if err != nil {
+			return err
+		}
+		if !record.Terminal || record.Result != operation.ResultSucceeded || record.RecoveryRequired || record.GenerationCommitState != operation.GenerationCommitCommitted || record.PostKubeadmHealthState != operation.PostKubeadmHealthPassed || !record.BootHealthPending {
+			return fmt.Errorf("%s upgrade did not commit a healthy candidate: %+v", item.node.Name, record)
+		}
+		if err := rebootIntoGeneration(ctx, item.node, record.CandidateGenerationID); err != nil {
+			return fmt.Errorf("reboot upgraded %s: %w", item.node.Name, err)
+		}
+		if err := activateNodeCNIFixture(ctx, item.node, cniFixtures[item.node.Name]); err != nil {
+			return fmt.Errorf("reactivate %s CNI fixture after upgrade reboot: %w", item.node.Name, err)
+		}
+		if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-after-"+item.node.Name+"-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
+			return err
+		}
+	}
+	for _, item := range []vmtest.RunningInstalledRuntimeNode{cpNode, workerNode} {
+		dir := filepath.Join(evidenceDir, item.Name, "upgrade")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		_, record, err := collectOperationEvidence(ctx, item, dir, "kubeadm-upgrade")
+		if err != nil {
+			return err
+		}
+		if record.KubernetesSysextUpdate == nil || record.KubernetesSysextUpdate.KubernetesBundleRef != bundle || record.KubernetesSysextUpdate.BundleManifestDigest == "" || record.KubernetesSysextUpdate.TargetSysextSHA256 == "" {
+			return fmt.Errorf("%s upgrade did not resolve the published bundle internally: %+v", item.Name, record.KubernetesSysextUpdate)
+		}
+		if item.Name == cpNode.Name && (record.KubernetesSysextUpdate.SnapshotDigest == "" || record.KubernetesSysextUpdate.SnapshotStorageLocation == "") {
+			return fmt.Errorf("%s upgrade did not capture etcd snapshot evidence", item.Name)
 		}
 	}
 	return nil


### PR DESCRIPTION
Add a cluster-scoped Kubernetes upgrade command that resolves published bundles and snapshot evidence on each node. The command validates the remaining rollout, advances one control-plane-first node per invocation, and directs operators to reboot and verify health before continuing.

Document the normal and recovery flows and cover the v1.36.0 to v1.36.1 path through the operation-backed VM scenario.