### PR TITLE
ux: complete managed upgrade rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,42 +199,31 @@ Supported changes compile into generation-scoped confext/sysext state and are
 applied live or on next boot according to the domain policy. See
 [Apply runtime configuration](docs/installing.md#apply-runtime-configuration).
 
-Host upgrades consume the published `katlos-upgrade-<version>-<arch>.squashfs`
-artifact. Plan before accepting a next-boot generation:
+Host upgrades take a release version and a node from the current workstation
+context. `katlctl` resolves the published image, stages it, reboots the node,
+and waits for the new generation to pass boot health:
 
 ```sh
-TAG=v2026.7.0-alpha.2
-VERSION=${TAG#v}
-IMAGE="katlos-upgrade-$VERSION-x86_64.squashfs"
-katlctl host upgrade \
-  --plan \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --candidate-generation "katlos-$VERSION" \
-  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE"
+katlctl host upgrade v2026.7.0-alpha.9 --node cp-1
 ```
 
-The node calculates and records the downloaded image identity before changing
-the inactive root slot.
+Add `--plan` to check the upgrade without changing or rebooting the node. The
+node calculates and records image identity internally before changing the
+inactive root slot.
 
 Kubernetes upgrades use the workstation cluster context and a readable bundle
 reference. Plan the whole control-plane-first rollout without supplying bundle
 digests, artifact paths, snapshot metadata, generation IDs, or operation IDs:
 
 ```sh
-katlctl cluster upgrade kubernetes \
-  --bundle ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1 \
-  --plan
+katlctl kubernetes upgrade v1.36.1-katl.1 --plan
 ```
 
-Remove `--plan` to upgrade the next eligible node. Reboot that node, verify
-cluster health, then rerun the same command to advance through control planes
-and workers one at a time. Each node fetches and verifies the selected bundle
-itself; control-plane nodes capture pre-mutation etcd snapshot evidence. See
-[Upgrade Kubernetes](docs/operations/upgrade-kubernetes.md).
-
-Remove `--plan` only after reviewing the response. Unattended fleet rollout is
-not a supported alpha workflow.
+Remove `--plan` to run the complete control-plane-first, worker-second rollout.
+The command upgrades and reboots one node at a time, requires boot health before
+continuing, and stops on the first failure. Each node fetches the selected
+bundle itself; control-plane nodes capture pre-mutation etcd snapshot evidence.
+See [Upgrade Kubernetes](docs/operations/upgrade-kubernetes.md).
 
 Mutating commands follow the node's durable operation to completion by default.
 Progress is written to stderr and the final structured result to stdout. A lost

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -20,6 +21,7 @@ import (
 )
 
 type kubernetesUpgradeOptions struct {
+	version       string
 	configPath    string
 	contextName   string
 	inventoryPath string
@@ -54,21 +56,34 @@ type kubernetesUpgradeTarget struct {
 	node       workstation.TopologyNode
 	role       string
 	conn       katlcAgentConnection
+	token      string
 	machineID  string
+	agentStart string
 	generation string
 	source     string
 	candidate  string
 }
 
 var kubernetesUpgradeNow = func() time.Time { return time.Now().UTC() }
+var kubernetesEndpointPollInterval = 2 * time.Second
+var dialKubernetesEndpoint = func(ctx context.Context, endpoint string) error {
+	conn, err := (&net.Dialer{Timeout: 2 * time.Second}).DialContext(ctx, "tcp", endpoint)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
 
 func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := kubernetesUpgradeOptions{timeout: 25 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "kubernetes",
+		Use:   "kubernetes VERSION",
 		Short: "Upgrade Kubernetes control planes and workers serially",
-		Args:  cobra.NoArgs,
-		RunE: func(*cobra.Command, []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.version = args[0]
+			}
 			return runKubernetesUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
@@ -76,6 +91,7 @@ func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) 
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl config context name")
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "cluster inventory instead of a workstation context")
 	cmd.Flags().StringVar(&opts.bundle, "bundle", "", "Kubernetes bundle image, for example ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1")
+	cmd.Flags().Lookup("bundle").Hidden = true
 	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate the complete rollout without accepting operations")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "per-node operation timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
@@ -93,7 +109,11 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 	if opts.timeout > 25*time.Minute {
 		return fmt.Errorf("--timeout must not exceed 25m")
 	}
-	image, err := kubernetesbundle.ParseImageReference(opts.bundle)
+	bundle, err := kubernetesUpgradeBundle(opts.version, opts.bundle)
+	if err != nil {
+		return err
+	}
+	image, err := kubernetesbundle.ParseImageReference(bundle)
 	if err != nil {
 		return fmt.Errorf("--bundle: %w", err)
 	}
@@ -107,7 +127,9 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 	}
 	defer func() {
 		for _, target := range targets {
-			_ = target.conn.Close()
+			if target.conn.Close != nil {
+				_ = target.conn.Close()
+			}
 		}
 	}()
 
@@ -131,7 +153,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 			return fmt.Errorf("plan node %s: %w", target.node.Name, err)
 		}
 		if accepted.InitialStatus == nil || accepted.InitialStatus.Phase != "accepted" && accepted.InitialStatus.Phase != "dry-run" {
-			return fmt.Errorf("node %s did not confirm the Kubernetes upgrade plan", target.node.Name)
+			return fmt.Errorf("node %s did not accept the Kubernetes upgrade plan", target.node.Name)
 		}
 		report.Nodes = append(report.Nodes, kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: "planned"})
 	}
@@ -140,13 +162,14 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 	}
 
 	report.Nodes = nil
-	for _, target := range targets[:1] {
+	for i := range targets {
+		target := &targets[i]
 		accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
 			ClientRequestId: "katlctl-" + target.candidate, OperationKind: "kubeadm-upgrade",
 			Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
 			ExpectedCurrentGenerationId: target.generation, OperationTimeout: opts.timeout.String(),
-			KubernetesSysextUpdate: kubernetesUpgradeBody(target, image),
+			KubernetesSysextUpdate: kubernetesUpgradeBody(*target, image),
 		})
 		if err != nil {
 			return fmt.Errorf("submit node %s: %w", target.node.Name, err)
@@ -163,9 +186,94 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 			_ = writeKubernetesUpgradeReport(stdout, report)
 			return fmt.Errorf("Kubernetes upgrade stopped at node %s: %s", target.node.Name, terminal.FailureReason)
 		}
+		if err := requestNodeReboot(ctx, target.conn.Client, target.machineID, target.candidate); err != nil {
+			report.Nodes[len(report.Nodes)-1].Result = "reboot-failed"
+			_ = writeKubernetesUpgradeReport(stdout, report)
+			return fmt.Errorf("Kubernetes upgrade stopped while rebooting node %s: %w", target.node.Name, err)
+		}
+		_ = target.conn.Close()
+		target.conn = katlcAgentConnection{}
+		bootCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+		conn, boot, err := waitNodeBootHealth(bootCtx, target.node.Name, target.node.ManagementEndpoint, target.token, target.agentStart, target.candidate, stderr)
+		cancel()
+		if err != nil {
+			report.Nodes[len(report.Nodes)-1].Result = "boot-health-failed"
+			report.Nodes[len(report.Nodes)-1].RecoveryRequired = true
+			_ = writeKubernetesUpgradeReport(stdout, report)
+			return fmt.Errorf("Kubernetes upgrade stopped after node %s reboot: %w", target.node.Name, err)
+		}
+		target.conn = conn
+		if kubernetesGenerationVersion(boot.Generation) != image.PayloadVersion {
+			report.Nodes[len(report.Nodes)-1].Result = "boot-health-failed"
+			_ = writeKubernetesUpgradeReport(stdout, report)
+			return fmt.Errorf("Kubernetes upgrade stopped at node %s: booted generation does not contain Kubernetes %s", target.node.Name, image.PayloadVersion)
+		}
+		if target.node.SystemRole == inventory.RoleControlPlane {
+			readyCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+			err := waitKubernetesEndpoint(readyCtx, topology.ControlPlaneEndpoint, target.node.Name, stderr)
+			cancel()
+			if err != nil {
+				report.Nodes[len(report.Nodes)-1].Result = "cluster-health-failed"
+				_ = writeKubernetesUpgradeReport(stdout, report)
+				return fmt.Errorf("Kubernetes upgrade stopped after node %s reboot: %w", target.node.Name, err)
+			}
+		}
+		report.Nodes[len(report.Nodes)-1].Phase = "boot-healthy"
+		report.Nodes[len(report.Nodes)-1].NextAction = ""
 	}
-	report.NextAction = "reboot " + targets[0].node.Name + ", confirm boot health, then rerun this command to advance the rollout"
+	report.NextAction = "rollout complete; every upgraded node rebooted into a healthy generation"
 	return writeKubernetesUpgradeReport(stdout, report)
+}
+
+func waitKubernetesEndpoint(ctx context.Context, endpoint, nodeName string, stderr io.Writer) error {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return fmt.Errorf("cluster control-plane endpoint is not configured")
+	}
+	for {
+		if err := dialKubernetesEndpoint(ctx, endpoint); err == nil {
+			_, _ = fmt.Fprintf(stderr, "kubernetes upgrade node=%s control-plane-ready endpoint=%s\n", nodeName, endpoint)
+			return nil
+		}
+		timer := time.NewTimer(kubernetesEndpointPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("control-plane endpoint %s did not return after node %s reboot: %w", endpoint, nodeName, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func kubernetesUpgradeBundle(version, explicit string) (string, error) {
+	version = strings.TrimSpace(version)
+	explicit = strings.TrimSpace(explicit)
+	if version != "" && explicit != "" {
+		return "", fmt.Errorf("VERSION cannot be combined with --bundle")
+	}
+	if explicit != "" {
+		return explicit, nil
+	}
+	if version == "" {
+		return "", fmt.Errorf("VERSION is required")
+	}
+	version = strings.TrimPrefix(version, "v")
+	if !strings.Contains(version, "-katl.") {
+		version += "-katl.1"
+	}
+	return "ghcr.io/katl-dev/kubernetes:v" + version, nil
+}
+
+func kubernetesGenerationVersion(value *agentapi.Generation) string {
+	if value == nil {
+		return ""
+	}
+	for _, ref := range value.Sysexts {
+		if ref.GetName() == "kubernetes" {
+			return strings.TrimSpace(ref.GetPayloadVersion())
+		}
+	}
+	return ""
 }
 
 func waitKubernetesUpgrade(ctx context.Context, client agentapi.KatlcAgentClient, operationID, nodeName string, stderr io.Writer) (*agentapi.OperationStatus, error) {
@@ -280,7 +388,7 @@ func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.R
 			return nil, fmt.Errorf("node %s current generation has no Kubernetes payload", node.Name)
 		}
 		candidate := kubernetesUpgradeCandidate(targetVersion, node.Name, runID)
-		inspected = append(inspected, kubernetesUpgradeTarget{node: node, conn: conn, machineID: status.MachineId, generation: generationID, source: sourceVersion, candidate: candidate})
+		inspected = append(inspected, kubernetesUpgradeTarget{node: node, conn: conn, token: token, machineID: status.MachineId, agentStart: status.AgentStartId, generation: generationID, source: sourceVersion, candidate: candidate})
 	}
 	baseVersion := ""
 	controlPlaneAtTarget := false

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -35,8 +35,8 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 	for _, name := range []string{"cp-1", "cp-2", "worker-1"} {
 		name := name
 		client := &fakeKatlcAgentClient{
-			nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-" + name, CurrentGenerationId: "gen-1"},
-			generation:      &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0", Sha256: strings.Repeat("a", 64)}}},
+			nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-" + name, AgentStartId: "before-" + name, CurrentGenerationId: "gen-1"},
+			generation:      &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0", Sha256: strings.Repeat("a", 64)}}},
 			submitAccepted:  &agentapi.OperationAccepted{OperationId: "internal-" + name},
 			operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "healthy", NextAction: "reboot for boot health"},
 		}
@@ -45,37 +45,45 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 				executionOrder = append(executionOrder, name)
 			}
 		}
+		client.onReboot = func(req *agentapi.RebootRequest) {
+			client.nodeStatus.AgentStartId = "after-" + name
+			client.nodeStatus.CurrentGenerationId = req.TargetGenerationId
+			client.generation = &agentapi.Generation{GenerationId: req.TargetGenerationId, CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1"}}}
+		}
 		clients[name] = client
 	}
 	byEndpoint := map[string]*fakeKatlcAgentClient{"192.0.2.1:9443": clients["cp-1"], "192.0.2.2:9443": clients["cp-2"], "192.0.2.4:9443": clients["worker-1"]}
 	previousDial := dialKatlcAgent
 	previousNow := kubernetesUpgradeNow
-	defer func() { dialKatlcAgent = previousDial; kubernetesUpgradeNow = previousNow }()
+	previousEndpointDial := dialKubernetesEndpoint
+	defer func() {
+		dialKatlcAgent = previousDial
+		kubernetesUpgradeNow = previousNow
+		dialKubernetesEndpoint = previousEndpointDial
+	}()
 	dialKatlcAgent = func(_ context.Context, endpoint, token string) (katlcAgentConnection, error) {
 		return katlcAgentConnection{Client: byEndpoint[endpoint], Close: func() error { return nil }}, nil
 	}
 	kubernetesUpgradeNow = func() time.Time { return time.Unix(42, 0).UTC() }
-	run := func() kubernetesUpgradeReport {
-		t.Helper()
-		var stdout bytes.Buffer
-		if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{configPath: configPath, bundle: "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1", timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
-			t.Fatal(err)
-		}
-		if strings.Contains(stdout.String(), "internal-") || strings.Contains(strings.ToLower(stdout.String()), "digest") {
-			t.Fatalf("output exposed internal operation data: %s", stdout.String())
-		}
-		var report kubernetesUpgradeReport
-		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
-			t.Fatal(err)
-		}
-		return report
+	dialKubernetesEndpoint = func(context.Context, string) error { return nil }
+	var stdout bytes.Buffer
+	if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{configPath: configPath, version: "v1.36.1-katl.1", timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
 	}
-
+	if strings.Contains(stdout.String(), "internal-") || strings.Contains(strings.ToLower(stdout.String()), "digest") {
+		t.Fatalf("output exposed internal operation data: %s", stdout.String())
+	}
+	var report kubernetesUpgradeReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 3 || !strings.Contains(report.NextAction, "complete") {
+		t.Fatalf("report = %#v", report)
+	}
 	roles := []string{"apply", "control-plane", "worker"}
 	for i, name := range []string{"cp-1", "cp-2", "worker-1"} {
-		report := run()
-		if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 1 || report.Nodes[0].Name != name || report.NextAction == "" {
-			t.Fatalf("run %d report = %#v", i+1, report)
+		if report.Nodes[i].Name != name || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "boot-healthy" {
+			t.Fatalf("node report %d = %#v", i, report.Nodes[i])
 		}
 		requests := clients[name].submitRequests
 		if len(requests) == 0 || requests[len(requests)-1].DryRun {
@@ -88,14 +96,12 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 		if body.TargetSysextPath != "" || body.TargetSysextSha256 != "" || body.SnapshotDigest != "" || body.CandidateGenerationId == "" {
 			t.Fatalf("%s request exposed internal artifact or snapshot inputs: %#v", name, body)
 		}
-		clients[name].generation.Sysexts[0].PayloadVersion = "v1.36.1"
+		if len(clients[name].rebootRequests) != 1 {
+			t.Fatalf("%s reboot requests = %#v", name, clients[name].rebootRequests)
+		}
 	}
 	if want := []string{"cp-1", "cp-2", "worker-1"}; !reflect.DeepEqual(executionOrder, want) {
 		t.Fatalf("execution order = %v, want %v", executionOrder, want)
-	}
-	report := run()
-	if len(report.Nodes) != 0 || !strings.Contains(report.NextAction, "already") {
-		t.Fatalf("completed report = %#v", report)
 	}
 }
 
@@ -116,10 +122,61 @@ func TestKubernetesUpgradePlanDoesNotExecute(t *testing.T) {
 		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
 	}
 	var stdout bytes.Buffer
-	if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{inventoryPath: inv, bundle: "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1", plan: true, timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
+	if err := run(context.Background(), []string{"kubernetes", "upgrade", "v1.36.1", "--inventory", inv, "--plan", "--timeout", "1m"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.submitRequests) != 1 || !client.submitRequests[0].DryRun || !strings.Contains(stdout.String(), `"result": "planned"`) {
 		t.Fatalf("requests=%#v output=%s", client.submitRequests, stdout.String())
+	}
+}
+
+func TestKubernetesUpgradeStopsAfterNodeFailure(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "katlctl.yaml")
+	var nodes strings.Builder
+	clients := map[string]*fakeKatlcAgentClient{}
+	for _, node := range []struct{ name, endpoint, role string }{{"cp-1", "192.0.2.1:9443", "control-plane"}, {"cp-2", "192.0.2.2:9443", "control-plane"}, {"worker-1", "192.0.2.3:9443", "worker"}} {
+		token := filepath.Join(root, node.name+".token")
+		if err := os.WriteFile(token, []byte("token\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = nodes.WriteString("      - name: " + node.name + "\n        managementEndpoint: " + node.endpoint + "\n        systemRole: " + node.role + "\n        credentialRef: file:" + token + "\n")
+		client := &fakeKatlcAgentClient{
+			nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-" + node.name, AgentStartId: "before-" + node.name, CurrentGenerationId: "gen-1"},
+			generation:     &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0"}}},
+			submitAccepted: &agentapi.OperationAccepted{OperationId: "upgrade-" + node.name},
+			operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded,
+				Phase: "healthy"},
+		}
+		name := node.name
+		client.onReboot = func(req *agentapi.RebootRequest) {
+			client.nodeStatus.AgentStartId = "after-" + name
+			client.nodeStatus.CurrentGenerationId = req.TargetGenerationId
+			client.generation = &agentapi.Generation{GenerationId: req.TargetGenerationId, CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1"}}}
+		}
+		clients[node.endpoint] = client
+	}
+	clients["192.0.2.2:9443"].operationStatus = &agentapi.OperationStatus{Terminal: true, Result: operation.ResultFailedNeedsRepair, Phase: "failed", FailureReason: "kubeadm failed", RecoveryRequired: true}
+	config := "currentContext: lab\ncontexts:\n  - name: lab\n    cluster: home\nclusters:\n  - name: home\n    controlPlaneEndpoint: 192.0.2.10:6443\n    nodes:\n" + nodes.String()
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldDial := dialKatlcAgent
+	oldEndpointDial := dialKubernetesEndpoint
+	dialKatlcAgent = func(_ context.Context, endpoint, _ string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: clients[endpoint], Close: func() error { return nil }}, nil
+	}
+	dialKubernetesEndpoint = func(context.Context, string) error { return nil }
+	t.Cleanup(func() { dialKatlcAgent = oldDial; dialKubernetesEndpoint = oldEndpointDial })
+
+	var stdout bytes.Buffer
+	err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{configPath: configPath, version: "v1.36.1", timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "stopped at node cp-2") {
+		t.Fatalf("runKubernetesUpgrade() error = %v", err)
+	}
+	for _, request := range clients["192.0.2.3:9443"].submitRequests {
+		if !request.DryRun {
+			t.Fatalf("worker executed after failure: %#v", request)
+		}
 	}
 }

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -109,6 +110,11 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	clusterWipeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl cluster wipe node"))
 	clusterCmd.AddCommand(clusterWipeCmd)
 	cmd.AddCommand(clusterCmd)
+	kubernetesCmd := &cobra.Command{Use: "kubernetes", Short: "Kubernetes lifecycle operations"}
+	kubernetesUpgradeCmd := newKubernetesUpgradeCommand(ctx, stdout, stderr)
+	kubernetesUpgradeCmd.Use = "upgrade VERSION"
+	kubernetesCmd.AddCommand(kubernetesUpgradeCmd)
+	cmd.AddCommand(kubernetesCmd)
 
 	configCmd := &cobra.Command{Use: "config", Short: "Katl configuration operations"}
 	configCmd.AddCommand(newConfigInitCommand(stdout, stderr))
@@ -142,6 +148,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 }
 
 type hostUpgradeOptions struct {
+	version             string
 	endpoint            string
 	agentTokenFile      string
 	workstationConfig   string
@@ -158,13 +165,27 @@ type hostUpgradeOptions struct {
 	output              string
 }
 
+type hostUpgradeReport struct {
+	Node       string `json:"node"`
+	Version    string `json:"version"`
+	Image      string `json:"image"`
+	Result     string `json:"result"`
+	Rebooted   bool   `json:"rebooted"`
+	BootHealth string `json:"bootHealth"`
+}
+
+var katlOSReleasePattern = regexp.MustCompile(`^[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
+
 func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := hostUpgradeOptions{actor: "katlctl host upgrade", waitTimeout: 30 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "upgrade",
-		Short: "Stage one KatlOS image for bounded next-boot activation",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Use:   "upgrade VERSION",
+		Short: "Upgrade one KatlOS host and verify its next boot",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.version = args[0]
+			}
 			return runHostUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
@@ -176,6 +197,9 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	cmd.Flags().StringVar(&opts.imageURL, "image-url", "", "HTTPS KatlOS upgrade image URL")
 	cmd.Flags().StringVar(&opts.imageLocalRef, "image-local-ref", "", "relative KatlOS image reference under the node artifact store")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
+	cmd.Flags().Lookup("image-url").Hidden = true
+	cmd.Flags().Lookup("image-local-ref").Hidden = true
+	cmd.Flags().Lookup("candidate-generation").Hidden = true
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
@@ -187,12 +211,25 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 }
 
 func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr io.Writer) error {
-	_ = stderr
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
+	}
+	direct := strings.TrimSpace(opts.version) != ""
+	if direct {
+		if strings.TrimSpace(opts.imageURL) != "" || strings.TrimSpace(opts.imageLocalRef) != "" || strings.TrimSpace(opts.candidateGeneration) != "" {
+			return fmt.Errorf("VERSION cannot be combined with expert image or candidate flags")
+		}
+		version, err := katlOSVersion(opts.version)
+		if err != nil {
+			return err
+		}
+		opts.version, opts.candidateGeneration = version, "katlos-"+version
+		if opts.noWait {
+			return fmt.Errorf("--no-wait is unavailable for a managed VERSION upgrade")
+		}
 	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
@@ -203,8 +240,10 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		ImageLocalRef:         strings.TrimSpace(opts.imageLocalRef),
 		CandidateGenerationID: strings.TrimSpace(opts.candidateGeneration),
 	}
-	if err := operation.ValidateHostUpgrade(request); err != nil {
-		return err
+	if !direct {
+		if err := operation.ValidateHostUpgrade(request); err != nil {
+			return err
+		}
 	}
 	target, err := resolveManagementTarget(managementTargetOptions{
 		configPath: opts.workstationConfig, contextName: opts.contextName, nodeName: opts.nodeName,
@@ -218,13 +257,40 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		return err
 	}
 	defer conn.Close()
+	status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return fmt.Errorf("read node status: %w", err)
+	}
+	if direct {
+		current, err := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: status.GetCurrentGenerationId()})
+		if err != nil {
+			return fmt.Errorf("read current node generation: %w", err)
+		}
+		architecture, err := nodeArtifactArchitecture(current)
+		if err != nil {
+			return err
+		}
+		request.ImageURL = katlOSReleaseURL(opts.version, architecture)
+		if err := operation.ValidateHostUpgrade(request); err != nil {
+			return err
+		}
+		if current.GetGenerationId() == request.CandidateGenerationID && current.GetCommitState() == generation.CommitStateCommitted && current.GetBootState() == generation.BootStateGood && current.GetHealthState() == generation.HealthStateHealthy {
+			node := target.nodeName
+			if node == "" {
+				node = target.endpoint
+			}
+			return writeJSON(stdout, hostUpgradeReport{Node: node, Version: opts.version, Image: request.ImageURL, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy})
+		}
+	}
 	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-		ApiVersion:      operation.APIVersion,
-		Kind:            "SubmitOperationRequest",
-		ClientRequestId: requestID,
-		OperationKind:   "host-upgrade",
-		Actor:           strings.TrimSpace(opts.actor),
-		DryRun:          opts.plan,
+		ApiVersion:                  operation.APIVersion,
+		Kind:                        "SubmitOperationRequest",
+		ClientRequestId:             requestID,
+		OperationKind:               "host-upgrade",
+		Actor:                       strings.TrimSpace(opts.actor),
+		ExpectedMachineId:           status.GetMachineId(),
+		ExpectedCurrentGenerationId: status.GetCurrentGenerationId(),
+		DryRun:                      opts.plan,
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
 			ImageUrl:              request.ImageURL,
 			ImageLocalRef:         request.ImageLocalRef,
@@ -234,10 +300,90 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
+	if direct {
+		report := hostUpgradeReport{Node: target.nodeName, Version: opts.version, Image: request.ImageURL, Result: "planned", BootHealth: "not-run"}
+		if report.Node == "" {
+			report.Node = target.endpoint
+		}
+		if opts.plan {
+			return writeJSON(stdout, report)
+		}
+		terminal, err := waitAcceptedOperationStatus(ctx, conn.Client, accepted, opts.waitTimeout, stderr)
+		if err != nil {
+			report.Result = "failed"
+			_ = writeJSON(stdout, report)
+			return err
+		}
+		if err := operationResultError(terminal); err != nil {
+			report.Result = terminal.GetResult()
+			_ = writeJSON(stdout, report)
+			return err
+		}
+		agentStart := status.GetAgentStartId()
+		if err := requestNodeReboot(ctx, conn.Client, status.GetMachineId(), request.CandidateGenerationID); err != nil {
+			report.Result = "staged"
+			_ = writeJSON(stdout, report)
+			return fmt.Errorf("reboot node %s: %w", report.Node, err)
+		}
+		_ = conn.Close()
+		bootCtx, cancel := context.WithTimeout(ctx, opts.waitTimeout)
+		verifiedConn, _, err := waitNodeBootHealth(bootCtx, report.Node, target.endpoint, target.token, agentStart, request.CandidateGenerationID, stderr)
+		cancel()
+		if err != nil {
+			report.Result = "failed"
+			report.Rebooted = true
+			report.BootHealth = "failed"
+			_ = writeJSON(stdout, report)
+			return err
+		}
+		_ = verifiedConn.Close()
+		report.Result = operation.ResultSucceeded
+		report.Rebooted = true
+		report.BootHealth = generation.HealthStateHealthy
+		return writeJSON(stdout, report)
+	}
 	if opts.plan || opts.noWait {
 		return writeOperationAccepted(stdout, accepted)
 	}
 	return waitAcceptedOperation(ctx, conn.Client, accepted, opts.waitTimeout, stdout, stderr)
+}
+
+func katlOSVersion(input string) (string, error) {
+	version := strings.TrimPrefix(strings.TrimSpace(input), "v")
+	if !katlOSReleasePattern.MatchString(version) {
+		return "", fmt.Errorf("VERSION %q must look like 2026.7.0-alpha.9", input)
+	}
+	return version, nil
+}
+
+func nodeArtifactArchitecture(current *agentapi.Generation) (string, error) {
+	for _, ref := range current.GetSysexts() {
+		architecture := strings.TrimSpace(ref.GetArchitecture())
+		switch architecture {
+		case "x86_64", "aarch64":
+			return architecture, nil
+		case "amd64":
+			return "x86_64", nil
+		case "arm64":
+			return "aarch64", nil
+		}
+	}
+	return "", fmt.Errorf("current node generation does not report a supported artifact architecture")
+}
+
+func katlOSReleaseURL(version, architecture string) string {
+	tag := "v" + version
+	name := "katlos-upgrade-" + version + "-" + architecture + ".squashfs"
+	return "https://github.com/katl-dev/katl/releases/download/" + tag + "/" + name
+}
+
+func writeJSON(stdout io.Writer, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(append(data, '\n'))
+	return err
 }
 
 type wipeClusterOptions struct {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1427,6 +1427,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 
 func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 	fake := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{MachineId: "machine-a", CurrentGenerationId: "generation-current"},
 		stageAccepted: &agentapi.OperationAccepted{
 			OperationId:   "host-upgrade-01",
 			OperationKind: "host-upgrade",
@@ -1463,6 +1464,41 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 		t.Fatalf("host upgrade request = %+v", request.HostUpgrade)
 	}
 	assertSuccessfulMutationOutput(t, stdout.Bytes())
+}
+
+func TestHostUpgradeVersionStagesRebootsAndVerifiesHealth(t *testing.T) {
+	fake := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current"},
+		generation:      &agentapi.Generation{GenerationId: "generation-current", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", Architecture: "x86_64"}}},
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "host-upgrade-01", OperationKind: "host-upgrade"},
+		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "arm-trial-boot"},
+	}
+	fake.onReboot = func(req *agentapi.RebootRequest) {
+		fake.nodeStatus.AgentStartId = "after"
+		fake.nodeStatus.CurrentGenerationId = req.TargetGenerationId
+		fake.generation = &agentapi.Generation{GenerationId: req.TargetGenerationId, CommitState: generation.CommitStateCommitted, BootState: generation.BootStateGood, HealthState: generation.HealthStateHealthy}
+	}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(context.Context, string, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"host", "upgrade", "v2026.7.0-alpha.9", "--endpoint", "node-a.example.test:9443", "--timeout", "1m"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	request := fake.submitRequest.GetHostUpgrade()
+	if request.GetImageUrl() != "https://github.com/katl-dev/katl/releases/download/v2026.7.0-alpha.9/katlos-upgrade-2026.7.0-alpha.9-x86_64.squashfs" || request.GetCandidateGenerationId() != "katlos-2026.7.0-alpha.9" {
+		t.Fatalf("host upgrade request = %#v", request)
+	}
+	var report hostUpgradeReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Result != operation.ResultSucceeded || !report.Rebooted || report.BootHealth != generation.HealthStateHealthy {
+		t.Fatalf("report = %#v", report)
+	}
 }
 
 func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
@@ -1802,6 +1838,8 @@ type fakeKatlcAgentClient struct {
 	operations        *agentapi.ListOperationsResponse
 	operationsRequest *agentapi.ListOperationsRequest
 	onSubmit          func(*agentapi.SubmitOperationRequest)
+	rebootRequests    []*agentapi.RebootRequest
+	onReboot          func(*agentapi.RebootRequest)
 }
 
 type fakeWipeClusterConnector struct {
@@ -1863,6 +1901,14 @@ func readyWipeClusterClient(machineID string) *fakeKatlcAgentClient {
 
 func (c *fakeKatlcAgentClient) GetNodeStatus(context.Context, *agentapi.GetNodeStatusRequest, ...grpc.CallOption) (*agentapi.NodeStatus, error) {
 	return c.nodeStatus, c.nodeStatusErr
+}
+
+func (c *fakeKatlcAgentClient) Reboot(_ context.Context, req *agentapi.RebootRequest, _ ...grpc.CallOption) (*agentapi.RebootAccepted, error) {
+	c.rebootRequests = append(c.rebootRequests, req)
+	if c.onReboot != nil {
+		c.onReboot(req)
+	}
+	return &agentapi.RebootAccepted{Scheduled: true, TargetGenerationId: req.TargetGenerationId}, nil
 }
 
 func (c *fakeKatlcAgentClient) ValidateConfig(_ context.Context, req *agentapi.ValidateConfigRequest, _ ...grpc.CallOption) (*agentapi.ConfigValidationResult, error) {

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -327,8 +327,19 @@ func writeMutationOperationStatus(stdout io.Writer, status *agentapi.OperationSt
 }
 
 func waitAcceptedOperation(ctx context.Context, client operationClient, accepted *agentapi.OperationAccepted, timeout time.Duration, stdout, stderr io.Writer) error {
+	status, err := waitAcceptedOperationStatus(ctx, client, accepted, timeout, stderr)
+	if writeErr := writeMutationOperationStatus(stdout, status); writeErr != nil {
+		return writeErr
+	}
+	if err != nil {
+		return err
+	}
+	return operationResultError(status)
+}
+
+func waitAcceptedOperationStatus(ctx context.Context, client operationClient, accepted *agentapi.OperationAccepted, timeout time.Duration, stderr io.Writer) (*agentapi.OperationStatus, error) {
 	if accepted == nil || strings.TrimSpace(accepted.GetOperationId()) == "" {
-		return fmt.Errorf("agent returned an empty operation acceptance")
+		return nil, fmt.Errorf("agent returned an empty operation acceptance")
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -338,7 +349,7 @@ func waitAcceptedOperation(ctx context.Context, client operationClient, accepted
 		var err error
 		status, err = client.GetOperation(waitCtx, request)
 		if err != nil {
-			return fmt.Errorf("get accepted operation %s: %w", accepted.GetOperationId(), err)
+			return nil, fmt.Errorf("get accepted operation %s: %w", accepted.GetOperationId(), err)
 		}
 	}
 	status = proto.Clone(status).(*agentapi.OperationStatus)
@@ -352,13 +363,10 @@ func waitAcceptedOperation(ctx context.Context, client operationClient, accepted
 	if !status.GetTerminal() {
 		status, err = followOperation(waitCtx, client, request, status, stderr)
 	}
-	if writeErr := writeMutationOperationStatus(stdout, status); writeErr != nil {
-		return writeErr
-	}
 	if err != nil {
-		return err
+		return status, err
 	}
-	return operationResultError(status)
+	return status, nil
 }
 
 func writeOperationAccepted(stdout io.Writer, accepted *agentapi.OperationAccepted) error {

--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+var upgradeRebootPollInterval = 2 * time.Second
+
+type verifiedNodeBoot struct {
+	Status     *agentapi.NodeStatus
+	Generation *agentapi.Generation
+}
+
+func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, machineID, targetGeneration string) error {
+	accepted, err := client.Reboot(ctx, &agentapi.RebootRequest{
+		ApiVersion:         generation.APIVersion,
+		Kind:               "RebootRequest",
+		Actor:              "katlctl upgrade rollout",
+		ExpectedMachineId:  strings.TrimSpace(machineID),
+		TargetGenerationId: strings.TrimSpace(targetGeneration),
+	})
+	if err != nil {
+		return err
+	}
+	if !accepted.GetScheduled() || accepted.GetTargetGenerationId() != strings.TrimSpace(targetGeneration) {
+		return fmt.Errorf("node did not schedule reboot into generation %s", targetGeneration)
+	}
+	return nil
+}
+
+func waitNodeBootHealth(ctx context.Context, nodeName, endpoint, token, previousAgentStart, targetGeneration string, stderr io.Writer) (katlcAgentConnection, verifiedNodeBoot, error) {
+	lastState := ""
+	for {
+		conn, err := dialKatlcAgent(ctx, endpoint, token)
+		if err == nil {
+			status, statusErr := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+			if statusErr == nil {
+				state := fmt.Sprintf("agent=%s generation=%s", status.GetAgentStartId(), status.GetCurrentGenerationId())
+				if state != lastState {
+					lastState = state
+					_, _ = fmt.Fprintf(stderr, "upgrade node=%s waiting-for-boot-health %s\n", nodeName, state)
+				}
+				if strings.TrimSpace(status.GetAgentStartId()) != "" && status.GetAgentStartId() != strings.TrimSpace(previousAgentStart) {
+					candidate, generationErr := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: targetGeneration})
+					if generationErr == nil {
+						if candidate.GetHealthState() == generation.HealthStateUnhealthy {
+							_ = conn.Close()
+							return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s rejected generation %s during boot health and rolled back", nodeName, targetGeneration)
+						}
+						if status.GetCurrentGenerationId() == targetGeneration && candidate.GetCommitState() == generation.CommitStateCommitted && candidate.GetBootState() == generation.BootStateGood && candidate.GetHealthState() == generation.HealthStateHealthy {
+							return conn, verifiedNodeBoot{Status: status, Generation: candidate}, nil
+						}
+					}
+				}
+			}
+			_ = conn.Close()
+		}
+
+		timer := time.NewTimer(upgradeRebootPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s did not return healthy on generation %s: %w", nodeName, targetGeneration, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -1,8 +1,9 @@
 # Upgrade a KatlOS Host
 
-KatlOS host upgrades are explicit, one-node-at-a-time, next-boot operations.
-They stage a root and UKI into the inactive slot and arm a bounded trial
-boot. They do not upgrade Kubernetes or orchestrate fleet availability.
+KatlOS host upgrades are one-node-at-a-time operations. The normal command
+resolves a release, stages its root and UKI into the inactive slot, reboots into
+a bounded trial, and waits for boot health. It does not upgrade Kubernetes or
+orchestrate availability across several hosts.
 
 ## Preconditions
 
@@ -10,69 +11,42 @@ boot. They do not upgrade Kubernetes or orchestrate fleet availability.
 - no other mutating node operation is active;
 - the selected upgrade SquashFS is from the intended KatlOS release;
 - the upgrade declares a compatible architecture and runtime interface;
-- the node can fetch the HTTPS image URL, or the image is already in its local
-  artifact store;
-- an operator controls the reboot window; and
+- the node can fetch release artifacts from GitHub;
+- the current workstation context contains the node and its enrolled agent
+  credential;
+- the command is run during the intended reboot window; and
 - Kubernetes and workload availability have been handled outside Katl.
-
-Choose the release and image name:
-
-```sh
-TAG=v2026.7.0-alpha.2
-VERSION=${TAG#v}
-IMAGE="katlos-upgrade-$VERSION-x86_64.squashfs"
-```
 
 ## Plan
 
 ```sh
-katlctl host upgrade \
-  --plan \
-  --endpoint cp-1.example.test:9443 \
-  --agent-token-file ./tokens/cp-1.token \
-  --candidate-generation "katlos-$VERSION" \
-  --image-url "https://github.com/katl-dev/katl/releases/download/$TAG/$IMAGE"
+katlctl host upgrade v2026.7.0-alpha.9 --node cp-1 --plan
 ```
 
-A plan response has dry-run status and no durable mutation. Review the image,
-candidate generation, resource locks, and refusal diagnostics.
+A plan response has no durable mutation and does not reboot the node.
 
 During staging, the node downloads or opens the image, calculates its SHA-256
 and size, records that resolved identity in the operation, and checks the image's
 component metadata before changing the inactive slot.
 
-## Stage the Trial
+## Upgrade
 
-Run the identical command without `--plan`. `katlctl` follows the durable stage
-operation and returns its terminal result.
-
-Do not reboot until the operation is terminal with `result: succeeded` and
-`nextAction` says to reboot into the bounded candidate trial. A terminal staging
-success still has `bootHealthPending: true`.
-
-## Reboot and Verify
-
-Reboot one node during the controlled window:
+Run the command without `--plan`:
 
 ```sh
-ssh root@cp-1.example.test systemctl reboot
+katlctl host upgrade v2026.7.0-alpha.9 --node cp-1
 ```
 
-After it returns:
-
-```sh
-ssh root@cp-1.example.test systemctl is-active katl-boot-complete.target
-ssh root@cp-1.example.test systemctl status katl-boot-health.service --no-pager
-ssh root@cp-1.example.test cat /var/lib/katl/boot/selection.json
-```
-
-Require the candidate generation to be the booted/default generation with no
-pending health validation before moving to another node. Also verify kubelet,
-the Kubernetes Node, and workload availability.
+`katlctl` follows staging progress, asks the authenticated node agent to reboot,
+waits for the agent to restart, and requires the selected generation to be
+committed, booted, and healthy. A successful JSON result has `rebooted: true`
+and `bootHealth: healthy`. Check workload availability before upgrading another
+host.
 
 ## Failure Boundary
 
-Boot health may select the previous known-good host generation. That does not
+Boot health may select the previous known-good host generation. `katlctl`
+reports that rollback and stops. It does not
 undo Kubernetes, etcd, workload, or external-infrastructure changes. If the
 operation record says `recoveryRequired: true`, or the node fails to return,
 stop the rollout and collect the evidence in [Troubleshoot KatlOS](troubleshoot.md).

--- a/docs/operations/upgrade-kubernetes.md
+++ b/docs/operations/upgrade-kubernetes.md
@@ -1,10 +1,9 @@
 # Upgrade Kubernetes
 
-Katl upgrades Kubernetes as an explicit cluster operation. `katlctl` validates
-every pending node, then upgrades one node per invocation. Rerunning the same
-command advances control planes before workers. The first control plane runs
-`kubeadm upgrade apply`; remaining control planes and workers run `kubeadm
-upgrade node`.
+Katl upgrades Kubernetes as an explicit, non-interactive cluster rollout.
+`katlctl` validates every pending node, then upgrades and reboots control planes
+before workers, one node at a time. The first control plane runs `kubeadm
+upgrade apply`; remaining control planes and workers run `kubeadm upgrade node`.
 
 ## Preconditions
 
@@ -23,8 +22,13 @@ An immutable `@sha256:` suffix is recommended but not required.
 
 ```sh
 katlctl cluster upgrade kubernetes \
-  --bundle ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1 \
-  --plan
+  v1.36.1-katl.1 --plan
+```
+
+The shorter top-level form is equivalent:
+
+```sh
+katlctl kubernetes upgrade v1.36.1-katl.1 --plan
 ```
 
 By default, `katlctl` uses the current context in its workstation configuration.
@@ -35,7 +39,7 @@ Kubernetes payload, derives the control-plane/worker order, and asks every
 pending node to validate its operation. It does not fetch a bundle, create a
 candidate generation, take a snapshot, or run kubeadm.
 
-Operators provide only the cluster selection and bundle reference. Katl derives
+Operators provide only the cluster selection and bundle version. Katl derives
 and records bundle digests, sysext paths and sizes, candidate generation IDs,
 operation IDs, and snapshot evidence internally.
 
@@ -44,38 +48,26 @@ operation IDs, and snapshot evidence internally.
 Run the same command without `--plan`:
 
 ```sh
-katlctl cluster upgrade kubernetes \
-  --bundle ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1
+katlctl kubernetes upgrade v1.36.1-katl.1
 ```
 
-The command validates every pending operation but executes only the next
-eligible node. That node fetches and verifies the OCI bundle before mutation.
+The command itself authorizes the rollout; there is no additional confirmation
+prompt. It validates every pending operation, then processes every eligible
+node serially. Each node fetches and verifies the OCI bundle before mutation.
 Control-plane nodes capture a local pre-upgrade etcd snapshot and member-list
 digest. The target sysext is mounted privately so target `kubeadm` runs while
 the source kubelet remains active. Katl releases the target kubelet only after
 kubeadm succeeds, performs local health checks, and commits the candidate
 generation.
 
-The command stops immediately on the first failed or recovery-required node. It
-does not continue through the remaining cluster.
+After each node-local operation succeeds, `katlctl` requests a reboot through
+the authenticated agent, waits for the agent to restart, and requires the
+target generation and Kubernetes payload to pass boot health before continuing.
+The command stops immediately on the first failed, rolled-back, or
+recovery-required node and does not touch the remaining nodes.
 
-## Reboot and verify
-
-After the node operation succeeds, reboot the named node. Wait for the node and
-its workloads to become healthy:
-
-```sh
-ssh root@cp-1.example.test systemctl reboot
-kubectl --kubeconfig ./kubeconfig get nodes -o wide
-kubectl --kubeconfig ./kubeconfig get pods -A
-```
-
-Also require `katl-boot-complete.target` to be active on the rebooted node. The
-upgrade is not fully proven until the committed candidate has passed boot
-health. Then rerun the same `katlctl cluster upgrade kubernetes` command. It
-recognizes nodes already on the target version and advances the next control
-plane or worker. Repeat the execute, reboot, and verify loop until the command
-reports that every node already runs the selected version.
+After a successful rollout, check workload-level health with your normal
+Kubernetes tooling, for example `kubectl get nodes` and `kubectl get pods -A`.
 
 ## Failure boundary
 

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -33,6 +33,7 @@ const (
 	APIVersion = operation.APIVersion
 
 	RequestKind                   = "SubmitOperationRequest"
+	RebootRequestKind             = "RebootRequest"
 	WorkerJoinMaterialRequestKind = "CreateWorkerJoinMaterialRequest"
 
 	DefaultListen = "tcp://0.0.0.0:9443"
@@ -69,6 +70,7 @@ type Server struct {
 	SupportedOperationKinds []string
 	Dispatcher              Dispatcher
 	RunJoinMaterial         ToolRunner
+	RunReboot               ToolRunner
 	Now                     func() time.Time
 	OperationID             func(string, time.Time) (string, error)
 	submitMu                sync.Mutex
@@ -84,9 +86,65 @@ func NewServer(root string, store operation.Store) *Server {
 		StartedAt:               now,
 		SupportedOperationKinds: append([]string(nil), bootstrapOperationKinds...),
 		RunJoinMaterial:         runChildProcess,
+		RunReboot:               runChildProcess,
 		Now:                     func() time.Time { return time.Now().UTC() },
 		OperationID:             defaultOperationID,
 	}
+}
+
+func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agentapi.RebootAccepted, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if req.ApiVersion != APIVersion {
+		return nil, status.Errorf(codes.InvalidArgument, "apiVersion must be %q", APIVersion)
+	}
+	if req.Kind != RebootRequestKind {
+		return nil, status.Errorf(codes.InvalidArgument, "kind must be %q", RebootRequestKind)
+	}
+	if strings.TrimSpace(req.Actor) == "" {
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	machineID, err := s.machineID()
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
+	}
+	if strings.TrimSpace(req.ExpectedMachineId) == "" || req.ExpectedMachineId != machineID {
+		return nil, status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
+	}
+	target := strings.TrimSpace(req.TargetGenerationId)
+	if err := cleanPublicID("targetGenerationID", target); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	_, generationStatus, err := generation.ReadGeneration(s.Root, target)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "read target generation: %v", err)
+	}
+	if generationStatus.CommitState != generation.CommitStateCommitted {
+		return nil, status.Errorf(codes.FailedPrecondition, "target generation %q is not committed", target)
+	}
+	selection, err := generation.ReadBootSelection(s.Root)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "read boot selection: %v", err)
+	}
+	if selection.TargetBootGenerationID != target && selection.DefaultGenerationID != target {
+		return nil, status.Errorf(codes.FailedPrecondition, "target generation %q is not selected for boot", target)
+	}
+	active, err := s.activeOperationIDs()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "read operation locks: %v", err)
+	}
+	if len(active) > 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot reboot while operation %s is active", strings.Join(active, ","))
+	}
+	if s.RunReboot == nil {
+		return nil, status.Error(codes.FailedPrecondition, "node reboot runner is not configured")
+	}
+	result := s.RunReboot(ctx, []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(toolFailure(result)))
+	}
+	return &agentapi.RebootAccepted{Scheduled: true, TargetGenerationId: target}, nil
 }
 
 func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusRequest) (*agentapi.NodeStatus, error) {

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -94,6 +94,34 @@ func TestListOperationsFiltersActiveRecords(t *testing.T) {
 	}
 }
 
+func TestRebootSchedulesCommittedSelectedGeneration(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	var argv []string
+	server.RunReboot = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		argv = append([]string(nil), got...)
+		return ToolResult{ExitStatus: 0}
+	}
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := server.Reboot(context.Background(), &agentapi.RebootRequest{
+		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
+		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accepted.Scheduled || accepted.TargetGenerationId != "generation-0" {
+		t.Fatalf("accepted = %#v", accepted)
+	}
+	want := []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("reboot argv = %#v, want %#v", argv, want)
+	}
+}
+
 func TestSubmitOperationRecordsDestructiveReset(t *testing.T) {
 	server := newTestServer(t)
 	var dispatched atomic.Int32

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -3033,6 +3033,134 @@ func (x *ConfigApplyStatus) GetSelectedKubeadmConfigName() string {
 	return ""
 }
 
+type RebootRequest struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion         string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind               string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor              string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId  string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	TargetGenerationId string                 `protobuf:"bytes,5,opt,name=target_generation_id,json=targetGenerationId,proto3" json:"target_generation_id,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *RebootRequest) Reset() {
+	*x = RebootRequest{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RebootRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RebootRequest) ProtoMessage() {}
+
+func (x *RebootRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RebootRequest.ProtoReflect.Descriptor instead.
+func (*RebootRequest) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *RebootRequest) GetApiVersion() string {
+	if x != nil {
+		return x.ApiVersion
+	}
+	return ""
+}
+
+func (x *RebootRequest) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *RebootRequest) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *RebootRequest) GetExpectedMachineId() string {
+	if x != nil {
+		return x.ExpectedMachineId
+	}
+	return ""
+}
+
+func (x *RebootRequest) GetTargetGenerationId() string {
+	if x != nil {
+		return x.TargetGenerationId
+	}
+	return ""
+}
+
+type RebootAccepted struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Scheduled          bool                   `protobuf:"varint,1,opt,name=scheduled,proto3" json:"scheduled,omitempty"`
+	TargetGenerationId string                 `protobuf:"bytes,2,opt,name=target_generation_id,json=targetGenerationId,proto3" json:"target_generation_id,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *RebootAccepted) Reset() {
+	*x = RebootAccepted{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RebootAccepted) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RebootAccepted) ProtoMessage() {}
+
+func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RebootAccepted.ProtoReflect.Descriptor instead.
+func (*RebootAccepted) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *RebootAccepted) GetScheduled() bool {
+	if x != nil {
+		return x.Scheduled
+	}
+	return false
+}
+
+func (x *RebootAccepted) GetTargetGenerationId() string {
+	if x != nil {
+		return x.TargetGenerationId
+	}
+	return ""
+}
+
 var File_internal_katlc_agentapi_agent_proto protoreflect.FileDescriptor
 
 const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
@@ -3354,10 +3482,21 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0efailure_reason\x18\x05 \x01(\tR\rfailureReason\x126\n" +
 	"\x17kubeadm_action_required\x18\x06 \x01(\bR\x15kubeadmActionRequired\x12?\n" +
 	"\x1cprevious_kubeadm_config_name\x18\a \x01(\tR\x19previousKubeadmConfigName\x12?\n" +
-	"\x1cselected_kubeadm_config_name\x18\b \x01(\tR\x19selectedKubeadmConfigName2\x8c\b\n" +
+	"\x1cselected_kubeadm_config_name\x18\b \x01(\tR\x19selectedKubeadmConfigName\"\xbc\x01\n" +
+	"\rRebootRequest\x12\x1f\n" +
+	"\vapi_version\x18\x01 \x01(\tR\n" +
+	"apiVersion\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x14\n" +
+	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
+	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\x120\n" +
+	"\x14target_generation_id\x18\x05 \x01(\tR\x12targetGenerationId\"`\n" +
+	"\x0eRebootAccepted\x12\x1c\n" +
+	"\tscheduled\x18\x01 \x01(\bR\tscheduled\x120\n" +
+	"\x14target_generation_id\x18\x02 \x01(\tR\x12targetGenerationId2\xd3\b\n" +
 	"\n" +
 	"KatlcAgent\x12O\n" +
-	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12]\n" +
+	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12E\n" +
+	"\x06Reboot\x12\x1c.katl.agent.v1.RebootRequest\x1a\x1d.katl.agent.v1.RebootAccepted\x12]\n" +
 	"\x0eValidateConfig\x12$.katl.agent.v1.ValidateConfigRequest\x1a%.katl.agent.v1.ConfigValidationResult\x12Z\n" +
 	"\x0fApplyGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
 	"\x0fStageGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
@@ -3381,7 +3520,7 @@ func file_internal_katlc_agentapi_agent_proto_rawDescGZIP() []byte {
 	return file_internal_katlc_agentapi_agent_proto_rawDescData
 }
 
-var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*GetNodeStatusRequest)(nil),                      // 0: katl.agent.v1.GetNodeStatusRequest
 	(*NodeStatus)(nil),                                // 1: katl.agent.v1.NodeStatus
@@ -3414,6 +3553,8 @@ var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*ExtensionRef)(nil),                              // 28: katl.agent.v1.ExtensionRef
 	(*GeneratedConfext)(nil),                          // 29: katl.agent.v1.GeneratedConfext
 	(*ConfigApplyStatus)(nil),                         // 30: katl.agent.v1.ConfigApplyStatus
+	(*RebootRequest)(nil),                             // 31: katl.agent.v1.RebootRequest
+	(*RebootAccepted)(nil),                            // 32: katl.agent.v1.RebootAccepted
 }
 var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	3,  // 0: katl.agent.v1.SubmitOperationRequest.bootstrap:type_name -> katl.agent.v1.BootstrapOperationRequest
@@ -3435,29 +3576,31 @@ var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	29, // 16: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
 	30, // 17: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
 	0,  // 18: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
-	5,  // 19: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
-	7,  // 20: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	7,  // 21: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	2,  // 22: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
-	13, // 23: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
-	16, // 24: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
-	17, // 25: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
-	22, // 26: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
-	24, // 27: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
-	26, // 28: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
-	1,  // 29: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
-	6,  // 30: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
-	15, // 31: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
-	15, // 32: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
-	15, // 33: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
-	14, // 34: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
-	19, // 35: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
-	18, // 36: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
-	23, // 37: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
-	25, // 38: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
-	27, // 39: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
-	29, // [29:40] is the sub-list for method output_type
-	18, // [18:29] is the sub-list for method input_type
+	31, // 19: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
+	5,  // 20: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
+	7,  // 21: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	7,  // 22: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	2,  // 23: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
+	13, // 24: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
+	16, // 25: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
+	17, // 26: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
+	22, // 27: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
+	24, // 28: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
+	26, // 29: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
+	1,  // 30: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
+	32, // 31: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
+	6,  // 32: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
+	15, // 33: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
+	15, // 34: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
+	15, // 35: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
+	14, // 36: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
+	19, // 37: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
+	18, // 38: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
+	23, // 39: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
+	25, // 40: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
+	27, // 41: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
+	30, // [30:42] is the sub-list for method output_type
+	18, // [18:30] is the sub-list for method input_type
 	18, // [18:18] is the sub-list for extension type_name
 	18, // [18:18] is the sub-list for extension extendee
 	0,  // [0:18] is the sub-list for field type_name
@@ -3474,7 +3617,7 @@ func file_internal_katlc_agentapi_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_katlc_agentapi_agent_proto_rawDesc), len(file_internal_katlc_agentapi_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/katl-dev/katl/internal/katlc/agentapi;agentapi";
 
 service KatlcAgent {
   rpc GetNodeStatus(GetNodeStatusRequest) returns (NodeStatus);
+  rpc Reboot(RebootRequest) returns (RebootAccepted);
   rpc ValidateConfig(ValidateConfigRequest) returns (ConfigValidationResult);
   rpc ApplyGeneration(GenerationApplyRequest) returns (OperationAccepted);
   rpc StageGeneration(GenerationApplyRequest) returns (OperationAccepted);
@@ -345,4 +346,17 @@ message ConfigApplyStatus {
   bool kubeadm_action_required = 6;
   string previous_kubeadm_config_name = 7;
   string selected_kubeadm_config_name = 8;
+}
+
+message RebootRequest {
+  string api_version = 1;
+  string kind = 2;
+  string actor = 3;
+  string expected_machine_id = 4;
+  string target_generation_id = 5;
+}
+
+message RebootAccepted {
+  bool scheduled = 1;
+  string target_generation_id = 2;
 }

--- a/internal/katlc/agentapi/agent_grpc.pb.go
+++ b/internal/katlc/agentapi/agent_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	KatlcAgent_GetNodeStatus_FullMethodName            = "/katl.agent.v1.KatlcAgent/GetNodeStatus"
+	KatlcAgent_Reboot_FullMethodName                   = "/katl.agent.v1.KatlcAgent/Reboot"
 	KatlcAgent_ValidateConfig_FullMethodName           = "/katl.agent.v1.KatlcAgent/ValidateConfig"
 	KatlcAgent_ApplyGeneration_FullMethodName          = "/katl.agent.v1.KatlcAgent/ApplyGeneration"
 	KatlcAgent_StageGeneration_FullMethodName          = "/katl.agent.v1.KatlcAgent/StageGeneration"
@@ -37,6 +38,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type KatlcAgentClient interface {
 	GetNodeStatus(ctx context.Context, in *GetNodeStatusRequest, opts ...grpc.CallOption) (*NodeStatus, error)
+	Reboot(ctx context.Context, in *RebootRequest, opts ...grpc.CallOption) (*RebootAccepted, error)
 	ValidateConfig(ctx context.Context, in *ValidateConfigRequest, opts ...grpc.CallOption) (*ConfigValidationResult, error)
 	ApplyGeneration(ctx context.Context, in *GenerationApplyRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
 	StageGeneration(ctx context.Context, in *GenerationApplyRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
@@ -61,6 +63,16 @@ func (c *katlcAgentClient) GetNodeStatus(ctx context.Context, in *GetNodeStatusR
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NodeStatus)
 	err := c.cc.Invoke(ctx, KatlcAgent_GetNodeStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *katlcAgentClient) Reboot(ctx context.Context, in *RebootRequest, opts ...grpc.CallOption) (*RebootAccepted, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RebootAccepted)
+	err := c.cc.Invoke(ctx, KatlcAgent_Reboot_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -181,6 +193,7 @@ func (c *katlcAgentClient) GetGeneration(ctx context.Context, in *GetGenerationR
 // for forward compatibility.
 type KatlcAgentServer interface {
 	GetNodeStatus(context.Context, *GetNodeStatusRequest) (*NodeStatus, error)
+	Reboot(context.Context, *RebootRequest) (*RebootAccepted, error)
 	ValidateConfig(context.Context, *ValidateConfigRequest) (*ConfigValidationResult, error)
 	ApplyGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error)
 	StageGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error)
@@ -203,6 +216,9 @@ type UnimplementedKatlcAgentServer struct{}
 
 func (UnimplementedKatlcAgentServer) GetNodeStatus(context.Context, *GetNodeStatusRequest) (*NodeStatus, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNodeStatus not implemented")
+}
+func (UnimplementedKatlcAgentServer) Reboot(context.Context, *RebootRequest) (*RebootAccepted, error) {
+	return nil, status.Error(codes.Unimplemented, "method Reboot not implemented")
 }
 func (UnimplementedKatlcAgentServer) ValidateConfig(context.Context, *ValidateConfigRequest) (*ConfigValidationResult, error) {
 	return nil, status.Error(codes.Unimplemented, "method ValidateConfig not implemented")
@@ -269,6 +285,24 @@ func _KatlcAgent_GetNodeStatus_Handler(srv interface{}, ctx context.Context, dec
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(KatlcAgentServer).GetNodeStatus(ctx, req.(*GetNodeStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _KatlcAgent_Reboot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RebootRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KatlcAgentServer).Reboot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KatlcAgent_Reboot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KatlcAgentServer).Reboot(ctx, req.(*RebootRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -456,6 +490,10 @@ var KatlcAgent_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetNodeStatus",
 			Handler:    _KatlcAgent_GetNodeStatus_Handler,
+		},
+		{
+			MethodName: "Reboot",
+			Handler:    _KatlcAgent_Reboot_Handler,
 		},
 		{
 			MethodName: "ValidateConfig",

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -740,53 +740,50 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		return fmt.Errorf("write katlctl upgrade context: %w", err)
 	}
-	for i, item := range []struct {
-		name string
-		node vmtest.RunningInstalledRuntimeNode
-	}{{"cp-1", cpNode}, {"worker-1", workerNode}} {
-		command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "cluster", "upgrade", "kubernetes", "--config", configPath, "--bundle", bundle, "--timeout", "25m")
-		command.Dir = repoRoot
-		stdout, err := command.Output()
-		if err != nil {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
-				_ = os.WriteFile(filepath.Join(evidenceDir, fmt.Sprintf("katlctl-kubernetes-upgrade-%d.stderr", i+1)), exitErr.Stderr, 0o600)
-			}
-			return fmt.Errorf("katlctl Kubernetes upgrade step %d: %w", i+1, err)
+	image, err := kubernetesbundle.ParseImageReference(bundle)
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "kubernetes", "upgrade", image.ArtifactVersion, "--config", configPath, "--timeout", "25m")
+	command.Dir = repoRoot
+	stdout, err := command.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			_ = os.WriteFile(filepath.Join(evidenceDir, "katlctl-kubernetes-upgrade.stderr"), exitErr.Stderr, 0o600)
 		}
-		if err := os.WriteFile(filepath.Join(evidenceDir, fmt.Sprintf("katlctl-kubernetes-upgrade-%d.json", i+1)), stdout, 0o600); err != nil {
-			return err
+		return fmt.Errorf("katlctl Kubernetes upgrade rollout: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(evidenceDir, "katlctl-kubernetes-upgrade.json"), stdout, 0o600); err != nil {
+		return err
+	}
+	var report struct {
+		SourceVersion string `json:"sourceVersion"`
+		TargetVersion string `json:"targetVersion"`
+		Nodes         []struct {
+			Name   string `json:"name"`
+			Result string `json:"result"`
+			Phase  string `json:"phase"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(stdout, &report); err != nil {
+		return fmt.Errorf("decode katlctl Kubernetes upgrade report: %w", err)
+	}
+	if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 2 {
+		return fmt.Errorf("unexpected katlctl Kubernetes upgrade report: %+v", report)
+	}
+	for i, want := range []string{"cp-1", "worker-1"} {
+		if report.Nodes[i].Name != want || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "boot-healthy" {
+			return fmt.Errorf("unexpected katlctl Kubernetes upgrade node report %d: %+v", i, report.Nodes[i])
 		}
-		var report struct {
-			SourceVersion string `json:"sourceVersion"`
-			TargetVersion string `json:"targetVersion"`
-			Nodes         []struct {
-				Name   string `json:"name"`
-				Result string `json:"result"`
-			} `json:"nodes"`
+	}
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cpNode, workerNode} {
+		if err := activateNodeCNIFixture(ctx, node, cniFixtures[node.Name]); err != nil {
+			return fmt.Errorf("reactivate %s CNI fixture after upgrade reboot: %w", node.Name, err)
 		}
-		if err := json.Unmarshal(stdout, &report); err != nil {
-			return fmt.Errorf("decode katlctl Kubernetes upgrade report step %d: %w", i+1, err)
-		}
-		if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 1 || report.Nodes[0].Name != item.name || report.Nodes[0].Result != operation.ResultSucceeded {
-			return fmt.Errorf("unexpected katlctl Kubernetes upgrade report step %d: %+v", i+1, report)
-		}
-		_, record, err := collectOperationEvidence(ctx, item.node, filepath.Join(evidenceDir, item.name, "upgrade-pre-reboot"), "kubeadm-upgrade")
-		if err != nil {
-			return err
-		}
-		if !record.Terminal || record.Result != operation.ResultSucceeded || record.RecoveryRequired || record.GenerationCommitState != operation.GenerationCommitCommitted || record.PostKubeadmHealthState != operation.PostKubeadmHealthPassed || !record.BootHealthPending {
-			return fmt.Errorf("%s upgrade did not commit a healthy candidate: %+v", item.node.Name, record)
-		}
-		if err := rebootIntoGeneration(ctx, item.node, record.CandidateGenerationID); err != nil {
-			return fmt.Errorf("reboot upgraded %s: %w", item.node.Name, err)
-		}
-		if err := activateNodeCNIFixture(ctx, item.node, cniFixtures[item.node.Name]); err != nil {
-			return fmt.Errorf("reactivate %s CNI fixture after upgrade reboot: %w", item.node.Name, err)
-		}
-		if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-after-"+item.node.Name+"-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
-			return err
-		}
+	}
+	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-after-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
+		return err
 	}
 	for _, item := range []vmtest.RunningInstalledRuntimeNode{cpNode, workerNode} {
 		dir := filepath.Join(evidenceDir, item.Name, "upgrade")
@@ -797,7 +794,8 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 		if err != nil {
 			return err
 		}
-		if record.KubernetesSysextUpdate == nil || record.KubernetesSysextUpdate.KubernetesBundleRef != bundle || record.KubernetesSysextUpdate.BundleManifestDigest == "" || record.KubernetesSysextUpdate.TargetSysextSHA256 == "" {
+		versionRef := image.Repository + ":" + image.Tag
+		if record.KubernetesSysextUpdate == nil || record.KubernetesSysextUpdate.KubernetesBundleRef != versionRef || record.KubernetesSysextUpdate.BundleManifestDigest == "" || record.KubernetesSysextUpdate.TargetSysextSHA256 == "" {
 			return fmt.Errorf("%s upgrade did not resolve the published bundle internally: %+v", item.Name, record.KubernetesSysextUpdate)
 		}
 		if item.Name == cpNode.Name && (record.KubernetesSysextUpdate.SnapshotDigest == "" || record.KubernetesSysextUpdate.SnapshotStorageLocation == "") {


### PR DESCRIPTION
Make host and Kubernetes upgrades version-driven managed workflows. Katl now reboots through the authenticated agent, verifies boot health, waits for control-plane readiness, and stops serial Kubernetes rollout on failure.