### PR TITLE
katlctl: streamline workstation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,24 +95,19 @@ available for PXE.
 
 ### 2. Describe the cluster once
 
-Author one `config.katl.dev/v1alpha1` `ClusterConfig` containing shared
-defaults and per-node overrides. It selects stable target-disk identities,
-networkd configuration, SSH keys, system roles, kubeadm input, and a Kubernetes
-bundle:
+Create one `config.katl.dev/v1alpha1` `ClusterConfig` containing shared
+defaults and per-node overrides. `katlctl config init` supplies a working DHCP
+and kubeadm-ready starting point; repeat `--node` for the intended topology:
 
-```yaml
-apiVersion: config.katl.dev/v1alpha1
-kind: ClusterConfig
-metadata:
-  name: katl-lab
-spec:
-  controlPlaneEndpoint: api.katl.test:6443
-  kubernetes:
-    version: v1.36.1
-    bundle: ghcr.io/katl-dev/kubernetes:<version>
-  # defaults, kubeadmConfigs, and nodes omitted here; use the complete example
-  # in docs/installing.md.
+```sh
+katlctl config init ./cluster.yaml \
+  --ssh-authorized-key ~/.ssh/id_ed25519.pub \
+  --node cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-KATL_CP_1_ROOT \
+  --node worker-1=worker,192.0.2.21,/dev/disk/by-id/ata-KATL_WORKER_1_ROOT
 ```
+
+Review the generated disk identities, addresses, Kubernetes selection, and
+network configuration before installing.
 
 Use the readable version tag on the normal path. Katl resolves the selected
 content once for the operation and checks what it downloads internally. An
@@ -159,10 +154,15 @@ activation. Kubernetes bootstrap is a separate operator action.
 
 ### 4. Bootstrap Kubernetes
 
-Once all installed nodes are reachable through their `katlc` endpoints, use the
-same cluster source. First retrieve each node's distinct
-agent token over SSH and populate the per-node `file:` credential references as
-described in [Access installed nodes](docs/operations/access.md):
+Once all installed nodes are reachable over SSH, enroll them from the same
+cluster source. This retrieves each distinct agent token, stores it privately,
+verifies the management API, and creates the current workstation context:
+
+```sh
+katlctl cluster enroll ./cluster.yaml
+```
+
+Then bootstrap without repeating endpoints or credential files:
 
 ```sh
 katlctl cluster bootstrap ./cluster.yaml \
@@ -178,20 +178,18 @@ kubeconfig to the operator.
 
 ## Configuration and upgrades
 
-`ClusterConfig` remains the user-authored source after installation. Preview a
-node-specific runtime request before submitting it:
+`ClusterConfig` remains the user-authored source after installation. An
+optional plan contacts the selected node but does not accept an operation:
 
 ```sh
-katlctl config render-node \
-  --source ./cluster.yaml \
-  --node cp-1 \
-  --desired-version 2 > cp-1.runtime.yaml
+katlctl config apply ./cluster.yaml --node cp-1 --plan
 ```
 
-Use `katlctl config apply validate` to plan through the node agent, then submit
-the identical inputs without `validate`. Supported changes compile into
-generation-scoped confext/sysext state and are applied live or on next boot
-according to the domain policy. See [Apply runtime configuration](docs/installing.md#apply-runtime-configuration).
+Run the command without `--plan` to apply it. `katlctl` derives config versions,
+generation names, validation, credentials, and operation tracking internally.
+Supported changes compile into generation-scoped confext/sysext state and are
+applied live or on next boot according to the domain policy. See
+[Apply runtime configuration](docs/installing.md#apply-runtime-configuration).
 
 Host upgrades consume the published `katlos-upgrade-<version>-<arch>.squashfs`
 artifact. Plan before accepting a next-boot generation:
@@ -240,8 +238,7 @@ discoverable afterward:
 
 ```sh
 katlctl operations list \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token
+  --node cp-1
 ```
 
 ## Release artifacts

--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/clusterplan"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/manifest"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultKubernetesVersion = "v1.36.1"
+	defaultKubernetesBundle  = "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1"
+)
+
+type configInitOptions struct {
+	outputPath        string
+	clusterName       string
+	controlPlane      string
+	kubernetesVersion string
+	kubernetesBundle  string
+	sshKeyPath        string
+	nodes             initNodeSpecs
+	force             bool
+}
+
+type initNodeSpec struct {
+	name    string
+	role    inventory.SystemRole
+	address string
+	disk    string
+}
+
+type initNodeSpecs []initNodeSpec
+
+func (values *initNodeSpecs) String() string { return "name=role,address,/dev/disk/by-id/..." }
+func (values *initNodeSpecs) Type() string   { return "node" }
+func (values *initNodeSpecs) Set(value string) error {
+	name, fields, ok := strings.Cut(strings.TrimSpace(value), "=")
+	parts := strings.Split(fields, ",")
+	if !ok || strings.TrimSpace(name) == "" || len(parts) != 3 {
+		return fmt.Errorf("node must be name=role,address,/dev/disk/by-id/...")
+	}
+	role := inventory.SystemRole(strings.TrimSpace(parts[0]))
+	if role != inventory.RoleControlPlane && role != inventory.RoleWorker {
+		return fmt.Errorf("node %q role must be %q or %q", name, inventory.RoleControlPlane, inventory.RoleWorker)
+	}
+	address := strings.TrimSpace(parts[1])
+	if net.ParseIP(address) == nil && !validHostname(address) {
+		return fmt.Errorf("node %q address %q is not an IP address or hostname", name, address)
+	}
+	disk := strings.TrimSpace(parts[2])
+	if !strings.HasPrefix(disk, "/dev/disk/by-id/") {
+		return fmt.Errorf("node %q disk must be a stable /dev/disk/by-id path", name)
+	}
+	*values = append(*values, initNodeSpec{name: strings.TrimSpace(name), role: role, address: address, disk: disk})
+	return nil
+}
+
+func newConfigInitCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := configInitOptions{
+		clusterName:       "katl-lab",
+		kubernetesVersion: defaultKubernetesVersion,
+		kubernetesBundle:  defaultKubernetesBundle,
+	}
+	cmd := &cobra.Command{
+		Use:   "init [PATH]",
+		Short: "Create an editable starter ClusterConfig",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.outputPath = args[0]
+			}
+			return runConfigInit(opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.clusterName, "name", opts.clusterName, "cluster name")
+	cmd.Flags().StringVar(&opts.controlPlane, "control-plane-endpoint", "", "stable Kubernetes API endpoint host:port; defaults to the first control-plane address")
+	cmd.Flags().StringVar(&opts.kubernetesVersion, "kubernetes-version", opts.kubernetesVersion, "Kubernetes payload version")
+	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", opts.kubernetesBundle, "Kubernetes bundle image")
+	cmd.Flags().StringVar(&opts.sshKeyPath, "ssh-authorized-key", "", "public SSH key file; defaults to ~/.ssh/id_ed25519.pub")
+	cmd.Flags().Var(&opts.nodes, "node", "node as name=role,address,/dev/disk/by-id/... (repeatable)")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "replace an existing output file")
+	return cmd
+}
+
+func runConfigInit(opts configInitOptions, stdout, stderr io.Writer) error {
+	_ = stderr
+	if len(opts.nodes) == 0 {
+		return fmt.Errorf("at least one --node is required")
+	}
+	configPath, err := workstation.ConfigPath()
+	if err != nil {
+		return err
+	}
+	sshKeyPath := strings.TrimSpace(opts.sshKeyPath)
+	if sshKeyPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("locate default SSH public key: %w", err)
+		}
+		sshKeyPath = home + "/.ssh/id_ed25519.pub"
+	}
+	keyData, err := os.ReadFile(sshKeyPath)
+	if err != nil {
+		return fmt.Errorf("read SSH public key %s: %w (use --ssh-authorized-key)", sshKeyPath, err)
+	}
+	sshKey := strings.TrimSpace(string(keyData))
+	if sshKey == "" || strings.ContainsAny(sshKey, "\r\n") {
+		return fmt.Errorf("SSH public key %s must contain one non-empty key", sshKeyPath)
+	}
+
+	controlPlane := strings.TrimSpace(opts.controlPlane)
+	if controlPlane == "" {
+		for _, node := range opts.nodes {
+			if node.role == inventory.RoleControlPlane {
+				controlPlane = net.JoinHostPort(node.address, "6443")
+				break
+			}
+		}
+	}
+	if controlPlane == "" {
+		return fmt.Errorf("at least one control-plane --node is required")
+	}
+
+	wipe := true
+	source := configbundle.SourceConfig{
+		APIVersion: configbundle.APIVersion,
+		Kind:       configbundle.Kind,
+		Metadata:   configbundle.Metadata{Name: strings.TrimSpace(opts.clusterName)},
+		Spec: configbundle.SourceSpec{
+			ControlPlaneEndpoint: controlPlane,
+			Kubernetes: configbundle.SourceKubernetesCluster{
+				Version: strings.TrimSpace(opts.kubernetesVersion),
+				Bundle:  strings.TrimSpace(opts.kubernetesBundle),
+			},
+			Defaults: configbundle.SourceNodeLayer{
+				Identity: configbundle.SourceIdentity{SSH: manifest.SSHIdentity{AuthorizedKeys: []string{sshKey}}},
+				Install:  configbundle.SourceInstallLayer{WipeTarget: &wipe},
+				Networkd: manifest.NetworkdConfig{Files: []manifest.NetworkdFile{{Name: "10-lan.network", Content: "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n"}}},
+			},
+			SystemRoleDefaults: map[inventory.SystemRole]configbundle.SourceNodeLayer{
+				inventory.RoleControlPlane: {Kubernetes: configbundle.SourceKubernetesLayer{Kubeadm: configbundle.SourceKubeadmRef{ConfigRef: "control-plane"}}},
+				inventory.RoleWorker:       {Kubernetes: configbundle.SourceKubernetesLayer{Kubeadm: configbundle.SourceKubeadmRef{ConfigRef: "worker"}}},
+			},
+			KubeadmConfigs: map[string]configbundle.SourceKubeadmConfig{
+				"control-plane": {Config: kubeadmInitConfig(opts.kubernetesVersion)},
+				"worker":        {Config: kubeadmJoinConfig()},
+			},
+		},
+	}
+	seen := map[string]struct{}{}
+	for _, node := range opts.nodes {
+		if _, ok := seen[node.name]; ok {
+			return fmt.Errorf("duplicate node name %q", node.name)
+		}
+		seen[node.name] = struct{}{}
+		credentialPath, err := workstation.CredentialPath(configPath, source.Metadata.Name, node.name)
+		if err != nil {
+			return err
+		}
+		source.Spec.Nodes = append(source.Spec.Nodes, configbundle.SourceNode{
+			Name: node.name, SystemRole: node.role,
+			Overrides: configbundle.SourceNodeLayer{
+				Identity:  configbundle.SourceIdentity{Hostname: node.name},
+				Install:   configbundle.SourceInstallLayer{TargetDisk: &manifest.DiskSelector{ByID: node.disk}},
+				Bootstrap: clusterplan.BootstrapLayer{Address: node.address, Access: inventory.Access{Method: "agent", CredentialRef: "file:" + credentialPath}},
+			},
+		})
+	}
+	data, err := yaml.Marshal(source)
+	if err != nil {
+		return fmt.Errorf("encode starter ClusterConfig: %w", err)
+	}
+	if _, err := configbundle.DecodeSource(strings.NewReader(string(data))); err != nil {
+		return fmt.Errorf("validate generated ClusterConfig: %w", err)
+	}
+	if strings.TrimSpace(opts.outputPath) == "" {
+		_, err = stdout.Write(data)
+		return err
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if opts.force {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+	file, err := os.OpenFile(opts.outputPath, flags, 0o600)
+	if err != nil {
+		return fmt.Errorf("create ClusterConfig %s: %w", opts.outputPath, err)
+	}
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return fmt.Errorf("write ClusterConfig %s: %w", opts.outputPath, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close ClusterConfig %s: %w", opts.outputPath, err)
+	}
+	fmt.Fprintf(stdout, "created %s\n", opts.outputPath)
+	return nil
+}
+
+func validHostname(value string) bool {
+	if value == "" || len(value) > 253 || strings.ContainsAny(value, " /:") {
+		return false
+	}
+	for _, label := range strings.Split(value, ".") {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return false
+		}
+	}
+	return true
+}
+
+func kubeadmInitConfig(version string) string {
+	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: " + strings.TrimSpace(version) + "\n"
+}
+
+func kubeadmJoinConfig() string {
+	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n"
+}

--- a/cmd/katlctl/enroll.go
+++ b/cmd/katlctl/enroll.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+	"github.com/spf13/cobra"
+)
+
+type enrollOptions struct {
+	sourcePath   string
+	configPath   string
+	contextName  string
+	sshUser      string
+	identityFile string
+	force        bool
+}
+
+type enrollNodeReport struct {
+	Name               string `json:"name"`
+	ManagementEndpoint string `json:"managementEndpoint"`
+	CredentialRef      string `json:"credentialRef"`
+	Connected          bool   `json:"connected"`
+}
+
+type enrollReport struct {
+	APIVersion string             `json:"apiVersion"`
+	Kind       string             `json:"kind"`
+	Context    string             `json:"context"`
+	ConfigPath string             `json:"configPath"`
+	Nodes      []enrollNodeReport `json:"nodes"`
+}
+
+var runEnrollmentSSH = func(ctx context.Context, user, address, identityFile string) ([]byte, error) {
+	args := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"}
+	if strings.TrimSpace(identityFile) != "" {
+		args = append(args, "-i", strings.TrimSpace(identityFile))
+	}
+	args = append(args, strings.TrimSpace(user)+"@"+strings.TrimSpace(address), "cat", "/var/lib/katl/agent/token")
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	data, err := cmd.Output()
+	if err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return nil, fmt.Errorf("%w: %s", err, message)
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+func newClusterEnrollCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := enrollOptions{sshUser: "root"}
+	cmd := &cobra.Command{
+		Use:   "enroll SOURCE",
+		Short: "Set up workstation access to installed KatlOS nodes",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			opts.sourcePath = args[0]
+			return runClusterEnroll(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "context name; defaults to the cluster name")
+	cmd.Flags().StringVar(&opts.sshUser, "ssh-user", opts.sshUser, "installed-node SSH user")
+	cmd.Flags().StringVar(&opts.identityFile, "identity-file", "", "SSH private key file")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "replace a different locally stored node token")
+	return cmd
+}
+
+func runClusterEnroll(ctx context.Context, opts enrollOptions, stdout, stderr io.Writer) error {
+	_ = stderr
+	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
+		SourcePath: opts.sourcePath, KatlctlVersion: version, KatlctlCommit: commit, CreatedBy: "katlctl cluster enroll",
+	})
+	if err != nil {
+		return fmt.Errorf("compile cluster config: %w", err)
+	}
+	bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
+	if err != nil {
+		return fmt.Errorf("read compiled cluster config: %w", err)
+	}
+	inv := bundle.Manifest.Cluster.BootstrapInventory
+	configPath := strings.TrimSpace(opts.configPath)
+	if configPath == "" {
+		configPath, err = workstation.ConfigPath()
+		if err != nil {
+			return err
+		}
+	}
+	contextName := strings.TrimSpace(opts.contextName)
+	if contextName == "" {
+		contextName = bundle.Manifest.ClusterName
+	}
+	clusterProfile := workstation.Cluster{Name: bundle.Manifest.ClusterName, ControlPlaneEndpoint: inv.ControlPlaneEndpoint}
+	report := enrollReport{APIVersion: "katl.dev/v1alpha1", Kind: "EnrollmentReport", Context: contextName, ConfigPath: configPath}
+
+	for _, node := range inv.Nodes {
+		credentialPath, ok := strings.CutPrefix(strings.TrimSpace(node.Access.CredentialRef), "file:")
+		if !ok || strings.TrimSpace(credentialPath) == "" {
+			credentialPath, err = workstation.CredentialPath(configPath, bundle.Manifest.ClusterName, node.Name)
+			if err != nil {
+				return err
+			}
+		}
+		tokenData, err := runEnrollmentSSH(ctx, opts.sshUser, node.Address, opts.identityFile)
+		if err != nil {
+			return fmt.Errorf("enroll node %s over SSH: %w", node.Name, err)
+		}
+		token := strings.TrimSpace(string(tokenData))
+		if token == "" || strings.ContainsAny(token, "\r\n") {
+			return fmt.Errorf("enroll node %s: installed agent token is empty or malformed", node.Name)
+		}
+		if err := writeManagedToken(credentialPath, token, opts.force); err != nil {
+			return fmt.Errorf("enroll node %s: %w", node.Name, err)
+		}
+		endpoint := net.JoinHostPort(strings.TrimSpace(node.Address), "9443")
+		conn, err := dialKatlcAgent(ctx, endpoint, token)
+		if err != nil {
+			return fmt.Errorf("verify node %s management endpoint: %w", node.Name, err)
+		}
+		status, statusErr := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+		closeErr := conn.Close()
+		if statusErr != nil {
+			return fmt.Errorf("verify node %s management endpoint: %w", node.Name, statusErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close node %s management endpoint: %w", node.Name, closeErr)
+		}
+		if strings.TrimSpace(status.GetMachineId()) == "" {
+			return fmt.Errorf("verify node %s management endpoint: agent did not report a machine identity", node.Name)
+		}
+		credentialRef := "file:" + credentialPath
+		clusterProfile.Nodes = append(clusterProfile.Nodes, workstation.Node{
+			Name: node.Name, ManagementEndpoint: endpoint, SystemRole: node.SystemRole, CredentialRef: credentialRef,
+		})
+		report.Nodes = append(report.Nodes, enrollNodeReport{Name: node.Name, ManagementEndpoint: endpoint, CredentialRef: credentialRef, Connected: true})
+	}
+
+	cfg := workstation.Config{}
+	if existing, loadErr := workstation.Load(configPath); loadErr == nil {
+		cfg = existing
+	} else if !errors.Is(loadErr, os.ErrNotExist) {
+		return loadErr
+	}
+	cfg = cfg.UpsertCluster(contextName, clusterProfile)
+	if err := workstation.Save(configPath, cfg); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode enrollment report: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func writeManagedToken(path, token string, force bool) error {
+	if existing, err := os.ReadFile(path); err == nil {
+		if strings.TrimSpace(string(existing)) == token {
+			return os.Chmod(path, 0o600)
+		}
+		if !force {
+			return fmt.Errorf("credential file %s contains a different token; use --force to replace it", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read credential file %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create credential directory: %w", err)
+	}
+	return os.WriteFile(path, []byte(token+"\n"), 0o600)
+}

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -98,6 +98,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	})
 
 	clusterCmd := &cobra.Command{Use: "cluster", Short: "Cluster lifecycle operations"}
+	clusterCmd.AddCommand(newClusterEnrollCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newClusterBootstrapCommand(ctx, stdout, stderr))
 	clusterUpgradeCmd := &cobra.Command{Use: "upgrade", Short: "Cluster upgrade operations"}
 	clusterUpgradeCmd.AddCommand(newKubernetesUpgradeCommand(ctx, stdout, stderr))
@@ -109,6 +110,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	cmd.AddCommand(clusterCmd)
 
 	configCmd := &cobra.Command{Use: "config", Short: "Katl configuration operations"}
+	configCmd.AddCommand(newConfigInitCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigPathCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigTopologyCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigValidateCommand(stdout, stderr))
@@ -141,6 +143,9 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 type hostUpgradeOptions struct {
 	endpoint            string
 	agentTokenFile      string
+	workstationConfig   string
+	contextName         string
+	nodeName            string
 	imageURL            string
 	imageLocalRef       string
 	candidateGeneration string
@@ -164,6 +169,9 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.imageURL, "image-url", "", "HTTPS KatlOS upgrade image URL")
 	cmd.Flags().StringVar(&opts.imageLocalRef, "image-local-ref", "", "relative KatlOS image reference under the node artifact store")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
@@ -182,9 +190,6 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.endpoint) == "" {
-		return fmt.Errorf("--endpoint is required")
-	}
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
@@ -200,11 +205,14 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if err := operation.ValidateHostUpgrade(request); err != nil {
 		return err
 	}
-	token, err := readAgentToken(opts.agentTokenFile)
+	target, err := resolveManagementTarget(managementTargetOptions{
+		configPath: opts.workstationConfig, contextName: opts.contextName, nodeName: opts.nodeName,
+		endpoint: opts.endpoint, agentTokenFile: opts.agentTokenFile,
+	})
 	if err != nil {
 		return err
 	}
-	conn, err := dialKatlcAgent(ctx, opts.endpoint, token)
+	conn, err := dialKatlcAgent(ctx, target.endpoint, target.token)
 	if err != nil {
 		return err
 	}
@@ -1174,6 +1182,8 @@ func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) 
 type configApplyOptions struct {
 	endpoint            string
 	agentTokenFile      string
+	workstationConfig   string
+	contextName         string
 	configPath          string
 	nodeConfig          nodeConfigInputOptions
 	mode                string
@@ -1186,13 +1196,21 @@ type configApplyOptions struct {
 	output              string
 }
 
+var configApplyNow = func() time.Time { return time.Now().UTC() }
+
 func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl config apply", output: "json"}
 	cmd := &cobra.Command{
-		Use:   "apply",
+		Use:   "apply [SOURCE]",
 		Short: "Validate or apply node configuration",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if strings.TrimSpace(opts.nodeConfig.sourcePath) != "" {
+					return fmt.Errorf("SOURCE cannot be combined with --source")
+				}
+				opts.nodeConfig.sourcePath = args[0]
+			}
 			return runConfigApply(ctx, opts, stdout, stderr)
 		},
 	}
@@ -1224,10 +1242,17 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.configPath, "file", "", "pre-rendered NodeConfigurationChange YAML")
 	addNodeConfigInputFlags(cmd, &opts.nodeConfig)
 	cmd.Flags().StringVar(&opts.mode, "mode", opts.mode, "apply mode: auto, live, or next-boot")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
+	for _, name := range []string{"source", "desired-version", "candidate-generation"} {
+		if flag := cmd.Flags().Lookup(name); flag != nil {
+			flag.Hidden = true
+		}
+	}
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
@@ -1241,9 +1266,6 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.endpoint) == "" {
-		return fmt.Errorf("--endpoint is required")
-	}
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
@@ -1255,6 +1277,22 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	intentInput := strings.TrimSpace(opts.nodeConfig.sourcePath) != "" || strings.TrimSpace(opts.nodeConfig.bundlePath) != ""
 	if fileInput == intentInput {
 		return fmt.Errorf("exactly one of --file, --source, or --config-bundle is required")
+	}
+	target, err := resolveManagementTarget(managementTargetOptions{
+		configPath: opts.workstationConfig, contextName: opts.contextName,
+		nodeName: opts.nodeConfig.nodeName, endpoint: opts.endpoint, agentTokenFile: opts.agentTokenFile,
+	})
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.nodeConfig.nodeName) == "" {
+		opts.nodeConfig.nodeName = target.nodeName
+	}
+	if strings.TrimSpace(opts.nodeConfig.desiredVersion) == "" && intentInput {
+		opts.nodeConfig.desiredVersion = strconv.FormatInt(configApplyNow().UnixNano(), 10)
+	}
+	if strings.TrimSpace(opts.candidateGeneration) == "" {
+		opts.candidateGeneration = "config-" + strconv.FormatInt(configApplyNow().UnixNano(), 10)
 	}
 	var configYAML []byte
 	if fileInput {
@@ -1271,19 +1309,12 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			return err
 		}
 	}
-	token, err := readAgentToken(opts.agentTokenFile)
-	if err != nil {
-		return err
-	}
-	conn, err := dialKatlcAgent(ctx, opts.endpoint, token)
+	conn, err := dialKatlcAgent(ctx, target.endpoint, target.token)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 	if opts.plan {
-		if strings.TrimSpace(opts.candidateGeneration) == "" {
-			return fmt.Errorf("--candidate-generation is required with --plan")
-		}
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion:            operation.APIVersion,
 			Kind:                  "ValidateConfigRequest",
@@ -1323,9 +1354,6 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	case generation.ApplyModeNextBoot:
 		accepted, err = conn.Client.StageGeneration(ctx, req)
 	case generation.ApplyModeAuto:
-		if strings.TrimSpace(opts.candidateGeneration) == "" {
-			return fmt.Errorf("--candidate-generation is required with --mode auto")
-		}
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion:            operation.APIVersion,
 			Kind:                  "ValidateConfigRequest",
@@ -1389,6 +1417,9 @@ type configApplyStatusOptions struct {
 	root               string
 	endpoint           string
 	agentTokenFile     string
+	workstationConfig  string
+	contextName        string
+	nodeName           string
 	generationID       string
 	activeGeneration   string
 	nextBootGeneration string
@@ -1408,6 +1439,9 @@ func newConfigApplyStatusCommand(ctx context.Context, stdout, stderr io.Writer) 
 	cmd.Flags().StringVar(&opts.root, "root", "/", "runtime root to inspect")
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.generationID, "generation", "", "generation id to query from katlc agent")
 	cmd.Flags().StringVar(&opts.activeGeneration, "active-generation", "", "active generation id")
 	cmd.Flags().StringVar(&opts.nextBootGeneration, "next-boot-generation", "", "next boot generation id")
@@ -1420,21 +1454,33 @@ func runConfigApplyStatus(ctx context.Context, opts configApplyStatusOptions, st
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.endpoint) != "" {
-		if strings.TrimSpace(opts.generationID) == "" {
-			return fmt.Errorf("--generation is required with --endpoint")
-		}
-		token, err := readAgentToken(opts.agentTokenFile)
+	remote := strings.TrimSpace(opts.endpoint) != "" || strings.TrimSpace(opts.workstationConfig) != "" || strings.TrimSpace(opts.contextName) != "" || strings.TrimSpace(opts.nodeName) != ""
+	if remote {
+		target, err := resolveManagementTarget(managementTargetOptions{
+			configPath: opts.workstationConfig, contextName: opts.contextName, nodeName: opts.nodeName,
+			endpoint: opts.endpoint, agentTokenFile: opts.agentTokenFile,
+		})
 		if err != nil {
 			return err
 		}
-		conn, err := dialKatlcAgent(ctx, opts.endpoint, token)
+		conn, err := dialKatlcAgent(ctx, target.endpoint, target.token)
 		if err != nil {
 			return err
 		}
 		defer conn.Close()
+		generationID := strings.TrimSpace(opts.generationID)
+		if generationID == "" {
+			status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+			if err != nil {
+				return err
+			}
+			generationID = strings.TrimSpace(status.GetCurrentGenerationId())
+			if generationID == "" {
+				return fmt.Errorf("node %q did not report a current generation", target.nodeName)
+			}
+		}
 		generation, err := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{
-			GenerationId:       opts.generationID,
+			GenerationId:       generationID,
 			IncludeConfigApply: true,
 		})
 		if err != nil {

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -40,6 +40,9 @@ type operationClient interface {
 type operationStatusOptions struct {
 	endpoint       string
 	agentTokenFile string
+	configPath     string
+	contextName    string
+	nodeName       string
 	operationID    string
 	diagnostics    string
 	watch          bool
@@ -50,6 +53,9 @@ type operationStatusOptions struct {
 type operationListOptions struct {
 	endpoint       string
 	agentTokenFile string
+	configPath     string
+	contextName    string
+	nodeName       string
 	activeOnly     bool
 	limit          int32
 	diagnostics    string
@@ -76,6 +82,9 @@ func newOperationStatusCommand(ctx context.Context, stdout, stderr io.Writer) *c
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.operationID, "operation-id", "", "accepted operation id")
 	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
 	cmd.Flags().BoolVar(&opts.watch, "watch", false, "follow the operation until it reaches terminal state")
@@ -96,6 +105,9 @@ func newOperationListCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().BoolVar(&opts.activeOnly, "active", false, "show only non-terminal operations")
 	cmd.Flags().Int32Var(&opts.limit, "limit", opts.limit, "maximum operations to return")
 	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
@@ -109,9 +121,6 @@ func runOperationList(ctx context.Context, opts operationListOptions, stdout, st
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.endpoint) == "" {
-		return fmt.Errorf("--endpoint is required")
-	}
 	if opts.limit < 1 || opts.limit > 100 {
 		return fmt.Errorf("--limit must be between 1 and 100")
 	}
@@ -121,13 +130,16 @@ func runOperationList(ctx context.Context, opts operationListOptions, stdout, st
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
-	token, err := readAgentToken(opts.agentTokenFile)
+	target, err := resolveManagementTarget(managementTargetOptions{
+		configPath: opts.configPath, contextName: opts.contextName, nodeName: opts.nodeName,
+		endpoint: opts.endpoint, agentTokenFile: opts.agentTokenFile,
+	})
 	if err != nil {
 		return err
 	}
 	requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
 	defer cancel()
-	conn, err := dialKatlcAgent(requestCtx, opts.endpoint, token)
+	conn, err := dialKatlcAgent(requestCtx, target.endpoint, target.token)
 	if err != nil {
 		return err
 	}
@@ -155,9 +167,6 @@ func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.endpoint) == "" {
-		return fmt.Errorf("--endpoint is required")
-	}
 	if strings.TrimSpace(opts.operationID) == "" {
 		return fmt.Errorf("--operation-id is required")
 	}
@@ -167,13 +176,16 @@ func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
-	token, err := readAgentToken(opts.agentTokenFile)
+	target, err := resolveManagementTarget(managementTargetOptions{
+		configPath: opts.configPath, contextName: opts.contextName, nodeName: opts.nodeName,
+		endpoint: opts.endpoint, agentTokenFile: opts.agentTokenFile,
+	})
 	if err != nil {
 		return err
 	}
 	requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
 	defer cancel()
-	conn, err := dialKatlcAgent(requestCtx, opts.endpoint, token)
+	conn, err := dialKatlcAgent(requestCtx, target.endpoint, target.token)
 	if err != nil {
 		return err
 	}

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/configapply"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+)
+
+const uxTestSSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"
+
+func TestConfigInitEmitsStarterClusterConfig(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519.pub")
+	if err := os.WriteFile(keyPath, []byte(uxTestSSHKey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(dir, "katlctl.yaml"))
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "init",
+		"--name", "homelab",
+		"--ssh-authorized-key", keyPath,
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-cp-root",
+		"--node", "worker-1=worker,192.0.2.21,/dev/disk/by-id/ata-worker-root",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	source, err := configbundle.DecodeSource(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Fatalf("DecodeSource() error = %v\n%s", err, stdout.String())
+	}
+	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "192.0.2.11:6443" || len(source.Spec.Nodes) != 2 {
+		t.Fatalf("generated source = %#v", source)
+	}
+	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Access.CredentialRef; !strings.Contains(got, "/credentials/homelab/cp-1.token") {
+		t.Fatalf("credentialRef = %q", got)
+	}
+}
+
+func TestClusterEnrollCreatesContextAndPrivateTokens(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "katlctl.yaml")
+	sourcePath := writeClusterConfig(t)
+	token := "node-token-value"
+	oldSSH := runEnrollmentSSH
+	runEnrollmentSSH = func(_ context.Context, user, address, identityFile string) ([]byte, error) {
+		if user != "root" || address != "10.0.0.11" || identityFile != "" {
+			t.Fatalf("SSH user=%q address=%q identity=%q", user, address, identityFile)
+		}
+		return []byte(token + "\n"), nil
+	}
+	t.Cleanup(func() { runEnrollmentSSH = oldSSH })
+	fake := &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine-cp-1"}}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(_ context.Context, endpoint, gotToken string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" || gotToken != token {
+			t.Fatalf("dial endpoint=%q token=%q", endpoint, gotToken)
+		}
+		return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"cluster", "enroll", sourcePath, "--config", configPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	cfg, err := workstation.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topology, err := cfg.SelectedTopology("lab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(topology.Nodes) != 1 || topology.Nodes[0].ManagementEndpoint != "10.0.0.11:9443" {
+		t.Fatalf("topology = %#v", topology)
+	}
+	credentialPath := strings.TrimPrefix(topology.Nodes[0].CredentialRef, "file:")
+	data, err := os.ReadFile(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != token {
+		t.Fatalf("stored token = %q", data)
+	}
+	info, err := os.Stat(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("token mode = %v", info.Mode().Perm())
+	}
+}
+
+func TestConfigApplyUsesContextAndDerivesBookkeeping(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "cp-1.token")
+	if err := os.WriteFile(tokenPath, []byte("token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(dir, "katlctl.yaml")
+	cfg := workstation.Config{CurrentContext: "lab", Contexts: []workstation.Context{{Name: "lab", Cluster: "lab"}}, Clusters: []workstation.Cluster{{
+		Name: "lab", Nodes: []workstation.Node{{Name: "cp-1", ManagementEndpoint: "10.0.0.11:9443", SystemRole: inventory.RoleControlPlane, CredentialRef: "file:" + tokenPath}},
+	}}}
+	if err := workstation.Save(configPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeKatlcAgentClient{
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		stageAccepted:  &agentapi.OperationAccepted{OperationId: "apply-1", OperationKind: "generation-apply", InitialStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded}},
+	}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(_ context.Context, endpoint, token string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" || token != "token" {
+			t.Fatalf("dial endpoint=%q token=%q", endpoint, token)
+		}
+		return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+	oldNow := configApplyNow
+	configApplyNow = func() time.Time { return time.Unix(0, 42).UTC() }
+	t.Cleanup(func() { configApplyNow = oldNow })
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "apply", writeClusterConfig(t), "--config", configPath, "--node", "cp-1"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	if fake.validateRequest == nil || fake.validateRequest.CandidateGenerationId != "config-42" {
+		t.Fatalf("validate request = %#v", fake.validateRequest)
+	}
+	change, err := configapply.DecodeNodeConfigurationChange(strings.NewReader(fake.validateRequest.ConfigYaml), configapply.TrustedBundleRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if change.DesiredVersion != "42" {
+		t.Fatalf("desired version = %q", change.DesiredVersion)
+	}
+}

--- a/cmd/katlctl/target.go
+++ b/cmd/katlctl/target.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+	"github.com/spf13/cobra"
+)
+
+type managementTargetOptions struct {
+	configPath     string
+	contextName    string
+	nodeName       string
+	endpoint       string
+	agentTokenFile string
+}
+
+type managementTarget struct {
+	nodeName string
+	endpoint string
+	token    string
+}
+
+func addManagementTargetFlags(cmd *cobra.Command, opts *managementTargetOptions) {
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "explicit katlc agent endpoint host:port")
+	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "explicit katlc agent bearer token file")
+}
+
+func resolveManagementTarget(opts managementTargetOptions) (managementTarget, error) {
+	if endpoint := strings.TrimSpace(opts.endpoint); endpoint != "" {
+		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
+			return managementTarget{}, fmt.Errorf("--endpoint cannot be combined with --config or --context")
+		}
+		token, err := readAgentToken(opts.agentTokenFile)
+		if err != nil {
+			return managementTarget{}, err
+		}
+		return managementTarget{nodeName: strings.TrimSpace(opts.nodeName), endpoint: endpoint, token: token}, nil
+	}
+
+	topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
+		ConfigPath:  strings.TrimSpace(opts.configPath),
+		ContextName: strings.TrimSpace(opts.contextName),
+	})
+	if err != nil {
+		return managementTarget{}, err
+	}
+	nodeName := strings.TrimSpace(opts.nodeName)
+	if nodeName == "" {
+		if len(topology.Nodes) != 1 {
+			return managementTarget{}, fmt.Errorf("--node is required because context %q contains %d nodes", topology.ContextName, len(topology.Nodes))
+		}
+		nodeName = topology.Nodes[0].Name
+	}
+	for _, node := range topology.Nodes {
+		if node.Name != nodeName {
+			continue
+		}
+		tokenPath := strings.TrimSpace(opts.agentTokenFile)
+		if tokenPath == "" {
+			ref := strings.TrimSpace(node.CredentialRef)
+			var ok bool
+			tokenPath, ok = strings.CutPrefix(ref, "file:")
+			if !ok {
+				return managementTarget{}, fmt.Errorf("node %q credentialRef must use file: for katlc management", nodeName)
+			}
+		}
+		token, err := readAgentToken(tokenPath)
+		if err != nil {
+			return managementTarget{}, err
+		}
+		return managementTarget{nodeName: nodeName, endpoint: node.ManagementEndpoint, token: token}, nil
+	}
+	return managementTarget{}, fmt.Errorf("node %q was not found in context %q", nodeName, topology.ContextName)
+}

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -450,12 +450,16 @@ topology, roles, kubeadm references, Kubernetes version, and OCI bundle
 selection. `--node-address node=address` remains available for an
 operator-observed address that differs from the compiled source.
 
-Each freshly installed node generates a distinct agent token. Retrieve it over
-SSH as described in [Access installed KatlOS nodes](operations/access.md), then
-store its workstation path in that node's `file:` credential reference. Do not
-put the token value in `ClusterConfig`. A common `--agent-token-file` is only a
-fallback when every selected node was deliberately provisioned with the same
-token; fresh installs do not have that property.
+Each freshly installed node generates a distinct agent token. Enroll the
+installed nodes before bootstrap:
+
+```text
+katlctl cluster enroll ./cluster.yaml
+```
+
+`katlctl` retrieves the tokens over SSH, stores them at the `file:` credential
+references with mode `0600`, verifies every management endpoint, and creates a
+workstation context. Do not put token values in `ClusterConfig`.
 
 `katlctl` is a bounded client. Node-local `katlc` validates and records the
 authoritative bootstrap operations, creates generation 1, runs `kubeadm`, and
@@ -475,46 +479,27 @@ node runtime configuration. `NodeConfigurationChange` is the node-agent
 operation envelope; normal users do not need to reverse-engineer or maintain it
 by hand.
 
-Inspect the exact per-node runtime request without contacting a node:
+Optionally plan the exact per-node runtime request through the node agent:
 
 ```text
-katlctl config render-node \
-  --source ./cluster.yaml \
-  --node cp-1 \
-  --desired-version 2 > cp-1.runtime.yaml
+katlctl config apply ./cluster.yaml --node cp-1 --plan
 ```
 
-`--desired-version` is a monotonically increasing unsigned number for this
-configuration source. It provides replay and stale-change protection. The
-source id defaults to `metadata.name`; use `--source-id` only when the same
-cluster needs independently versioned configuration streams.
-
-Plan the change through the node agent before accepting an operation:
-
-```text
-katlctl config apply validate \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --source ./cluster.yaml \
-  --node cp-1 \
-  --desired-version 2 \
-  --candidate-generation config-2
-```
+`katlctl` derives the source version, candidate generation, authenticated
+endpoint, validation request, and operation tracking. These are internal
+replay and lifecycle details, not operator inputs.
 
 If the source has already been compiled, use the bundle instead of
 recompiling it:
 
 ```text
-katlctl config apply validate \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
+katlctl config apply \
   --config-bundle ./katl-lab.katlcfg \
   --node cp-1 \
-  --desired-version 2 \
-  --candidate-generation config-2
+  --plan
 ```
 
-Remove `validate` to submit the accepted plan. The default `--mode auto` uses
+Remove `--plan` to submit the accepted plan. The default `--mode auto` uses
 the agent's domain matrix to choose live apply or next boot; `--mode live` and
 `--mode next-boot` request an explicit policy and are rejected when unsafe.
 Keep the same configuration inputs when submitting. `katlctl` generates the

--- a/docs/internal/katlctl-workstation-config.md
+++ b/docs/internal/katlctl-workstation-config.md
@@ -39,7 +39,9 @@ XDG_CONFIG_HOME
 
 ## Schema
 
-The file is a minimal client-side profile store:
+The file is a minimal client-side profile store. `katlctl cluster enroll
+SOURCE` creates or updates it on the normal path; operators do not need to
+author this YAML by hand:
 
 ```yaml
 currentContext: prod
@@ -66,7 +68,9 @@ KatlOS system roles, credential references, and optionally the stable
 control-plane endpoint used by operator workflows.
 
 The config must not contain inline bearer tokens, private keys, kubeconfigs, or
-cluster PKI. Store references to credentials, not credential material.
+cluster PKI. Enrollment stores per-node bearer tokens beneath the adjacent
+`credentials/<cluster>/` directory with mode `0600` and records only `file:`
+references here.
 
 `katlctl config topology` prints the resolved context topology as JSON.
 The topology output includes `credentialRef` values because they are operator

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -36,7 +36,7 @@ Keep these artifacts together for the life of an evaluation:
 - the KatlOS release URL and assets used;
 - the source `ClusterConfig` and any `.katlcfg` produced for PXE or offline use;
 - the Kubernetes OCI reference;
-- one protected agent token file per node;
+- one enrolled workstation context with a protected agent token per node;
 - the kubeconfig, command results, generation IDs, and relevant timestamps; and
 - independent etcd, application, and persistent-data backups.
 
@@ -59,8 +59,7 @@ or recent node work later with:
 
 ```sh
 katlctl operations list \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token
+  --node cp-1
 ```
 
 `katlctl operation status --operation-id ID` remains an advanced diagnostic

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -11,9 +11,10 @@ Internet, an untrusted LAN, or a shared production network. Use an isolated
 evaluation management network and restrict port `9443` at the surrounding
 firewall.
 
-SSH is the supported way to retrieve the initial per-node token. Treat token
-files like private keys: store them with mode `0600`, never commit them, never
-put token values in `ClusterConfig`, and redact them from logs and issues.
+`katlctl cluster enroll` uses SSH once to retrieve each initial per-node token,
+stores it with mode `0600`, and creates a workstation context. Treat the managed
+files like private keys: never commit them, never put token values in
+`ClusterConfig`, and redact them from logs and issues.
 
 The installed system keeps an operator dashboard on VGA `tty1`. It reports the
 node addresses, boot and generation health, installer handoff state, and a live
@@ -38,24 +39,24 @@ Expected state before Kubernetes bootstrap:
 - runtime handoff reports `waiting-for-cluster-bootstrap`; and
 - `katl-kubeadm-ready.target` is not active yet.
 
-## Collect One Token Per Node
+## Enroll the Cluster
 
-Create a protected workstation directory, then copy each token over SSH using
-the node address selected during installation:
+Use the same source used for installation:
 
 ```sh
-install -d -m 0700 ./tokens
-umask 077
-ssh root@192.0.2.11 'cat /var/lib/katl/agent/token' > ./tokens/cp-1.token
-ssh root@192.0.2.21 'cat /var/lib/katl/agent/token' > ./tokens/worker-1.token
-chmod 0600 ./tokens/*.token
+katlctl cluster enroll ./cluster.yaml
 ```
 
-Each freshly installed node generates its own token. Do not assume one fallback
-token authenticates to the entire cluster.
+The command connects as `root` using the workstation's normal SSH agent. Use
+`--identity-file PATH` or `--ssh-user USER` when needed. For every node it:
 
-In `ClusterConfig`, use a reference to each workstation token path, not secret
-material. `file:` paths are read by `katlctl` on the workstation:
+- reads `/var/lib/katl/agent/token` without printing it;
+- writes the configured `file:` credential with mode `0600`;
+- verifies authenticated access to TCP port `9443`; and
+- writes or updates the selected cluster in `katlctl.yaml`.
+
+`katlctl config init` generates the matching credential references. In a
+hand-authored `ClusterConfig`, use workstation paths rather than secret values:
 
 ```yaml
 nodes:
@@ -66,7 +67,7 @@ nodes:
         address: 192.0.2.11
         access:
           method: agent
-          credentialRef: file:/absolute/path/to/tokens/cp-1.token
+            credentialRef: file:/home/operator/.config/katl/credentials/katl-lab/cp-1.token
   - name: worker-1
     systemRole: worker
     overrides:
@@ -74,24 +75,25 @@ nodes:
         address: 192.0.2.21
         access:
           method: agent
-          credentialRef: file:/absolute/path/to/tokens/worker-1.token
+            credentialRef: file:/home/operator/.config/katl/credentials/katl-lab/worker-1.token
 ```
 
-The paths may exist after the bundle is compiled, but they must contain the
-matching node tokens before `katlctl cluster bootstrap` runs.
+Each freshly installed node generates its own token. Do not assume one fallback
+token authenticates to the entire cluster. Enrollment refuses to overwrite a
+different local token unless `--force` is explicit.
 
 ## Connectivity Check
 
-From the operator workstation, confirm only that the intended isolated path is
-reachable:
+Inspect the resolved context after enrollment:
 
 ```sh
-nc -vz 192.0.2.11 9443
-nc -vz 192.0.2.21 9443
+katlctl config topology
+katlctl operations list --node cp-1
 ```
 
-A TCP connection is not proof of authenticated agent health. The first
-plan/dry-run command in each lifecycle runbook is the authenticated preflight.
+Enrollment has already performed the authenticated agent health check. Normal
+management commands now need only `--node`; `--context` selects a non-current
+cluster. Explicit `--endpoint` and `--agent-token-file` remain expert overrides.
 
 There is no supported alpha token-rotation workflow. If a token is exposed,
 isolate the node and treat the evaluation identity as compromised; do not

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -7,7 +7,7 @@ an explicit mutation of node-local kubeadm state and the Kubernetes API.
 
 - every intended node completed [generation 0 handoff](access.md);
 - the same `ClusterConfig` source used for installation is available;
-- each node has a reachable address and protected per-node token file;
+- `katlctl cluster enroll ./cluster.yaml` completed successfully;
 - the Kubernetes bundle reference names a version compatible with the KatlOS
   runtime;
 - the control-plane endpoint resolves or routes as designed; and
@@ -37,8 +37,7 @@ katlctl cluster bootstrap ./cluster.yaml \
   --kubeconfig-out ./kubeconfig
 ```
 
-When every node has a `file:` credential reference, do not add a common
-`--agent-token-file`; `katlctl` reads the per-node files. Use
+The enrolled `file:` credential references are read automatically. Use
 `--node-address node=address` only for an observed address that differs from the
 compiled source.
 
@@ -68,8 +67,7 @@ unclear, discover the affected node's current and recent operations:
 
 ```sh
 katlctl operations list \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token
+  --node cp-1
 ```
 
 ## Establish Cluster Networking

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -16,30 +16,15 @@ It excludes disk/install policy, system role, Kubernetes bundle selection, and
 kubeadm lifecycle state. A desired kubeadm input may be rendered and recorded as
 requiring a later explicit action; config apply does not run kubeadm.
 
-## Render and Review
+## Plan an Apply
 
-Use a monotonically increasing desired version for this source:
-
-```sh
-katlctl config render-node \
-  --source ./cluster.yaml \
-  --node cp-1 \
-  --desired-version 2 > cp-1.runtime.yaml
-```
-
-Review the rendered files before contacting the node. Do not place private
-keys, bearer tokens, or other secret values in source configuration.
-
-## Validate Through the Node
+An optional plan compiles the selected node configuration and asks the node to
+validate it without accepting an operation:
 
 ```sh
-katlctl config apply validate \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --source ./cluster.yaml \
+katlctl config apply ./cluster.yaml \
   --node cp-1 \
-  --desired-version 2 \
-  --candidate-generation config-2
+  --plan
 ```
 
 Validation reports the changed domains and accepted apply mode without
@@ -47,32 +32,28 @@ accepting an operation. The default `auto` lets the domain policy select live or
 next-boot application. Request `--mode live` or `--mode next-boot` only when you
 intend to constrain that policy; unsafe requests are refused.
 
-If the source has already been compiled, replace `--source` with:
+If the source has already been compiled, use the expert bundle input instead of
+the positional source:
 
-```text
---config-bundle ./katl-lab.katlcfg
+```sh
+katlctl config apply --config-bundle ./katl-lab.katlcfg --node cp-1 --plan
 ```
 
 Katl derives and verifies the bundle's integrity metadata from the file.
 
 ## Apply the Reviewed Request
 
-Run the same arguments without the `validate` subcommand:
+Run the same arguments without `--plan`:
 
 ```sh
-katlctl config apply \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --source ./cluster.yaml \
-  --node cp-1 \
-  --desired-version 2 \
-  --candidate-generation config-2
+katlctl config apply ./cluster.yaml --node cp-1
 ```
 
-Keep the configuration inputs identical to the reviewed plan. `katlctl`
-generates the retry identity, follows the durable apply, and exits only after a
-terminal result. Require `terminal: true` and `result: succeeded`. If
-`recoveryRequired` is true, stop and follow `failureReason` and `nextAction`.
+`katlctl` resolves the selected workstation context, reads the node credential,
+derives the monotonically increasing desired version and candidate generation,
+validates the change, follows the durable apply, and exits only after a terminal
+result. Require `terminal: true` and `result: succeeded`. If `recoveryRequired`
+is true, stop and follow `failureReason` and `nextAction`.
 
 ## Check Generation Status
 
@@ -80,12 +61,12 @@ Query the candidate through the agent:
 
 ```sh
 katlctl config apply status \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --generation config-2
+  --node cp-1
 ```
 
-For a live change, require committed state and healthy config-apply evidence.
+The command selects the node's current generation automatically. Pass
+`--generation` only to inspect an older or staged generation. For a live change,
+require committed state and healthy config-apply evidence.
 For a next-boot change, require committed staged state, reboot in a controlled
 window, then require the candidate to become healthy after
 `katl-boot-complete.target`.

--- a/internal/katlctl/workstation/config.go
+++ b/internal/katlctl/workstation/config.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const credentialsDirName = "credentials"
+
 type Config struct {
 	CurrentContext string    `json:"currentContext" yaml:"currentContext"`
 	Contexts       []Context `json:"contexts" yaml:"contexts"`
@@ -112,6 +114,93 @@ func Load(path string) (Config, error) {
 		return Config{}, err
 	}
 	return cfg, nil
+}
+
+// Save writes a workstation configuration atomically. The containing
+// directory and file are private because the configuration points at local
+// credential material even though it does not contain the credentials itself.
+func Save(path string, cfg Config) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("katlctl config path is required")
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode katlctl config: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create katlctl config directory: %w", err)
+	}
+	temp, err := os.CreateTemp(dir, ".katlctl-*.yaml")
+	if err != nil {
+		return fmt.Errorf("create katlctl config temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("protect katlctl config temporary file: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return fmt.Errorf("write katlctl config temporary file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close katlctl config temporary file: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace katlctl config: %w", err)
+	}
+	return nil
+}
+
+// CredentialPath returns the private token location managed by katlctl for a
+// node. It intentionally lives beside, rather than inside, katlctl.yaml.
+func CredentialPath(configPath, clusterName, nodeName string) (string, error) {
+	if err := validateName("cluster", clusterName); err != nil {
+		return "", err
+	}
+	if err := validateName("node", nodeName); err != nil {
+		return "", err
+	}
+	configPath = strings.TrimSpace(configPath)
+	if configPath == "" {
+		var err error
+		configPath, err = ConfigPath()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(filepath.Dir(configPath), credentialsDirName, clusterName, nodeName+".token"), nil
+}
+
+// UpsertCluster installs or replaces one cluster and its context while
+// retaining unrelated workstation profiles.
+func (cfg Config) UpsertCluster(contextName string, cluster Cluster) Config {
+	contextName = strings.TrimSpace(contextName)
+	cluster.Name = strings.TrimSpace(cluster.Name)
+	nextContexts := make([]Context, 0, len(cfg.Contexts)+1)
+	for _, existing := range cfg.Contexts {
+		if strings.TrimSpace(existing.Name) != contextName {
+			nextContexts = append(nextContexts, existing)
+		}
+	}
+	nextContexts = append(nextContexts, Context{Name: contextName, Cluster: cluster.Name})
+	nextClusters := make([]Cluster, 0, len(cfg.Clusters)+1)
+	for _, existing := range cfg.Clusters {
+		if strings.TrimSpace(existing.Name) != cluster.Name {
+			nextClusters = append(nextClusters, existing)
+		}
+	}
+	nextClusters = append(nextClusters, cluster)
+	cfg.CurrentContext = contextName
+	cfg.Contexts = nextContexts
+	cfg.Clusters = nextClusters
+	return cfg
 }
 
 func (cfg Config) Validate() error {

--- a/internal/katlctl/workstation/config_test.go
+++ b/internal/katlctl/workstation/config_test.go
@@ -286,6 +286,41 @@ func TestExplicitInventoryDoesNotBorrowFromConfig(t *testing.T) {
 	}
 }
 
+func TestSaveAndUpsertClusterPreservePrivateConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "katlctl.yaml")
+	cfg := Config{}.UpsertCluster("lab", Cluster{
+		Name:  "lab",
+		Nodes: []Node{{Name: "cp-1", ManagementEndpoint: "cp-1.test:9443", SystemRole: inventory.RoleControlPlane, CredentialRef: "file:/secure/cp-1.token"}},
+	})
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CurrentContext != "lab" || len(loaded.Clusters) != 1 {
+		t.Fatalf("loaded config = %#v", loaded)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode = %v", info.Mode().Perm())
+	}
+}
+
+func TestCredentialPathLivesBesideConfig(t *testing.T) {
+	path, err := CredentialPath("/tmp/katl/katlctl.yaml", "lab", "cp-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "/tmp/katl/credentials/lab/cp-1.token" {
+		t.Fatalf("CredentialPath() = %q", path)
+	}
+}
+
 func writeConfig(t *testing.T, data string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "katlctl.yaml")


### PR DESCRIPTION
Adds starter ClusterConfig generation and one-command node enrollment, then uses the resulting context across routine node management. Config apply now accepts the cluster source directly and derives version and generation bookkeeping internally.