### PR TITLE
installer: report operational startup progress

### DIFF
--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -57,6 +57,9 @@ func runManifest(ctx context.Context, manifestPath, stateDir, inputMode, inputSo
 	if err != nil {
 		return err
 	}
+	install.ReportStep = func(step installer.StepID) {
+		reportInstallerProgress(stdout, "install step "+string(step), false)
+	}
 	runner := installer.NewRunner(installer.PreseededManifestPlan(), install)
 
 	if err := runner.Run(ctx); err != nil {
@@ -136,6 +139,9 @@ func runBundle(ctx context.Context, bundlePath, selectedNode, expectedDigest, st
 	install, err := bundleRunnerContext(bundlePath, manifestPath, stateDir, inputMode, inputSource, selected)
 	if err != nil {
 		return err
+	}
+	install.ReportStep = func(step installer.StepID) {
+		reportInstallerProgress(stdout, "install step "+string(step), false)
 	}
 	runner := installer.NewRunner(installer.PreseededManifestPlan(), install)
 	if err := runner.Run(ctx); err != nil {
@@ -271,6 +277,7 @@ func runBoot(ctx context.Context, runDir, etcDir, handoffAddr string, stdout io.
 }
 
 func runBootWithHandoff(ctx context.Context, runDir, etcDir, handoffAddr string, stdout io.Writer, handoffRunner func(context.Context, string, string, io.Writer) error) error {
+	reportInstallerProgress(stdout, "reading installer boot inputs", false)
 	input, err := bootInput(runDir, etcDir)
 	if err != nil {
 		return err
@@ -285,13 +292,17 @@ func runBootWithHandoff(ctx context.Context, runDir, etcDir, handoffAddr string,
 
 	switch input.Action {
 	case installer.InstallActionHoldForDebug:
+		reportInstallerProgress(stdout, "debug hold active", true)
 		fmt.Fprintln(stdout, "katlos-install debug hold active")
 		<-ctx.Done()
 		return ctx.Err()
 	case installer.InstallActionWaitForConfig:
+		reportInstallerProgress(stdout, "configuration handoff mode selected; starting listener", true)
 		return handoffRunner(ctx, runDir, handoffAddr, stdout)
 	case installer.InstallActionRun:
+		reportInstallerProgress(stdout, "automatic install mode selected", true)
 		if input.BundleURL != "" {
+			reportInstallerProgress(stdout, "downloading configuration bundle", false)
 			bundlePath, err := fetchBundleURL(ctx, input.BundleURL, input.BundleSHA256, runDir)
 			if err != nil {
 				return err
@@ -300,9 +311,11 @@ func runBootWithHandoff(ctx context.Context, runDir, etcDir, handoffAddr string,
 			return runBundle(ctx, bundlePath, input.NodeName, input.BundleDigest, filepath.Join(runDir, "state"), inputMode, bundleURL, stdout)
 		}
 		if input.BundlePath != "" {
+			reportInstallerProgress(stdout, "loading local configuration bundle", false)
 			return runBundle(ctx, input.BundlePath, input.NodeName, input.BundleDigest, filepath.Join(runDir, "state"), inputMode, input.BundlePath, stdout)
 		}
 		if input.ManifestURL != "" {
+			reportInstallerProgress(stdout, "downloading install manifest", false)
 			manifestPath, err := fetchManifestURL(ctx, input.ManifestURL, input.ManifestSHA256, runDir)
 			if err != nil {
 				return err
@@ -310,6 +323,7 @@ func runBootWithHandoff(ctx context.Context, runDir, etcDir, handoffAddr string,
 			fmt.Fprintf(stdout, "katlos-install downloaded manifest url=%s path=%s\n", manifestURL, manifestPath)
 			return runManifest(ctx, manifestPath, filepath.Join(runDir, "state"), inputMode, manifestURL, stdout)
 		}
+		reportInstallerProgress(stdout, "loading local install manifest", false)
 		return runManifest(ctx, input.ManifestPath, filepath.Join(runDir, "state"), inputMode, input.ManifestPath, stdout)
 	default:
 		return fmt.Errorf("unsupported install action %q", input.Action)
@@ -540,6 +554,7 @@ func readFile(path string) ([]byte, bool) {
 }
 
 func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) error {
+	reportInstallerProgress(stdout, "starting configuration handoff listener on "+addr, false)
 	media, _, err := loadInstallMedia()
 	if err != nil {
 		return err
@@ -569,15 +584,18 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 	defer httpServer.Shutdown(context.Background())
 
 	fmt.Fprintln(stdout, "katlos-install waiting for handoff announcement address")
+	reportInstallerProgress(stdout, "waiting for a network address to announce", false)
 	baseURL, err := waitHandoffAnnouncementBaseURL(ctx, listener.Addr())
 	if err != nil {
 		return err
 	}
 	fmt.Fprintln(stdout, server.Announcement(baseURL))
+	reportInstallerProgress(stdout, "waiting for configuration at "+baseURL, false)
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		if bundle := server.Bundle(); len(bundle.Data) > 0 {
+			reportInstallerProgress(stdout, "configuration received for node "+bundle.NodeName, false)
 			bundlePath := filepath.Join(runDir, "config.katlcfg")
 			if err := os.MkdirAll(runDir, 0o755); err != nil {
 				return fmt.Errorf("create handoff dir: %w", err)
@@ -591,6 +609,7 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 			return err
 		}
 		if len(server.Manifest()) > 0 {
+			reportInstallerProgress(stdout, "install manifest received", false)
 			manifestPath := filepath.Join(runDir, "install-manifest.json")
 			if err := os.MkdirAll(runDir, 0o755); err != nil {
 				return fmt.Errorf("create handoff dir: %w", err)

--- a/cmd/katlos-install/main_test.go
+++ b/cmd/katlos-install/main_test.go
@@ -430,6 +430,13 @@ kind: InitConfiguration
 }
 
 func TestBootWait(t *testing.T) {
+	previousNotify := notifySystemd
+	t.Cleanup(func() { notifySystemd = previousNotify })
+	var notifications []string
+	notifySystemd = func(payload string) error {
+		notifications = append(notifications, payload)
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 
@@ -452,6 +459,9 @@ func TestBootWait(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "waiting for config") {
 		t.Fatalf("stdout = %q, want handoff announcement", got)
+	}
+	if len(notifications) < 2 || !strings.Contains(notifications[0], "STATUS=reading installer boot inputs") || !strings.Contains(notifications[1], "READY=1\nSTATUS=configuration handoff mode selected") {
+		t.Fatalf("notifications = %#v", notifications)
 	}
 }
 

--- a/cmd/katlos-install/systemd_notify.go
+++ b/cmd/katlos-install/systemd_notify.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+)
+
+var notifySystemd = sendSystemdNotification
+
+func reportInstallerProgress(stdout io.Writer, message string, ready bool) {
+	message = strings.Join(strings.Fields(message), " ")
+	if message == "" {
+		return
+	}
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	fmt.Fprintf(stdout, "katlos-install progress: %s\n", message)
+	payload := "STATUS=" + message
+	if ready {
+		payload = "READY=1\n" + payload
+	}
+	if err := notifySystemd(payload); err != nil {
+		fmt.Fprintf(stdout, "katlos-install progress: unable to update systemd status: %v\n", err)
+	}
+}
+
+func sendSystemdNotification(payload string) error {
+	socket := strings.TrimSpace(os.Getenv("NOTIFY_SOCKET"))
+	if socket == "" {
+		return nil
+	}
+	if strings.HasPrefix(socket, "@") {
+		socket = "\x00" + strings.TrimPrefix(socket, "@")
+	}
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: socket, Net: "unixgram"})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/katlos-install/systemd_notify_test.go
+++ b/cmd/katlos-install/systemd_notify_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReportInstallerProgressMarksServiceReady(t *testing.T) {
+	previous := notifySystemd
+	t.Cleanup(func() { notifySystemd = previous })
+	var notification string
+	notifySystemd = func(payload string) error {
+		notification = payload
+		return nil
+	}
+	var stdout bytes.Buffer
+	reportInstallerProgress(&stdout, "  configuration\n handoff   ready ", true)
+	if notification != "READY=1\nSTATUS=configuration handoff ready" {
+		t.Fatalf("notification = %q", notification)
+	}
+	if got := stdout.String(); got != "katlos-install progress: configuration handoff ready\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestSendSystemdNotification(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notify.sock")
+	listener, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	t.Setenv("NOTIFY_SOCKET", path)
+	if err := sendSystemdNotification("READY=1\nSTATUS=waiting for configuration"); err != nil {
+		t.Fatal(err)
+	}
+	if err := listener.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buffer := make([]byte, 256)
+	n, _, err := listener.ReadFromUnix(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buffer[:n]); !strings.Contains(got, "READY=1") || !strings.Contains(got, "STATUS=waiting for configuration") {
+		t.Fatalf("notification = %q", got)
+	}
+}

--- a/docs/internal/v0.1-supported-image-surface.md
+++ b/docs/internal/v0.1-supported-image-surface.md
@@ -49,6 +49,7 @@ Supported installer services and units:
 
 | Unit | Surface | Notes |
 | --- | --- | --- |
+| `katl-installer.target` | supported | dedicated installer boot target; keeps the initrd environment active without misreporting the installer as starting. |
 | `katlos-install.service` | supported | boot-time installer operation. |
 | `katl-input-apply.service` | supported | applies installer handoff input. |
 | `katl-installer-smoke.service` | VM/test-only | smoke signal, not a production install contract. |
@@ -185,6 +186,7 @@ The image-surface trim Beads must make these checks enforceable:
 Installer image required paths:
 
 - `/usr/bin/katlos-install`
+- `katl-installer.target`
 - `katlos-install.service`
 - `katl-input-apply.service`
 - `systemd-networkd.service`
@@ -228,7 +230,7 @@ Runtime rootfs denied paths:
 - `/usr/bin/kubeadm`, `/usr/bin/kubelet`, `/usr/bin/kubectl`, `/usr/bin/crictl`
 - `/usr/bin/helm`, `/usr/bin/flux`, `/usr/bin/cilium`, `/usr/bin/rook`,
   `/usr/bin/coredns`
-- installer-only units such as `katlos-install.service`,
+- installer-only units such as `katl-installer.target`, `katlos-install.service`,
   `katl-input-apply.service`, and `katl-installer-smoke.service`
 
 Runtime rootfs explicit non-surface allowances:

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -85,6 +85,7 @@ type Context struct {
 	NodeMaterialDigest    string
 	InstallMaterialDigest string
 	PreviousStatus        *installstatus.Record
+	ReportStep            func(StepID)
 }
 
 type Step interface {
@@ -176,6 +177,9 @@ func (r Runner) Run(ctx context.Context) error {
 	}
 
 	for _, step := range r.plan {
+		if r.ctx.ReportStep != nil {
+			r.ctx.ReportStep(step.ID())
+		}
 		if err := step.Run(ctx, r.ctx); err != nil {
 			if statusErr := recordFailure(ctx, r.ctx, step.ID(), err); statusErr != nil {
 				return fmt.Errorf("%s: %w", step.ID(), errors.Join(err, fmt.Errorf("record failure status: %w", statusErr)))

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -80,6 +80,23 @@ func TestPreseededManifestPlanSkipsLocalConfigWait(t *testing.T) {
 	}
 }
 
+func TestRunnerReportsStepBeforeExecution(t *testing.T) {
+	store := &MemoryStateStore{}
+	var reported []StepID
+	install := &Context{
+		Commands:   &NoopCommandRunner{},
+		Store:      store,
+		ReportStep: func(step StepID) { reported = append(reported, step) },
+	}
+	runner := NewRunner(Plan{stubStep{id: DiscoverInstallerInput}, stubStep{id: WaitForLocalConfig}}, install)
+	if err := runner.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if want := []StepID{DiscoverInstallerInput, WaitForLocalConfig}; !reflect.DeepEqual(reported, want) {
+		t.Fatalf("reported steps = %#v, want %#v", reported, want)
+	}
+}
+
 func TestBuildClusterIntentPersistsBootstrapPlanContext(t *testing.T) {
 	root := t.TempDir()
 	installedAt := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)

--- a/internal/scriptstest/installer_service_test.go
+++ b/internal/scriptstest/installer_service_test.go
@@ -1,0 +1,41 @@
+package scriptstest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallerServiceHasOperationalReadiness(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "mkosi.profiles", "installer-image", "mkosi.extra", "usr", "lib", "systemd", "system", "katlos-install.service")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := string(data)
+	for _, want := range []string{"Type=notify", "NotifyAccess=main", "StandardOutput=journal+console", "StandardError=journal+console"} {
+		if !strings.Contains(unit, want) {
+			t.Fatalf("installer service missing %q", want)
+		}
+	}
+	if strings.Contains(unit, "Type=oneshot") {
+		t.Fatal("installer wait-for-config service must not remain an activating oneshot")
+	}
+	targetPath := filepath.Join(root, "mkosi.profiles", "installer-image", "mkosi.extra", "usr", "lib", "systemd", "system", "katl-installer.target")
+	target, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(target), "After=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service") {
+		t.Fatal("installer target does not wait for operational installer readiness")
+	}
+	config, err := os.ReadFile(filepath.Join(root, "mkosi.profiles", "installer-image", "mkosi.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), "rd.systemd.unit=katl-installer.target") {
+		t.Fatal("installer image does not boot to the dedicated installer target")
+	}
+}

--- a/internal/vmtest/scenarios/installer_iso_vmtest_test.go
+++ b/internal/vmtest/scenarios/installer_iso_vmtest_test.go
@@ -33,7 +33,7 @@ func TestInstallerISOBootSmoke(t *testing.T) {
 		vmtest.Scenario{Name: "installer-iso-boot"},
 		vmtest.InstallerBootConfig{
 			InstallerISO: iso,
-			Expect:       "katl input: mounted install media",
+			Expect:       "katlos-install progress: waiting for configuration at",
 			VM: vmtest.VMConfig{
 				KVM:     options.KVM,
 				RAMMiB:  2048,

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -50,7 +50,7 @@ RemoveFiles=
         /usr/share/dnf5
         /usr/share/licenses/pkgconf
         /var/lib/rpm-state
-KernelCommandLine=console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6
+KernelCommandLine=console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6 rd.systemd.unit=katl-installer.target
 Hostname=katl-installer
 Autologin=yes
 MakeInitrd=yes

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katl-installer.target
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katl-installer.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Katl installer environment
+DefaultDependencies=no
+Wants=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service
+After=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service
+AllowIsolate=yes

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katlos-install.service
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katlos-install.service
@@ -6,7 +6,8 @@ After=katl-input-apply.service systemd-networkd.service systemd-resolved.service
 Before=initrd.target
 
 [Service]
-Type=oneshot
+Type=notify
+NotifyAccess=main
 TimeoutStartSec=30min
 ExecStart=/usr/bin/katlos-install --boot
 StandardOutput=journal+console

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,7 +11,7 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "7325d4a2b2a0475d12eb7461b8382658d3cdf770857b9e6cb6ba827f3a416896",
+      "configSHA256": "41a87f150b3c17e86797efdc7a4af6ea77f55ef0d336c527f0cce3b4885df895",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -82,6 +82,7 @@ for path in \
     /usr/bin/findmnt \
     /usr/bin/sshd \
     /usr/lib/systemd/system/katlos-install.service \
+    /usr/lib/systemd/system/katl-installer.target \
     /usr/lib/systemd/system/katl-input-apply.service \
     /usr/lib/systemd/system/katl-installer-smoke.service \
     /usr/lib/systemd/system/systemd-networkd.service \
@@ -95,6 +96,9 @@ do
 done
 
 file_has /usr/lib/systemd/system/katlos-install.service "ExecStart=/usr/bin/katlos-install --boot"
+file_has /usr/lib/systemd/system/katlos-install.service "Type=notify"
+file_has /usr/lib/systemd/system/katlos-install.service "NotifyAccess=main"
+file_has /usr/lib/systemd/system/katl-installer.target "Wants=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service"
 file_has /usr/lib/systemd/system/katl-input-apply.service "ExecStart=/usr/bin/katlos-install --apply-input"
 file_has /usr/lib/systemd/system/katl-installer-smoke.service "Katl installer ready"
 file_has /etc/systemd/system/sshd.service.d/10-katl-disabled.conf "ConditionPathExists=/etc/katl/installer-ssh.enabled"


### PR DESCRIPTION
Stop presenting the normal wait-for-configuration state as an indefinitely starting service. Boot into a dedicated installer target, use systemd notify readiness, and mirror startup plus typed install-step progress to the journal and consoles.

The ISO smoke test now requires the operational handoff message rather than passing as soon as installation media mounts.