### PR TITLE
docs: select latest published release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Katl
 
 [![Fast Checks](https://github.com/katl-dev/katl/actions/workflows/fast-checks.yml/badge.svg)](https://github.com/katl-dev/katl/actions/workflows/fast-checks.yml)
-[![Release](https://img.shields.io/github/v/release/katl-dev/katl?include_prereleases&sort=semver)](https://github.com/katl-dev/katl/releases)
+[![Release](https://img.shields.io/github/v/release/katl-dev/katl?include_prereleases&sort=date)](https://github.com/katl-dev/katl/releases)
 [![License](https://img.shields.io/github/license/katl-dev/katl)](LICENSE)
 
 Katl produces and maintains **KatlOS**, an immutable, installable, upgradeable,

--- a/internal/scriptstest/readme_test.go
+++ b/internal/scriptstest/readme_test.go
@@ -1,0 +1,17 @@
+package scriptstest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadmeReleaseBadgeUsesPublicationOrder(t *testing.T) {
+	readme := string(mustReadFile(t, repoRoot(t)+"/README.md"))
+	const badge = "https://img.shields.io/github/v/release/katl-dev/katl?include_prereleases&sort=date"
+	if !strings.Contains(readme, badge) {
+		t.Fatalf("README release badge must select the latest published prerelease with %q", badge)
+	}
+	if strings.Contains(readme, "include_prereleases&sort=semver") {
+		t.Fatal("README release badge must not rank dev and alpha releases by SemVer identifiers")
+	}
+}


### PR DESCRIPTION
Orders the README release badge by publication date so the current alpha release is not outranked by an older dev identifier. Adds a focused regression test for the badge query.