### PR TITLE
katlctl: discover installers and reuse config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,23 @@ Attach or write `katl-installer.iso` using your normal UEFI virtual-media or USB
 workflow, then boot it. The installer reports progress on both a local VGA
 console and a 115200-baud serial console. Secure Boot must remain disabled until
 Katl publishes signed boot artifacts. Without preseed input, the installer waits
-safely and prints its HTTP handoff URL. On the trusted provisioning network,
-apply the cluster source while selecting the node by name:
+safely. From the trusted provisioning network, discover waiting installers and
+their stable disk identities:
 
 ```sh
-INSTALLER_ENDPOINT=http://192.0.2.10:8080
-katlctl install apply ./cluster.yaml \
-  --endpoint "$INSTALLER_ENDPOINT" \
-  --node cp-1
+katlctl install discover
 ```
+
+Update the node's target disk if discovery shows a different stable identity,
+then apply the cluster source. When exactly one installer is waiting, no URL
+needs to be copied from the console:
+
+```sh
+katlctl install apply ./cluster.yaml --node cp-1
+```
+
+With multiple waiting installers, select the intended URL from discovery with
+`--endpoint`.
 
 The command validates and compiles the source locally, confirms the installer
 is waiting, submits the selected configuration once, and waits for reboot-ready

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -48,6 +48,7 @@ type installHandoffReport struct {
 
 func newInstallCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{Use: "install", Short: "KatlOS installer handoff operations"}
+	cmd.AddCommand(newInstallDiscoverCommand(ctx, stdout, stderr))
 	cmd.AddCommand(newInstallApplyCommand(ctx, stdout, stderr))
 	cmd.AddCommand(newInstallStatusCommand(ctx, stdout, stderr))
 	return cmd
@@ -64,7 +65,7 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 			return runInstallApply(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL such as http://192.0.2.10:8080")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL; discovers a unique waiting installer when omitted")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the cluster config")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
@@ -75,14 +76,15 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 func newInstallStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := installStatusOptions{timeout: 15 * time.Second, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "Report a waiting or running KatlOS installer",
-		Args:  cobra.NoArgs,
+		Use:     "status",
+		Aliases: []string{"inspect"},
+		Short:   "Report a waiting or running KatlOS installer",
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runInstallStatus(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL such as http://192.0.2.10:8080")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL; discovers a unique waiting installer when omitted")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "status request timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
 	return cmd
@@ -92,7 +94,7 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	endpoint, err := normalizeInstallerEndpoint(opts.endpoint)
+	endpoint, err := resolveInstallerEndpoint(ctx, opts.endpoint, opts.timeout)
 	if err != nil {
 		return err
 	}
@@ -164,7 +166,7 @@ func runInstallStatus(ctx context.Context, opts installStatusOptions, stdout, st
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	endpoint, err := normalizeInstallerEndpoint(opts.endpoint)
+	endpoint, err := resolveInstallerEndpoint(ctx, opts.endpoint, opts.timeout)
 	if err != nil {
 		return err
 	}

--- a/cmd/katlctl/install_discover.go
+++ b/cmd/katlctl/install_discover.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/handoff"
+	"github.com/spf13/cobra"
+)
+
+type installDiscoverOptions struct {
+	timeout time.Duration
+	output  string
+}
+
+type discoveredInstaller struct {
+	Endpoint string                `json:"endpoint"`
+	Status   handoff.HandoffStatus `json:"status"`
+}
+
+type installDiscoveryReport struct {
+	APIVersion string                `json:"apiVersion"`
+	Kind       string                `json:"kind"`
+	Installers []discoveredInstaller `json:"installers"`
+}
+
+var installerInterfaceAddrs = net.InterfaceAddrs
+var installerDiscoveryProbe = func(ctx context.Context, endpoint string, timeout time.Duration) (handoff.HandoffStatus, error) {
+	return fetchInstallStatus(ctx, &http.Client{Timeout: timeout}, endpoint)
+}
+
+func newInstallDiscoverCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := installDiscoverOptions{timeout: 3 * time.Second, output: "json"}
+	cmd := &cobra.Command{
+		Use:   "discover",
+		Short: "Find waiting KatlOS installers and inspect their disks",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runInstallDiscover(ctx, opts, stdout, stderr)
+		},
+	}
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall local-network discovery timeout")
+	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	return cmd
+}
+
+func runInstallDiscover(ctx context.Context, opts installDiscoverOptions, stdout, stderr io.Writer) error {
+	_ = stderr
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want json", opts.output)
+	}
+	installers, err := discoverInstallers(ctx, opts.timeout)
+	if err != nil {
+		return err
+	}
+	report := installDiscoveryReport{APIVersion: "katl.dev/v1alpha1", Kind: "InstallerDiscovery", Installers: installers}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode installer discovery: %w", err)
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+func resolveInstallerEndpoint(ctx context.Context, value string, timeout time.Duration) (string, error) {
+	if strings.TrimSpace(value) != "" {
+		return normalizeInstallerEndpoint(value)
+	}
+	if timeout <= 0 || timeout > 3*time.Second {
+		timeout = 3 * time.Second
+	}
+	installers, err := discoverInstallers(ctx, timeout)
+	if err != nil {
+		return "", err
+	}
+	waiting := make([]string, 0, len(installers))
+	for _, installer := range installers {
+		if installer.Status.State == handoff.HandoffWaiting {
+			waiting = append(waiting, installer.Endpoint)
+		}
+	}
+	switch len(waiting) {
+	case 0:
+		return "", fmt.Errorf("no waiting KatlOS installer was discovered; run katlctl install discover or pass --endpoint")
+	case 1:
+		return waiting[0], nil
+	default:
+		return "", fmt.Errorf("discovered %d waiting KatlOS installers (%s); select one with --endpoint", len(waiting), strings.Join(waiting, ", "))
+	}
+}
+
+func discoverInstallers(ctx context.Context, timeout time.Duration) ([]discoveredInstaller, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("--timeout must be positive")
+	}
+	candidates, err := localInstallerCandidates()
+	if err != nil {
+		return nil, err
+	}
+	discoveryCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	requestTimeout := 750 * time.Millisecond
+	if timeout < requestTimeout {
+		requestTimeout = timeout
+	}
+	jobs := make(chan string)
+	results := make(chan discoveredInstaller, len(candidates))
+	workers := 64
+	if len(candidates) < workers {
+		workers = len(candidates)
+	}
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for endpoint := range jobs {
+				status, err := installerDiscoveryProbe(discoveryCtx, endpoint, requestTimeout)
+				if err == nil {
+					results <- discoveredInstaller{Endpoint: endpoint, Status: status}
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, endpoint := range candidates {
+			select {
+			case jobs <- endpoint:
+			case <-discoveryCtx.Done():
+				return
+			}
+		}
+	}()
+	done := make(chan struct{})
+	go func() {
+		group.Wait()
+		close(results)
+		close(done)
+	}()
+	var installers []discoveredInstaller
+	for result := range results {
+		installers = append(installers, result)
+	}
+	<-done
+	sort.Slice(installers, func(i, j int) bool { return installers[i].Endpoint < installers[j].Endpoint })
+	return installers, nil
+}
+
+func localInstallerCandidates() ([]string, error) {
+	addrs, err := installerInterfaceAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("list local network addresses: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil || ip == nil || ip.IsLoopback() || ip.To4() == nil {
+			continue
+		}
+		ipv4 := ip.To4()
+		for host := 1; host < 255; host++ {
+			candidate := net.IPv4(ipv4[0], ipv4[1], ipv4[2], byte(host)).String()
+			seen["http://"+net.JoinHostPort(candidate, "8080")] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil, fmt.Errorf("no non-loopback IPv4 network is available for installer discovery; pass --endpoint")
+	}
+	candidates := make([]string, 0, len(seen))
+	for endpoint := range seen {
+		candidates = append(candidates, endpoint)
+	}
+	sort.Strings(candidates)
+	return candidates, nil
+}

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,38 @@ import (
 	"github.com/katl-dev/katl/internal/installer/handoff"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
+
+func TestInstallDiscoverFindsWaitingInstallerAndDisks(t *testing.T) {
+	oldAddrs := installerInterfaceAddrs
+	installerInterfaceAddrs = func() ([]net.Addr, error) {
+		return []net.Addr{&net.IPNet{IP: net.ParseIP("192.0.2.5"), Mask: net.CIDRMask(24, 32)}}, nil
+	}
+	t.Cleanup(func() { installerInterfaceAddrs = oldAddrs })
+	oldProbe := installerDiscoveryProbe
+	installerDiscoveryProbe = func(_ context.Context, endpoint string, _ time.Duration) (handoff.HandoffStatus, error) {
+		if endpoint != "http://192.0.2.42:8080" {
+			return handoff.HandoffStatus{}, fmt.Errorf("not an installer")
+		}
+		return handoff.HandoffStatus{State: handoff.HandoffWaiting, InstallStatus: installstatus.New(installstatus.StateWaitingForConfig, time.Now()), Disks: []handoff.HandoffDisk{{Path: "/dev/vda", ByID: []string{"/dev/disk/by-id/virtio-root"}, Selectable: true}}}, nil
+	}
+	t.Cleanup(func() { installerDiscoveryProbe = oldProbe })
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"install", "discover"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	var report installDiscoveryReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Installers) != 1 || report.Installers[0].Endpoint != "http://192.0.2.42:8080" || !report.Installers[0].Status.Disks[0].Selectable {
+		t.Fatalf("report = %#v", report)
+	}
+	endpoint, err := resolveInstallerEndpoint(context.Background(), "", time.Second)
+	if err != nil || endpoint != "http://192.0.2.42:8080" {
+		t.Fatalf("resolveInstallerEndpoint() = %q, %v", endpoint, err)
+	}
+}
 
 func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
 	server := handoff.NewHandoffServer(nil)

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -240,32 +241,42 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 }
 
 type wipeClusterOptions struct {
-	command         string
-	selectedNodes   stringList
-	inventoryPath   string
-	all             bool
-	allowPartial    bool
-	confirm         bool
-	acknowledgement string
-	clientRequestID string
-	agentTokenFile  string
-	planOnly        bool
-	noWait          bool
-	timeout         string
-	output          string
+	command           string
+	selectedNodes     stringList
+	sourcePath        string
+	inventoryPath     string
+	configBundlePath  string
+	workstationConfig string
+	contextName       string
+	all               bool
+	allowPartial      bool
+	confirm           bool
+	acknowledgement   string
+	clientRequestID   string
+	agentTokenFile    string
+	planOnly          bool
+	noWait            bool
+	timeout           string
+	output            string
 }
 
 func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
 	opts := wipeClusterOptions{command: commandName, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "wipe",
+		Use:   "wipe [SOURCE]",
 		Short: "Destructively reset cluster nodes for installer-media reinstall",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.sourcePath = args[0]
+			}
 			return runWipeClusterOptions(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
+	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
+	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "select every node in the inventory")
 	cmd.Flags().BoolVar(&opts.allowPartial, "allow-partial-cluster", false, "allow a partial cluster target set")
 	cmd.Flags().BoolVar(&opts.confirm, "confirm-destructive-wipe", false, "confirm destructive wipe")
@@ -286,14 +297,13 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.inventoryPath) == "" {
-		return fmt.Errorf("--inventory is required")
-	}
-	if !opts.confirm {
-		return fmt.Errorf("--confirm-destructive-wipe is required")
-	}
-	if opts.acknowledgement != wipeAcknowledgementText {
-		return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
+	if !opts.planOnly {
+		if !opts.confirm {
+			return fmt.Errorf("--confirm-destructive-wipe is required")
+		}
+		if opts.acknowledgement != wipeAcknowledgementText {
+			return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
+		}
 	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
@@ -307,7 +317,11 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 		return fmt.Errorf("--all and --node cannot be combined")
 	}
 
-	inv, err := loadInventory(opts.inventoryPath)
+	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	if err != nil {
+		return err
+	}
+	inv, err = overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
 	if err != nil {
 		return err
 	}
@@ -320,6 +334,7 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 		return err
 	}
 	report := newWipeClusterReport(opts.planOnly, partial, targets)
+	report.AcknowledgementAccepted = opts.confirm && opts.acknowledgement == wipeAcknowledgementText
 	report.Command = opts.command
 	if partial && !opts.allowPartial {
 		report.Refusals = append(report.Refusals, "partial cluster wipe requires --allow-partial-cluster")
@@ -355,31 +370,41 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 }
 
 type wipeNodeOptions struct {
-	command         string
-	selectedNodes   stringList
-	inventoryPath   string
-	kubeconfigPath  string
-	confirm         bool
-	acknowledgement string
-	clientRequestID string
-	agentTokenFile  string
-	planOnly        bool
-	noWait          bool
-	timeout         string
-	output          string
+	command           string
+	selectedNodes     stringList
+	sourcePath        string
+	inventoryPath     string
+	configBundlePath  string
+	workstationConfig string
+	contextName       string
+	kubeconfigPath    string
+	confirm           bool
+	acknowledgement   string
+	clientRequestID   string
+	agentTokenFile    string
+	planOnly          bool
+	noWait            bool
+	timeout           string
+	output            string
 }
 
 func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
 	opts := wipeNodeOptions{command: commandName, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "node",
+		Use:   "node [SOURCE]",
 		Short: "Destructively reset one node for installer-media reinstall",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.sourcePath = args[0]
+			}
 			return runWipeNodeOptions(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
+	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
+	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.kubeconfigPath, "kubeconfig", "", "path to operator kubeconfig")
 	cmd.Flags().BoolVar(&opts.confirm, "confirm-destructive-wipe", false, "confirm destructive wipe")
 	cmd.Flags().StringVar(&opts.acknowledgement, "acknowledge", "", "required destructive acknowledgement text")
@@ -399,20 +424,19 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if strings.TrimSpace(opts.inventoryPath) == "" {
-		return fmt.Errorf("--inventory is required")
-	}
 	if len(opts.selectedNodes.values) != 1 {
 		return fmt.Errorf("exactly one --node is required")
 	}
 	if !opts.planOnly && strings.TrimSpace(opts.kubeconfigPath) == "" {
 		return fmt.Errorf("--kubeconfig is required")
 	}
-	if !opts.confirm {
-		return fmt.Errorf("--confirm-destructive-wipe is required")
-	}
-	if opts.acknowledgement != wipeAcknowledgementText {
-		return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
+	if !opts.planOnly {
+		if !opts.confirm {
+			return fmt.Errorf("--confirm-destructive-wipe is required")
+		}
+		if opts.acknowledgement != wipeAcknowledgementText {
+			return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
+		}
 	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
@@ -423,7 +447,11 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return fmt.Errorf("--timeout must be a positive duration")
 	}
 
-	inv, err := loadInventory(opts.inventoryPath)
+	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	if err != nil {
+		return err
+	}
+	inv, err = overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
 	if err != nil {
 		return err
 	}
@@ -437,6 +465,7 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 	}
 	target := targets[0]
 	report := newWipeNodeReport(opts.planOnly, partial, target)
+	report.AcknowledgementAccepted = opts.confirm && opts.acknowledgement == wipeAcknowledgementText
 	report.Command = opts.command
 	if target.SystemRole == inventory.RoleControlPlane {
 		report.KubernetesCleanup = "refused"
@@ -484,6 +513,66 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return printErr
 	}
 	return submitErr
+}
+
+func loadWipeInventory(sourcePath, bundlePath, inventoryPath string) (inventory.Inventory, error) {
+	inputs := 0
+	for _, value := range []string{sourcePath, bundlePath, inventoryPath} {
+		if strings.TrimSpace(value) != "" {
+			inputs++
+		}
+	}
+	if inputs != 1 {
+		return inventory.Inventory{}, fmt.Errorf("exactly one cluster config SOURCE, --config-bundle, or --inventory is required")
+	}
+	if strings.TrimSpace(inventoryPath) != "" {
+		return loadInventory(inventoryPath)
+	}
+	if strings.TrimSpace(sourcePath) != "" {
+		archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
+			SourcePath: sourcePath, KatlctlVersion: version, KatlctlCommit: commit, CreatedBy: "katlctl cluster wipe",
+		})
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("compile cluster config: %w", err)
+		}
+		bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("read compiled cluster config: %w", err)
+		}
+		return bundle.Manifest.Cluster.BootstrapInventory, nil
+	}
+	bundle, err := configbundle.ReadBundleFile(bundlePath, "")
+	if err != nil {
+		return inventory.Inventory{}, err
+	}
+	return bundle.Manifest.Cluster.BootstrapInventory, nil
+}
+
+func overlayWipeContext(inv inventory.Inventory, configPath, contextName string) (inventory.Inventory, error) {
+	if strings.TrimSpace(configPath) == "" && strings.TrimSpace(contextName) == "" {
+		return inv, nil
+	}
+	topology, err := workstation.ResolveTopology(workstation.ResolveRequest{ConfigPath: strings.TrimSpace(configPath), ContextName: strings.TrimSpace(contextName)})
+	if err != nil {
+		return inventory.Inventory{}, err
+	}
+	byName := make(map[string]workstation.TopologyNode, len(topology.Nodes))
+	for _, node := range topology.Nodes {
+		byName[node.Name] = node
+	}
+	for index := range inv.Nodes {
+		node, ok := byName[inv.Nodes[index].Name]
+		if !ok {
+			return inventory.Inventory{}, fmt.Errorf("node %q from wipe input is missing from context %q", inv.Nodes[index].Name, topology.ContextName)
+		}
+		host, _, err := net.SplitHostPort(node.ManagementEndpoint)
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("node %q management endpoint: %w", node.Name, err)
+		}
+		inv.Nodes[index].Address = host
+		inv.Nodes[index].Access = inventory.Access{Method: "agent", CredentialRef: node.CredentialRef}
+	}
+	return inv, nil
 }
 
 type wipeClusterReport struct {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -950,6 +950,33 @@ func TestWipeClusterPlanPrintsNodeLocalOperations(t *testing.T) {
 	}
 }
 
+func TestWipeClusterPlanAcceptsClusterConfigWithoutDestructiveAcknowledgement(t *testing.T) {
+	sourcePath := writeClusterConfig(t)
+	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
+		"cp-1": readyWipeClusterClient("cp-machine"),
+	})
+	old := newWipeClusterConnector
+	newWipeClusterConnector = func(string) cluster.AgentConnector { return connector }
+	t.Cleanup(func() { newWipeClusterConnector = old })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"cluster", "wipe", sourcePath,
+		"--all",
+		"--plan",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	var report wipeClusterReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if !report.Plan || report.AcknowledgementAccepted || len(report.Targets) != 1 || report.Targets[0].Name != "cp-1" {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
 func TestWipeClusterSubmitsDestructiveResetToAllNodes(t *testing.T) {
 	inventoryPath := writeInventory(t)
 	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{

--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -567,6 +567,12 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 		return err
 	}
 	server := handoff.NewHandoffServerWithDefaultImage(nil, media.Image)
+	facts, discoveryErr := discovery.NewCommandDiscoverySource(installer.NewExecCommandRunner()).Discover(ctx)
+	if discoveryErr != nil {
+		fmt.Fprintf(stdout, "katlos-install hardware discovery: %v\n", discoveryErr)
+	} else {
+		server.SetHardwareFacts(facts)
+	}
 	writeConsoleInstallStatus(runDir, server.Status().InstallStatus, stdout)
 	server.SetStatusReader(func() (installstatus.Record, error) {
 		return installstatus.ReadFile(filepath.Join(runDir, "state", "status.json"))

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -304,8 +304,8 @@ create or operate DHCP, iPXE, or matchbox configuration.
 ## ISO Or Local Handoff
 
 Boot the same `katl-installer.iso` on each node without preseed input. The
-installer mounts its embedded KatlOS image read-only, prints a handoff URL and
-waits without mutating disks.
+installer mounts its embedded KatlOS image read-only and waits without mutating
+disks.
 The VGA console keeps a KatlOS dashboard on `tty1` showing installer state,
 active network addresses, the handoff URL, disk-mutation status, and a
 live tail of the boot journal. Press `Ctrl+Alt+F2` for a local recovery shell;
@@ -316,20 +316,26 @@ path. Use only the provisioning network and never expose port 8080 to an
 untrusted network. The installer accepts one valid submission and then closes
 the handoff path.
 
-For `cp-1`, first confirm the installer is waiting:
+Discover waiting installers and their disk inventory from the workstation:
 
 ```sh
-INSTALLER_ENDPOINT=http://192.0.2.10:8080
-katlctl install status --endpoint "$INSTALLER_ENDPOINT"
+katlctl install discover
 ```
+
+The report marks a disk `selectable` only when it is a writable whole disk, is
+not mounted, and has a stable by-id, WWN, or serial selector. Copy the intended
+stable selector into the matching node in `cluster.yaml`; never substitute the
+transient `/dev/vda` or `/dev/sda` path.
 
 Apply the cluster source directly:
 
 ```sh
-katlctl install apply ./cluster.yaml \
-  --endpoint "$INSTALLER_ENDPOINT" \
-  --node cp-1
+katlctl install apply ./cluster.yaml --node cp-1
 ```
+
+`katlctl` selects the endpoint automatically when exactly one installer is
+waiting. If multiple installers are present, choose the intended discovery
+result with `--endpoint URL`.
 
 For the worker, boot the same ISO and apply the same source with
 `--node worker-1`. `katlctl install apply` compiles and validates the source and

--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -16,12 +16,22 @@ Required destructive acknowledgement text:
 I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.
 ```
 
-Required common flags:
+Normal input:
 
 ```text
---inventory PATH
-  Cluster inventory containing node names, addresses, roles, and node-local
-  katlc access credentials or credential references.
+SOURCE
+  The retained ClusterConfig used for installation and enrollment. katlctl
+  compiles its internal inventory automatically. --config-bundle and
+  --inventory remain expert alternatives.
+
+--context NAME
+  Optional workstation context override for management addresses and
+  credential references.
+```
+
+Required execution flags:
+
+```text
 
 --confirm-destructive-wipe
   Required boolean flag. Short flags such as --yes or --force are not aliases.
@@ -37,8 +47,9 @@ Optional common flags:
 
 ```text
 --plan
-  Validate targets, credentials, acknowledgement, and visible cluster state, then
-  print the planned per-node actions without accepting node-local operations.
+  Validate targets, credentials, and visible cluster state, then print the
+  planned per-node actions without accepting node-local operations. Planning
+  does not require destructive acknowledgement.
 
 --timeout DURATION
   Upper bound for client-side waits. Timeout stops waiting but does not cancel an
@@ -95,7 +106,7 @@ State preserved:
 
 Requests are refused before node-local mutation when:
 
-- The acknowledgement flag or exact acknowledgement text is missing.
+- An executing request is missing the acknowledgement flag or exact text.
 - Target selection is empty, duplicated, or ambiguous.
 - The inventory lacks a node address, role, or usable node-local credential for a
   selected node.
@@ -119,7 +130,7 @@ Failure behavior:
 Command:
 
 ```text
-katlctl wipe node --inventory PATH --node NAME --kubeconfig PATH \
+katlctl cluster wipe node SOURCE --node NAME --kubeconfig PATH \
   --confirm-destructive-wipe --acknowledge TEXT
 ```
 
@@ -168,7 +179,7 @@ Result:
 Command:
 
 ```text
-katlctl cluster wipe --inventory PATH --all \
+katlctl cluster wipe SOURCE --all \
   --confirm-destructive-wipe --acknowledge TEXT
 ```
 

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -18,44 +18,11 @@ before accepting the operation.
 - stop if a control-plane or etcd member is expected to remain part of the same
   cluster.
 
-The current wipe commands accept a low-level bootstrap inventory, not the
-verified `.katlcfg` directly. This is an acknowledged alpha UX gap. The
-inventory must describe the same installed nodes, addresses, roles, per-node
-token references, Kubernetes version, and bundle reference recorded in the
-compiled cluster intent. Do not use an older inventory merely because its nodes
-are reachable. A two-node shape is:
-
-```yaml
-controlPlaneEndpoint: api.katl.test:6443
-kubernetesVersion: v1.36.0
-kubernetesBundle: ghcr.io/katl-dev/kubernetes:<version>
-nodes:
-  - name: cp-1
-    address: 192.0.2.11
-    systemRole: control-plane
-    access:
-      method: agent
-      credentialRef: file:/absolute/path/to/tokens/cp-1.token
-    kubeadmConfig:
-      ref: control-plane
-      path: /etc/katl/kubeadm/control-plane/config.yaml
-      intent: control-plane
-    kubernetesVersion: v1.36.0
-  - name: worker-1
-    address: 192.0.2.21
-    systemRole: worker
-    access:
-      method: agent
-      credentialRef: file:/absolute/path/to/tokens/worker-1.token
-    kubeadmConfig:
-      ref: worker
-      path: /etc/katl/kubeadm/worker/config.yaml
-      intent: worker
-    kubernetesVersion: v1.36.0
-```
-
-Compare it with the retained config source, bundle report, and live cluster
-before planning. Native config-bundle input is tracked for a future release.
+Use the retained `ClusterConfig` as the normal input. `katlctl` compiles the
+internal inventory itself. `--config-bundle` remains available for PXE/offline
+material and `--inventory` for expert recovery tooling. Add `--context NAME`
+when the enrolled workstation context should override the source's management
+addresses and credential references.
 
 The required acknowledgement is intentionally exact:
 
@@ -67,20 +34,26 @@ I understand this will remove KatlOS disk boot artifacts on the selected nodes s
 
 ```sh
 katlctl cluster wipe \
+  ./cluster.yaml \
   --plan \
-  --inventory ./cluster-inventory.yaml \
+  --all
+```
+
+Planning is non-mutating and does not require destructive acknowledgement.
+Review every target, address, role, wiped surface, preserved surface, and
+refusal.
+
+Execute only when the cluster is intentionally being discarded:
+
+```sh
+katlctl cluster wipe ./cluster.yaml \
   --all \
   --confirm-destructive-wipe \
   --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.'
 ```
 
-Even a plan requires the acknowledgement so automation cannot casually turn a
-review command into a destructive one. Review every target, address, role,
-wiped surface, preserved surface, and refusal.
-
-Run the identical command without `--plan` only when the cluster is intentionally
-being discarded. The command follows every node-local destructive reset and
-reports each terminal result.
+The command follows every node-local destructive reset and reports each
+terminal result.
 
 Do not proceed to reinstall until every intended reset reports `terminal: true`
 and `result: succeeded`. Treat `recoveryRequired: true` as a stop condition.
@@ -91,11 +64,9 @@ Single-node wipe coordinates Kubernetes Node cleanup before the node-local reset
 
 ```sh
 katlctl cluster wipe node \
+  ./cluster.yaml \
   --plan \
-  --inventory ./cluster-inventory.yaml \
-  --node worker-1 \
-  --confirm-destructive-wipe \
-  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.'
+  --node worker-1
 ```
 
 Execution additionally requires `--kubeconfig ./kubeconfig`. If Kubernetes

--- a/internal/installer/handoff/handoff.go
+++ b/internal/installer/handoff/handoff.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/discovery"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
@@ -32,6 +34,7 @@ type HandoffServer struct {
 	bundle   []byte
 	nodeName string
 	status   installstatus.Record
+	disks    []HandoffDisk
 }
 
 type HandoffStatus struct {
@@ -40,6 +43,19 @@ type HandoffStatus struct {
 	BundleAccepted   bool                 `json:"bundleAccepted,omitempty"`
 	SelectedNode     string               `json:"selectedNode,omitempty"`
 	InstallStatus    installstatus.Record `json:"installStatus"`
+	Disks            []HandoffDisk        `json:"disks,omitempty"`
+}
+
+type HandoffDisk struct {
+	Path       string   `json:"path"`
+	ByID       []string `json:"byID,omitempty"`
+	WWN        string   `json:"wwn,omitempty"`
+	Serial     string   `json:"serial,omitempty"`
+	Model      string   `json:"model,omitempty"`
+	SizeBytes  uint64   `json:"sizeBytes"`
+	ReadOnly   bool     `json:"readOnly,omitempty"`
+	Mounted    bool     `json:"mounted,omitempty"`
+	Selectable bool     `json:"selectable"`
 }
 
 type BundlePayload struct {
@@ -95,6 +111,7 @@ func (s *HandoffServer) Status() HandoffStatus {
 		BundleAccepted:   len(s.bundle) > 0,
 		SelectedNode:     s.nodeName,
 		InstallStatus:    s.status,
+		Disks:            append([]HandoffDisk(nil), s.disks...),
 	}
 	reader := s.statusReader
 	s.mu.Unlock()
@@ -105,6 +122,40 @@ func (s *HandoffServer) Status() HandoffStatus {
 		}
 	}
 	return status
+}
+
+func (s *HandoffServer) SetHardwareFacts(facts discovery.HardwareFacts) {
+	disks := make([]HandoffDisk, 0, len(facts.BlockDevices))
+	for _, device := range facts.BlockDevices {
+		if device.Type != discovery.DeviceDisk {
+			continue
+		}
+		mounted := len(device.Mountpoints) > 0
+		for _, partition := range device.Partitions {
+			mounted = mounted || len(partition.Mountpoints) > 0
+		}
+		for _, mount := range facts.Mounts {
+			if mount.Source == device.Path {
+				mounted = true
+			}
+			for _, partition := range device.Partitions {
+				if mount.Source == partition.Path {
+					mounted = true
+				}
+			}
+		}
+		byID := append([]string(nil), device.ByID...)
+		sort.Strings(byID)
+		disks = append(disks, HandoffDisk{
+			Path: device.Path, ByID: byID, WWN: device.WWN, Serial: device.Serial,
+			Model: device.Model, SizeBytes: device.SizeBytes, ReadOnly: device.ReadOnly,
+			Mounted: mounted, Selectable: !device.ReadOnly && !mounted && (len(byID) > 0 || device.WWN != "" || device.Serial != ""),
+		})
+	}
+	sort.Slice(disks, func(i, j int) bool { return disks[i].Path < disks[j].Path })
+	s.mu.Lock()
+	s.disks = disks
+	s.mu.Unlock()
 }
 
 func (s *HandoffServer) SetStatusReader(reader func() (installstatus.Record, error)) {

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/discovery"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
 
@@ -47,6 +48,23 @@ func TestHandoffServerHealthStatusAndAnnouncement(t *testing.T) {
 	announcement := server.Announcement("http://192.0.2.10:8080/")
 	if announcement != "katlos-install waiting for config at http://192.0.2.10:8080/v1/config-bundle" {
 		t.Fatalf("announcement = %q", announcement)
+	}
+}
+
+func TestHandoffStatusReportsStableSelectableDisks(t *testing.T) {
+	server := newTestHandoffServer(t)
+	server.SetHardwareFacts(discovery.HardwareFacts{
+		BlockDevices: []discovery.BlockDevice{
+			{Path: "/dev/vda", Type: discovery.DeviceDisk, ByID: []string{"/dev/disk/by-id/virtio-root"}, Model: "Virtual Disk", SizeBytes: 64 << 30},
+			{Path: "/dev/vdb", Type: discovery.DeviceDisk, Serial: "data", SizeBytes: 128 << 30, Partitions: []discovery.BlockDevice{{Path: "/dev/vdb1", Mountpoints: []string{"/mnt"}}}},
+		},
+	})
+	status := server.Status()
+	if len(status.Disks) != 2 || !status.Disks[0].Selectable || status.Disks[0].ByID[0] != "/dev/disk/by-id/virtio-root" {
+		t.Fatalf("disks = %#v", status.Disks)
+	}
+	if status.Disks[1].Selectable || !status.Disks[1].Mounted {
+		t.Fatalf("mounted disk = %#v", status.Disks[1])
 	}
 }
 


### PR DESCRIPTION
Discovers waiting installers and their stable disk identities, and selects a unique endpoint automatically. Wipe workflows now consume the retained ClusterConfig or bundle, support workstation context overrides, and reserve destructive acknowledgement for execution.