### PR TITLE
installer: simplify trusted-network apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,16 @@ Use the readable version tag on the normal path. Katl resolves the selected
 content once for the operation and checks what it downloads internally. An
 immutable digest pin remains available as an optional reproducibility control.
 
-Compile one bundle for all nodes. The command checks the source as part of
-building it:
+Keep `cluster.yaml` as the operator-facing source. `katlctl` compiles the
+internal bundle automatically when installing and bootstrapping. Explicit
+bundle output remains available for PXE and offline provisioning:
 
 ```sh
 katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
 ```
 
-Katl verifies the bundle's content-addressed structure whenever it reads the
-file; operators do not need to copy or pass its internal digests.
+Operators do not need to produce this file for the normal ISO path or copy any
+of its internal digests.
 
 ### 3. Install each node
 
@@ -134,27 +135,19 @@ Attach or write `katl-installer.iso` using your normal UEFI virtual-media or USB
 workflow, then boot it. The installer reports progress on both a local VGA
 console and a 115200-baud serial console. Secure Boot must remain disabled until
 Katl publishes signed boot artifacts. Without preseed input, the installer waits
-safely and prints an HTTP handoff URL and one-time token. Store the token in a
-protected temporary file, then submit the same bundle to every node while
-selecting that node by name:
+safely and prints its HTTP handoff URL. On the trusted provisioning network,
+apply the cluster source while selecting the node by name:
 
 ```sh
 INSTALLER_ENDPOINT=http://192.0.2.10:8080
-umask 077
-read -rsp 'Installer token: ' INSTALL_TOKEN; printf '\n'
-printf '%s\n' "$INSTALL_TOKEN" > ./installer.token
-unset INSTALL_TOKEN
-
-katlctl install apply \
+katlctl install apply ./cluster.yaml \
   --endpoint "$INSTALLER_ENDPOINT" \
-  --token-file ./installer.token \
-  --config-bundle ./katl-lab.katlcfg \
   --node cp-1
 ```
 
-The command validates the bundle and selected node locally, confirms the
-installer is waiting, submits once, and waits for reboot-ready or a classified
-failure. Remove the temporary token file after the handoff.
+The command validates and compiles the source locally, confirms the installer
+is waiting, submits the selected configuration once, and waits for reboot-ready
+or a classified failure.
 
 Installation is destructive only when both the resolved node sets
 `install.wipeTarget: true` and boot input authorizes automatic installation.
@@ -167,13 +160,12 @@ activation. Kubernetes bootstrap is a separate operator action.
 ### 4. Bootstrap Kubernetes
 
 Once all installed nodes are reachable through their `katlc` endpoints, use the
-same config bundle. First retrieve each node's distinct
+same cluster source. First retrieve each node's distinct
 agent token over SSH and populate the per-node `file:` credential references as
 described in [Access installed nodes](docs/operations/access.md):
 
 ```sh
-katlctl cluster bootstrap \
-  --config-bundle ./katl-lab.katlcfg \
+katlctl cluster bootstrap ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -21,14 +20,12 @@ import (
 const (
 	maxInstallBundleSize   = 64 << 20
 	maxInstallResponseSize = 1 << 20
-	maxInstallTokenSize    = 4 << 10
+	installApplyCreator    = "katlctl install apply"
 )
 
 type installApplyOptions struct {
 	endpoint   string
-	token      string
-	tokenFile  string
-	bundlePath string
+	sourcePath string
 	nodeName   string
 	noWait     bool
 	timeout    time.Duration
@@ -59,18 +56,16 @@ func newInstallCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := installApplyOptions{timeout: 30 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "apply",
-		Short: "Submit one config bundle to a waiting KatlOS installer",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Use:   "apply SOURCE",
+		Short: "Compile a cluster config and apply it to a waiting KatlOS installer",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			opts.sourcePath = args[0]
 			return runInstallApply(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL such as http://192.0.2.10:8080")
-	cmd.Flags().StringVar(&opts.token, "token", "", "one-time installer token; --token-file avoids shell history exposure")
-	cmd.Flags().StringVar(&opts.tokenFile, "token-file", "", "protected file containing the one-time installer token")
-	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "Katl config bundle")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the config bundle")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the cluster config")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
@@ -104,25 +99,31 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
-	token, err := readInstallToken(opts.token, opts.tokenFile)
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(opts.bundlePath) == "" {
-		return fmt.Errorf("--config-bundle is required")
+	if strings.TrimSpace(opts.sourcePath) == "" {
+		return fmt.Errorf("source config path is required")
 	}
 	if strings.TrimSpace(opts.nodeName) == "" {
 		return fmt.Errorf("--node is required")
 	}
-	if err := validateInstallBundleSize(opts.bundlePath); err != nil {
-		return err
+	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
+		SourcePath:     opts.sourcePath,
+		KatlctlVersion: version,
+		KatlctlCommit:  commit,
+		CreatedBy:      installApplyCreator,
+	})
+	if err != nil {
+		return fmt.Errorf("compile cluster config: %w", err)
 	}
-	selected, err := configbundle.ReadSelectedNodeFile(opts.bundlePath, configbundle.ReadOptions{
+	if len(archive) > maxInstallBundleSize {
+		return fmt.Errorf("compiled config bundle size %d exceeds %d bytes", len(archive), maxInstallBundleSize)
+	}
+	selected, err := configbundle.ReadSelectedNode(bytes.NewReader(archive), configbundle.ReadOptions{
+		ExpectedDigest:          result.Digest,
 		NodeName:                opts.nodeName,
 		AllowMissingKatlosImage: true,
 	})
 	if err != nil {
-		return fmt.Errorf("validate config bundle: %w", err)
+		return fmt.Errorf("select node from compiled cluster config: %w", err)
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, opts.timeout)
@@ -130,15 +131,15 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	client := &http.Client{Timeout: requestTimeout(opts.timeout)}
 	before, err := fetchInstallStatus(waitCtx, client, endpoint)
 	if err != nil {
-		return redactInstallError(err, token)
+		return err
 	}
 	if before.State != handoff.HandoffWaiting {
 		return fmt.Errorf("installer is not accepting config: state=%s selectedNode=%s", before.State, before.SelectedNode)
 	}
 
-	accepted, err := submitInstallBundle(waitCtx, client, endpoint, token, opts.bundlePath, selected.BundleDigest, selected.Node.Name)
+	accepted, err := submitInstallBundle(waitCtx, client, endpoint, archive, selected.BundleDigest, selected.Node.Name)
 	if err != nil {
-		return redactInstallError(err, token)
+		return err
 	}
 	report := newInstallHandoffReport(endpoint, selected.Node.Name, accepted)
 	if opts.noWait {
@@ -146,7 +147,7 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	}
 	status, err := waitForInstall(waitCtx, client, endpoint, accepted, stderr)
 	if err != nil {
-		return redactInstallError(err, token)
+		return err
 	}
 	report.Handoff = status
 	if err := writeInstallReport(stdout, report); err != nil {
@@ -207,63 +208,6 @@ func normalizeInstallerEndpoint(value string) (string, error) {
 	return strings.TrimRight(parsed.String(), "/"), nil
 }
 
-func readInstallToken(value, path string) (string, error) {
-	value = strings.TrimSpace(value)
-	path = strings.TrimSpace(path)
-	if (value == "") == (path == "") {
-		return "", fmt.Errorf("exactly one of --token or --token-file is required")
-	}
-	if path != "" {
-		file, err := os.Open(path)
-		if err != nil {
-			return "", fmt.Errorf("open installer token file: %w", err)
-		}
-		defer file.Close()
-		info, err := file.Stat()
-		if err != nil {
-			return "", fmt.Errorf("stat installer token file: %w", err)
-		}
-		if !info.Mode().IsRegular() {
-			return "", fmt.Errorf("installer token file must be a regular file")
-		}
-		if info.Mode().Perm()&0o077 != 0 {
-			return "", fmt.Errorf("installer token file permissions must not allow group or other access")
-		}
-		data, err := io.ReadAll(io.LimitReader(file, maxInstallTokenSize+1))
-		if err != nil {
-			return "", fmt.Errorf("read installer token file: %w", err)
-		}
-		if len(data) > maxInstallTokenSize {
-			return "", fmt.Errorf("installer token file exceeds %d bytes", maxInstallTokenSize)
-		}
-		value = strings.TrimSpace(string(data))
-	}
-	if value == "" {
-		return "", fmt.Errorf("installer token is empty")
-	}
-	if strings.ContainsAny(value, "\r\n") {
-		return "", fmt.Errorf("installer token must be one line")
-	}
-	return value, nil
-}
-
-func validateInstallBundleSize(path string) error {
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("stat config bundle: %w", err)
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("config bundle must be a regular file")
-	}
-	if info.Size() <= 0 {
-		return fmt.Errorf("config bundle is empty")
-	}
-	if info.Size() > maxInstallBundleSize {
-		return fmt.Errorf("config bundle size %d exceeds %d bytes", info.Size(), maxInstallBundleSize)
-	}
-	return nil
-}
-
 func fetchInstallStatus(ctx context.Context, client *http.Client, endpoint string) (handoff.HandoffStatus, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/v1/status", nil)
 	if err != nil {
@@ -273,12 +217,7 @@ func fetchInstallStatus(ctx context.Context, client *http.Client, endpoint strin
 	return doInstallRequest(client, req, "read installer status")
 }
 
-func submitInstallBundle(ctx context.Context, client *http.Client, endpoint, token, path, digest, node string) (handoff.HandoffStatus, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return handoff.HandoffStatus{}, fmt.Errorf("open config bundle: %w", err)
-	}
-	defer file.Close()
+func submitInstallBundle(ctx context.Context, client *http.Client, endpoint string, archive []byte, digest, node string) (handoff.HandoffStatus, error) {
 	requestURL, err := url.Parse(endpoint + "/v1/config-bundle")
 	if err != nil {
 		return handoff.HandoffStatus{}, fmt.Errorf("create installer handoff URL: %w", err)
@@ -287,14 +226,11 @@ func submitInstallBundle(ctx context.Context, client *http.Client, endpoint, tok
 	query.Set("node", node)
 	query.Set("digest", digest)
 	requestURL.RawQuery = query.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), file)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(archive))
 	if err != nil {
 		return handoff.HandoffStatus{}, fmt.Errorf("create installer handoff request: %w", err)
 	}
-	if info, statErr := file.Stat(); statErr == nil {
-		req.ContentLength = info.Size()
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.ContentLength = int64(len(archive))
 	req.Header.Set("Content-Type", "application/vnd.katl.config.bundle.v1")
 	req.Header.Set("Accept", "application/json")
 	return doInstallRequest(client, req, "submit installer config bundle")
@@ -411,11 +347,4 @@ func writeInstallReport(stdout io.Writer, report installHandoffReport) error {
 	}
 	_, err = stdout.Write(append(data, '\n'))
 	return err
-}
-
-func redactInstallError(err error, token string) error {
-	if err == nil || strings.TrimSpace(token) == "" {
-		return err
-	}
-	return fmt.Errorf("%s", strings.ReplaceAll(err.Error(), token, "<redacted>"))
 }

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -20,15 +18,12 @@ import (
 )
 
 func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
-	server, err := handoff.NewHandoffServer("install-token", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := handoff.NewHandoffServer(nil)
 	ts := httptest.NewServer(server.Handler())
 	defer ts.Close()
 
 	var stdout, stderr bytes.Buffer
-	err = run(context.Background(), []string{"install", "status", "--endpoint", ts.URL}, &stdout, &stderr)
+	err := run(context.Background(), []string{"install", "status", "--endpoint", ts.URL}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
 	}
@@ -41,21 +36,16 @@ func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
 	}
 }
 
-func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
-	server, err := handoff.NewHandoffServer("install-token", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
+	sourcePath := writeClusterConfig(t)
+	server := handoff.NewHandoffServer(nil)
 	ts := httptest.NewServer(server.Handler())
 	defer ts.Close()
 
 	var stdout, stderr bytes.Buffer
-	err = run(context.Background(), []string{
-		"install", "apply",
+	err := run(context.Background(), []string{
+		"install", "apply", sourcePath,
 		"--endpoint", ts.URL,
-		"--token", "install-token",
-		"--config-bundle", bundlePath,
 		"--node", "cp-1",
 		"--no-wait",
 	}, &stdout, &stderr)
@@ -75,35 +65,25 @@ func TestInstallApplyValidatesAndSubmitsBundle(t *testing.T) {
 	}
 }
 
-func TestInstallApplyReadsProtectedTokenFile(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
-	server, err := handoff.NewHandoffServer("file-token", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ts := httptest.NewServer(server.Handler())
-	defer ts.Close()
-	tokenPath := filepath.Join(t.TempDir(), "installer.token")
-	if err := os.WriteFile(tokenPath, []byte("file-token\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
+func TestInstallApplyHelpKeepsBundleInternal(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	err = run(context.Background(), []string{
-		"install", "apply",
-		"--endpoint", ts.URL,
-		"--token-file", tokenPath,
-		"--config-bundle", bundlePath,
-		"--node", "cp-1",
-		"--no-wait",
-	}, &stdout, &stderr)
+	err := run(context.Background(), []string{"install", "apply", "--help"}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	help := stdout.String()
+	if !strings.Contains(help, "katlctl install apply SOURCE") {
+		t.Fatalf("help does not advertise source input:\n%s", help)
+	}
+	for _, hiddenDetail := range []string{"--config-bundle", "--token", "--token-file"} {
+		if strings.Contains(help, hiddenDetail) {
+			t.Fatalf("help exposes %q:\n%s", hiddenDetail, help)
+		}
 	}
 }
 
 func TestInstallApplyWaitsForRebootReady(t *testing.T) {
-	bundlePath, bundleDigest := writeConfigBundle(t)
+	sourcePath := writeClusterConfig(t)
 	var statusRequests atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/status", func(w http.ResponseWriter, _ *http.Request) {
@@ -117,7 +97,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(status)
 	})
 	mux.HandleFunc("POST /v1/config-bundle", func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer wait-token" || r.URL.Query().Get("node") != "cp-1" || r.URL.Query().Get("digest") != bundleDigest {
+		if r.Header.Get("Authorization") != "" || r.URL.Query().Get("node") != "cp-1" || !strings.HasPrefix(r.URL.Query().Get("digest"), "sha256:") {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
@@ -132,10 +112,8 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply",
+		"install", "apply", sourcePath,
 		"--endpoint", ts.URL,
-		"--token", "wait-token",
-		"--config-bundle", bundlePath,
 		"--node", "cp-1",
 		"--timeout", "5s",
 	}, &stdout, &stderr)
@@ -152,7 +130,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 }
 
 func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
+	sourcePath := writeClusterConfig(t)
 	var statusRequests atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/status", func(w http.ResponseWriter, _ *http.Request) {
@@ -171,8 +149,7 @@ func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", "--endpoint", ts.URL, "--token", "failure-token",
-		"--config-bundle", bundlePath,
+		"install", "apply", sourcePath, "--endpoint", ts.URL,
 		"--node", "cp-1", "--timeout", "5s",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "failed-before-mutation") || !strings.Contains(err.Error(), "target disk was not found") {
@@ -184,7 +161,7 @@ func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
 }
 
 func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
+	sourcePath := writeClusterConfig(t)
 	var requests atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		requests.Add(1)
@@ -194,8 +171,7 @@ func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", "--endpoint", ts.URL, "--token", "local-token",
-		"--config-bundle", bundlePath,
+		"install", "apply", sourcePath, "--endpoint", ts.URL,
 		"--node", "missing-node", "--no-wait",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "missing-node") {
@@ -206,9 +182,8 @@ func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
 	}
 }
 
-func TestInstallApplyRedactsTokenFromHTTPFailure(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
-	const token = "secret-install-token"
+func TestInstallApplySendsNoAuthorization(t *testing.T) {
+	sourcePath := writeClusterConfig(t)
 	var requests atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
@@ -216,17 +191,20 @@ func TestInstallApplyRedactsTokenFromHTTPFailure(t *testing.T) {
 			return
 		}
 		requests.Add(1)
-		http.Error(w, "rejected "+token, http.StatusUnauthorized)
+		if r.Header.Get("Authorization") != "" || r.Header.Get("X-Katl-Install-Token") != "" {
+			http.Error(w, "unexpected authorization", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(installTestStatus(handoff.HandoffAccepted, installstatus.StateRunning, "Validate"))
 	}))
 	defer ts.Close()
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", "--endpoint", ts.URL, "--token", token,
-		"--config-bundle", bundlePath,
+		"install", "apply", sourcePath, "--endpoint", ts.URL,
 		"--node", "cp-1", "--no-wait",
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "<redacted>") || strings.Contains(err.Error(), token) {
+	if err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 	if requests.Load() != 1 {
@@ -234,7 +212,7 @@ func TestInstallApplyRedactsTokenFromHTTPFailure(t *testing.T) {
 	}
 }
 
-func TestInstallApplyRejectsInvalidEndpointAndOversizedBundle(t *testing.T) {
+func TestInstallApplyRejectsInvalidEndpoint(t *testing.T) {
 	for _, endpoint := range []string{"installer.test:8080", "ftp://installer.test", "http://user@installer.test", "http://installer.test/path", "http://installer.test?token=secret"} {
 		var stdout, stderr bytes.Buffer
 		err := run(context.Background(), []string{"install", "status", "--endpoint", endpoint}, &stdout, &stderr)
@@ -243,25 +221,6 @@ func TestInstallApplyRejectsInvalidEndpointAndOversizedBundle(t *testing.T) {
 		}
 	}
 
-	path := filepath.Join(t.TempDir(), "large.katlcfg")
-	file, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := file.Truncate(maxInstallBundleSize + 1); err != nil {
-		t.Fatal(err)
-	}
-	if err := file.Close(); err != nil {
-		t.Fatal(err)
-	}
-	var stdout, stderr bytes.Buffer
-	err = run(context.Background(), []string{
-		"install", "apply", "--endpoint", "http://installer.test:8080", "--token", "token",
-		"--config-bundle", path, "--node", "cp-1",
-	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "exceeds") {
-		t.Fatalf("oversized bundle error = %v", err)
-	}
 }
 
 func installTestStatus(handoffState handoff.HandoffState, state, step string) handoff.HandoffStatus {
@@ -278,7 +237,7 @@ func installTestStatus(handoffState handoff.HandoffState, state, step string) ha
 }
 
 func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
+	sourcePath := writeClusterConfig(t)
 	var submitted atomic.Bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
@@ -296,43 +255,10 @@ func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", "--endpoint", ts.URL, "--token", "token",
-		"--config-bundle", bundlePath,
+		"install", "apply", sourcePath, "--endpoint", ts.URL,
 		"--node", "cp-1", "--timeout", "3s",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "became unavailable") || !strings.Contains(err.Error(), "Partition") {
-		t.Fatalf("run() error = %v", err)
-	}
-}
-
-func TestInstallTokenFlagsAreExclusive(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
-	for _, args := range [][]string{
-		{"--token", "a", "--token-file", "token-file"},
-		{},
-	} {
-		base := []string{"install", "apply", "--endpoint", "http://installer.test:8080", "--config-bundle", bundlePath, "--node", "cp-1", "--no-wait"}
-		base = append(base, args...)
-		var stdout, stderr bytes.Buffer
-		err := run(context.Background(), base, &stdout, &stderr)
-		if err == nil || !strings.Contains(err.Error(), "exactly one") {
-			t.Fatalf("args=%v error=%v", args, err)
-		}
-	}
-}
-
-func TestInstallTokenFileMustBePrivate(t *testing.T) {
-	bundlePath, _ := writeConfigBundle(t)
-	tokenPath := filepath.Join(t.TempDir(), "installer.token")
-	if err := os.WriteFile(tokenPath, []byte("token\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{
-		"install", "apply", "--endpoint", "http://installer.test:8080", "--token-file", tokenPath,
-		"--config-bundle", bundlePath, "--node", "cp-1", "--no-wait",
-	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "permissions") {
 		t.Fatalf("run() error = %v", err)
 	}
 }

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -52,6 +52,7 @@ var newWipeClusterConnector = func(token string) cluster.AgentConnector {
 
 const (
 	configBundleCreator      = "katlctl config bundle"
+	clusterBootstrapCreator  = "katlctl cluster bootstrap"
 	wipeClusterOperationKind = "destructive-reset"
 	wipeAcknowledgementText  = "I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity."
 )
@@ -1594,6 +1595,7 @@ func firstNonEmpty(values ...string) string {
 
 type clusterBootstrapOptions struct {
 	addresses                              addressOverrides
+	sourcePath                             string
 	inventoryPath                          string
 	configBundlePath                       string
 	initNode                               string
@@ -1615,10 +1617,13 @@ type clusterBootstrapOptions struct {
 func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := clusterBootstrapOptions{}
 	cmd := &cobra.Command{
-		Use:   "bootstrap",
-		Short: "Bootstrap Kubernetes from a Katl config bundle or node inventory",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Use:   "bootstrap [SOURCE]",
+		Short: "Bootstrap Kubernetes from a cluster config or node inventory",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.sourcePath = args[0]
+			}
 			return runClusterBootstrap(ctx, opts, stdout, stderr)
 		},
 	}
@@ -1699,22 +1704,42 @@ func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdo
 }
 
 func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, error) {
+	sourcePath := strings.TrimSpace(opts.sourcePath)
 	inventoryPath := strings.TrimSpace(opts.inventoryPath)
 	bundlePath := strings.TrimSpace(opts.configBundlePath)
-	if inventoryPath == "" && bundlePath == "" {
-		return inventory.Inventory{}, fmt.Errorf("exactly one of --config-bundle or --inventory is required")
+	inputs := 0
+	for _, value := range []string{sourcePath, inventoryPath, bundlePath} {
+		if value != "" {
+			inputs++
+		}
 	}
-	if inventoryPath != "" && bundlePath != "" {
-		return inventory.Inventory{}, fmt.Errorf("--config-bundle and --inventory are mutually exclusive")
+	if inputs != 1 {
+		return inventory.Inventory{}, fmt.Errorf("exactly one cluster config SOURCE, --config-bundle, or --inventory is required")
 	}
-	if bundlePath == "" {
+	if inventoryPath != "" {
 		return loadInventory(inventoryPath)
 	}
 	if strings.TrimSpace(opts.kubernetesBundle) != "" {
-		return inventory.Inventory{}, fmt.Errorf("--kubernetes-bundle conflicts with the selection embedded in --config-bundle")
+		return inventory.Inventory{}, fmt.Errorf("--kubernetes-bundle conflicts with the selection embedded in the cluster config")
 	}
 	if strings.TrimSpace(opts.controlPlaneEndpoint) != "" {
-		return inventory.Inventory{}, fmt.Errorf("--control-plane-endpoint conflicts with the endpoint embedded in --config-bundle")
+		return inventory.Inventory{}, fmt.Errorf("--control-plane-endpoint conflicts with the endpoint embedded in the cluster config")
+	}
+	if sourcePath != "" {
+		archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
+			SourcePath:     sourcePath,
+			KatlctlVersion: version,
+			KatlctlCommit:  commit,
+			CreatedBy:      clusterBootstrapCreator,
+		})
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("compile cluster config: %w", err)
+		}
+		bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("read compiled cluster config: %w", err)
+		}
+		return bundle.Manifest.Cluster.BootstrapInventory, nil
 	}
 	bundle, err := configbundle.ReadBundleFile(bundlePath, "")
 	if err != nil {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -684,11 +684,35 @@ func TestClusterBootstrapReturnsAgentBootstrapError(t *testing.T) {
 	}
 }
 
-func TestClusterBootstrapRequiresInventory(t *testing.T) {
+func TestClusterBootstrapRequiresInput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{"cluster", "bootstrap"}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "exactly one of --config-bundle or --inventory is required") {
+	if err == nil || !strings.Contains(err.Error(), "exactly one cluster config SOURCE") {
 		t.Fatalf("run() error = %v, want input error", err)
+	}
+}
+
+func TestClusterBootstrapCompilesSourceInventory(t *testing.T) {
+	sourcePath := writeClusterConfig(t)
+	var got cluster.Request
+	old := runAgentBootstrap
+	runAgentBootstrap = func(_ context.Context, request cluster.Request, _ cluster.AgentBootstrapDependencies) (cluster.Result, error) {
+		got = request
+		return cluster.Result{Plan: inventory.Plan{InitNode: request.InitNode}}, nil
+	}
+	t.Cleanup(func() { runAgentBootstrap = old })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"cluster", "bootstrap", sourcePath,
+		"--init-node", "cp-1",
+		"--dry-run",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if got.Inventory.ControlPlaneEndpoint != "api.katl.test:6443" || got.Inventory.KubernetesVersion != "v1.36.1" || len(got.Inventory.Nodes) != 1 {
+		t.Fatalf("source inventory = %#v", got.Inventory)
 	}
 }
 
@@ -722,13 +746,15 @@ func TestClusterBootstrapUsesConfigBundleInventory(t *testing.T) {
 
 func TestClusterBootstrapRejectsConfigBundleConflicts(t *testing.T) {
 	bundlePath, _ := writeConfigBundle(t)
+	sourcePath := writeClusterConfig(t)
 	inventoryPath := writeInventory(t)
 	tests := []struct {
 		name string
 		args []string
 		want string
 	}{
-		{name: "inventory", args: []string{"--config-bundle", bundlePath, "--inventory", inventoryPath}, want: "mutually exclusive"},
+		{name: "inventory", args: []string{"--config-bundle", bundlePath, "--inventory", inventoryPath}, want: "exactly one"},
+		{name: "source and bundle", args: []string{sourcePath, "--config-bundle", bundlePath}, want: "exactly one"},
 		{name: "Kubernetes", args: []string{"--config-bundle", bundlePath, "--kubernetes-bundle", "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.2"}, want: "conflicts with the selection embedded"},
 		{name: "endpoint", args: []string{"--config-bundle", bundlePath, "--control-plane-endpoint", "other.test:6443"}, want: "conflicts with the endpoint embedded"},
 	}
@@ -2245,18 +2271,23 @@ spec:
 
 func writeConfigBundle(t *testing.T) (string, string) {
 	t.Helper()
-	dir := t.TempDir()
-	sourcePath := filepath.Join(dir, "cluster.yaml")
-	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	sourcePath := writeClusterConfig(t)
 	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{SourcePath: sourcePath})
 	if err != nil {
 		t.Fatalf("BuildArchive() error = %v", err)
 	}
-	bundlePath := filepath.Join(dir, "cluster.katlcfg")
+	bundlePath := filepath.Join(filepath.Dir(sourcePath), "cluster.katlcfg")
 	if err := os.WriteFile(bundlePath, archive, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return bundlePath, result.Digest
+}
+
+func writeClusterConfig(t *testing.T) string {
+	t.Helper()
+	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
+	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return sourcePath
 }

--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -566,10 +566,7 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 	if err != nil {
 		return err
 	}
-	server, err := handoff.NewHandoffServerWithDefaultImage("", nil, media.Image)
-	if err != nil {
-		return err
-	}
+	server := handoff.NewHandoffServerWithDefaultImage(nil, media.Image)
 	writeConsoleInstallStatus(runDir, server.Status().InstallStatus, stdout)
 	server.SetStatusReader(func() (installstatus.Record, error) {
 		return installstatus.ReadFile(filepath.Join(runDir, "state", "status.json"))
@@ -597,7 +594,7 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 	if err != nil {
 		return err
 	}
-	if err := operatorconsole.WriteHandoff(consoleHandoffPath, baseURL, server.Token()); err != nil {
+	if err := operatorconsole.WriteHandoff(consoleHandoffPath, baseURL); err != nil {
 		fmt.Fprintf(stdout, "katlos-install console handoff projection: %v\n", err)
 	}
 	fmt.Fprintln(stdout, server.Announcement(baseURL))

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -228,14 +228,13 @@ The release ISO supplies `katlosImage`, so do not put an external KatlOS URL in
 this source for the ISO flow. PXE uses the same source but adds an explicit
 `spec.katlosImage` descriptor for the published loose SquashFS.
 
-Compile the source. Katl checks it as part of building the bundle:
-
-```sh
-katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
-```
+The ISO flow consumes this source directly: `katlctl install apply` and
+`katlctl cluster bootstrap` compile the internal bundle automatically. Produce
+an explicit bundle only for PXE or offline provisioning, as shown in the next
+section.
 
 Katl maintains the bundle's internal consistency metadata itself. Operators do
-not need to retain or pass it.
+not need to retain it, pass it on the ISO path, or handle its digests.
 
 The destructive guard has two parts: the resolved node must set
 `install.wipeTarget: true`, and boot input must set `katl.install.mode=auto`.
@@ -259,6 +258,12 @@ spec:
     architecture: x86_64
     runtimeInterface: katl-runtime-1
     role: install
+```
+
+Compile the PXE artifact explicitly:
+
+```sh
+katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
 ```
 
 Current bundle-oriented kernel arguments are:
@@ -300,15 +305,16 @@ create or operate DHCP, iPXE, or matchbox configuration.
 
 Boot the same `katl-installer.iso` on each node without preseed input. The
 installer mounts its embedded KatlOS image read-only, prints a handoff URL and
-one-time token to the console and journal, and waits without mutating disks.
+waits without mutating disks.
 The VGA console keeps a KatlOS dashboard on `tty1` showing installer state,
-active network addresses, the handoff URL and token, disk-mutation status, and a
+active network addresses, the handoff URL, disk-mutation status, and a
 live tail of the boot journal. Press `Ctrl+Alt+F2` for a local recovery shell;
 the dashboard, serial journal, and SSH service operate independently.
 
-The current handoff uses a bearer token over unencrypted HTTP. Use only an
-isolated provisioning network, never expose port 8080 to an untrusted network,
-and remove the temporary token file after use.
+The handoff is intentionally unauthenticated HTTP for the trusted home-lab
+path. Use only the provisioning network and never expose port 8080 to an
+untrusted network. The installer accepts one valid submission and then closes
+the handoff path.
 
 For `cp-1`, first confirm the installer is waiting:
 
@@ -317,26 +323,16 @@ INSTALLER_ENDPOINT=http://192.0.2.10:8080
 katlctl install status --endpoint "$INSTALLER_ENDPOINT"
 ```
 
-Copy the one-time token from the console into a protected temporary file, then
-submit the bundle:
+Apply the cluster source directly:
 
 ```sh
-umask 077
-read -rsp 'Installer token: ' INSTALL_TOKEN; printf '\n'
-printf '%s\n' "$INSTALL_TOKEN" > ./installer.token
-unset INSTALL_TOKEN
-
-katlctl install apply \
+katlctl install apply ./cluster.yaml \
   --endpoint "$INSTALLER_ENDPOINT" \
-  --token-file ./installer.token \
-  --config-bundle ./katl-lab.katlcfg \
   --node cp-1
-
-rm -f ./installer.token
 ```
 
-For the worker, boot the same ISO and submit the same file with
-`--node worker-1`. `katlctl install apply` validates the archive integrity and
+For the worker, boot the same ISO and apply the same source with
+`--node worker-1`. `katlctl install apply` compiles and validates the source and
 selected node before contacting the installer. The installer
 then validates the compiled install material and embedded KatlOS image before
 it can mutate the selected disk. The endpoint refuses later submissions.
@@ -440,20 +436,18 @@ patch updates. An unpinned tag is resolved once for the operation record; a
 digest pin prevents the tag from selecting different content before that point.
 
 After all nodes are installed and reachable through their node-local `katlc`
-management endpoints, bootstrap directly from the same bundle:
+management endpoints, bootstrap directly from the same source:
 
 ```text
-katlctl cluster bootstrap \
-  --config-bundle katl-lab.katlcfg \
+katlctl cluster bootstrap ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out kubeconfig \
   --overwrite-kubeconfig
 ```
 
-The bundle supplies the control-plane endpoint, node topology, roles, kubeadm
-references, Kubernetes version, and OCI bundle selection. Do not combine
-`--config-bundle` with `--inventory`, `--control-plane-endpoint`, or
-`--kubernetes-bundle`. `--node-address node=address` remains available for an
+Katl compiles the source internally to obtain the control-plane endpoint, node
+topology, roles, kubeadm references, Kubernetes version, and OCI bundle
+selection. `--node-address node=address` remains available for an
 operator-observed address that differs from the compiled source.
 
 Each freshly installed node generates a distinct agent token. Retrieve it over

--- a/docs/internal/initial-design.md
+++ b/docs/internal/initial-design.md
@@ -118,8 +118,9 @@ The active installer flow is Katl-native:
 1. User-managed boot infrastructure or local VM boots installer-image.
 2. katlos-install reads kernel arguments, embedded media, local files, or enters
    local handoff mode.
-3. If no manifest is present, local handoff starts a token-protected HTTP
-   endpoint and waits for exactly one install manifest.
+3. If no manifest is present, local handoff starts an unauthenticated HTTP
+   endpoint on the trusted provisioning network and waits for exactly one
+   install configuration.
 4. katlos-install validates the manifest before any destructive disk action.
 5. katlos-install verifies the KatlOS image and trust material. It does not
    bundle or fetch a Kubernetes sysext.

--- a/docs/internal/installer-boot-artifact-variants.md
+++ b/docs/internal/installer-boot-artifact-variants.md
@@ -176,8 +176,8 @@ inline node config containing secrets
 ```
 
 Secret-bearing material must arrive through protected fetched input, local
-handoff with an operator token, offline media with an explicit trust boundary,
-or a later dedicated secret channel.
+handoff on a trusted provisioning network, offline media with an explicit trust
+boundary, or a later dedicated secret channel.
 
 ## Variant Behavior
 

--- a/docs/internal/installer-runtime-design.md
+++ b/docs/internal/installer-runtime-design.md
@@ -181,7 +181,7 @@ In waiting mode, `katlos-install` should:
 ```text
 bring up installer networking
 start a small HTTP server
-print the installer IP address, URL, and one-time token to console and journal
+print the installer IP address and URL to console and journal
 serve a read-only status endpoint
 accept exactly one install manifest submission
 validate the submitted manifest before any destructive action
@@ -199,9 +199,10 @@ POST /v1/install
 `POST /v1/install` should accept the same install manifest used by preseeded
 network installs. The API must not introduce a separate configuration model.
 
-The handoff mode should require a one-time token by default. For local VM tests
-tests, the token can be captured from the serial log. A deliberately insecure
-test-only mode may exist, but it must be explicit.
+The handoff is intentionally unauthenticated on the supported trusted-network
+path. It accepts exactly one structurally valid submission and stops accepting
+configuration when installation begins. Operators must keep the listener on an
+isolated provisioning network.
 
 This mode is only for supplying initial installer input. It is not a long-lived
 runtime management API and it must not continue running after install begins.

--- a/docs/support.md
+++ b/docs/support.md
@@ -43,9 +43,10 @@ TCP. Restrict port 9443 to an isolated evaluation management network. It is not
 a production-grade remote-management trust boundary, even when artifact
 provenance verification succeeds.
 
-The ISO install handoff similarly sends its one-time bearer token over
-unencrypted HTTP. Restrict port 8080 to an isolated provisioning network and
-remove copied token files after the installer accepts the bundle.
+The ISO install handoff is intentionally unauthenticated HTTP for the supported
+trusted home-lab path. Restrict port 8080 to the provisioning network: the
+installer accepts one structurally valid configuration and then closes the
+handoff path.
 
 This proves which repository workflow produced the bytes. It does not provide:
 

--- a/internal/installer/handoff/handoff.go
+++ b/internal/installer/handoff/handoff.go
@@ -2,10 +2,7 @@ package handoff
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -25,7 +22,6 @@ const (
 )
 
 type HandoffServer struct {
-	token              string
 	validate           func([]byte) error
 	defaultKatlosImage manifest.KatlosImage
 	statusReader       func() (installstatus.Record, error)
@@ -51,18 +47,11 @@ type BundlePayload struct {
 	NodeName string
 }
 
-func NewHandoffServer(token string, validate func([]byte) error) (*HandoffServer, error) {
-	return NewHandoffServerWithDefaultImage(token, validate, manifest.KatlosImage{})
+func NewHandoffServer(validate func([]byte) error) *HandoffServer {
+	return NewHandoffServerWithDefaultImage(validate, manifest.KatlosImage{})
 }
 
-func NewHandoffServerWithDefaultImage(token string, validate func([]byte) error, defaultImage manifest.KatlosImage) (*HandoffServer, error) {
-	if strings.TrimSpace(token) == "" {
-		generated, err := GenerateHandoffToken()
-		if err != nil {
-			return nil, err
-		}
-		token = generated
-	}
+func NewHandoffServerWithDefaultImage(validate func([]byte) error, defaultImage manifest.KatlosImage) *HandoffServer {
 	if validate == nil {
 		validate = func(data []byte) error {
 			_, _, err := manifest.DecodeWithDefaultImage(bytes.NewReader(data), defaultImage)
@@ -74,24 +63,11 @@ func NewHandoffServerWithDefaultImage(token string, validate func([]byte) error,
 	status.InputMode = installstatus.InputModeLocalHandoff
 	status.InputSource = installstatus.InputModeLocalHandoff
 	return &HandoffServer{
-		token:              token,
 		validate:           validate,
 		defaultKatlosImage: defaultImage,
 		state:              HandoffWaiting,
 		status:             status,
-	}, nil
-}
-
-func GenerateHandoffToken() (string, error) {
-	var raw [24]byte
-	if _, err := rand.Read(raw[:]); err != nil {
-		return "", fmt.Errorf("generate handoff token: %w", err)
 	}
-	return hex.EncodeToString(raw[:]), nil
-}
-
-func (s *HandoffServer) Token() string {
-	return s.token
 }
 
 func (s *HandoffServer) Manifest() []byte {
@@ -138,7 +114,7 @@ func (s *HandoffServer) SetStatusReader(reader func() (installstatus.Record, err
 }
 
 func (s *HandoffServer) Announcement(baseURL string) string {
-	return fmt.Sprintf("katlos-install waiting for config at %s/v1/config-bundle token=%s", strings.TrimRight(baseURL, "/"), s.token)
+	return "katlos-install waiting for config at " + strings.TrimRight(baseURL, "/") + "/v1/config-bundle"
 }
 
 func (s *HandoffServer) Handler() http.Handler {
@@ -160,11 +136,6 @@ func (s *HandoffServer) handleStatus(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *HandoffServer) handleInstall(w http.ResponseWriter, r *http.Request) {
-	if !s.authorized(r) {
-		http.Error(w, "missing or invalid token", http.StatusUnauthorized)
-		return
-	}
-
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
 	if err != nil {
 		http.Error(w, "read manifest", http.StatusBadRequest)
@@ -213,10 +184,6 @@ func (s *HandoffServer) handleInstall(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HandoffServer) handleConfigBundle(w http.ResponseWriter, r *http.Request) {
-	if !s.authorized(r) {
-		http.Error(w, "missing or invalid token", http.StatusUnauthorized)
-		return
-	}
 	nodeName := strings.TrimSpace(firstNonEmpty(r.URL.Query().Get("node"), r.Header.Get("X-Katl-Node-Name")))
 	expectedDigest := strings.TrimSpace(firstNonEmpty(r.URL.Query().Get("digest"), r.Header.Get("X-Katl-Bundle-Digest")))
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 64<<20))
@@ -271,14 +238,6 @@ func (s *HandoffServer) handleConfigBundle(w http.ResponseWriter, r *http.Reques
 	s.mu.Unlock()
 
 	writeJSON(w, response)
-}
-
-func (s *HandoffServer) authorized(r *http.Request) bool {
-	if r.Header.Get("X-Katl-Install-Token") == s.token {
-		return true
-	}
-	auth := r.Header.Get("Authorization")
-	return auth == "Bearer "+s.token
 }
 
 func ValidateInstallManifestEnvelope(data []byte) error {

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -45,8 +45,7 @@ func TestHandoffServerHealthStatusAndAnnouncement(t *testing.T) {
 	}
 
 	announcement := server.Announcement("http://192.0.2.10:8080/")
-	if !strings.Contains(announcement, "http://192.0.2.10:8080/v1/config-bundle") ||
-		!strings.Contains(announcement, "token=test-token") {
+	if announcement != "katlos-install waiting for config at http://192.0.2.10:8080/v1/config-bundle" {
 		t.Fatalf("announcement = %q", announcement)
 	}
 }
@@ -74,19 +73,13 @@ func TestHandoffStatusUsesDurableInstallerState(t *testing.T) {
 	}
 }
 
-func TestHandoffServerRequiresTokenAndAcceptsOneManifest(t *testing.T) {
+func TestHandoffServerAcceptsOneManifest(t *testing.T) {
 	server := newTestHandoffServer(t)
 	ts := httptest.NewServer(server.Handler())
 	defer ts.Close()
 
 	manifest := validManifestJSON()
-	resp := postManifest(t, ts.URL, "", manifest)
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("POST without token status = %d, want 401", resp.StatusCode)
-	}
-	resp.Body.Close()
-
-	resp = postManifest(t, ts.URL, "test-token", manifest)
+	resp := postManifest(t, ts.URL, manifest)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("POST valid manifest status = %d, want 200", resp.StatusCode)
@@ -102,7 +95,7 @@ func TestHandoffServerRequiresTokenAndAcceptsOneManifest(t *testing.T) {
 		t.Fatalf("status image URL = %q", status.InstallStatus.KatlosImage.URL)
 	}
 
-	resp = postManifest(t, ts.URL, "test-token", manifest)
+	resp = postManifest(t, ts.URL, manifest)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("second POST status = %d, want 409", resp.StatusCode)
@@ -115,13 +108,7 @@ func TestHandoffServerAcceptsConfigBundleWithSelectedNode(t *testing.T) {
 	defer ts.Close()
 	bundle, result := validConfigBundle(t)
 
-	resp := postBundle(t, ts.URL, "", "cp-1", result.Digest, bundle)
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("POST bundle without token status = %d, want 401", resp.StatusCode)
-	}
-	resp.Body.Close()
-
-	resp = postBundle(t, ts.URL, "test-token", "cp-1", result.Digest, bundle)
+	resp := postBundle(t, ts.URL, "cp-1", result.Digest, bundle)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("POST valid bundle status = %d, want 200", resp.StatusCode)
@@ -138,7 +125,7 @@ func TestHandoffServerAcceptsConfigBundleWithSelectedNode(t *testing.T) {
 		t.Fatalf("install status missing bundle digests: %#v", status.InstallStatus)
 	}
 
-	resp = postManifest(t, ts.URL, "test-token", validManifestJSON())
+	resp = postManifest(t, ts.URL, validManifestJSON())
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("manifest after bundle status = %d, want 409", resp.StatusCode)
@@ -151,7 +138,7 @@ func TestHandoffServerRejectsConfigBundleWithoutSelectedNode(t *testing.T) {
 	defer ts.Close()
 	bundle, result := validConfigBundle(t)
 
-	resp := postBundle(t, ts.URL, "test-token", "", result.Digest, bundle)
+	resp := postBundle(t, ts.URL, "", result.Digest, bundle)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("POST bundle without node status = %d, want 400", resp.StatusCode)
@@ -166,7 +153,7 @@ func TestHandoffServerValidatesBeforeAccepting(t *testing.T) {
 	ts := httptest.NewServer(server.Handler())
 	defer ts.Close()
 
-	resp := postManifest(t, ts.URL, "test-token", []byte(`{"apiVersion":"wrong","kind":"InstallManifest"}`))
+	resp := postManifest(t, ts.URL, []byte(`{"apiVersion":"wrong","kind":"InstallManifest"}`))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("invalid manifest status = %d, want 400", resp.StatusCode)
@@ -230,21 +217,14 @@ func TestValidateManifestEnvelope(t *testing.T) {
 
 func newTestHandoffServer(t *testing.T) *HandoffServer {
 	t.Helper()
-	server, err := NewHandoffServer("test-token", nil)
-	if err != nil {
-		t.Fatalf("NewHandoffServer() error = %v", err)
-	}
-	return server
+	return NewHandoffServer(nil)
 }
 
-func postManifest(t *testing.T, baseURL, token string, manifest []byte) *http.Response {
+func postManifest(t *testing.T, baseURL string, manifest []byte) *http.Response {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/install", bytes.NewReader(manifest))
 	if err != nil {
 		t.Fatalf("NewRequest() error = %v", err)
-	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -253,14 +233,11 @@ func postManifest(t *testing.T, baseURL, token string, manifest []byte) *http.Re
 	return resp
 }
 
-func postBundle(t *testing.T, baseURL, token, node, digest string, bundle []byte) *http.Response {
+func postBundle(t *testing.T, baseURL, node, digest string, bundle []byte) *http.Response {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/config-bundle?node="+node+"&digest="+digest, bytes.NewReader(bundle))
 	if err != nil {
 		t.Fatalf("NewRequest() error = %v", err)
-	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/operatorconsole/handoff.go
+++ b/internal/operatorconsole/handoff.go
@@ -9,18 +9,17 @@ import (
 	"time"
 )
 
-func WriteHandoff(path, url, token string) error {
+func WriteHandoff(path, url string) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return fmt.Errorf("handoff projection path is required")
 	}
 	record := Handoff{
 		URL:       strings.TrimRight(strings.TrimSpace(url), "/") + "/v1/config-bundle",
-		Token:     strings.TrimSpace(token),
 		UpdatedAt: time.Now().UTC(),
 	}
-	if strings.TrimSpace(url) == "" || record.Token == "" {
-		return fmt.Errorf("handoff URL and token are required")
+	if strings.TrimSpace(url) == "" {
+		return fmt.Errorf("handoff URL is required")
 	}
 	data, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -39,6 +39,5 @@ type NetworkInterface struct {
 
 type Handoff struct {
 	URL       string    `json:"url"`
-	Token     string    `json:"token"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -18,14 +18,14 @@ func (a testAddr) String() string  { return string(a) }
 
 func TestWriteAndReadHandoff(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "console", "handoff.json")
-	if err := WriteHandoff(path, "http://192.0.2.10:8080/", "test-token"); err != nil {
+	if err := WriteHandoff(path, "http://192.0.2.10:8080/"); err != nil {
 		t.Fatalf("WriteHandoff() error = %v", err)
 	}
 	record, err := ReadHandoff(path)
 	if err != nil {
 		t.Fatalf("ReadHandoff() error = %v", err)
 	}
-	if record.URL != "http://192.0.2.10:8080/v1/config-bundle" || record.Token != "test-token" || record.UpdatedAt.IsZero() {
+	if record.URL != "http://192.0.2.10:8080/v1/config-bundle" || record.UpdatedAt.IsZero() {
 		t.Fatalf("handoff = %#v", record)
 	}
 	info, err := os.Stat(path)
@@ -48,7 +48,7 @@ func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 		t.Fatal(err)
 	}
 	handoffPath := filepath.Join(root, "handoff.json")
-	if err := WriteHandoff(handoffPath, "http://192.0.2.10:8080", "token"); err != nil {
+	if err := WriteHandoff(handoffPath, "http://192.0.2.10:8080"); err != nil {
 		t.Fatal(err)
 	}
 	collector := Collector{
@@ -76,7 +76,7 @@ func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 	if len(snapshot.Network) != 1 || strings.Join(snapshot.Network[0].Addresses, ",") != "192.0.2.10/24" {
 		t.Fatalf("snapshot network = %#v", snapshot.Network)
 	}
-	if snapshot.Handoff.Token != "token" {
+	if snapshot.Handoff.URL != "http://192.0.2.10:8080/v1/config-bundle" {
 		t.Fatalf("snapshot handoff = %#v", snapshot)
 	}
 	network := &snapshot.Network[0]
@@ -96,7 +96,7 @@ func TestRenderInstallerDashboard(t *testing.T) {
 		CurrentStep:         "InstallRootSlot",
 		TargetDisk:          "/dev/disk/by-id/virtio-root",
 		DestructiveMutation: true,
-		Handoff:             Handoff{URL: "http://192.0.2.10:8080/v1/config-bundle", Token: "secret-token"},
+		Handoff:             Handoff{URL: "http://192.0.2.10:8080/v1/config-bundle"},
 		Network:             []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
 	}
 	journal := testJournal{[]byte("old line"), []byte("installing root\x1b[31m"), []byte("latest line")}
@@ -108,7 +108,7 @@ func TestRenderInstallerDashboard(t *testing.T) {
 		"Network:      enp1s0: 192.0.2.10/24",
 		"Disk changes: started - do not power off",
 		"Configure:    http://192.0.2.10:8080/v1/config-bundle",
-		"Token:        secret-token",
+		"Run: katlctl install apply <cluster.yaml> --endpoint <base URL> --node <name>",
 		"Journal (live)",
 		"installing root[31m",
 		"Ctrl+Alt+F2: local console | SSH disabled by installer config",

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -93,8 +93,7 @@ func (render *Renderer) Append(dst []byte, snapshot *Snapshot, journal Journal, 
 	}
 	if snapshot.Handoff.URL != "" {
 		render.fieldLine("Configure").appendString(snapshot.Handoff.URL).finish()
-		render.fieldLine("Token").appendString(snapshot.Handoff.Token).finish()
-		render.line().appendString("From another machine use: katlctl install apply").finish()
+		render.line().appendString("Run: katlctl install apply <cluster.yaml> --endpoint <base URL> --node <name>").finish()
 	}
 	appendWrappedField(render, "Error", snapshot.LastError)
 	appendWrappedField(render, "Next action", snapshot.RetryHint)
@@ -363,7 +362,7 @@ func statusRows(snapshot *Snapshot, width int) int {
 		rows++
 	}
 	if snapshot.Handoff.URL != "" {
-		rows += 3
+		rows += 2
 	}
 	if snapshot.LastError != "" {
 		rows += wrappedRows(snapshot.LastError, width)

--- a/internal/vmtest/first_install.go
+++ b/internal/vmtest/first_install.go
@@ -33,9 +33,8 @@ type FirstInstallConfig struct {
 	SelectedNode    string
 	GuestHandoff    bool
 	PreseedManifest bool
-	HandoffToken    string
 	HandoffURL      string
-	HandoffPoster   func(context.Context, string, string, []byte) (int, string, error)
+	HandoffPoster   func(context.Context, string, []byte) (int, string, error)
 	TargetDisk      DiskFixture
 	DiskRunner      DiskRunner
 	PreseedRunner   DiskRunner
@@ -55,7 +54,6 @@ const (
 type handoffLog struct {
 	URL          string `json:"url"`
 	PostURL      string `json:"postUrl,omitempty"`
-	Token        string `json:"token,omitempty"`
 	ManifestPath string `json:"manifestPath"`
 	Announcement string `json:"announcement,omitempty"`
 	GuestAddress string `json:"guestAddress,omitempty"`
@@ -685,7 +683,7 @@ func runToolOutput(ctx context.Context, name string, args ...string) ([]byte, er
 }
 
 func deliverGuestHandoff(ctx context.Context, result Result, config FirstInstallConfig, manifest []byte, event SerialHookEvent, serialText string) error {
-	announcement, url, token, err := parseHandoffAnnouncement(serialText)
+	announcement, url, err := parseHandoffAnnouncement(serialText)
 	if err != nil {
 		return err
 	}
@@ -697,7 +695,6 @@ func deliverGuestHandoff(ctx context.Context, result Result, config FirstInstall
 	request := handoffLog{
 		URL:          url,
 		PostURL:      postURL,
-		Token:        token,
 		ManifestPath: result.Artifacts.InstallManifest,
 		Announcement: announcement,
 		GuestAddress: handoffGuestAddress(url),
@@ -708,7 +705,7 @@ func deliverGuestHandoff(ctx context.Context, result Result, config FirstInstall
 	if err := writeJSON(result.Artifacts.HandoffRequest, request); err != nil {
 		return err
 	}
-	status, body, err := postHandoff(ctx, config, postURL, token, manifest)
+	status, body, err := postHandoff(ctx, config, postURL, manifest)
 	if err != nil {
 		return fmt.Errorf("guest handoff post failed: %w; %s", err, handoffContext(request))
 	}
@@ -742,7 +739,7 @@ func handoffContext(log handoffLog) string {
 	return strings.Join(parts, "; ")
 }
 
-func parseHandoffAnnouncement(serialText string) (announcement string, url string, token string, err error) {
+func parseHandoffAnnouncement(serialText string) (announcement string, url string, err error) {
 	for _, line := range strings.Split(serialText, "\n") {
 		line = strings.TrimSpace(line)
 		if strings.Contains(line, guestHandoffSignal) {
@@ -750,48 +747,32 @@ func parseHandoffAnnouncement(serialText string) (announcement string, url strin
 		}
 	}
 	if announcement == "" {
-		return "", "", "", errors.New("handoff announcement not found in installer serial log")
+		return "", "", errors.New("handoff announcement not found in installer serial log")
 	}
 	start := strings.Index(announcement, guestHandoffSignal)
 	if start < 0 {
-		return "", "", "", fmt.Errorf("could not parse handoff announcement: %s", announcement)
+		return "", "", fmt.Errorf("could not parse handoff announcement: %s", announcement)
 	}
-	payload := strings.TrimSpace(announcement[start+len(guestHandoffSignal):])
-	const tokenPrefix = " token="
-	tokenStart := strings.LastIndex(payload, tokenPrefix)
-	if tokenStart < 0 {
-		return "", "", "", fmt.Errorf("could not parse handoff token from announcement: %s", announcement)
+	url = strings.TrimSpace(announcement[start+len(guestHandoffSignal):])
+	if url == "" {
+		return "", "", fmt.Errorf("could not parse handoff URL from announcement: %s", announcement)
 	}
-	url = strings.TrimSpace(payload[:tokenStart])
-	token = strings.TrimSpace(payload[tokenStart+len(tokenPrefix):])
-	if url == "" || token == "" {
-		return "", "", "", fmt.Errorf("could not parse handoff URL/token from announcement: %s", announcement)
-	}
-	return announcement, url, token, nil
+	return announcement, url, nil
 }
 
 func deliverHandoff(ctx context.Context, result Result, config FirstInstallConfig, manifest []byte) error {
 	url := config.HandoffURL
-	token := config.HandoffToken
 	var announcement string
 	var handler http.Handler
 	if url == "" {
-		server, err := handoff.NewHandoffServer(token, nil)
-		if err != nil {
-			return err
-		}
+		server := handoff.NewHandoffServer(nil)
 		handler = server.Handler()
 		url = handoffPostURL("http://vmtest.local/v1/install", config)
-		token = server.Token()
 		announcement = server.Announcement("http://vmtest.local")
-	}
-	if token == "" {
-		return errors.New("handoff token is required")
 	}
 
 	request := handoffLog{
 		URL:          url,
-		Token:        token,
 		ManifestPath: result.Artifacts.InstallManifest,
 		Announcement: announcement,
 	}
@@ -800,32 +781,32 @@ func deliverHandoff(ctx context.Context, result Result, config FirstInstallConfi
 	}
 
 	if handler != nil {
-		status, body, err := postLocal(ctx, handler, url, token, config, manifest)
+		status, body, err := postLocal(ctx, handler, url, config, manifest)
 		if err != nil {
 			return err
 		}
 		return writeHandoff(result, url, status, body)
 	}
-	status, body, err := postHandoff(ctx, config, url, token, manifest)
+	status, body, err := postHandoff(ctx, config, url, manifest)
 	if err != nil {
 		return err
 	}
 	return writeHandoff(result, url, status, body)
 }
 
-func postHandoff(ctx context.Context, config FirstInstallConfig, url, token string, manifest []byte) (int, string, error) {
+func postHandoff(ctx context.Context, config FirstInstallConfig, url string, manifest []byte) (int, string, error) {
 	payload, contentType, err := handoffPayload(config, manifest)
 	if err != nil {
 		return 0, "", err
 	}
 	url = handoffPostURL(url, config)
 	if config.HandoffPoster != nil {
-		return config.HandoffPoster(ctx, url, token, payload)
+		return config.HandoffPoster(ctx, url, payload)
 	}
-	return postRemote(ctx, url, token, payload, contentType)
+	return postRemote(ctx, url, payload, contentType)
 }
 
-func postLocal(ctx context.Context, handler http.Handler, url, token string, config FirstInstallConfig, manifest []byte) (int, string, error) {
+func postLocal(ctx context.Context, handler http.Handler, url string, config FirstInstallConfig, manifest []byte) (int, string, error) {
 	payload, contentType, err := handoffPayload(config, manifest)
 	if err != nil {
 		return 0, "", err
@@ -835,7 +816,6 @@ func postLocal(ctx context.Context, handler http.Handler, url, token string, con
 		return 0, "", err
 	}
 	httpRequest.Header.Set("Content-Type", contentType)
-	httpRequest.Header.Set("X-Katl-Install-Token", token)
 	response := &responseCapture{header: http.Header{}}
 	handler.ServeHTTP(response, httpRequest)
 	if response.status == 0 {
@@ -844,13 +824,12 @@ func postLocal(ctx context.Context, handler http.Handler, url, token string, con
 	return response.status, response.body.String(), nil
 }
 
-func postRemote(ctx context.Context, url, token string, payload []byte, contentType string) (int, string, error) {
+func postRemote(ctx context.Context, url string, payload []byte, contentType string) (int, string, error) {
 	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return 0, "", err
 	}
 	httpRequest.Header.Set("Content-Type", contentType)
-	httpRequest.Header.Set("X-Katl-Install-Token", token)
 	client := &http.Client{Timeout: 5 * time.Second}
 	response, err := client.Do(httpRequest)
 	if err != nil {

--- a/internal/vmtest/first_install_test.go
+++ b/internal/vmtest/first_install_test.go
@@ -32,7 +32,6 @@ func TestFirstInstall(t *testing.T) {
 			VM:           vmConfig,
 		},
 		Manifest:        []byte(firstManifest()),
-		HandoffToken:    "test-token",
 		TargetDisk:      TargetDisk("root", string(DiskRaw), "64M"),
 		DiskRunner:      fileDiskRunner{},
 		InstallerRunner: fakeVM("Katl installer ready"),
@@ -83,7 +82,6 @@ func TestFirstInstallFailure(t *testing.T) {
 			VM:           vmConfig,
 		},
 		Manifest:        []byte(firstManifest()),
-		HandoffToken:    "test-token",
 		TargetDisk:      TargetDisk("root", string(DiskRaw), "64M"),
 		DiskRunner:      fileDiskRunner{},
 		InstallerRunner: fakeVM("Katl installer ready"),
@@ -140,7 +138,6 @@ func TestFirstInstallFailsFastOnInstallerServiceFailure(t *testing.T) {
 			VM:           vmConfig,
 		},
 		Manifest:        []byte(firstManifest()),
-		HandoffToken:    "test-token",
 		TargetDisk:      TargetDisk("root", string(DiskRaw), "64M"),
 		DiskRunner:      fileDiskRunner{},
 		InstallerRunner: fakeVMWithExecutor(vmExec{write: "katlos-install.service: Failed with result 'exit-code'.\ncollect facts failed\n"}),
@@ -160,10 +157,7 @@ func TestFirstInstallGuestHandoffUsesAnnouncementURL(t *testing.T) {
 	runtime := writeFixture(t, root, "runtime.squashfs", "runtime")
 	_, vmConfig := vmFixture(t)
 	vmConfig.HostForwards = nil
-	server, err := handoff.NewHandoffServer("guest-token", nil)
-	if err != nil {
-		t.Fatalf("NewHandoffServer() error = %v", err)
-	}
+	server := handoff.NewHandoffServer(nil)
 	handoffPosted := make(chan struct{})
 	installerSerial := stagedVMExec{
 		first: server.Announcement("http://10.0.2.15:8080") + "\n",
@@ -186,11 +180,11 @@ func TestFirstInstallGuestHandoffUsesAnnouncementURL(t *testing.T) {
 		},
 		Manifest:     []byte(firstManifest()),
 		GuestHandoff: true,
-		HandoffPoster: func(ctx context.Context, url, token string, manifest []byte) (int, string, error) {
+		HandoffPoster: func(ctx context.Context, url string, manifest []byte) (int, string, error) {
 			if url != "http://10.0.2.15:8080/v1/install" {
 				t.Fatalf("handoff post URL = %q", url)
 			}
-			status, body, err := postLocal(ctx, server.Handler(), url, token, FirstInstallConfig{}, manifest)
+			status, body, err := postLocal(ctx, server.Handler(), url, FirstInstallConfig{}, manifest)
 			if err == nil {
 				close(handoffPosted)
 			}
@@ -240,7 +234,7 @@ func TestFirstInstallGuestHandoffPostsConfigBundle(t *testing.T) {
 	vmConfig.HostForwards = nil
 	posted := make(chan struct{})
 	installerSerial := stagedVMExec{
-		first: guestHandoffSignal + "http://10.0.2.15:8080 token=guest-token\n",
+		first: guestHandoffSignal + "http://10.0.2.15:8080\n",
 		wait:  posted,
 		then:  guestHandoffAcceptedSignal + "/run/katl/config.katlcfg\n" + bundleCompletedSignal + "/run/katl/config.katlcfg\n",
 	}
@@ -261,12 +255,9 @@ func TestFirstInstallGuestHandoffPostsConfigBundle(t *testing.T) {
 		ConfigBundle: bundle,
 		SelectedNode: "cp-1",
 		GuestHandoff: true,
-		HandoffPoster: func(_ context.Context, url, token string, payload []byte) (int, string, error) {
+		HandoffPoster: func(_ context.Context, url string, payload []byte) (int, string, error) {
 			if url != "http://10.0.2.15:8080/config-bundle?node=cp-1" {
 				t.Fatalf("handoff post URL = %q", url)
-			}
-			if token != "guest-token" {
-				t.Fatalf("handoff token = %q", token)
 			}
 			if string(payload) != "bundle" {
 				t.Fatalf("handoff payload = %q", payload)
@@ -301,10 +292,7 @@ func TestFirstInstallGuestHandoffFailureIncludesDebugContext(t *testing.T) {
 	runtime := writeFixture(t, root, "runtime.squashfs", "runtime")
 	_, vmConfig := vmFixture(t)
 	vmConfig.HostForwards = nil
-	server, err := handoff.NewHandoffServer("guest-token", nil)
-	if err != nil {
-		t.Fatalf("NewHandoffServer() error = %v", err)
-	}
+	server := handoff.NewHandoffServer(nil)
 	result, err := RunFirstInstall(context.Background(), NewRunner(Options{
 		StateRoot: root,
 		RunID:     "run-1",
@@ -320,7 +308,7 @@ func TestFirstInstallGuestHandoffFailureIncludesDebugContext(t *testing.T) {
 		},
 		Manifest:     []byte(firstManifest()),
 		GuestHandoff: true,
-		HandoffPoster: func(context.Context, string, string, []byte) (int, string, error) {
+		HandoffPoster: func(context.Context, string, []byte) (int, string, error) {
 			return 0, "", fmt.Errorf("network unreachable")
 		},
 		TargetDisk:      TargetDisk("root", string(DiskRaw), "64M"),
@@ -588,7 +576,6 @@ func TestFirstInstallUsesInstalledESPExtractor(t *testing.T) {
 			return outputDir, nil
 		},
 		Manifest:        []byte(firstManifest()),
-		HandoffToken:    "test-token",
 		TargetDisk:      TargetDisk("root", string(DiskRaw), "64M"),
 		DiskRunner:      fileDiskRunner{},
 		InstallerRunner: fakeVM("Katl installer ready"),


### PR DESCRIPTION
Remove installer token copying from the trusted provisioning path and make install and Kubernetes bootstrap consume ClusterConfig YAML directly. Explicit bundle generation remains available for PXE and offline workflows.