### PR TITLE
release: parallelize artifact production

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -54,6 +54,8 @@ jobs:
     needs: identity
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    outputs:
+      mkosi-version: ${{ steps.mkosi-version.outputs.version }}
 
     env:
       GOTOOLCHAIN: auto
@@ -107,22 +109,21 @@ jobs:
           restore-keys: |
             katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build cached mkosi builder
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Containerfile.mkosi
-          load: true
-          tags: ${{ env.KATL_MKOSI_IMAGE }}
-          cache-from: type=gha,scope=katl-mkosi-builder
-          cache-to: type=gha,mode=max,scope=katl-mkosi-builder
-
       - name: Build runtime
         shell: bash
         run: scripts/mkosi build-runtime
+
+      - name: Resolve mkosi version
+        id: mkosi-version
+        shell: bash
+        run: |
+          version="$(docker run --rm "$KATL_MKOSI_IMAGE" mkosi --version)"
+          version="${version#mkosi }"
+          if [[ ! "$version" =~ ^[0-9]+([.][0-9]+)*$ ]]; then
+            echo "unexpected mkosi version from builder: $version" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Verify runtime
         shell: bash
@@ -136,10 +137,29 @@ jobs:
               scripts/check-runtime-boot-asset
             '
 
-      - name: Upload runtime intermediates
+      - name: Package install and upgrade images concurrently
+        shell: bash
+        run: |
+          install_status=0
+          upgrade_status=0
+          scripts/build-katlos-install-image &
+          install_pid=$!
+          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/build-katlos-install-image &
+          upgrade_pid=$!
+          wait "$install_pid" || install_status=$?
+          wait "$upgrade_pid" || upgrade_status=$?
+          ((install_status == 0 && upgrade_status == 0))
+
+      - name: Verify KatlOS images
+        shell: bash
+        run: |
+          scripts/check-katlos-install-image
+          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/check-katlos-install-image
+
+      - name: Upload runtime and KatlOS image intermediates
         uses: actions/upload-artifact@v7
         with:
-          name: katl-runtime-${{ github.sha }}
+          name: katl-runtime-images-${{ github.sha }}
           path: |
             _build/mkosi/katl-runtime-root.squashfs
             _build/mkosi/katl-runtime-root.squashfs.json
@@ -147,6 +167,13 @@ jobs:
             _build/mkosi/katl-runtime.efi
             _build/mkosi/katl-runtime.efi.json
             _build/mkosi/katl-runtime.efi.sha256
+            _build/mkosi/katl-runtime.packages.tsv
+            _build/mkosi/katlos-install-*.squashfs
+            _build/mkosi/katlos-install-*.squashfs.json
+            _build/mkosi/katlos-install-*.squashfs.sha256
+            _build/mkosi/katlos-upgrade-*.squashfs
+            _build/mkosi/katlos-upgrade-*.squashfs.json
+            _build/mkosi/katlos-upgrade-*.squashfs.sha256
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -208,18 +235,6 @@ jobs:
           key: katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-${{ steps.mkosi-cache.outputs.key }}
           restore-keys: |
             katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Load cached mkosi builder
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Containerfile.mkosi
-          load: true
-          tags: ${{ env.KATL_MKOSI_IMAGE }}
-          cache-from: type=gha,scope=katl-mkosi-builder
 
       - name: Build installer
         shell: bash
@@ -286,69 +301,6 @@ jobs:
           retention-days: 1
           compression-level: 0
 
-  katlos-images:
-    name: Package And Verify KatlOS Images
-    needs:
-      - identity
-      - runtime
-    runs-on: ubuntu-24.04
-
-    env:
-      KATL_ARCHITECTURE: x86_64
-      KATL_BUILD_COMMIT: ${{ github.sha }}
-      KATL_VERSION: ${{ needs.identity.outputs.version }}
-      KATL_VMTEST_IMAGE_SUPPORT: "0"
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Download verified runtime
-        uses: actions/download-artifact@v8
-        with:
-          name: katl-runtime-${{ github.sha }}
-          path: _build/mkosi
-
-      - name: Package install and upgrade images concurrently
-        shell: bash
-        run: |
-          install_status=0
-          upgrade_status=0
-          scripts/build-katlos-install-image &
-          install_pid=$!
-          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/build-katlos-install-image &
-          upgrade_pid=$!
-          wait "$install_pid" || install_status=$?
-          wait "$upgrade_pid" || upgrade_status=$?
-          ((install_status == 0 && upgrade_status == 0))
-
-      - name: Verify KatlOS images
-        shell: bash
-        run: |
-          scripts/check-katlos-install-image
-          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/check-katlos-install-image
-
-      - name: Upload KatlOS image intermediates
-        uses: actions/upload-artifact@v7
-        with:
-          name: katlos-images-${{ github.sha }}
-          path: |
-            _build/mkosi/katlos-install-*.squashfs
-            _build/mkosi/katlos-install-*.squashfs.json
-            _build/mkosi/katlos-install-*.squashfs.sha256
-            _build/mkosi/katlos-upgrade-*.squashfs
-            _build/mkosi/katlos-upgrade-*.squashfs.json
-            _build/mkosi/katlos-upgrade-*.squashfs.sha256
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
-
   assemble:
     name: Assemble And Verify Katl Release
     needs:
@@ -356,7 +308,6 @@ jobs:
       - runtime
       - installer
       - katlctl
-      - katlos-images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -368,9 +319,7 @@ jobs:
       GOTOOLCHAIN: auto
       KATL_ARCHITECTURE: x86_64
       KATL_BUILD_COMMIT: ${{ github.sha }}
-      KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
       KATL_VERSION: ${{ needs.identity.outputs.version }}
-      KATL_VMTEST_IMAGE_SUPPORT: "0"
 
     steps:
       - name: Check out repository
@@ -384,10 +333,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download runtime intermediates
+      - name: Download runtime and KatlOS image intermediates
         uses: actions/download-artifact@v8
         with:
-          name: katl-runtime-${{ github.sha }}
+          name: katl-runtime-images-${{ github.sha }}
           path: _build/mkosi
 
       - name: Download installer intermediates
@@ -396,69 +345,37 @@ jobs:
           name: katl-installer-${{ github.sha }}
           path: _build/mkosi
 
-      - name: Download KatlOS image intermediates
-        uses: actions/download-artifact@v8
-        with:
-          name: katlos-images-${{ github.sha }}
-          path: _build/mkosi
-
       - name: Download katlctl intermediate
         uses: actions/download-artifact@v8
         with:
           name: katlctl-${{ github.sha }}
           path: _build/mkosi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Load cached mkosi builder
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Containerfile.mkosi
-          load: true
-          tags: ${{ env.KATL_MKOSI_IMAGE }}
-          cache-from: type=gha,scope=katl-mkosi-builder
-
-      - name: Assemble ISO and verify release artifacts
+      - name: Install ISO assembly tools
         shell: bash
         run: |
-          docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/work" \
-            --workdir /work \
-            --env KATL_REPO_ROOT=/work \
-            --env KATL_VERSION \
-            --env KATL_ARCHITECTURE \
-            --env KATL_BUILD_COMMIT \
-            --env KATL_VMTEST_IMAGE_SUPPORT \
-            "$KATL_MKOSI_IMAGE" \
-            bash -euo pipefail -c '
-              scripts/build-installer-iso >/dev/null
-              go run ./cmd/katl-mkosi-artifacts write >/dev/null
-              scripts/check-runtime-root
-              scripts/check-runtime-boot-asset
-              scripts/check-installer-image
-              scripts/check-installer-iso
-              scripts/check-katlos-install-image
-              KATL_KATLOS_IMAGE_ROLE=upgrade scripts/check-katlos-install-image
-            '
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes dosfstools mtools xorriso
+
+      - name: Assemble and verify installer ISO
+        shell: bash
+        run: |
+          scripts/build-installer-iso >/dev/null
+          go run ./cmd/katl-mkosi-artifacts write-installer-artifacts >/dev/null
+          scripts/check-installer-iso
 
       - name: Verify release resource lock
         shell: bash
+        env:
+          MKOSI_VERSION: ${{ needs.runtime.outputs.mkosi-version }}
         run: |
-          mkosi_version="$(docker run --rm "$KATL_MKOSI_IMAGE" mkosi --version)"
-          mkosi_version="${mkosi_version#mkosi }"
-          if [[ ! "$mkosi_version" =~ ^[0-9]+([.][0-9]+)*$ ]]; then
-            echo "unexpected mkosi version from builder: $mkosi_version" >&2
-            exit 1
-          fi
           go run ./cmd/katl-resource-lock prepare-mkosi \
             -manifest _build/release-resource-test-manifest.json \
             -lock mkosi.profiles/resource-package-lock.json \
             -mode strict \
             -run-id "release-${KATL_VERSION}-${GITHUB_SHA:0:12}" \
             -git-revision "$GITHUB_SHA" \
-            -mkosi-version "$mkosi_version" \
+            -mkosi-version "$MKOSI_VERSION" \
             -package-set installer-image \
             -package-set runtime \
             -package-set katlos-install-image

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -21,17 +21,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build And Verify Katl Artifacts
+  identity:
+    name: Resolve Release Identity
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
-    permissions:
-      attestations: write
-      contents: read
-      id-token: write
     outputs:
       artifact-name: ${{ steps.release.outputs.artifact-name }}
       version: ${{ steps.release.outputs.version }}
+
+    env:
+      KATL_ARCHITECTURE: x86_64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Resolve release identity
+        id: release
+        shell: bash
+        env:
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          version="$(scripts/katl-release-artifacts version \
+            "$GITHUB_EVENT_NAME" "$GITHUB_REF_TYPE" "$GITHUB_REF_NAME" \
+            "$MANUAL_VERSION")"
+          short_sha="${GITHUB_SHA:0:12}"
+          artifact_name="katl-${version}-${KATL_ARCHITECTURE}-${short_sha}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+  runtime:
+    name: Build And Verify Runtime
+    needs: identity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
 
     env:
       GOTOOLCHAIN: auto
@@ -39,13 +61,12 @@ jobs:
       KATL_BUILD_COMMIT: ${{ github.sha }}
       KATL_CONTAINER_RUNTIME: docker
       KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
+      KATL_VERSION: ${{ needs.identity.outputs.version }}
       KATL_VMTEST_IMAGE_SUPPORT: "0"
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -86,38 +107,320 @@ jobs:
           restore-keys: |
             katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
 
-      - name: Resolve release identity
-        id: release
-        shell: bash
-        env:
-          MANUAL_VERSION: ${{ inputs.version }}
-        run: |
-          version="$(scripts/katl-release-artifacts version \
-            "$GITHUB_EVENT_NAME" "$GITHUB_REF_TYPE" "$GITHUB_REF_NAME" \
-            "$MANUAL_VERSION")"
-          short_sha="${GITHUB_SHA:0:12}"
-          artifact_name="katl-${version}-${KATL_ARCHITECTURE}-${short_sha}"
-          echo "KATL_VERSION=$version" >> "$GITHUB_ENV"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Show build environment
-        shell: bash
-        run: |
-          go version
-          docker version
-          df -h "$GITHUB_WORKSPACE"
+      - name: Build cached mkosi builder
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Containerfile.mkosi
+          load: true
+          tags: ${{ env.KATL_MKOSI_IMAGE }}
+          cache-from: type=gha,scope=katl-mkosi-builder
+          cache-to: type=gha,mode=max,scope=katl-mkosi-builder
 
-      - name: Build documented release artifacts
+      - name: Build runtime
+        shell: bash
+        run: scripts/mkosi build-runtime
+
+      - name: Verify runtime
         shell: bash
         run: |
-          scripts/mkosi build-runtime
-          scripts/mkosi build-katlos-install-image
-          scripts/mkosi build-installer-iso
-          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/mkosi build-katlos-install-image
-          scripts/katl-release-artifacts build-katlctl "$KATL_VERSION"
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --workdir /work \
+            "$KATL_MKOSI_IMAGE" \
+            bash -euo pipefail -c '
+              scripts/check-runtime-root
+              scripts/check-runtime-boot-asset
+            '
 
-      - name: Verify built artifacts
+      - name: Upload runtime intermediates
+        uses: actions/upload-artifact@v7
+        with:
+          name: katl-runtime-${{ github.sha }}
+          path: |
+            _build/mkosi/katl-runtime-root.squashfs
+            _build/mkosi/katl-runtime-root.squashfs.json
+            _build/mkosi/katl-runtime-root.squashfs.sha256
+            _build/mkosi/katl-runtime.efi
+            _build/mkosi/katl-runtime.efi.json
+            _build/mkosi/katl-runtime.efi.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  installer:
+    name: Build And Verify Installer
+    needs: identity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    env:
+      GOTOOLCHAIN: auto
+      KATL_ARCHITECTURE: x86_64
+      KATL_BUILD_COMMIT: ${{ github.sha }}
+      KATL_CONTAINER_RUNTIME: docker
+      KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
+      KATL_VERSION: ${{ needs.identity.outputs.version }}
+      KATL_VMTEST_IMAGE_SUPPORT: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Restore Katl Go build caches
+        uses: actions/cache@v6
+        with:
+          path: |
+            _build/go-mod
+            _build/go-cache
+          key: katl-go-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: |
+            katl-go-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-
+
+      - name: Resolve mkosi cache identity
+        id: mkosi-cache
+        shell: bash
+        run: |
+          digest="$({
+            sha256sum \
+              Containerfile.mkosi \
+              mkosi.conf \
+              mkosi.profiles/installer-image/mkosi.conf \
+              mkosi.profiles/kubernetes-sysext/kubernetes.env \
+              mkosi.profiles/kubernetes-sysext/mkosi.conf \
+              mkosi.profiles/runtime/mkosi.conf
+          } | sha256sum | cut -d ' ' -f 1)"
+          echo "key=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Restore mkosi package cache
+        uses: actions/cache@v6
+        with:
+          path: _build/mkosi/package-cache
+          key: katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-${{ steps.mkosi-cache.outputs.key }}
+          restore-keys: |
+            katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Load cached mkosi builder
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Containerfile.mkosi
+          load: true
+          tags: ${{ env.KATL_MKOSI_IMAGE }}
+          cache-from: type=gha,scope=katl-mkosi-builder
+
+      - name: Build installer
+        shell: bash
+        run: scripts/mkosi build-installer
+
+      - name: Verify installer
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --workdir /work \
+            "$KATL_MKOSI_IMAGE" \
+            scripts/check-installer-image
+
+      - name: Upload installer intermediates
+        uses: actions/upload-artifact@v7
+        with:
+          name: katl-installer-${{ github.sha }}
+          path: |
+            _build/mkosi/katl-installer.efi
+            _build/mkosi/katl-installer.efi.json
+            _build/mkosi/katl-installer.efi.sha256
+            _build/mkosi/katl-installer.initrd
+            _build/mkosi/katl-installer.initrd.json
+            _build/mkosi/katl-installer.initrd.sha256
+            _build/mkosi/katl-installer.packages.tsv
+            _build/mkosi/katl-installer.vmlinuz
+            _build/mkosi/katl-installer.vmlinuz.json
+            _build/mkosi/katl-installer.vmlinuz.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  katlctl:
+    name: Build And Verify katlctl
+    needs: identity
+    runs-on: ubuntu-24.04
+
+    env:
+      KATL_ARCHITECTURE: x86_64
+      KATL_BUILD_COMMIT: ${{ github.sha }}
+      KATL_VERSION: ${{ needs.identity.outputs.version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build katlctl
+        shell: bash
+        run: scripts/katl-release-artifacts build-katlctl "$KATL_VERSION"
+
+      - name: Upload katlctl intermediate
+        uses: actions/upload-artifact@v7
+        with:
+          name: katlctl-${{ github.sha }}
+          path: _build/mkosi/katlctl-*
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  katlos-images:
+    name: Package And Verify KatlOS Images
+    needs:
+      - identity
+      - runtime
+    runs-on: ubuntu-24.04
+
+    env:
+      KATL_ARCHITECTURE: x86_64
+      KATL_BUILD_COMMIT: ${{ github.sha }}
+      KATL_VERSION: ${{ needs.identity.outputs.version }}
+      KATL_VMTEST_IMAGE_SUPPORT: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download verified runtime
+        uses: actions/download-artifact@v8
+        with:
+          name: katl-runtime-${{ github.sha }}
+          path: _build/mkosi
+
+      - name: Package install and upgrade images concurrently
+        shell: bash
+        run: |
+          install_status=0
+          upgrade_status=0
+          scripts/build-katlos-install-image &
+          install_pid=$!
+          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/build-katlos-install-image &
+          upgrade_pid=$!
+          wait "$install_pid" || install_status=$?
+          wait "$upgrade_pid" || upgrade_status=$?
+          ((install_status == 0 && upgrade_status == 0))
+
+      - name: Verify KatlOS images
+        shell: bash
+        run: |
+          scripts/check-katlos-install-image
+          KATL_KATLOS_IMAGE_ROLE=upgrade scripts/check-katlos-install-image
+
+      - name: Upload KatlOS image intermediates
+        uses: actions/upload-artifact@v7
+        with:
+          name: katlos-images-${{ github.sha }}
+          path: |
+            _build/mkosi/katlos-install-*.squashfs
+            _build/mkosi/katlos-install-*.squashfs.json
+            _build/mkosi/katlos-install-*.squashfs.sha256
+            _build/mkosi/katlos-upgrade-*.squashfs
+            _build/mkosi/katlos-upgrade-*.squashfs.json
+            _build/mkosi/katlos-upgrade-*.squashfs.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  assemble:
+    name: Assemble And Verify Katl Release
+    needs:
+      - identity
+      - runtime
+      - installer
+      - katlctl
+      - katlos-images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
+    env:
+      GOTOOLCHAIN: auto
+      KATL_ARCHITECTURE: x86_64
+      KATL_BUILD_COMMIT: ${{ github.sha }}
+      KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
+      KATL_VERSION: ${{ needs.identity.outputs.version }}
+      KATL_VMTEST_IMAGE_SUPPORT: "0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download runtime intermediates
+        uses: actions/download-artifact@v8
+        with:
+          name: katl-runtime-${{ github.sha }}
+          path: _build/mkosi
+
+      - name: Download installer intermediates
+        uses: actions/download-artifact@v8
+        with:
+          name: katl-installer-${{ github.sha }}
+          path: _build/mkosi
+
+      - name: Download KatlOS image intermediates
+        uses: actions/download-artifact@v8
+        with:
+          name: katlos-images-${{ github.sha }}
+          path: _build/mkosi
+
+      - name: Download katlctl intermediate
+        uses: actions/download-artifact@v8
+        with:
+          name: katlctl-${{ github.sha }}
+          path: _build/mkosi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Load cached mkosi builder
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Containerfile.mkosi
+          load: true
+          tags: ${{ env.KATL_MKOSI_IMAGE }}
+          cache-from: type=gha,scope=katl-mkosi-builder
+
+      - name: Assemble ISO and verify release artifacts
         shell: bash
         run: |
           docker run --rm \
@@ -126,8 +429,12 @@ jobs:
             --env KATL_REPO_ROOT=/work \
             --env KATL_VERSION \
             --env KATL_ARCHITECTURE \
+            --env KATL_BUILD_COMMIT \
+            --env KATL_VMTEST_IMAGE_SUPPORT \
             "$KATL_MKOSI_IMAGE" \
             bash -euo pipefail -c '
+              scripts/build-installer-iso >/dev/null
+              go run ./cmd/katl-mkosi-artifacts write >/dev/null
               scripts/check-runtime-root
               scripts/check-runtime-boot-asset
               scripts/check-installer-image
@@ -169,7 +476,7 @@ jobs:
       - name: Upload GitHub Actions artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.release.outputs.artifact-name }}
+          name: ${{ needs.identity.outputs.artifact-name }}
           path: dist/
           if-no-files-found: error
           retention-days: 30
@@ -178,7 +485,9 @@ jobs:
   publish-tag:
     name: Publish GitHub Release Assets
     if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: build
+    needs:
+      - identity
+      - assemble
     runs-on: ubuntu-24.04
     permissions:
       attestations: read
@@ -188,14 +497,14 @@ jobs:
       - name: Download verified artifacts
         uses: actions/download-artifact@v8
         with:
-          name: ${{ needs.build.outputs.artifact-name }}
+          name: ${{ needs.identity.outputs.artifact-name }}
           path: dist
 
       - name: Publish tag release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          KATL_VERSION: ${{ needs.build.outputs.version }}
+          KATL_VERSION: ${{ needs.identity.outputs.version }}
         run: |
           prerelease=()
           if [[ "$KATL_VERSION" == *-* ]]; then
@@ -220,10 +529,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          for artifact in dist/*; do
-            gh attestation verify "$artifact" \
-              --repo "$GITHUB_REPOSITORY" \
-              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-artifacts.yml" \
-              --source-ref "$GITHUB_REF" \
-              --source-digest "$GITHUB_SHA" >/dev/null
-          done
+          # The inner shell expands its positional artifact argument.
+          # shellcheck disable=SC2016
+          find dist -mindepth 1 -maxdepth 1 -type f -print0 | \
+            xargs -0 -r -n1 -P4 bash -euo pipefail -c '
+              artifact="$1"
+              gh attestation verify "$artifact" \
+                --repo "$GITHUB_REPOSITORY" \
+                --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-artifacts.yml" \
+                --source-ref "$GITHUB_REF" \
+                --source-digest "$GITHUB_SHA" >/dev/null
+            ' _

--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -60,6 +60,15 @@ func run(args []string, stdout, stderr io.Writer, environ []string) error {
 		}
 		fmt.Fprintf(stdout, "artifact index: %s\n", relPath(repoRoot, indexPath))
 		return nil
+	case "write-installer-artifacts":
+		if len(args) != 0 {
+			return fmt.Errorf("write-installer-artifacts does not accept arguments")
+		}
+		if err := writeInstallerArtifacts(cfg); err != nil {
+			return err
+		}
+		fmt.Fprintln(stdout, "installer artifact metadata written")
+		return nil
 	case "write-runtime-index":
 		indexPath := cfg.DefaultIndex
 		if len(args) > 1 {
@@ -113,6 +122,7 @@ func run(args []string, stdout, stderr io.Writer, environ []string) error {
 }
 
 const usage = `Usage: katl-mkosi-artifacts [write [INDEX]]
+	   katl-mkosi-artifacts write-installer-artifacts
 	   katl-mkosi-artifacts write-runtime-index [INDEX]
        katl-mkosi-artifacts path KIND [INDEX]
        katl-mkosi-artifacts write-runtime-root --artifact PATH
@@ -997,38 +1007,11 @@ func writeIndex(indexPath string, cfg config) error {
 		}
 	}
 	includeInstallerISO := cfg.InstallerISOExplicit || fileExists(cfg.InstallerISO)
-	if includeInstallerISO {
-		if err := requireFile("installer ISO", cfg.InstallerISO, cfg.RepoRoot); err != nil {
-			return err
-		}
+	if err := writeInstallerArtifacts(cfg); err != nil {
+		return err
 	}
 
 	created := time.Now().UTC().Format(time.RFC3339)
-	bootArtifacts := []struct {
-		role   string
-		format string
-		path   string
-	}{
-		{"installer-uki", "uki", cfg.InstallerUKI},
-		{"installer-kernel", "linux-kernel", cfg.InstallerKernel},
-		{"installer-initrd", "initrd", cfg.InstallerInitrd},
-	}
-	if includeInstallerISO {
-		bootArtifacts = append(bootArtifacts, struct {
-			role   string
-			format string
-			path   string
-		}{"installer-iso", "iso", cfg.InstallerISO})
-	}
-	for _, artifact := range bootArtifacts {
-		if err := writeChecksum(artifact.path); err != nil {
-			return err
-		}
-		if err := writeBootMetadata(artifact.role, artifact.format, artifact.path, created, cfg); err != nil {
-			return err
-		}
-	}
-
 	entries := []artifactEntry{}
 	indexedArtifacts := []struct {
 		kind     string
@@ -1082,6 +1065,42 @@ func writeIndex(indexPath string, cfg config) error {
 	}
 	if err := os.WriteFile(indexPath, append(data, '\n'), 0o644); err != nil {
 		return fmt.Errorf("write artifact index %s: %w", relPath(cfg.RepoRoot, indexPath), err)
+	}
+	return nil
+}
+
+func writeInstallerArtifacts(cfg config) error {
+	artifacts := []struct {
+		label  string
+		role   string
+		format string
+		path   string
+	}{
+		{"installer UKI", "installer-uki", "uki", cfg.InstallerUKI},
+		{"installer kernel", "installer-kernel", "linux-kernel", cfg.InstallerKernel},
+		{"installer initrd", "installer-initrd", "initrd", cfg.InstallerInitrd},
+	}
+	if cfg.InstallerISOExplicit || fileExists(cfg.InstallerISO) {
+		artifacts = append(artifacts, struct {
+			label  string
+			role   string
+			format string
+			path   string
+		}{"installer ISO", "installer-iso", "iso", cfg.InstallerISO})
+	}
+	for _, artifact := range artifacts {
+		if err := requireFile(artifact.label, artifact.path, cfg.RepoRoot); err != nil {
+			return err
+		}
+	}
+	created := time.Now().UTC().Format(time.RFC3339)
+	for _, artifact := range artifacts {
+		if err := writeChecksum(artifact.path); err != nil {
+			return err
+		}
+		if err := writeBootMetadata(artifact.role, artifact.format, artifact.path, created, cfg); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -112,6 +112,38 @@ func TestWriteAndPath(t *testing.T) {
 	}
 }
 
+func TestWriteInstallerArtifactsDoesNotRequireRuntime(t *testing.T) {
+	repo := testRepoRoot(t)
+	workDir := testWorkDir(t, repo)
+	installerUKI := writeTestFile(t, workDir, "installer.efi", "installer uki")
+	installerKernel := writeTestFile(t, workDir, "vmlinuz", "kernel")
+	installerInitrd := writeTestFile(t, workDir, "initrd", "initrd")
+
+	var stdout bytes.Buffer
+	err := run([]string{"write-installer-artifacts"}, &stdout, &bytes.Buffer{}, []string{
+		"KATL_BUILD_COMMIT=test-build",
+		"KATL_VERSION=2026.7.0-dev.1",
+		"KATL_ARCHITECTURE=x86_64",
+		"KATL_INSTALLER_UKI=" + installerUKI,
+		"KATL_INSTALLER_KERNEL=" + installerKernel,
+		"KATL_INSTALLER_INITRD=" + installerInitrd,
+	})
+	if err != nil {
+		t.Fatalf("write installer artifacts error = %v", err)
+	}
+	if stdout.String() != "installer artifact metadata written\n" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	for _, artifact := range []string{installerUKI, installerKernel, installerInitrd} {
+		if _, err := os.Stat(artifact + ".json"); err != nil {
+			t.Errorf("installer metadata missing for %s: %v", artifact, err)
+		}
+		if _, err := os.Stat(artifact + ".sha256"); err != nil {
+			t.Errorf("installer checksum missing for %s: %v", artifact, err)
+		}
+	}
+}
+
 func TestWriteIncludesExistingInstallerISO(t *testing.T) {
 	repo := testRepoRoot(t)
 	workDir := testWorkDir(t, repo)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -228,13 +228,11 @@ files as assets on the matching GitHub Release.
 
 Release production uses a dependency-aware job graph. Runtime, installer, and
 `katlctl` builds start concurrently. The install and upgrade images are then
-packaged concurrently from the one verified runtime artifact, and a final job
+packaged concurrently from the one verified runtime build, and a final job
 assembles the installer ISO from those verified intermediates before staging
-and attesting the complete release set. The Fedora mkosi builder uses the
-GitHub Actions cache backend for reusable Docker layers; mkosi package and Go
-build caches remain scoped independently. Published-asset provenance checks
-use bounded concurrency because every release asset has an independent
-attestation.
+and attesting the complete release set. Mkosi package and Go build caches remain
+scoped independently. Published-asset provenance checks use bounded concurrency
+because every release asset has an independent attestation.
 
 KatlOS release versions use `YYYY.M.PATCH` calendar versions with `-dev.N`,
 `-alpha.N`, `-beta.N`, and `-rc.N` prereleases. The first public alpha for the

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -226,6 +226,16 @@ with an explicit version for build verification. Release-branch and manual runs
 retain one GitHub Actions artifact; tag runs additionally publish those exact
 files as assets on the matching GitHub Release.
 
+Release production uses a dependency-aware job graph. Runtime, installer, and
+`katlctl` builds start concurrently. The install and upgrade images are then
+packaged concurrently from the one verified runtime artifact, and a final job
+assembles the installer ISO from those verified intermediates before staging
+and attesting the complete release set. The Fedora mkosi builder uses the
+GitHub Actions cache backend for reusable Docker layers; mkosi package and Go
+build caches remain scoped independently. Published-asset provenance checks
+use bounded concurrency because every release asset has an independent
+attestation.
+
 KatlOS release versions use `YYYY.M.PATCH` calendar versions with `-dev.N`,
 `-alpha.N`, `-beta.N`, and `-rc.N` prereleases. The first public alpha for the
 July 2026 line is `2026.7.0-alpha.1`; the stable identity is `2026.7.0`. Use

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -103,13 +103,10 @@ func TestKatlReleaseWorkflowBuildGraph(t *testing.T) {
 		"  runtime:\n",
 		"  installer:\n",
 		"  katlctl:\n",
-		"  katlos-images:\n",
 		"  assemble:\n",
-		"docker/build-push-action@",
-		"cache-from: type=gha,scope=katl-mkosi-builder",
-		"name: katl-runtime-${{ github.sha }}",
+		"name: katl-runtime-images-${{ github.sha }}",
 		"name: katl-installer-${{ github.sha }}",
-		"name: katlos-images-${{ github.sha }}",
+		"_build/mkosi/katl-runtime.packages.tsv",
 		"scripts/build-katlos-install-image &",
 		"KATL_KATLOS_IMAGE_ROLE=upgrade scripts/build-katlos-install-image &",
 	} {
@@ -118,15 +115,13 @@ func TestKatlReleaseWorkflowBuildGraph(t *testing.T) {
 		}
 	}
 
-	images := workflow[strings.Index(workflow, "  katlos-images:\n"):strings.Index(workflow, "  assemble:\n")]
-	assertTextContains(t, images, "- runtime", "Download verified runtime")
 	assemble := workflow[strings.Index(workflow, "  assemble:\n"):strings.Index(workflow, "  publish-tag:\n")]
 	assertTextContains(t, assemble,
 		"- runtime",
 		"- installer",
 		"- katlctl",
-		"- katlos-images",
 		"scripts/build-installer-iso",
+		"write-installer-artifacts",
 		"actions/attest@v4",
 	)
 	if !regexp.MustCompile(`xargs[^\n]*-P[1-9][0-9]*`).MatchString(workflow) {

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestKubernetesBundleWorkflowContract(t *testing.T) {
@@ -83,6 +85,52 @@ func TestKubernetesBundleWorkflowContract(t *testing.T) {
 	}
 	if strings.Contains(releaseWorkflow, "--generate-notes") {
 		t.Fatal("KatlOS releases must use the tested staged release notes")
+	}
+}
+
+func TestKatlReleaseWorkflowBuildGraph(t *testing.T) {
+	repo := repoRoot(t)
+	workflow := string(mustReadFile(t, repo+"/.github/workflows/release-artifacts.yml"))
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(workflow), &document); err != nil {
+		t.Fatalf("parse KatlOS release workflow: %v", err)
+	}
+
+	if count := strings.Count(workflow, "scripts/mkosi build-runtime"); count != 1 {
+		t.Fatalf("KatlOS release workflow runtime build count = %d, want exactly one", count)
+	}
+	for _, value := range []string{
+		"  runtime:\n",
+		"  installer:\n",
+		"  katlctl:\n",
+		"  katlos-images:\n",
+		"  assemble:\n",
+		"docker/build-push-action@",
+		"cache-from: type=gha,scope=katl-mkosi-builder",
+		"name: katl-runtime-${{ github.sha }}",
+		"name: katl-installer-${{ github.sha }}",
+		"name: katlos-images-${{ github.sha }}",
+		"scripts/build-katlos-install-image &",
+		"KATL_KATLOS_IMAGE_ROLE=upgrade scripts/build-katlos-install-image &",
+	} {
+		if !strings.Contains(workflow, value) {
+			t.Fatalf("KatlOS release workflow missing parallel build contract %q", value)
+		}
+	}
+
+	images := workflow[strings.Index(workflow, "  katlos-images:\n"):strings.Index(workflow, "  assemble:\n")]
+	assertTextContains(t, images, "- runtime", "Download verified runtime")
+	assemble := workflow[strings.Index(workflow, "  assemble:\n"):strings.Index(workflow, "  publish-tag:\n")]
+	assertTextContains(t, assemble,
+		"- runtime",
+		"- installer",
+		"- katlctl",
+		"- katlos-images",
+		"scripts/build-installer-iso",
+		"actions/attest@v4",
+	)
+	if !regexp.MustCompile(`xargs[^\n]*-P[1-9][0-9]*`).MatchString(workflow) {
+		t.Fatal("KatlOS release workflow does not verify published attestations with bounded concurrency")
 	}
 }
 

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -87,7 +87,7 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
 		"_build/mkosi/workspace/installer",
 		"_build/mkosi/workspace/runtime",
 	)
-	if got := readLinesForScripts(t, goArgs); !reflect.DeepEqual(got, []string{"run", "./cmd/katl-mkosi-artifacts", "write"}) {
+	if got := readLinesForScripts(t, goArgs); !reflect.DeepEqual(got, []string{"run", "./cmd/katl-mkosi-artifacts", "write-installer-artifacts"}) {
 		t.Fatalf("go args = %#v", got)
 	}
 	if got := strings.TrimSpace(string(mustReadFile(t, filepath.Join(repo, "_build", "mkosi", "katl-installer.packages.tsv")))); got != "systemd\t0:259.6-1.fc44.x86_64" {

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -351,7 +351,6 @@ target_outputs() {
     case "$1" in
         installer)
             printf '%s\n' \
-                "$build_dir/artifacts.json" \
                 "$build_dir/katl-installer.efi" \
                 "$build_dir/katl-installer.efi.json" \
                 "$build_dir/katl-installer.efi.sha256" \
@@ -366,6 +365,7 @@ target_outputs() {
         installer-iso)
             target_outputs installer
             printf '%s\n' \
+                "$build_dir/artifacts.json" \
                 "$build_dir/katl-installer.iso" \
                 "$build_dir/katl-installer.iso.json" \
                 "$build_dir/katl-installer.iso.sha256"
@@ -733,7 +733,8 @@ if [[ "$runtime" == direct ]]; then
         write_installer_package_set || status=1
     fi
     if [[ "$status" -eq 0 && -n "$installer_package_set" ]]; then
-        GOCACHE="${GOCACHE:-$TMPDIR/katl-go-cache}" go run ./cmd/katl-mkosi-artifacts write >/dev/null || status=1
+        GOCACHE="${GOCACHE:-$TMPDIR/katl-go-cache}" \
+            go run ./cmd/katl-mkosi-artifacts write-installer-artifacts >/dev/null || status=1
     fi
     if [[ "$status" -eq 0 && -n "$cache_target" ]]; then
         store_target_cache "$cache_target"
@@ -931,7 +932,11 @@ set +e
         fi
     fi
     if [[ "$status" -eq 0 && -n "${KATL_INSTALLER_PACKAGE_SET:-}" ]]; then
-        if ! mkosi_artifacts write >/dev/null; then
+        metadata_command=write-installer-artifacts
+        if [[ "${KATL_EMIT_INSTALLER_ISO:-0}" == 1 ]]; then
+            metadata_command=write
+        fi
+        if ! mkosi_artifacts "$metadata_command" >/dev/null; then
             status=1
         fi
     fi


### PR DESCRIPTION
Build runtime, installer, and katlctl concurrently, package both KatlOS images from one runtime build, and assemble one verified release set. Decouples installer metadata from the combined artifact index and bounds published provenance verification.