### PR TITLE
docs: align runbooks with direct config input

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,9 +5,10 @@ with the task that matches the current node state; do not skip directly to a
 mutating command.
 
 KatlOS is experimental. Read the [support boundary](../support.md) before using
-these procedures. The current installer handoff and management API use bearer
-authentication over unencrypted HTTP/TCP and are suitable only on isolated
-evaluation networks.
+these procedures. The ephemeral installer handoff is intentionally
+unauthenticated HTTP, while the installed-node management API uses bearer
+authentication over unencrypted TCP. Keep both on isolated evaluation
+networks.
 
 ## Lifecycle Map
 
@@ -33,7 +34,7 @@ workstation, not inside the KatlOS image.
 Keep these artifacts together for the life of an evaluation:
 
 - the KatlOS release URL and assets used;
-- the source `ClusterConfig` and compiled `.katlcfg` bundle;
+- the source `ClusterConfig` and any `.katlcfg` produced for PXE or offline use;
 - the Kubernetes OCI reference;
 - one protected agent token file per node;
 - the kubeconfig, command results, generation IDs, and relevant timestamps; and
@@ -76,6 +77,6 @@ Normal configuration apply currently covers hostname, SSH authorized keys, and
 systemd-networkd files. Disk policy, system role, Kubernetes bundle selection,
 and kubeadm lifecycle changes require a named lifecycle operation or reinstall.
 
-There is no supported alpha workflow for automatic fleet rollout, Kubernetes
-version upgrades, etcd disaster recovery, failed control-plane replacement,
-agent-token rotation, or general cluster reconciliation.
+There is no supported alpha workflow for automatic host fleet rollout, etcd
+disaster recovery, failed control-plane replacement, agent-token rotation, or
+general cluster reconciliation.

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -6,7 +6,7 @@ an explicit mutation of node-local kubeadm state and the Kubernetes API.
 ## Prerequisites
 
 - every intended node completed [generation 0 handoff](access.md);
-- the same `.katlcfg` bundle used for installation is available;
+- the same `ClusterConfig` source used for installation is available;
 - each node has a reachable address and protected per-node token file;
 - the Kubernetes bundle reference names a version compatible with the KatlOS
   runtime;
@@ -17,17 +17,13 @@ Katl fetches the Kubernetes bundle during this operation. Nodes need registry
 and CA access to `ghcr.io` unless the bundle is supplied through an explicitly
 supported local mechanism.
 
-## Rebuild Changed Intent
+## Review Changed Intent
 
-If the source changed before any node was installed, rebuild the bundle. Do not
-silently replace the bundle after installation:
+If the source changed after installation, review the diff before bootstrap and
+make sure it still describes the installed nodes. `katlctl` compiles the source
+internally; the normal path does not require a separate bundle file.
 
-```sh
-katlctl config bundle ./cluster.yaml --output ./katl-lab.katlcfg
-```
-
-Katl maintains the bundle's internal consistency metadata; it is not an
-operator input.
+Do not silently replace the cluster intent merely to make bootstrap proceed.
 
 ## Dry Run
 
@@ -35,9 +31,8 @@ Validate topology, node access, bundle selection, and bootstrap ordering without
 running kubeadm:
 
 ```sh
-katlctl cluster bootstrap \
+katlctl cluster bootstrap ./cluster.yaml \
   --dry-run \
-  --config-bundle ./katl-lab.katlcfg \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig
 ```
@@ -56,8 +51,7 @@ Kubernetes version, and bundle reference. A dry run must not create generation
 Run the same command without `--dry-run`:
 
 ```sh
-katlctl cluster bootstrap \
-  --config-bundle ./katl-lab.katlcfg \
+katlctl cluster bootstrap ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig
@@ -86,8 +80,7 @@ management workflow, or explicitly include reviewed manifests and readiness
 conditions:
 
 ```sh
-katlctl cluster bootstrap \
-  --config-bundle ./katl-lab.katlcfg \
+katlctl cluster bootstrap ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --bootstrap-manifest ./cni.yaml \

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -12,8 +12,8 @@ before accepting the operation.
 
 - preserve any required external backups and recovery material;
 - confirm which cluster identity is being discarded;
-- save the inventory, release assets, config source, bundle, kubeconfig, and
-  operation evidence;
+- save the inventory, release assets, config source, any PXE bundle,
+  kubeconfig, and operation evidence;
 - ensure all selected nodes can boot the intended installer path; and
 - stop if a control-plane or etcd member is expected to remain part of the same
   cluster.
@@ -108,7 +108,7 @@ not implemented as a supported operation.
 After every selected wipe operation succeeds:
 
 1. boot the verified installer ISO or PXE path;
-2. submit the intended config bundle and node selection;
+2. apply the intended `ClusterConfig` source and node selection;
 3. inspect the target disk again before authorizing installer wipe;
 4. complete generation 0 handoff; and
 5. treat the result as a new cluster identity unless a future supported


### PR DESCRIPTION
Teach the direct ClusterConfig path consistently in the Kubernetes bootstrap and reinstall runbooks. Correct adjacent operator-guide statements that still described the old installer and Kubernetes upgrade boundaries.