### PR TITLE
console: render dashboard into reusable buffers

### DIFF
--- a/cmd/katl-console/main.go
+++ b/cmd/katl-console/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -74,10 +75,15 @@ func run(ctx context.Context, args []string) error {
 		StatusPath:  strings.TrimSpace(*statusPath),
 		HandoffPath: strings.TrimSpace(*handoffPath),
 	}
+	snapshotPathValue := strings.TrimSpace(*snapshotPath)
+	var snapshot operatorconsole.Snapshot
+	var renderBuffer []byte
+	var dashboard operatorconsole.Renderer
 	ticker := time.NewTicker(*refresh)
 	defer ticker.Stop()
 	for {
-		if err := render(tty, strings.TrimSpace(*snapshotPath), collector.Collect(ring.Lines())); err != nil {
+		collector.Collect(&snapshot)
+		if err := render(tty, snapshotPathValue, &snapshot, ring, &dashboard, &renderBuffer); err != nil {
 			return err
 		}
 		select {
@@ -88,14 +94,24 @@ func run(ctx context.Context, args []string) error {
 	}
 }
 
-func render(tty *os.File, snapshotPath string, snapshot operatorconsole.Snapshot) error {
+func render(tty *os.File, snapshotPath string, snapshot *operatorconsole.Snapshot, journal operatorconsole.Journal, dashboard *operatorconsole.Renderer, buffer *[]byte) error {
 	width, height := terminalSize(tty)
-	plain := operatorconsole.Render(snapshot, width, height)
-	if _, err := io.WriteString(tty, "\x1b[H\x1b[2J"+plain); err != nil {
+	required := len("\x1b[H\x1b[2J") + operatorconsole.RenderCapacity(width, height)
+	if cap(*buffer) < required {
+		*buffer = make([]byte, 0, required)
+	}
+	data := (*buffer)[:0]
+	data = append(data, "\x1b[H\x1b[2J"...)
+	plainStart := len(data)
+	data = dashboard.Append(data, snapshot, journal, width, height)
+	*buffer = data
+	if written, err := tty.Write(data); err != nil {
 		return fmt.Errorf("render dashboard: %w", err)
+	} else if written != len(data) {
+		return fmt.Errorf("render dashboard: %w", io.ErrShortWrite)
 	}
 	if snapshotPath != "" {
-		if err := writeSnapshot(snapshotPath, []byte(plain)); err != nil {
+		if err := writeSnapshot(snapshotPath, data[plainStart:]); err != nil {
 			return err
 		}
 	}
@@ -139,31 +155,69 @@ func writeSnapshot(path string, data []byte) error {
 
 type journalRing struct {
 	mu    sync.Mutex
-	limit int
-	lines []string
+	lines [][]byte
+	start int
+	count int
 }
+
+const journalLineCapacity = 1024
 
 func newJournalRing(limit int) *journalRing {
-	return &journalRing{limit: limit}
+	storage := make([]byte, limit*journalLineCapacity)
+	lines := make([][]byte, limit)
+	for index := range lines {
+		start := index * journalLineCapacity
+		lines[index] = storage[start : start : start+journalLineCapacity]
+	}
+	return &journalRing{lines: lines}
 }
 
-func (r *journalRing) Add(line string) {
+func (r *journalRing) Add(line []byte) {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return
+	}
+	r.mu.Lock()
+	copy(r.nextLineLocked(len(line)), line)
+	r.mu.Unlock()
+}
+
+func (r *journalRing) AddString(line string) {
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return
 	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.lines = append(r.lines, line)
-	if len(r.lines) > r.limit {
-		r.lines = append([]string(nil), r.lines[len(r.lines)-r.limit:]...)
-	}
+	copy(r.nextLineLocked(len(line)), line)
+	r.mu.Unlock()
 }
 
-func (r *journalRing) Lines() []string {
+func (r *journalRing) nextLineLocked(length int) []byte {
+	index := (r.start + r.count) % len(r.lines)
+	if r.count == len(r.lines) {
+		index = r.start
+		r.start = (r.start + 1) % len(r.lines)
+	} else {
+		r.count++
+	}
+	if cap(r.lines[index]) < length {
+		r.lines[index] = make([]byte, length)
+	} else {
+		r.lines[index] = r.lines[index][:length]
+	}
+	return r.lines[index]
+}
+
+func (r *journalRing) AppendTail(dst []byte, rows, width int) ([]byte, int) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	return append([]string(nil), r.lines...)
+	rows = min(rows, r.count)
+	first := r.count - rows
+	for offset := range rows {
+		index := (r.start + first + offset) % len(r.lines)
+		dst = operatorconsole.AppendJournalLine(dst, r.lines[index], width)
+	}
+	r.mu.Unlock()
+	return dst, rows
 }
 
 func followJournal(ctx context.Context, ring *journalRing) {
@@ -173,7 +227,7 @@ func followJournal(ctx context.Context, ring *journalRing) {
 			return
 		}
 		if err != nil {
-			ring.Add("journal stream unavailable: " + err.Error())
+			ring.AddString("journal stream unavailable: " + err.Error())
 		}
 		select {
 		case <-ctx.Done():
@@ -198,7 +252,7 @@ func streamJournal(ctx context.Context, ring *journalRing, command commandContex
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	var stderrText strings.Builder
+	var stderrText bytes.Buffer
 	done := make(chan struct{})
 	go func() {
 		_, _ = io.Copy(&stderrText, stderr)
@@ -207,7 +261,7 @@ func streamJournal(ctx context.Context, ring *journalRing, command commandContex
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 4096), 256<<10)
 	for scanner.Scan() {
-		ring.Add(scanner.Text())
+		ring.Add(scanner.Bytes())
 	}
 	scanErr := scanner.Err()
 	waitErr := cmd.Wait()
@@ -216,7 +270,7 @@ func streamJournal(ctx context.Context, ring *journalRing, command commandContex
 		return scanErr
 	}
 	if waitErr != nil && !errors.Is(ctx.Err(), context.Canceled) {
-		if detail := strings.TrimSpace(stderrText.String()); detail != "" {
+		if detail := bytes.TrimSpace(stderrText.Bytes()); len(detail) > 0 {
 			return fmt.Errorf("%w: %s", waitErr, detail)
 		}
 		return waitErr

--- a/cmd/katl-console/main_test.go
+++ b/cmd/katl-console/main_test.go
@@ -3,17 +3,57 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestJournalRingIsBounded(t *testing.T) {
 	ring := newJournalRing(2)
-	ring.Add("one")
-	ring.Add("two")
-	ring.Add("three")
-	if got := ring.Lines(); !reflect.DeepEqual(got, []string{"two", "three"}) {
-		t.Fatalf("Lines() = %#v", got)
+	ring.Add([]byte("one"))
+	ring.Add([]byte("two"))
+	ring.Add([]byte("three"))
+	got, rows := ring.AppendTail(make([]byte, 0, 32), 2, 80)
+	if rows != 2 || string(got) != "two\nthree\n" {
+		t.Fatalf("AppendTail() = %q, %d rows", got, rows)
+	}
+}
+
+func TestJournalRingReusesPreallocatedLines(t *testing.T) {
+	ring := newJournalRing(2)
+	line := []byte(strings.Repeat("x", journalLineCapacity))
+	buffer := make([]byte, 0, 4096)
+	allocations := testing.AllocsPerRun(1000, func() {
+		ring.Add(line)
+		buffer, _ = ring.AppendTail(buffer[:0], 2, 80)
+	})
+	if allocations != 0 {
+		t.Fatalf("journal add/render allocations = %v, want 0", allocations)
+	}
+}
+
+func TestJournalRingSPSC(t *testing.T) {
+	ring := newJournalRing(32)
+	done := make(chan struct{})
+	go func() {
+		line := []byte("journal line")
+		for range 10_000 {
+			ring.Add(line)
+		}
+		close(done)
+	}()
+
+	buffer := make([]byte, 0, 4096)
+	for {
+		var rows int
+		buffer, rows = ring.AppendTail(buffer[:0], 8, 80)
+		if rows > 8 {
+			t.Fatalf("AppendTail() rows = %d, want at most 8", rows)
+		}
+		select {
+		case <-done:
+			return
+		default:
+		}
 	}
 }
 

--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -22,11 +22,12 @@ type Collector struct {
 	Addrs       func(net.Interface) ([]net.Addr, error)
 }
 
-func (c Collector) Collect(journal []string) Snapshot {
-	snapshot := Snapshot{
+func (c Collector) Collect(snapshot *Snapshot) {
+	network := snapshot.Network
+	*snapshot = Snapshot{
 		Mode:    c.Mode,
 		Version: strings.TrimSpace(c.Version),
-		Journal: append([]string(nil), journal...),
+		Network: network[:0],
 	}
 	if c.Hostname == nil {
 		c.Hostname = os.Hostname
@@ -40,7 +41,7 @@ func (c Collector) Collect(journal []string) Snapshot {
 	if hostname, err := c.Hostname(); err == nil {
 		snapshot.Hostname = hostname
 	}
-	snapshot.Network = c.collectNetwork()
+	snapshot.Network = c.collectNetwork(snapshot.Network)
 	snapshot.SSHEnabled = c.Mode == ModeRuntime || fileExists(rooted(c.Root, "/etc/katl/installer-ssh.enabled"))
 
 	statusPath := c.StatusPath
@@ -84,24 +85,34 @@ func (c Collector) Collect(journal []string) Snapshot {
 			}
 		}
 	} else {
-		c.collectGeneration(&snapshot)
+		c.collectGeneration(snapshot)
 	}
-	return snapshot
 }
 
-func (c Collector) collectNetwork() []NetworkInterface {
+func (c Collector) collectNetwork(result []NetworkInterface) []NetworkInterface {
 	interfaces, err := c.Interfaces()
 	if err != nil {
-		return nil
+		return result[:0]
 	}
-	result := make([]NetworkInterface, 0, len(interfaces))
+	if cap(result) < len(interfaces) {
+		result = make([]NetworkInterface, 0, len(interfaces))
+	} else {
+		result = result[:0]
+	}
 	for _, iface := range interfaces {
 		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
 			continue
 		}
-		item := NetworkInterface{Name: iface.Name}
+		index := len(result)
+		result = result[:index+1]
+		addressesBuffer := result[index].Addresses[:0]
+		result[index] = NetworkInterface{Name: iface.Name, Addresses: addressesBuffer}
+		item := &result[index]
 		addresses, err := c.Addrs(iface)
 		if err == nil {
+			if cap(item.Addresses) < len(addresses) {
+				item.Addresses = make([]string, 0, len(addresses))
+			}
 			for _, address := range addresses {
 				ip, _, err := net.ParseCIDR(address.String())
 				if err != nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
@@ -111,7 +122,6 @@ func (c Collector) collectNetwork() []NetworkInterface {
 			}
 		}
 		sort.Strings(item.Addresses)
-		result = append(result, item)
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
 	return result

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -30,7 +30,6 @@ type Snapshot struct {
 	SSHEnabled          bool
 	UpdatedAt           time.Time
 	StatusError         string
-	Journal             []string
 }
 
 type NetworkInterface struct {

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -68,15 +68,22 @@ func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 			return nil, nil
 		},
 	}
-	snapshot := collector.Collect([]string{"one", "two"})
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
 	if snapshot.State != installstatus.StateRunning || snapshot.CurrentStep != "InstallRootSlot" || !snapshot.DestructiveMutation {
 		t.Fatalf("snapshot status = %#v", snapshot)
 	}
 	if len(snapshot.Network) != 1 || strings.Join(snapshot.Network[0].Addresses, ",") != "192.0.2.10/24" {
 		t.Fatalf("snapshot network = %#v", snapshot.Network)
 	}
-	if snapshot.Handoff.Token != "token" || len(snapshot.Journal) != 2 {
-		t.Fatalf("snapshot handoff/journal = %#v", snapshot)
+	if snapshot.Handoff.Token != "token" {
+		t.Fatalf("snapshot handoff = %#v", snapshot)
+	}
+	network := &snapshot.Network[0]
+	address := &snapshot.Network[0].Addresses[0]
+	collector.Collect(&snapshot)
+	if &snapshot.Network[0] != network || &snapshot.Network[0].Addresses[0] != address {
+		t.Fatal("Collect() did not reuse snapshot network storage")
 	}
 }
 
@@ -91,9 +98,10 @@ func TestRenderInstallerDashboard(t *testing.T) {
 		DestructiveMutation: true,
 		Handoff:             Handoff{URL: "http://192.0.2.10:8080/v1/config-bundle", Token: "secret-token"},
 		Network:             []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
-		Journal:             []string{"old line", "installing root\x1b[31m", "latest line"},
 	}
-	got := Render(snapshot, 80, 25)
+	journal := testJournal{[]byte("old line"), []byte("installing root\x1b[31m"), []byte("latest line")}
+	var renderer Renderer
+	got := string(renderer.Append(make([]byte, 0, RenderCapacity(80, 25)), &snapshot, journal, 80, 25))
 	for _, want := range []string{
 		"KatlOS Installer  2026.7.0-alpha.9",
 		"State:        Installing",
@@ -121,7 +129,7 @@ func TestRenderInstallerDashboard(t *testing.T) {
 }
 
 func TestRenderRuntimeFailure(t *testing.T) {
-	got := Render(Snapshot{
+	snapshot := Snapshot{
 		Mode:             ModeRuntime,
 		Version:          "2026.7.0-alpha.9",
 		Hostname:         "cp-1",
@@ -133,10 +141,45 @@ func TestRenderRuntimeFailure(t *testing.T) {
 		RetryHint:        "inspect the previous generation",
 		SSHEnabled:       true,
 		Network:          []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
-	}, 80, 20)
+	}
+	var renderer Renderer
+	got := string(renderer.Append(make([]byte, 0, RenderCapacity(80, 20)), &snapshot, nil, 80, 20))
 	for _, want := range []string{"Installed system needs repair", "Generation:   4  boot=failed health=unhealthy", "Error:", "boot health check failed", "SSH: ssh root@192.0.2.20"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
 	}
+}
+
+func TestRendererReusesBuffer(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:       ModeRuntime,
+		State:      installstatus.StateKubeadmReady,
+		SSHEnabled: true,
+	}
+	journal := testJournal{[]byte("journal line")}
+	var renderer Renderer
+	buffer := make([]byte, 0, RenderCapacity(80, 25))
+	buffer = renderer.Append(buffer, &snapshot, &journal, 80, 25)
+	start := &buffer[0]
+
+	allocations := testing.AllocsPerRun(1000, func() {
+		buffer = renderer.Append(buffer[:0], &snapshot, &journal, 80, 25)
+	})
+	if allocations != 0 {
+		t.Fatalf("Renderer.Append() allocations = %v, want 0", allocations)
+	}
+	if &buffer[0] != start {
+		t.Fatal("Renderer.Append() replaced caller-owned buffer")
+	}
+}
+
+type testJournal [][]byte
+
+func (j testJournal) AppendTail(dst []byte, rows, width int) ([]byte, int) {
+	rows = min(rows, len(j))
+	for _, line := range j[len(j)-rows:] {
+		dst = AppendJournalLine(dst, line, width)
+	}
+	return dst, rows
 }

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -1,206 +1,485 @@
 package operatorconsole
 
 import (
-	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 )
 
-func Render(snapshot Snapshot, width, height int) string {
-	if width < 40 {
-		width = 40
-	}
-	if height < 12 {
-		height = 12
-	}
-	lines := make([]string, 0, height)
-	title := "KatlOS"
-	if snapshot.Mode == ModeInstaller {
-		title += " Installer"
-	}
-	if snapshot.Version != "" {
-		title += "  " + snapshot.Version
-	}
-	lines = append(lines, title, strings.Repeat("=", min(width, 72)))
-	lines = append(lines, field("State", stateLabel(snapshot.State)))
-	if snapshot.Hostname != "" {
-		lines = append(lines, field("Node", snapshot.Hostname))
-	}
-	lines = append(lines, networkLines(snapshot.Network)...)
-	if snapshot.CurrentStep != "" {
-		lines = append(lines, field("Current step", snapshot.CurrentStep))
-	}
-	if snapshot.TargetDisk != "" {
-		lines = append(lines, field("Target disk", snapshot.TargetDisk))
-	}
-	if snapshot.Generation != "" {
-		value := snapshot.Generation
-		if snapshot.GenerationBoot != "" || snapshot.GenerationHealth != "" {
-			value += fmt.Sprintf("  boot=%s health=%s", fallback(snapshot.GenerationBoot, "unknown"), fallback(snapshot.GenerationHealth, "unknown"))
-		}
-		lines = append(lines, field("Generation", value))
-	}
-	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
-		mutation := "not started"
-		if snapshot.DestructiveMutation {
-			mutation = "started - do not power off"
-		}
-		lines = append(lines, field("Disk changes", mutation))
-	}
-	if snapshot.Handoff.URL != "" {
-		lines = append(lines, field("Configure", snapshot.Handoff.URL), field("Token", snapshot.Handoff.Token))
-		lines = append(lines, "From another machine use: katlctl install apply")
-	}
-	if snapshot.LastError != "" {
-		lines = append(lines, wrapField("Error", snapshot.LastError, width)...)
-	}
-	if snapshot.RetryHint != "" {
-		lines = append(lines, wrapField("Next action", snapshot.RetryHint, width)...)
-	}
-	if snapshot.StatusError != "" {
-		lines = append(lines, wrapField("Status read", snapshot.StatusError, width)...)
+const (
+	minimumWidth  = 40
+	minimumHeight = 12
+	fieldWidth    = 14
+)
+
+// Journal appends its newest lines to dst. Implementations may retain a lock
+// while appending because the caller has already reserved enough render memory.
+type Journal interface {
+	AppendTail(dst []byte, rows, width int) ([]byte, int)
+}
+
+// RenderCapacity returns enough capacity for a complete render without growth.
+// UTFMax accounts for every terminal cell containing a four-byte UTF-8 rune.
+func RenderCapacity(width, height int) int {
+	width, height = renderDimensions(width, height)
+	return height * (width*utf8.UTFMax + 1)
+}
+
+// Renderer retains line state between calls so fluent line construction does
+// not allocate.
+type Renderer struct {
+	dst         []byte
+	width       int
+	contentRows int
+	rows        int
+	lineState   lineWriter
+}
+
+// Append appends a dashboard to caller-owned memory.
+func (render *Renderer) Append(dst []byte, snapshot *Snapshot, journal Journal, width, height int) []byte {
+	width, height = renderDimensions(width, height)
+	*render = Renderer{
+		dst:         dst,
+		width:       width,
+		contentRows: height - 1,
 	}
 
-	footer := "Ctrl+Alt+F2: local console"
-	if snapshot.SSHEnabled {
-		if address := firstIPv4(snapshot.Network); address != "" {
-			footer += " | SSH: ssh root@" + address
-		} else {
-			footer += " | SSH enabled"
-		}
-	} else if snapshot.Mode == ModeInstaller {
-		footer += " | SSH disabled by installer config"
+	line := render.line().appendString("KatlOS")
+	if snapshot.Mode == ModeInstaller {
+		line.appendString(" Installer")
 	}
-	journalRows := height - len(lines) - 3
+	if snapshot.Version != "" {
+		line.appendString("  ")
+		line.appendString(snapshot.Version)
+	}
+	line.finish()
+
+	line = render.line()
+	for range min(width, 72) {
+		line.appendByte('=')
+	}
+	line.finish()
+
+	render.fieldLine("State").appendString(stateLabel(snapshot.State)).finish()
+	if snapshot.Hostname != "" {
+		render.fieldLine("Node").appendString(snapshot.Hostname).finish()
+	}
+	appendNetwork(render, snapshot.Network)
+	if snapshot.CurrentStep != "" {
+		render.fieldLine("Current step").appendString(snapshot.CurrentStep).finish()
+	}
+	if snapshot.TargetDisk != "" {
+		render.fieldLine("Target disk").appendString(snapshot.TargetDisk).finish()
+	}
+	if snapshot.Generation != "" {
+		line = render.fieldLine("Generation")
+		line.appendString(snapshot.Generation)
+		if snapshot.GenerationBoot != "" || snapshot.GenerationHealth != "" {
+			line.appendString("  boot=")
+			line.appendString(fallback(snapshot.GenerationBoot, "unknown"))
+			line.appendString(" health=")
+			line.appendString(fallback(snapshot.GenerationHealth, "unknown"))
+		}
+		line.finish()
+	}
+	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
+		line = render.fieldLine("Disk changes")
+		if snapshot.DestructiveMutation {
+			line.appendString("started - do not power off")
+		} else {
+			line.appendString("not started")
+		}
+		line.finish()
+	}
+	if snapshot.Handoff.URL != "" {
+		render.fieldLine("Configure").appendString(snapshot.Handoff.URL).finish()
+		render.fieldLine("Token").appendString(snapshot.Handoff.Token).finish()
+		render.line().appendString("From another machine use: katlctl install apply").finish()
+	}
+	appendWrappedField(render, "Error", snapshot.LastError)
+	appendWrappedField(render, "Next action", snapshot.RetryHint)
+	appendWrappedField(render, "Status read", snapshot.StatusError)
+
+	journalRows := height - statusRows(snapshot, width) - 3
 	if journalRows < 2 {
 		journalRows = 2
 	}
-	lines = append(lines, "", "Journal (live)")
-	journal := snapshot.Journal
-	if len(journal) > journalRows {
-		journal = journal[len(journal)-journalRows:]
+	render.finishBlank()
+	render.line().appendString("Journal (live)").finish()
+	if remaining := render.contentRows - render.rows; journal != nil && remaining > 0 {
+		journalRows = min(journalRows, remaining)
+		var written int
+		render.dst, written = journal.AppendTail(render.dst, journalRows, width)
+		render.rows += written
 	}
-	for _, line := range journal {
-		lines = append(lines, truncate(sanitize(line), width))
+	for render.rows < render.contentRows {
+		render.finishBlank()
 	}
-	for len(lines) < height-1 {
-		lines = append(lines, "")
+
+	footer := newLine(render.dst, width)
+	footer.appendString("Ctrl+Alt+F2: local console")
+	if snapshot.SSHEnabled {
+		if address := firstIPv4(snapshot.Network); address != "" {
+			footer.appendString(" | SSH: ssh root@")
+			footer.appendString(address)
+		} else {
+			footer.appendString(" | SSH enabled")
+		}
+	} else if snapshot.Mode == ModeInstaller {
+		footer.appendString(" | SSH disabled by installer config")
 	}
-	if len(lines) >= height {
-		lines = lines[:height-1]
-	}
-	lines = append(lines, truncate(footer, width))
-	for i := range lines {
-		lines[i] = truncate(lines[i], width)
-	}
-	return strings.Join(lines, "\n") + "\n"
+	return footer.end()
 }
 
-func networkLines(network []NetworkInterface) []string {
-	if len(network) == 0 {
-		return []string{field("Network", "waiting for an active interface")}
+// AppendJournalLine sanitizes, truncates, and appends one journal row.
+func AppendJournalLine(dst, value []byte, width int) []byte {
+	if width < minimumWidth {
+		width = minimumWidth
 	}
-	lines := make([]string, 0, len(network))
-	for i, iface := range network {
-		value := iface.Name + ": configuring"
-		if len(iface.Addresses) > 0 {
-			value = iface.Name + ": " + strings.Join(iface.Addresses, ", ")
+	line := newLine(dst, width)
+	line.appendBytes(value)
+	return line.end()
+}
+
+func (r *Renderer) line() *lineWriter {
+	if r.rows >= r.contentRows {
+		r.lineState = lineWriter{owner: r}
+		return &r.lineState
+	}
+	r.lineState = newLine(r.dst, r.width)
+	r.lineState.owner = r
+	return &r.lineState
+}
+
+func (r *Renderer) fieldLine(label string) *lineWriter {
+	line := r.line()
+	if !line.active {
+		return line
+	}
+	line.appendString(label)
+	if label != "" {
+		line.appendByte(':')
+	}
+	for line.columns < fieldWidth {
+		line.appendByte(' ')
+	}
+	return line
+}
+
+func (r *Renderer) continuationLine() *lineWriter {
+	line := r.line()
+	if !line.active {
+		return line
+	}
+	for range fieldWidth {
+		line.appendByte(' ')
+	}
+	return line
+}
+
+func (r *Renderer) finishLine(line *lineWriter) {
+	if r.rows < r.contentRows {
+		r.dst = line.end()
+	}
+	r.rows++
+}
+
+func (r *Renderer) finishBlank() {
+	r.line().finish()
+}
+
+type lineWriter struct {
+	owner     *Renderer
+	dst       []byte
+	lastRune  int
+	width     int
+	columns   int
+	truncated bool
+	active    bool
+}
+
+func newLine(dst []byte, width int) lineWriter {
+	return lineWriter{dst: dst, lastRune: len(dst), width: width, active: true}
+}
+
+func (l *lineWriter) appendByte(value byte) *lineWriter {
+	if !l.active || l.truncated {
+		return l
+	}
+	if l.columns == l.width {
+		l.truncated = true
+		return l
+	}
+	l.lastRune = len(l.dst)
+	l.dst = append(l.dst, value)
+	l.columns++
+	return l
+}
+
+func (l *lineWriter) appendString(value string) *lineWriter {
+	for len(value) > 0 && !l.truncated && l.active {
+		r, size := utf8.DecodeRuneInString(value)
+		encoded := value[:size]
+		value = value[size:]
+		if r == '\t' {
+			l.appendByte(' ')
+			continue
 		}
+		if unicode.IsControl(r) {
+			continue
+		}
+		if l.columns == l.width {
+			l.truncated = true
+			return l
+		}
+		l.lastRune = len(l.dst)
+		if r == utf8.RuneError && size == 1 {
+			l.dst = utf8.AppendRune(l.dst, r)
+		} else {
+			l.dst = append(l.dst, encoded...)
+		}
+		l.columns++
+	}
+	return l
+}
+
+func (l *lineWriter) appendBytes(value []byte) *lineWriter {
+	for len(value) > 0 && !l.truncated && l.active {
+		r, size := utf8.DecodeRune(value)
+		encoded := value[:size]
+		value = value[size:]
+		if r == '\t' {
+			l.appendByte(' ')
+			continue
+		}
+		if unicode.IsControl(r) {
+			continue
+		}
+		if l.columns == l.width {
+			l.truncated = true
+			return l
+		}
+		l.lastRune = len(l.dst)
+		if r == utf8.RuneError && size == 1 {
+			l.dst = utf8.AppendRune(l.dst, r)
+		} else {
+			l.dst = append(l.dst, encoded...)
+		}
+		l.columns++
+	}
+	return l
+}
+
+func (l *lineWriter) finish() {
+	l.owner.finishLine(l)
+}
+
+func (l *lineWriter) end() []byte {
+	if !l.active {
+		return l.dst
+	}
+	if l.truncated {
+		l.dst = l.dst[:l.lastRune]
+		l.dst = append(l.dst, '~')
+	}
+	return append(l.dst, '\n')
+}
+
+func appendNetwork(render *Renderer, network []NetworkInterface) {
+	if len(network) == 0 {
+		render.fieldLine("Network").appendString("waiting for an active interface").finish()
+		return
+	}
+	for index, iface := range network {
 		label := ""
-		if i == 0 {
+		if index == 0 {
 			label = "Network"
 		}
-		lines = append(lines, field(label, value))
+		line := render.fieldLine(label)
+		line.appendString(iface.Name)
+		if len(iface.Addresses) == 0 {
+			line.appendString(": configuring")
+		} else {
+			line.appendString(": ")
+			for addressIndex, address := range iface.Addresses {
+				if addressIndex > 0 {
+					line.appendString(", ")
+				}
+				line.appendString(address)
+			}
+		}
+		line.finish()
 	}
-	return lines
+}
+
+func appendWrappedField(render *Renderer, label, value string) {
+	if value == "" {
+		return
+	}
+	available := max(render.width-fieldWidth, 10)
+	line := render.fieldLine(label)
+	position := 0
+	currentWidth := 0
+	wroteWord := false
+	for {
+		word, next, width, ok := nextWord(value, position)
+		if !ok {
+			break
+		}
+		position = next
+		if wroteWord && currentWidth+1+width > available {
+			line.finish()
+			line = render.continuationLine()
+			currentWidth = 0
+			wroteWord = false
+		}
+		if wroteWord {
+			line.appendByte(' ')
+			currentWidth++
+		}
+		line.appendString(word)
+		currentWidth += width
+		wroteWord = true
+	}
+	line.finish()
+}
+
+func statusRows(snapshot *Snapshot, width int) int {
+	rows := 3 // title, separator, state
+	if snapshot.Hostname != "" {
+		rows++
+	}
+	rows += max(len(snapshot.Network), 1)
+	if snapshot.CurrentStep != "" {
+		rows++
+	}
+	if snapshot.TargetDisk != "" {
+		rows++
+	}
+	if snapshot.Generation != "" {
+		rows++
+	}
+	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
+		rows++
+	}
+	if snapshot.Handoff.URL != "" {
+		rows += 3
+	}
+	if snapshot.LastError != "" {
+		rows += wrappedRows(snapshot.LastError, width)
+	}
+	if snapshot.RetryHint != "" {
+		rows += wrappedRows(snapshot.RetryHint, width)
+	}
+	if snapshot.StatusError != "" {
+		rows += wrappedRows(snapshot.StatusError, width)
+	}
+	return rows
+}
+
+func wrappedRows(value string, width int) int {
+	available := max(width-fieldWidth, 10)
+	position := 0
+	rows := 0
+	currentWidth := 0
+	for {
+		_, next, wordWidth, ok := nextWord(value, position)
+		if !ok {
+			break
+		}
+		position = next
+		if rows == 0 {
+			rows = 1
+			currentWidth = wordWidth
+			continue
+		}
+		if currentWidth+1+wordWidth > available {
+			rows++
+			currentWidth = wordWidth
+		} else {
+			currentWidth += 1 + wordWidth
+		}
+	}
+	return max(rows, 1)
+}
+
+func nextWord(value string, position int) (string, int, int, bool) {
+	for position < len(value) {
+		r, size := utf8.DecodeRuneInString(value[position:])
+		if wordSeparator(r) {
+			position += size
+			continue
+		}
+		if !unicode.IsControl(r) {
+			break
+		}
+		position += size
+	}
+	if position == len(value) {
+		return "", position, 0, false
+	}
+	start := position
+	width := 0
+	for position < len(value) {
+		r, size := utf8.DecodeRuneInString(value[position:])
+		if wordSeparator(r) {
+			break
+		}
+		position += size
+		if !unicode.IsControl(r) {
+			width++
+		}
+	}
+	return value[start:position], position, width, true
+}
+
+func wordSeparator(r rune) bool {
+	return r == '\t' || (!unicode.IsControl(r) && unicode.IsSpace(r))
 }
 
 func stateLabel(state string) string {
-	labels := map[string]string{
-		"starting-installer":            "Starting installer",
-		"starting-runtime":              "Starting installed system",
-		"running":                       "Installing",
-		"debug-hold":                    "Debug hold; installation disabled",
-		"waiting-for-config":            "Waiting for configuration",
-		"install-refused":               "Installation refused",
-		"failed-before-mutation":        "Installation failed; disk unchanged",
-		"failed-after-mutation":         "Installation failed; repair required",
-		"reboot-requested":              "Installation complete; rebooting",
-		"kubeadm-ready":                 "Ready for Kubernetes bootstrap",
-		"waiting-for-cluster-bootstrap": "Waiting for Kubernetes bootstrap",
-		"runtime-booted-not-ready":      "Installed system booted; not ready",
-		"runtime-failed-needs-repair":   "Installed system needs repair",
+	switch state {
+	case "starting-installer":
+		return "Starting installer"
+	case "starting-runtime":
+		return "Starting installed system"
+	case "running":
+		return "Installing"
+	case "debug-hold":
+		return "Debug hold; installation disabled"
+	case "waiting-for-config":
+		return "Waiting for configuration"
+	case "install-refused":
+		return "Installation refused"
+	case "failed-before-mutation":
+		return "Installation failed; disk unchanged"
+	case "failed-after-mutation":
+		return "Installation failed; repair required"
+	case "reboot-requested":
+		return "Installation complete; rebooting"
+	case "kubeadm-ready":
+		return "Ready for Kubernetes bootstrap"
+	case "waiting-for-cluster-bootstrap":
+		return "Waiting for Kubernetes bootstrap"
+	case "runtime-booted-not-ready":
+		return "Installed system booted; not ready"
+	case "runtime-failed-needs-repair":
+		return "Installed system needs repair"
+	default:
+		return fallback(state, "Unknown")
 	}
-	if label := labels[state]; label != "" {
-		return label
-	}
-	return fallback(state, "Unknown")
-}
-
-func field(label, value string) string {
-	if label == "" {
-		return fmt.Sprintf("%-14s%s", "", value)
-	}
-	return fmt.Sprintf("%-14s%s", label+":", value)
-}
-
-func wrapField(label, value string, width int) []string {
-	prefix := field(label, "")
-	available := width - utf8.RuneCountInString(prefix)
-	if available < 10 {
-		available = 10
-	}
-	words := strings.Fields(sanitize(value))
-	if len(words) == 0 {
-		return []string{prefix}
-	}
-	var lines []string
-	current := ""
-	for _, word := range words {
-		if current != "" && utf8.RuneCountInString(current)+1+utf8.RuneCountInString(word) > available {
-			lines = append(lines, prefix+current)
-			prefix = strings.Repeat(" ", utf8.RuneCountInString(prefix))
-			current = word
-			continue
-		}
-		if current != "" {
-			current += " "
-		}
-		current += word
-	}
-	return append(lines, prefix+current)
-}
-
-func sanitize(value string) string {
-	return strings.Map(func(r rune) rune {
-		if r == '\t' {
-			return ' '
-		}
-		if unicode.IsControl(r) {
-			return -1
-		}
-		return r
-	}, value)
-}
-
-func truncate(value string, width int) string {
-	runes := []rune(value)
-	if len(runes) <= width {
-		return value
-	}
-	if width < 2 {
-		return string(runes[:width])
-	}
-	return string(runes[:width-1]) + "~"
 }
 
 func firstIPv4(network []NetworkInterface) string {
 	for _, iface := range network {
 		for _, address := range iface.Addresses {
-			if strings.Contains(address, ".") {
-				return strings.SplitN(address, "/", 2)[0]
+			if strings.IndexByte(address, '.') < 0 {
+				continue
 			}
+			if slash := strings.IndexByte(address, '/'); slash >= 0 {
+				return address[:slash]
+			}
+			return address
 		}
 	}
 	return ""
@@ -211,4 +490,8 @@ func fallback(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func renderDimensions(width, height int) (int, int) {
+	return max(width, minimumWidth), max(height, minimumHeight)
 }


### PR DESCRIPTION
## Summary

Render the operator dashboard directly into reusable caller-owned byte memory, reuse collector network storage, and retain journal output in a preallocated fixed-capacity byte ring.

This removes per-refresh string construction, journal slice cloning, and string-to-byte conversions while narrowing synchronization to journal slot writes and selected-tail rendering. The fluent line renderer keeps the dashboard layout readable without reintroducing warmed-path allocations.

Validated by the repository-wide Go test suite and race-enabled console and operator-console tests, including zero-allocation and concurrent SPSC coverage.
