### PR TITLE
console: add operator dashboard

### DIFF
--- a/cmd/katl-console/main.go
+++ b/cmd/katl-console/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/katl-dev/katl/internal/operatorconsole"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	version = "0.0.0-dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	if err := run(ctx, os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "katl-console: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("katl-console", flag.ContinueOnError)
+	modeValue := flags.String("mode", "", "console mode: installer or runtime")
+	ttyPath := flags.String("tty", "/dev/tty1", "virtual terminal to own")
+	statusPath := flags.String("status", "", "override install status path")
+	handoffPath := flags.String("handoff", operatorconsole.HandoffPath, "installer handoff projection path")
+	snapshotPath := flags.String("snapshot", "/run/katl/console/rendered.txt", "plain-text rendered dashboard snapshot")
+	refresh := flags.Duration("refresh", time.Second, "dashboard refresh interval")
+	journalLines := flags.Int("journal-lines", 200, "maximum buffered journal lines")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	mode := operatorconsole.Mode(strings.TrimSpace(*modeValue))
+	if mode != operatorconsole.ModeInstaller && mode != operatorconsole.ModeRuntime {
+		return fmt.Errorf("mode must be installer or runtime")
+	}
+	if *refresh <= 0 {
+		return fmt.Errorf("refresh interval must be positive")
+	}
+	if *journalLines < 1 {
+		return fmt.Errorf("journal-lines must be positive")
+	}
+
+	tty, err := os.OpenFile(*ttyPath, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open dashboard tty %s: %w", *ttyPath, err)
+	}
+	defer tty.Close()
+	_, _ = io.WriteString(tty, "\x1b[?25l\x1b[2J")
+	defer io.WriteString(tty, "\x1b[?25h\n")
+
+	ring := newJournalRing(*journalLines)
+	go followJournal(ctx, ring)
+	collector := operatorconsole.Collector{
+		Mode:        mode,
+		Version:     version,
+		StatusPath:  strings.TrimSpace(*statusPath),
+		HandoffPath: strings.TrimSpace(*handoffPath),
+	}
+	ticker := time.NewTicker(*refresh)
+	defer ticker.Stop()
+	for {
+		if err := render(tty, strings.TrimSpace(*snapshotPath), collector.Collect(ring.Lines())); err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func render(tty *os.File, snapshotPath string, snapshot operatorconsole.Snapshot) error {
+	width, height := terminalSize(tty)
+	plain := operatorconsole.Render(snapshot, width, height)
+	if _, err := io.WriteString(tty, "\x1b[H\x1b[2J"+plain); err != nil {
+		return fmt.Errorf("render dashboard: %w", err)
+	}
+	if snapshotPath != "" {
+		if err := writeSnapshot(snapshotPath, []byte(plain)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func terminalSize(tty *os.File) (int, int) {
+	size, err := unix.IoctlGetWinsize(int(tty.Fd()), unix.TIOCGWINSZ)
+	if err != nil || size.Col == 0 || size.Row == 0 {
+		return 80, 25
+	}
+	return int(size.Col), int(size.Row)
+}
+
+func writeSnapshot(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create dashboard snapshot directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".rendered-*")
+	if err != nil {
+		return fmt.Errorf("create dashboard snapshot: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o644); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish dashboard snapshot: %w", err)
+	}
+	return nil
+}
+
+type journalRing struct {
+	mu    sync.Mutex
+	limit int
+	lines []string
+}
+
+func newJournalRing(limit int) *journalRing {
+	return &journalRing{limit: limit}
+}
+
+func (r *journalRing) Add(line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lines = append(r.lines, line)
+	if len(r.lines) > r.limit {
+		r.lines = append([]string(nil), r.lines[len(r.lines)-r.limit:]...)
+	}
+}
+
+func (r *journalRing) Lines() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.lines...)
+}
+
+func followJournal(ctx context.Context, ring *journalRing) {
+	for ctx.Err() == nil {
+		err := streamJournal(ctx, ring, exec.CommandContext)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			ring.Add("journal stream unavailable: " + err.Error())
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+type commandContext func(context.Context, string, ...string) *exec.Cmd
+
+func streamJournal(ctx context.Context, ring *journalRing, command commandContext) error {
+	cmd := command(ctx, "journalctl", "--boot", "--follow", "--lines=100", "--output=short-monotonic", "--no-pager")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	var stderrText strings.Builder
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&stderrText, stderr)
+		close(done)
+	}()
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 4096), 256<<10)
+	for scanner.Scan() {
+		ring.Add(scanner.Text())
+	}
+	scanErr := scanner.Err()
+	waitErr := cmd.Wait()
+	<-done
+	if scanErr != nil {
+		return scanErr
+	}
+	if waitErr != nil && !errors.Is(ctx.Err(), context.Canceled) {
+		if detail := strings.TrimSpace(stderrText.String()); detail != "" {
+			return fmt.Errorf("%w: %s", waitErr, detail)
+		}
+		return waitErr
+	}
+	return nil
+}

--- a/cmd/katl-console/main_test.go
+++ b/cmd/katl-console/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestJournalRingIsBounded(t *testing.T) {
+	ring := newJournalRing(2)
+	ring.Add("one")
+	ring.Add("two")
+	ring.Add("three")
+	if got := ring.Lines(); !reflect.DeepEqual(got, []string{"two", "three"}) {
+		t.Fatalf("Lines() = %#v", got)
+	}
+}
+
+func TestWriteSnapshotReplacesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "console", "rendered.txt")
+	if err := writeSnapshot(path, []byte("first\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSnapshot(path, []byte("second\n")); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "second\n" {
+		t.Fatalf("snapshot = %q", data)
+	}
+}

--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -27,12 +27,14 @@ import (
 	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
+	"github.com/katl-dev/katl/internal/operatorconsole"
 )
 
 var (
-	version = "dev"
-	commit  = "unknown"
-	date    = "unknown"
+	version            = "dev"
+	commit             = "unknown"
+	date               = "unknown"
+	consoleHandoffPath = operatorconsole.HandoffPath
 )
 
 func main() {
@@ -292,6 +294,11 @@ func runBootWithHandoff(ctx context.Context, runDir, etcDir, handoffAddr string,
 
 	switch input.Action {
 	case installer.InstallActionHoldForDebug:
+		status := installstatus.New(installstatus.StateDebugHold, time.Now().UTC())
+		status.CurrentStep = "DebugHold"
+		status.InputMode = inputMode
+		status.InputSource = inputMode
+		writeConsoleInstallStatus(runDir, status, stdout)
 		reportInstallerProgress(stdout, "debug hold active", true)
 		fmt.Fprintln(stdout, "katlos-install debug hold active")
 		<-ctx.Done()
@@ -563,6 +570,7 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 	if err != nil {
 		return err
 	}
+	writeConsoleInstallStatus(runDir, server.Status().InstallStatus, stdout)
 	server.SetStatusReader(func() (installstatus.Record, error) {
 		return installstatus.ReadFile(filepath.Join(runDir, "state", "status.json"))
 	})
@@ -588,6 +596,9 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 	baseURL, err := waitHandoffAnnouncementBaseURL(ctx, listener.Addr())
 	if err != nil {
 		return err
+	}
+	if err := operatorconsole.WriteHandoff(consoleHandoffPath, baseURL, server.Token()); err != nil {
+		fmt.Fprintf(stdout, "katlos-install console handoff projection: %v\n", err)
 	}
 	fmt.Fprintln(stdout, server.Announcement(baseURL))
 	reportInstallerProgress(stdout, "waiting for configuration at "+baseURL, false)
@@ -632,6 +643,17 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 			return err
 		case <-ticker.C:
 		}
+	}
+}
+
+func writeConsoleInstallStatus(runDir string, status installstatus.Record, stdout io.Writer) {
+	path := filepath.Join(runDir, "state", "status.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintf(stdout, "katlos-install console status: %v\n", err)
+		return
+	}
+	if err := installstatus.WriteFile(path, status); err != nil {
+		fmt.Fprintf(stdout, "katlos-install console status: %v\n", err)
 	}
 }
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -301,6 +301,10 @@ create or operate DHCP, iPXE, or matchbox configuration.
 Boot the same `katl-installer.iso` on each node without preseed input. The
 installer mounts its embedded KatlOS image read-only, prints a handoff URL and
 one-time token to the console and journal, and waits without mutating disks.
+The VGA console keeps a KatlOS dashboard on `tty1` showing installer state,
+active network addresses, the handoff URL and token, disk-mutation status, and a
+live tail of the boot journal. Press `Ctrl+Alt+F2` for a local recovery shell;
+the dashboard, serial journal, and SSH service operate independently.
 
 The current handoff uses a bearer token over unencrypted HTTP. Use only an
 isolated provisioning network, never expose port 8080 to an untrusted network,

--- a/docs/internal/v0.1-supported-image-surface.md
+++ b/docs/internal/v0.1-supported-image-surface.md
@@ -38,6 +38,7 @@ Supported v0.1 installer commands:
 | --- | --- | --- |
 | `katlos-install --boot` | supported | systemd-started installer entrypoint. |
 | `katlos-install` subcommands needed by installer state tests | supported | only documented installer workflows are stable. |
+| `katl-console` | supported internal | read-only `tty1` operator dashboard; not a configuration API. |
 | `systemctl`, `journalctl`, `networkctl`, `resolvectl`, `ip` | debug/break-glass | allowed for installer diagnosis, not a configuration API. |
 | `ssh`/`sshd` | conditional support | only when installer config enables `/etc/katl/installer-ssh.enabled`; key-only root access. |
 | `curl` | internal installer fetch helper | not a supported general download tool. |
@@ -50,6 +51,7 @@ Supported installer services and units:
 | --- | --- | --- |
 | `katl-installer.target` | supported | dedicated installer boot target; keeps the initrd environment active without misreporting the installer as starting. |
 | `katlos-install.service` | supported | boot-time installer operation. |
+| `katl-console.service` | supported | owns VGA `tty1`; `tty2`, SSH, and serial remain separate recovery surfaces. |
 | `katl-input-apply.service` | supported | applies installer handoff input. |
 | `katl-installer-smoke.service` | VM/test-only | smoke signal, not a production install contract. |
 | `systemd-networkd.service` and `systemd-resolved.service` | supported | installer networking and DNS. |
@@ -86,6 +88,7 @@ Supported v0.1 runtime commands:
 | Command | Surface | Notes |
 | --- | --- | --- |
 | `katlc` | supported | node-local state/config/operation command and agent CLI. |
+| `katl-console` | supported internal | renders node, network, generation, health, and journal state on VGA `tty1`. |
 | `katl-boot-health`, `katl-runtime-status`, `katl-generation-activate` | internal supported | stable as Katl unit entrypoints, not operator CLIs. |
 | `systemctl`, `journalctl`, `networkctl`, `resolvectl`, `bootctl`, `importctl` | break-glass/debug | allowed for inspection and recovery, not declarative config. |
 | `ssh`/`sshd` | supported node access | used for operator recovery and VM tests; configured through Katl-owned input/state. |
@@ -99,6 +102,7 @@ Supported runtime services and targets:
 | Unit | Surface | Notes |
 | --- | --- | --- |
 | `katlc-agent.service` | supported | node management endpoint. |
+| `katl-console.service` | supported | read-only VGA status and journal dashboard. |
 | `katl-generation-activate.service` | supported internal | generation activation unit. |
 | `katl-boot-complete.target`, `katl-boot-health.service`, `katl-boot-deadman.*` | supported | boot health contract. |
 | `katl-runtime-handoff-status.service` | supported | runtime status and handoff evidence. |
@@ -205,10 +209,12 @@ Installer image denied paths:
 Runtime rootfs required paths:
 
 - `/usr/bin/katlc`
+- `/usr/bin/katl-console`
 - `/usr/lib/katl/runtime/katl-boot-health`
 - `/usr/lib/katl/runtime/katl-runtime-status`
 - `/usr/lib/katl/runtime/katl-generation-activate`
 - `katlc-agent.service`
+- `katl-console.service`
 - `katl-generation-activate.service`
 - `katl-boot-complete.target`
 - `katl-kubeadm-ready.target`

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -15,6 +15,11 @@ SSH is the supported way to retrieve the initial per-node token. Treat token
 files like private keys: store them with mode `0600`, never commit them, never
 put token values in `ClusterConfig`, and redact them from logs and issues.
 
+The installed system keeps an operator dashboard on VGA `tty1`. It reports the
+node addresses, boot and generation health, installer handoff state, and a live
+journal tail. Press `Ctrl+Alt+F2` for the local login console. The dashboard does
+not replace SSH or `katlctl`; it is a read-only view of the same durable state.
+
 ## Confirm Generation 0
 
 On each node:

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -4,6 +4,11 @@ Troubleshooting starts by identifying the lifecycle boundary that failed. Do
 not retry a mutating command until its durable state and mutation boundary are
 known.
 
+On an attached VGA or ipKVM console, `tty1` is the KatlOS status dashboard and
+includes current network addresses plus a live journal tail. Use
+`Ctrl+Alt+F2` for a local shell. The last rendered dashboard is also available
+at `/run/katl/console/rendered.txt` for collection over SSH.
+
 ## First Classification
 
 | Symptom | Primary evidence |

--- a/internal/installer/status/status.go
+++ b/internal/installer/status/status.go
@@ -28,6 +28,7 @@ const (
 
 const (
 	StateRunning                    = "running"
+	StateDebugHold                  = "debug-hold"
 	StateWaitingForConfig           = "waiting-for-config"
 	StateInstallRefused             = "install-refused"
 	StateFailedBeforeMutation       = "failed-before-mutation"

--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -1,0 +1,161 @@
+package operatorconsole
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	installstatus "github.com/katl-dev/katl/internal/installer/status"
+)
+
+type Collector struct {
+	Mode        Mode
+	Version     string
+	Root        string
+	StatusPath  string
+	HandoffPath string
+	Hostname    func() (string, error)
+	Interfaces  func() ([]net.Interface, error)
+	Addrs       func(net.Interface) ([]net.Addr, error)
+}
+
+func (c Collector) Collect(journal []string) Snapshot {
+	snapshot := Snapshot{
+		Mode:    c.Mode,
+		Version: strings.TrimSpace(c.Version),
+		Journal: append([]string(nil), journal...),
+	}
+	if c.Hostname == nil {
+		c.Hostname = os.Hostname
+	}
+	if c.Interfaces == nil {
+		c.Interfaces = net.Interfaces
+	}
+	if c.Addrs == nil {
+		c.Addrs = func(iface net.Interface) ([]net.Addr, error) { return iface.Addrs() }
+	}
+	if hostname, err := c.Hostname(); err == nil {
+		snapshot.Hostname = hostname
+	}
+	snapshot.Network = c.collectNetwork()
+	snapshot.SSHEnabled = c.Mode == ModeRuntime || fileExists(rooted(c.Root, "/etc/katl/installer-ssh.enabled"))
+
+	statusPath := c.StatusPath
+	if statusPath == "" {
+		if c.Mode == ModeInstaller {
+			statusPath = rooted(c.Root, "/run/katl/state/status.json")
+		} else {
+			statusPath, _ = installstatus.RuntimeStatusPath(cleanRoot(c.Root))
+		}
+	}
+	record, err := installstatus.ReadFile(statusPath)
+	if err == nil {
+		snapshot.State = record.State
+		snapshot.CurrentStep = record.CurrentStep
+		snapshot.InputMode = record.InputMode
+		snapshot.TargetDisk = record.TargetDiskStableID
+		snapshot.Generation = record.InstalledGeneration
+		snapshot.DestructiveMutation = record.DestructiveMutation
+		snapshot.LastError = record.LastError
+		snapshot.RetryHint = record.RetryHint
+		snapshot.UpdatedAt = record.UpdatedAt
+	} else if !errors.Is(err, os.ErrNotExist) {
+		snapshot.StatusError = err.Error()
+	}
+	if snapshot.State == "" {
+		if c.Mode == ModeInstaller {
+			snapshot.State = "starting-installer"
+		} else {
+			snapshot.State = "starting-runtime"
+		}
+	}
+	if c.Mode == ModeInstaller {
+		path := c.HandoffPath
+		if path == "" {
+			path = rooted(c.Root, HandoffPath)
+		}
+		if handoff, err := ReadHandoff(path); err == nil {
+			snapshot.Handoff = handoff
+			if snapshot.State == "starting-installer" {
+				snapshot.State = installstatus.StateWaitingForConfig
+			}
+		}
+	} else {
+		c.collectGeneration(&snapshot)
+	}
+	return snapshot
+}
+
+func (c Collector) collectNetwork() []NetworkInterface {
+	interfaces, err := c.Interfaces()
+	if err != nil {
+		return nil
+	}
+	result := make([]NetworkInterface, 0, len(interfaces))
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		item := NetworkInterface{Name: iface.Name}
+		addresses, err := c.Addrs(iface)
+		if err == nil {
+			for _, address := range addresses {
+				ip, _, err := net.ParseCIDR(address.String())
+				if err != nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+					continue
+				}
+				item.Addresses = append(item.Addresses, address.String())
+			}
+		}
+		sort.Strings(item.Addresses)
+		result = append(result, item)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+func (c Collector) collectGeneration(snapshot *Snapshot) {
+	root := cleanRoot(c.Root)
+	selection, err := generation.ReadBootSelection(root)
+	if err != nil {
+		return
+	}
+	id := strings.TrimSpace(selection.BootedGenerationID)
+	if id == "" {
+		id = strings.TrimSpace(selection.DefaultGenerationID)
+	}
+	if id == "" {
+		return
+	}
+	snapshot.Generation = id
+	_, status, err := generation.ReadGeneration(root, id)
+	if err != nil {
+		return
+	}
+	snapshot.GenerationBoot = status.BootState
+	snapshot.GenerationHealth = status.HealthState
+}
+
+func cleanRoot(root string) string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "/"
+	}
+	return root
+}
+
+func rooted(root, path string) string {
+	root = cleanRoot(root)
+	if root == "/" {
+		return path
+	}
+	return strings.TrimRight(root, "/") + path
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/operatorconsole/handoff.go
+++ b/internal/operatorconsole/handoff.go
@@ -1,0 +1,66 @@
+package operatorconsole
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func WriteHandoff(path, url, token string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("handoff projection path is required")
+	}
+	record := Handoff{
+		URL:       strings.TrimRight(strings.TrimSpace(url), "/") + "/v1/config-bundle",
+		Token:     strings.TrimSpace(token),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if strings.TrimSpace(url) == "" || record.Token == "" {
+		return fmt.Errorf("handoff URL and token are required")
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal handoff projection: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create handoff projection directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".handoff-*")
+	if err != nil {
+		return fmt.Errorf("create handoff projection: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return fmt.Errorf("protect handoff projection: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return fmt.Errorf("write handoff projection: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close handoff projection: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish handoff projection: %w", err)
+	}
+	return nil
+}
+
+func ReadHandoff(path string) (Handoff, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Handoff{}, err
+	}
+	var record Handoff
+	if err := json.Unmarshal(data, &record); err != nil {
+		return Handoff{}, fmt.Errorf("decode handoff projection: %w", err)
+	}
+	return record, nil
+}

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -1,0 +1,45 @@
+package operatorconsole
+
+import "time"
+
+const HandoffPath = "/run/katl/console/handoff.json"
+
+type Mode string
+
+const (
+	ModeInstaller Mode = "installer"
+	ModeRuntime   Mode = "runtime"
+)
+
+type Snapshot struct {
+	Mode                Mode
+	Version             string
+	Hostname            string
+	State               string
+	CurrentStep         string
+	InputMode           string
+	TargetDisk          string
+	Generation          string
+	GenerationBoot      string
+	GenerationHealth    string
+	DestructiveMutation bool
+	LastError           string
+	RetryHint           string
+	Handoff             Handoff
+	Network             []NetworkInterface
+	SSHEnabled          bool
+	UpdatedAt           time.Time
+	StatusError         string
+	Journal             []string
+}
+
+type NetworkInterface struct {
+	Name      string
+	Addresses []string
+}
+
+type Handoff struct {
+	URL       string    `json:"url"`
+	Token     string    `json:"token"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -1,0 +1,142 @@
+package operatorconsole
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	installstatus "github.com/katl-dev/katl/internal/installer/status"
+)
+
+type testAddr string
+
+func (a testAddr) Network() string { return "ip" }
+func (a testAddr) String() string  { return string(a) }
+
+func TestWriteAndReadHandoff(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "console", "handoff.json")
+	if err := WriteHandoff(path, "http://192.0.2.10:8080/", "test-token"); err != nil {
+		t.Fatalf("WriteHandoff() error = %v", err)
+	}
+	record, err := ReadHandoff(path)
+	if err != nil {
+		t.Fatalf("ReadHandoff() error = %v", err)
+	}
+	if record.URL != "http://192.0.2.10:8080/v1/config-bundle" || record.Token != "test-token" || record.UpdatedAt.IsZero() {
+		t.Fatalf("handoff = %#v", record)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("handoff permissions = %o", info.Mode().Perm())
+	}
+}
+
+func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
+	root := t.TempDir()
+	statusPath := filepath.Join(root, "status.json")
+	record := installstatus.New(installstatus.StateRunning, time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC))
+	record.CurrentStep = "InstallRootSlot"
+	record.TargetDiskStableID = "/dev/disk/by-id/virtio-root"
+	record.DestructiveMutation = true
+	if err := installstatus.WriteFile(statusPath, record); err != nil {
+		t.Fatal(err)
+	}
+	handoffPath := filepath.Join(root, "handoff.json")
+	if err := WriteHandoff(handoffPath, "http://192.0.2.10:8080", "token"); err != nil {
+		t.Fatal(err)
+	}
+	collector := Collector{
+		Mode:        ModeInstaller,
+		Version:     "2026.7.0-alpha.9",
+		Root:        root,
+		StatusPath:  statusPath,
+		HandoffPath: handoffPath,
+		Hostname:    func() (string, error) { return "katl-installer", nil },
+		Interfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 1, Name: "lo", Flags: net.FlagUp | net.FlagLoopback}, {Index: 2, Name: "enp1s0", Flags: net.FlagUp}}, nil
+		},
+		Addrs: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "enp1s0" {
+				return []net.Addr{testAddr("fe80::1/64"), testAddr("192.0.2.10/24")}, nil
+			}
+			return nil, nil
+		},
+	}
+	snapshot := collector.Collect([]string{"one", "two"})
+	if snapshot.State != installstatus.StateRunning || snapshot.CurrentStep != "InstallRootSlot" || !snapshot.DestructiveMutation {
+		t.Fatalf("snapshot status = %#v", snapshot)
+	}
+	if len(snapshot.Network) != 1 || strings.Join(snapshot.Network[0].Addresses, ",") != "192.0.2.10/24" {
+		t.Fatalf("snapshot network = %#v", snapshot.Network)
+	}
+	if snapshot.Handoff.Token != "token" || len(snapshot.Journal) != 2 {
+		t.Fatalf("snapshot handoff/journal = %#v", snapshot)
+	}
+}
+
+func TestRenderInstallerDashboard(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:                ModeInstaller,
+		Version:             "2026.7.0-alpha.9",
+		Hostname:            "katl-installer",
+		State:               installstatus.StateRunning,
+		CurrentStep:         "InstallRootSlot",
+		TargetDisk:          "/dev/disk/by-id/virtio-root",
+		DestructiveMutation: true,
+		Handoff:             Handoff{URL: "http://192.0.2.10:8080/v1/config-bundle", Token: "secret-token"},
+		Network:             []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
+		Journal:             []string{"old line", "installing root\x1b[31m", "latest line"},
+	}
+	got := Render(snapshot, 80, 25)
+	for _, want := range []string{
+		"KatlOS Installer  2026.7.0-alpha.9",
+		"State:        Installing",
+		"Network:      enp1s0: 192.0.2.10/24",
+		"Disk changes: started - do not power off",
+		"Configure:    http://192.0.2.10:8080/v1/config-bundle",
+		"Token:        secret-token",
+		"Journal (live)",
+		"installing root[31m",
+		"Ctrl+Alt+F2: local console | SSH disabled by installer config",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q:\n%s", want, got)
+		}
+	}
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+	if len(lines) != 25 {
+		t.Fatalf("rendered rows = %d, want 25", len(lines))
+	}
+	for number, line := range lines {
+		if len([]rune(line)) > 80 {
+			t.Fatalf("line %d width = %d", number+1, len([]rune(line)))
+		}
+	}
+}
+
+func TestRenderRuntimeFailure(t *testing.T) {
+	got := Render(Snapshot{
+		Mode:             ModeRuntime,
+		Version:          "2026.7.0-alpha.9",
+		Hostname:         "cp-1",
+		State:            installstatus.StateRuntimeFailedNeedsRepair,
+		Generation:       "4",
+		GenerationBoot:   "failed",
+		GenerationHealth: "unhealthy",
+		LastError:        "boot health check failed",
+		RetryHint:        "inspect the previous generation",
+		SSHEnabled:       true,
+		Network:          []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
+	}, 80, 20)
+	for _, want := range []string{"Installed system needs repair", "Generation:   4  boot=failed health=unhealthy", "Error:", "boot health check failed", "SSH: ssh root@192.0.2.20"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -1,0 +1,214 @@
+package operatorconsole
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+func Render(snapshot Snapshot, width, height int) string {
+	if width < 40 {
+		width = 40
+	}
+	if height < 12 {
+		height = 12
+	}
+	lines := make([]string, 0, height)
+	title := "KatlOS"
+	if snapshot.Mode == ModeInstaller {
+		title += " Installer"
+	}
+	if snapshot.Version != "" {
+		title += "  " + snapshot.Version
+	}
+	lines = append(lines, title, strings.Repeat("=", min(width, 72)))
+	lines = append(lines, field("State", stateLabel(snapshot.State)))
+	if snapshot.Hostname != "" {
+		lines = append(lines, field("Node", snapshot.Hostname))
+	}
+	lines = append(lines, networkLines(snapshot.Network)...)
+	if snapshot.CurrentStep != "" {
+		lines = append(lines, field("Current step", snapshot.CurrentStep))
+	}
+	if snapshot.TargetDisk != "" {
+		lines = append(lines, field("Target disk", snapshot.TargetDisk))
+	}
+	if snapshot.Generation != "" {
+		value := snapshot.Generation
+		if snapshot.GenerationBoot != "" || snapshot.GenerationHealth != "" {
+			value += fmt.Sprintf("  boot=%s health=%s", fallback(snapshot.GenerationBoot, "unknown"), fallback(snapshot.GenerationHealth, "unknown"))
+		}
+		lines = append(lines, field("Generation", value))
+	}
+	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
+		mutation := "not started"
+		if snapshot.DestructiveMutation {
+			mutation = "started - do not power off"
+		}
+		lines = append(lines, field("Disk changes", mutation))
+	}
+	if snapshot.Handoff.URL != "" {
+		lines = append(lines, field("Configure", snapshot.Handoff.URL), field("Token", snapshot.Handoff.Token))
+		lines = append(lines, "From another machine use: katlctl install apply")
+	}
+	if snapshot.LastError != "" {
+		lines = append(lines, wrapField("Error", snapshot.LastError, width)...)
+	}
+	if snapshot.RetryHint != "" {
+		lines = append(lines, wrapField("Next action", snapshot.RetryHint, width)...)
+	}
+	if snapshot.StatusError != "" {
+		lines = append(lines, wrapField("Status read", snapshot.StatusError, width)...)
+	}
+
+	footer := "Ctrl+Alt+F2: local console"
+	if snapshot.SSHEnabled {
+		if address := firstIPv4(snapshot.Network); address != "" {
+			footer += " | SSH: ssh root@" + address
+		} else {
+			footer += " | SSH enabled"
+		}
+	} else if snapshot.Mode == ModeInstaller {
+		footer += " | SSH disabled by installer config"
+	}
+	journalRows := height - len(lines) - 3
+	if journalRows < 2 {
+		journalRows = 2
+	}
+	lines = append(lines, "", "Journal (live)")
+	journal := snapshot.Journal
+	if len(journal) > journalRows {
+		journal = journal[len(journal)-journalRows:]
+	}
+	for _, line := range journal {
+		lines = append(lines, truncate(sanitize(line), width))
+	}
+	for len(lines) < height-1 {
+		lines = append(lines, "")
+	}
+	if len(lines) >= height {
+		lines = lines[:height-1]
+	}
+	lines = append(lines, truncate(footer, width))
+	for i := range lines {
+		lines[i] = truncate(lines[i], width)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func networkLines(network []NetworkInterface) []string {
+	if len(network) == 0 {
+		return []string{field("Network", "waiting for an active interface")}
+	}
+	lines := make([]string, 0, len(network))
+	for i, iface := range network {
+		value := iface.Name + ": configuring"
+		if len(iface.Addresses) > 0 {
+			value = iface.Name + ": " + strings.Join(iface.Addresses, ", ")
+		}
+		label := ""
+		if i == 0 {
+			label = "Network"
+		}
+		lines = append(lines, field(label, value))
+	}
+	return lines
+}
+
+func stateLabel(state string) string {
+	labels := map[string]string{
+		"starting-installer":            "Starting installer",
+		"starting-runtime":              "Starting installed system",
+		"running":                       "Installing",
+		"debug-hold":                    "Debug hold; installation disabled",
+		"waiting-for-config":            "Waiting for configuration",
+		"install-refused":               "Installation refused",
+		"failed-before-mutation":        "Installation failed; disk unchanged",
+		"failed-after-mutation":         "Installation failed; repair required",
+		"reboot-requested":              "Installation complete; rebooting",
+		"kubeadm-ready":                 "Ready for Kubernetes bootstrap",
+		"waiting-for-cluster-bootstrap": "Waiting for Kubernetes bootstrap",
+		"runtime-booted-not-ready":      "Installed system booted; not ready",
+		"runtime-failed-needs-repair":   "Installed system needs repair",
+	}
+	if label := labels[state]; label != "" {
+		return label
+	}
+	return fallback(state, "Unknown")
+}
+
+func field(label, value string) string {
+	if label == "" {
+		return fmt.Sprintf("%-14s%s", "", value)
+	}
+	return fmt.Sprintf("%-14s%s", label+":", value)
+}
+
+func wrapField(label, value string, width int) []string {
+	prefix := field(label, "")
+	available := width - utf8.RuneCountInString(prefix)
+	if available < 10 {
+		available = 10
+	}
+	words := strings.Fields(sanitize(value))
+	if len(words) == 0 {
+		return []string{prefix}
+	}
+	var lines []string
+	current := ""
+	for _, word := range words {
+		if current != "" && utf8.RuneCountInString(current)+1+utf8.RuneCountInString(word) > available {
+			lines = append(lines, prefix+current)
+			prefix = strings.Repeat(" ", utf8.RuneCountInString(prefix))
+			current = word
+			continue
+		}
+		if current != "" {
+			current += " "
+		}
+		current += word
+	}
+	return append(lines, prefix+current)
+}
+
+func sanitize(value string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, value)
+}
+
+func truncate(value string, width int) string {
+	runes := []rune(value)
+	if len(runes) <= width {
+		return value
+	}
+	if width < 2 {
+		return string(runes[:width])
+	}
+	return string(runes[:width-1]) + "~"
+}
+
+func firstIPv4(network []NetworkInterface) string {
+	for _, iface := range network {
+		for _, address := range iface.Addresses {
+			if strings.Contains(address, ".") {
+				return strings.SplitN(address, "/", 2)[0]
+			}
+		}
+	}
+	return ""
+}
+
+func fallback(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/scriptstest/installer_service_test.go
+++ b/internal/scriptstest/installer_service_test.go
@@ -28,7 +28,7 @@ func TestInstallerServiceHasOperationalReadiness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(target), "After=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service") {
+	if !strings.Contains(string(target), "After=systemd-journald.service katl-console.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service") {
 		t.Fatal("installer target does not wait for operational installer readiness")
 	}
 	config, err := os.ReadFile(filepath.Join(root, "mkosi.profiles", "installer-image", "mkosi.conf"))

--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -85,6 +85,33 @@ func TestReleaseRootPackagingIsCompressedAndPruned(t *testing.T) {
 	assertTextContains(t, installerBuild, `-ldflags="-s -w`)
 }
 
+func TestOperatorConsoleOwnsTTY1AndPreservesRecoveryAccess(t *testing.T) {
+	repo := repoRoot(t)
+	installerUnit := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles", "installer-image", "mkosi.extra", "usr", "lib", "systemd", "system", "katl-console.service")))
+	runtimeUnit := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles", "runtime", "mkosi.extra", "usr", "lib", "systemd", "system", "katl-console.service")))
+	for name, unit := range map[string]string{"installer": installerUnit, "runtime": runtimeUnit} {
+		assertTextContains(t, unit,
+			"TTYPath=/dev/tty1",
+			"StandardInput=tty",
+			"StandardOutput=tty",
+			"Conflicts=getty@tty1.service",
+			"Restart=always",
+		)
+		if !strings.Contains(unit, "--mode="+name) {
+			t.Fatalf("%s console unit does not select its mode", name)
+		}
+	}
+	for _, profile := range []string{"installer-image", "runtime"} {
+		build := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles", profile, "mkosi.build")))
+		assertTextContains(t, build,
+			`./cmd/katl-console`,
+			`getty.target.wants/getty@tty2.service`,
+		)
+		dropIn := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles", profile, "mkosi.extra", "usr", "lib", "systemd", "system", "getty@tty1.service.d", "10-katl-console.conf")))
+		assertTextContains(t, dropIn, "ConditionPathExists=!/usr/bin/katl-console")
+	}
+}
+
 func runRuntimeBuild(t *testing.T, repo, bin, dest, support string) {
 	t.Helper()
 	cmd := exec.Command(filepath.Join(repo, "mkosi.profiles", "runtime", "mkosi.build"))

--- a/mkosi.profiles/installer-image/mkosi.build
+++ b/mkosi.profiles/installer-image/mkosi.build
@@ -41,6 +41,21 @@ go build \
     -o "$DESTDIR/usr/bin/katlos-install" \
     ./cmd/katlos-install
 
+CGO_ENABLED=0 \
+GOOS=linux \
+GOARCH=amd64 \
+GOCACHE="$builddir/go-build" \
+GOMODCACHE="$gomodcache" \
+go build \
+    -trimpath \
+    -buildvcs=false \
+    -ldflags="-s -w -X main.version=$version -X main.commit=$commit -X main.date=$date" \
+    -o "$DESTDIR/usr/bin/katl-console" \
+    ./cmd/katl-console
+
+mkdir -p "$DESTDIR/usr/lib/systemd/system/getty.target.wants"
+ln -sf ../getty@.service "$DESTDIR/usr/lib/systemd/system/getty.target.wants/getty@tty2.service"
+
 if [[ -n "${KATL_INSTALLER_PACKAGE_SET:-}" ]]; then
     mkdir -p "$(dirname "$KATL_INSTALLER_PACKAGE_SET")"
     rpm \

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=!/usr/bin/katl-console

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katl-console.service
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katl-console.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=KatlOS operator console
+DefaultDependencies=no
+Wants=systemd-journald.service systemd-networkd.service
+After=systemd-journald.service systemd-networkd.service
+Before=initrd.target
+Conflicts=getty@tty1.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/katl-console --mode=installer --tty=/dev/tty1
+Restart=always
+RestartSec=1s
+StandardInput=tty
+StandardOutput=tty
+StandardError=journal
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katl-installer.target
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/system/katl-installer.target
@@ -1,6 +1,6 @@
 [Unit]
 Description=Katl installer environment
 DefaultDependencies=no
-Wants=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service
-After=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service
+Wants=systemd-journald.service katl-console.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service
+After=systemd-journald.service katl-console.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service
 AllowIsolate=yes

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,14 +11,14 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "86e84c70a2852003f0c2aed005c79099d19421f9cf1d570628e7fff60719fad2",
+      "configSHA256": "829e7117cf23570c0dc7ba6b737be20a390a5f2b447fefebd0dd4a70b3581921",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },
     {
       "name": "runtime",
       "path": "mkosi.profiles/runtime",
-      "configSHA256": "9062938143e7c9240e8fa1bd3924eec19df75dfd0e0b1a00236ca9886a2b4472",
+      "configSHA256": "64e34b5a505b008e7861031323cd9af98230ae61526f404a02dbb4cb469df49e",
       "packageSetRef": "runtime",
       "mkosiVersion": "26"
     },

--- a/mkosi.profiles/runtime/mkosi.build
+++ b/mkosi.profiles/runtime/mkosi.build
@@ -53,6 +53,23 @@ go build \
     -o "$DESTDIR/usr/bin/katlc" \
     ./cmd/katlc
 
+CGO_ENABLED=0 \
+GOOS=linux \
+GOARCH=amd64 \
+GOCACHE="$builddir/go-build" \
+GOMODCACHE="$gomodcache" \
+go build \
+    -trimpath \
+    -buildvcs=false \
+    -ldflags="-s -w -X main.version=$version -X main.commit=$commit -X main.date=$date" \
+    -o "$DESTDIR/usr/bin/katl-console" \
+    ./cmd/katl-console
+
+mkdir -p "$DESTDIR/usr/lib/systemd/system/getty.target.wants"
+ln -sf ../getty@.service "$DESTDIR/usr/lib/systemd/system/getty.target.wants/getty@tty2.service"
+mkdir -p "$DESTDIR/usr/lib/systemd/system/multi-user.target.wants"
+ln -sf ../katl-console.service "$DESTDIR/usr/lib/systemd/system/multi-user.target.wants/katl-console.service"
+
 if [[ "$vmtest_image_support" == 1 ]]; then
     mkdir -p \
         "$DESTDIR/usr/lib/katl/vmtest" \

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=!/usr/bin/katl-console

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-console.service
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-console.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=KatlOS operator console
+Wants=systemd-journald.service systemd-networkd.service
+After=systemd-journald.service systemd-networkd.service local-fs.target
+Conflicts=getty@tty1.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/katl-console --mode=runtime --tty=/dev/tty1
+Restart=always
+RestartSec=1s
+StandardInput=tty
+StandardOutput=tty
+StandardError=journal
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -91,6 +91,7 @@ file_has() {
 
 for path in \
     /usr/bin/katlos-install \
+    /usr/bin/katl-console \
     /usr/bin/systemctl \
     /usr/bin/journalctl \
     /usr/bin/networkctl \
@@ -108,6 +109,7 @@ for path in \
     /usr/bin/findmnt \
     /usr/bin/sshd \
     /usr/lib/systemd/system/katlos-install.service \
+    /usr/lib/systemd/system/katl-console.service \
     /usr/lib/systemd/system/katl-installer.target \
     /usr/lib/systemd/system/katl-input-apply.service \
     /usr/lib/systemd/system/katl-installer-smoke.service \
@@ -117,6 +119,8 @@ for path in \
     /etc/systemd/system/sshd.service.d/10-katl-disabled.conf \
     /etc/systemd/journald.conf.d/10-katl-installer-console.conf \
     /usr/lib/systemd/network/80-katl-installer-dhcp.network \
+    /usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf \
+    /usr/lib/systemd/system/getty.target.wants/getty@tty2.service \
     /usr/lib/modules-load.d/50-katl-installer.conf
 do
     has_path "$path"
@@ -126,7 +130,10 @@ file_has /usr/lib/systemd/system/katlos-install.service "ExecStart=/usr/bin/katl
 file_has /usr/lib/systemd/system/katlos-install.service "Type=notify"
 file_has /usr/lib/systemd/system/katlos-install.service "NotifyAccess=main"
 file_has /usr/lib/systemd/system/katlos-install.service "After=katl-input-apply.service systemd-modules-load.service"
-file_has /usr/lib/systemd/system/katl-installer.target "Wants=systemd-journald.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service"
+file_has /usr/lib/systemd/system/katl-console.service "ExecStart=/usr/bin/katl-console --mode=installer --tty=/dev/tty1"
+file_has /usr/lib/systemd/system/katl-console.service "TTYPath=/dev/tty1"
+file_has /usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf "ConditionPathExists=!/usr/bin/katl-console"
+file_has /usr/lib/systemd/system/katl-installer.target "Wants=systemd-journald.service katl-console.service katl-input-apply.service systemd-networkd.service systemd-resolved.service katl-installer-smoke.service katlos-install.service"
 file_has /usr/lib/systemd/system/katl-input-apply.service "ExecStart=/usr/bin/katlos-install --apply-input"
 file_has /usr/lib/systemd/system/katl-installer-smoke.service "Katl installer ready"
 file_has /etc/systemd/system/sshd.service.d/10-katl-disabled.conf "ConditionPathExists=/etc/katl/installer-ssh.enabled"

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -194,6 +194,7 @@ for path in \
     /usr/libexec/cni/ptp \
     /usr/libexec/cni/portmap \
     /usr/bin/katlc \
+    /usr/bin/katl-console \
     /usr/lib/katl/runtime/katl-boot-health \
     /usr/lib/katl/runtime/katl-runtime-status \
     /usr/lib/katl/runtime/katl-generation-activate \
@@ -219,6 +220,7 @@ for path in \
     /usr/lib/systemd/system/katl-state-projection-check.service \
     /usr/lib/systemd/system/katl-runtime-handoff-status.service \
     /usr/lib/systemd/system/katlc-agent.service \
+    /usr/lib/systemd/system/katl-console.service \
     /usr/lib/systemd/system/containerd.service.d/10-katl-runtime.conf \
     /usr/lib/systemd/system/systemd-networkd.service.d/10-katl-confext.conf \
     /usr/lib/systemd/system/kubelet.service.d/10-katl-runtime.conf \
@@ -232,6 +234,9 @@ for path in \
     /usr/lib/systemd/system/katl-boot-complete.target.requires/katl-boot-health.service \
     /usr/lib/systemd/system/katl-boot-complete.target.requires/katl-runtime-handoff-status.service \
     /usr/lib/systemd/system/multi-user.target.wants/katlc-agent.service \
+    /usr/lib/systemd/system/multi-user.target.wants/katl-console.service \
+    /usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf \
+    /usr/lib/systemd/system/getty.target.wants/getty@tty2.service \
     /usr/lib/systemd/system/multi-user.target.wants/katl-runtime-boot-signal.service
 do
     has_path "$path"
@@ -281,6 +286,9 @@ root_locked
 file_has /usr/lib/systemd/system/katl-runtime-boot-signal.service "Katl runtime reached systemd userspace"
 file_has /usr/lib/systemd/system/katl-runtime-boot-signal.service "StandardOutput=journal+console"
 file_has /usr/lib/systemd/system/katl-runtime-boot-signal.service "SyslogIdentifier=katl-runtime-boot"
+file_has /usr/lib/systemd/system/katl-console.service "ExecStart=/usr/bin/katl-console --mode=runtime --tty=/dev/tty1"
+file_has /usr/lib/systemd/system/katl-console.service "TTYPath=/dev/tty1"
+file_has /usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf "ConditionPathExists=!/usr/bin/katl-console"
 has_path /usr/lib/katl/runtime/katl-runtime-status
 has_path /etc/katl
 has_path /etc/kubernetes

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -182,10 +182,12 @@ target_go_binaries() {
     case "$1" in
         installer | installer-iso)
             printf '%s\t%s\t%s\n' "included-binary:/usr/bin/katlos-install" "./cmd/katlos-install" "versioned"
+            printf '%s\t%s\t%s\n' "included-binary:/usr/bin/katl-console" "./cmd/katl-console" "versioned"
             printf '%s\t%s\t%s\n' "metadata-tool:katl-mkosi-artifacts" "./cmd/katl-mkosi-artifacts" "plain"
             ;;
         runtime)
             printf '%s\t%s\t%s\n' "included-binary:/usr/bin/katlc" "./cmd/katlc" "versioned"
+            printf '%s\t%s\t%s\n' "included-binary:/usr/bin/katl-console" "./cmd/katl-console" "versioned"
             if [[ "$vmtest_image_support" == 1 ]]; then
                 printf '%s\t%s\t%s\n' "included-binary:/usr/lib/katl/vmtest/katl-vmtest-agent" "./cmd/katl-vmtest-agent" "versioned"
             fi


### PR DESCRIPTION
Adds a tty1 operator dashboard to the installer and installed runtime. It shows typed system state, active network addresses, handoff guidance, and a bounded live journal while preserving tty2, SSH, and serial access.