### PR TITLE
kubernetes: upgrade bundles without reboot

### DIFF
--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +27,8 @@ type kubernetesUpgradeOptions struct {
 	contextName   string
 	inventoryPath string
 	bundle        string
+	cordon        bool
+	kubeconfig    string
 	plan          bool
 	timeout       time.Duration
 	output        string
@@ -56,9 +59,7 @@ type kubernetesUpgradeTarget struct {
 	node       workstation.TopologyNode
 	role       string
 	conn       katlcAgentConnection
-	token      string
 	machineID  string
-	agentStart string
 	generation string
 	source     string
 	candidate  string
@@ -78,7 +79,7 @@ func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) 
 	opts := kubernetesUpgradeOptions{timeout: 25 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
 		Use:   "kubernetes VERSION",
-		Short: "Upgrade Kubernetes control planes and workers serially",
+		Short: "Upgrade Kubernetes control planes and workers online",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 1 {
@@ -92,6 +93,8 @@ func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) 
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "cluster inventory instead of a workstation context")
 	cmd.Flags().StringVar(&opts.bundle, "bundle", "", "Kubernetes bundle image, for example ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1")
 	cmd.Flags().Lookup("bundle").Hidden = true
+	cmd.Flags().BoolVar(&opts.cordon, "cordon", false, "temporarily cordon each node during its online upgrade")
+	cmd.Flags().StringVar(&opts.kubeconfig, "kubeconfig", "", "operator kubeconfig used with --cordon")
 	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate the complete rollout without accepting operations")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "per-node operation timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
@@ -108,6 +111,12 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 	}
 	if opts.timeout > 25*time.Minute {
 		return fmt.Errorf("--timeout must not exceed 25m")
+	}
+	if opts.cordon && strings.TrimSpace(opts.kubeconfig) == "" {
+		return fmt.Errorf("--kubeconfig is required with --cordon")
+	}
+	if !opts.cordon && strings.TrimSpace(opts.kubeconfig) != "" {
+		return fmt.Errorf("--kubeconfig is only used with --cordon")
 	}
 	bundle, err := kubernetesUpgradeBundle(opts.version, opts.bundle)
 	if err != nil {
@@ -164,65 +173,91 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 	report.Nodes = nil
 	for i := range targets {
 		target := &targets[i]
-		accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
-			ClientRequestId: "katlctl-" + target.candidate, OperationKind: "kubeadm-upgrade",
-			Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
-			ExpectedCurrentGenerationId: target.generation, OperationTimeout: opts.timeout.String(),
-			KubernetesSysextUpdate: kubernetesUpgradeBody(*target, image),
-		})
-		if err != nil {
-			return fmt.Errorf("submit node %s: %w", target.node.Name, err)
-		}
-		waitCtx, cancel := context.WithTimeout(ctx, opts.timeout)
-		terminal, err := waitKubernetesUpgrade(waitCtx, target.conn.Client, accepted.OperationId, target.node.Name, stderr)
-		cancel()
-		if err != nil {
-			return fmt.Errorf("wait for node %s: %w", target.node.Name, err)
-		}
-		nodeReport := kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: terminal.Result, Phase: terminal.Phase, RecoveryRequired: terminal.RecoveryRequired, NextAction: terminal.NextAction}
+		nodeReport, err := runKubernetesUpgradeTarget(ctx, topology, opts, *target, image, stderr)
 		report.Nodes = append(report.Nodes, nodeReport)
-		if terminal.Result != operation.ResultSucceeded {
+		if err != nil {
 			_ = writeKubernetesUpgradeReport(stdout, report)
-			return fmt.Errorf("Kubernetes upgrade stopped at node %s: %s", target.node.Name, terminal.FailureReason)
+			return err
 		}
-		if err := requestNodeReboot(ctx, target.conn.Client, target.machineID, target.candidate); err != nil {
-			report.Nodes[len(report.Nodes)-1].Result = "reboot-failed"
-			_ = writeKubernetesUpgradeReport(stdout, report)
-			return fmt.Errorf("Kubernetes upgrade stopped while rebooting node %s: %w", target.node.Name, err)
+	}
+	report.NextAction = "rollout complete; every upgraded node is healthy on the target Kubernetes version without reboot"
+	return writeKubernetesUpgradeReport(stdout, report)
+}
+
+func runKubernetesUpgradeTarget(ctx context.Context, topology workstation.ResolvedTopology, opts kubernetesUpgradeOptions, target kubernetesUpgradeTarget, image kubernetesbundle.ImageReference, stderr io.Writer) (nodeReport kubernetesUpgradeNodeReport, resultErr error) {
+	nodeReport = kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion}
+	cordoned := false
+	if opts.cordon {
+		if err := setKubernetesNodeCordon(ctx, opts.kubeconfig, target.node.Name, true); err != nil {
+			nodeReport.Result = "cordon-failed"
+			return nodeReport, fmt.Errorf("Kubernetes upgrade stopped while cordoning node %s: %w", target.node.Name, err)
 		}
-		_ = target.conn.Close()
-		target.conn = katlcAgentConnection{}
-		bootCtx, cancel := context.WithTimeout(ctx, opts.timeout)
-		conn, boot, err := waitNodeBootHealth(bootCtx, target.node.Name, target.node.ManagementEndpoint, target.token, target.agentStart, target.candidate, stderr)
+		cordoned = true
+		defer func() {
+			if !cordoned {
+				return
+			}
+			if err := setKubernetesNodeCordon(ctx, opts.kubeconfig, target.node.Name, false); err != nil {
+				if resultErr == nil {
+					nodeReport.Result = "uncordon-failed"
+				}
+				nodeReport.NextAction = "uncordon the node after confirming it is healthy"
+				resultErr = errors.Join(resultErr, fmt.Errorf("uncordon node %s: %w", target.node.Name, err))
+			}
+		}()
+	}
+	accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
+		ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
+		ClientRequestId: "katlctl-" + target.candidate, OperationKind: "kubeadm-upgrade",
+		Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
+		ExpectedCurrentGenerationId: target.generation, OperationTimeout: opts.timeout.String(),
+		KubernetesSysextUpdate: kubernetesUpgradeBody(target, image),
+	})
+	if err != nil {
+		nodeReport.Result = "submit-failed"
+		return nodeReport, fmt.Errorf("submit node %s: %w", target.node.Name, err)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	terminal, err := waitKubernetesUpgrade(waitCtx, target.conn.Client, accepted.OperationId, target.node.Name, stderr)
+	cancel()
+	if err != nil {
+		nodeReport.Result = "wait-failed"
+		return nodeReport, fmt.Errorf("wait for node %s: %w", target.node.Name, err)
+	}
+	nodeReport.Result = terminal.Result
+	nodeReport.Phase = terminal.Phase
+	nodeReport.RecoveryRequired = terminal.RecoveryRequired
+	nodeReport.NextAction = terminal.NextAction
+	if terminal.Result != operation.ResultSucceeded {
+		return nodeReport, fmt.Errorf("Kubernetes upgrade stopped at node %s: %s", target.node.Name, terminal.FailureReason)
+	}
+	if target.node.SystemRole == inventory.RoleControlPlane {
+		readyCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+		err := waitKubernetesEndpoint(readyCtx, topology.ControlPlaneEndpoint, target.node.Name, stderr)
 		cancel()
 		if err != nil {
-			report.Nodes[len(report.Nodes)-1].Result = "boot-health-failed"
-			report.Nodes[len(report.Nodes)-1].RecoveryRequired = true
-			_ = writeKubernetesUpgradeReport(stdout, report)
-			return fmt.Errorf("Kubernetes upgrade stopped after node %s reboot: %w", target.node.Name, err)
+			nodeReport.Result = "cluster-health-failed"
+			return nodeReport, fmt.Errorf("Kubernetes upgrade stopped after node %s: %w", target.node.Name, err)
 		}
-		target.conn = conn
-		if kubernetesGenerationVersion(boot.Generation) != image.PayloadVersion {
-			report.Nodes[len(report.Nodes)-1].Result = "boot-health-failed"
-			_ = writeKubernetesUpgradeReport(stdout, report)
-			return fmt.Errorf("Kubernetes upgrade stopped at node %s: booted generation does not contain Kubernetes %s", target.node.Name, image.PayloadVersion)
-		}
-		if target.node.SystemRole == inventory.RoleControlPlane {
-			readyCtx, cancel := context.WithTimeout(ctx, opts.timeout)
-			err := waitKubernetesEndpoint(readyCtx, topology.ControlPlaneEndpoint, target.node.Name, stderr)
-			cancel()
-			if err != nil {
-				report.Nodes[len(report.Nodes)-1].Result = "cluster-health-failed"
-				_ = writeKubernetesUpgradeReport(stdout, report)
-				return fmt.Errorf("Kubernetes upgrade stopped after node %s reboot: %w", target.node.Name, err)
-			}
-		}
-		report.Nodes[len(report.Nodes)-1].Phase = "boot-healthy"
-		report.Nodes[len(report.Nodes)-1].NextAction = ""
 	}
-	report.NextAction = "rollout complete; every upgraded node rebooted into a healthy generation"
-	return writeKubernetesUpgradeReport(stdout, report)
+	nodeReport.Phase = "healthy"
+	nodeReport.NextAction = ""
+	return nodeReport, nil
+}
+
+func setKubernetesNodeCordon(ctx context.Context, kubeconfig, node string, cordon bool) error {
+	verb := "uncordon"
+	if cordon {
+		verb = "cordon"
+	}
+	result, err := operatorKubectlRunner.Run(ctx, []string{"kubectl", "--kubeconfig", filepath.Clean(kubeconfig), verb, node})
+	if err != nil {
+		return err
+	}
+	if result.ExitStatus != 0 {
+		return fmt.Errorf("kubectl %s failed: %s", verb, inventory.Redact(strings.TrimSpace(result.Stderr)))
+	}
+	return nil
 }
 
 func waitKubernetesEndpoint(ctx context.Context, endpoint, nodeName string, stderr io.Writer) error {
@@ -262,18 +297,6 @@ func kubernetesUpgradeBundle(version, explicit string) (string, error) {
 		version += "-katl.1"
 	}
 	return "ghcr.io/katl-dev/kubernetes:v" + version, nil
-}
-
-func kubernetesGenerationVersion(value *agentapi.Generation) string {
-	if value == nil {
-		return ""
-	}
-	for _, ref := range value.Sysexts {
-		if ref.GetName() == "kubernetes" {
-			return strings.TrimSpace(ref.GetPayloadVersion())
-		}
-	}
-	return ""
 }
 
 func waitKubernetesUpgrade(ctx context.Context, client agentapi.KatlcAgentClient, operationID, nodeName string, stderr io.Writer) (*agentapi.OperationStatus, error) {
@@ -388,7 +411,7 @@ func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.R
 			return nil, fmt.Errorf("node %s current generation has no Kubernetes payload", node.Name)
 		}
 		candidate := kubernetesUpgradeCandidate(targetVersion, node.Name, runID)
-		inspected = append(inspected, kubernetesUpgradeTarget{node: node, conn: conn, token: token, machineID: status.MachineId, agentStart: status.AgentStartId, generation: generationID, source: sourceVersion, candidate: candidate})
+		inspected = append(inspected, kubernetesUpgradeTarget{node: node, conn: conn, machineID: status.MachineId, generation: generationID, source: sourceVersion, candidate: candidate})
 	}
 	baseVersion := ""
 	controlPlaneAtTarget := false

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
 )
 
 func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
@@ -38,17 +40,12 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 			nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-" + name, AgentStartId: "before-" + name, CurrentGenerationId: "gen-1"},
 			generation:      &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0", Sha256: strings.Repeat("a", 64)}}},
 			submitAccepted:  &agentapi.OperationAccepted{OperationId: "internal-" + name},
-			operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "healthy", NextAction: "reboot for boot health"},
+			operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "healthy"},
 		}
 		client.onSubmit = func(req *agentapi.SubmitOperationRequest) {
 			if !req.DryRun {
 				executionOrder = append(executionOrder, name)
 			}
-		}
-		client.onReboot = func(req *agentapi.RebootRequest) {
-			client.nodeStatus.AgentStartId = "after-" + name
-			client.nodeStatus.CurrentGenerationId = req.TargetGenerationId
-			client.generation = &agentapi.Generation{GenerationId: req.TargetGenerationId, CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1"}}}
 		}
 		clients[name] = client
 	}
@@ -82,7 +79,7 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 	}
 	roles := []string{"apply", "control-plane", "worker"}
 	for i, name := range []string{"cp-1", "cp-2", "worker-1"} {
-		if report.Nodes[i].Name != name || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "boot-healthy" {
+		if report.Nodes[i].Name != name || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "healthy" {
 			t.Fatalf("node report %d = %#v", i, report.Nodes[i])
 		}
 		requests := clients[name].submitRequests
@@ -96,8 +93,8 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 		if body.TargetSysextPath != "" || body.TargetSysextSha256 != "" || body.SnapshotDigest != "" || body.CandidateGenerationId == "" {
 			t.Fatalf("%s request exposed internal artifact or snapshot inputs: %#v", name, body)
 		}
-		if len(clients[name].rebootRequests) != 1 {
-			t.Fatalf("%s reboot requests = %#v", name, clients[name].rebootRequests)
+		if len(clients[name].rebootRequests) != 0 {
+			t.Fatalf("%s unexpectedly rebooted: %#v", name, clients[name].rebootRequests)
 		}
 	}
 	if want := []string{"cp-1", "cp-2", "worker-1"}; !reflect.DeepEqual(executionOrder, want) {
@@ -130,6 +127,49 @@ func TestKubernetesUpgradePlanDoesNotExecute(t *testing.T) {
 	}
 }
 
+func TestKubernetesUpgradeCordonRequiresKubeconfig(t *testing.T) {
+	err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{version: "v1.36.1", cordon: true, timeout: time.Minute, output: "json"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "--kubeconfig is required with --cordon") {
+		t.Fatalf("runKubernetesUpgrade() error = %v", err)
+	}
+}
+
+func TestKubernetesUpgradeCordonIsExplicitAndNonDraining(t *testing.T) {
+	runner := &fakeKubectlRunner{}
+	previous := operatorKubectlRunner
+	operatorKubectlRunner = runner
+	t.Cleanup(func() { operatorKubectlRunner = previous })
+	client := &fakeKatlcAgentClient{
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "upgrade-worker-1"},
+		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "healthy"},
+	}
+	image, err := kubernetesbundle.ParseImageReference("ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := runKubernetesUpgradeTarget(context.Background(), workstation.ResolvedTopology{}, kubernetesUpgradeOptions{cordon: true, kubeconfig: "/tmp/admin.conf", timeout: time.Minute}, kubernetesUpgradeTarget{
+		node: workstation.TopologyNode{Name: "worker-1", SystemRole: "worker"}, role: "worker", conn: katlcAgentConnection{Client: client}, machineID: "machine-worker-1", generation: "gen0", source: "v1.36.0", candidate: "gen1",
+	}, image, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Result != operation.ResultSucceeded || report.Phase != "healthy" {
+		t.Fatalf("report = %#v", report)
+	}
+	want := [][]string{
+		{"kubectl", "--kubeconfig", "/tmp/admin.conf", "cordon", "worker-1"},
+		{"kubectl", "--kubeconfig", "/tmp/admin.conf", "uncordon", "worker-1"},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("kubectl calls = %#v, want %#v", runner.calls, want)
+	}
+	for _, call := range runner.calls {
+		if strings.Contains(strings.Join(call, " "), "drain") {
+			t.Fatalf("cordon option invoked drain: %#v", runner.calls)
+		}
+	}
+}
+
 func TestKubernetesUpgradeStopsAfterNodeFailure(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "katlctl.yaml")
@@ -147,12 +187,6 @@ func TestKubernetesUpgradeStopsAfterNodeFailure(t *testing.T) {
 			submitAccepted: &agentapi.OperationAccepted{OperationId: "upgrade-" + node.name},
 			operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded,
 				Phase: "healthy"},
-		}
-		name := node.name
-		client.onReboot = func(req *agentapi.RebootRequest) {
-			client.nodeStatus.AgentStartId = "after-" + name
-			client.nodeStatus.CurrentGenerationId = req.TargetGenerationId
-			client.generation = &agentapi.Generation{GenerationId: req.TargetGenerationId, CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1"}}}
 		}
 		clients[node.endpoint] = client
 	}

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -47,7 +47,7 @@ var runAgentBootstrap = cluster.RunAgentBootstrap
 var runAgentWorkerJoin = cluster.RunAgentWorkerJoin
 var dialVMTestAgent = vmtest.DialAgent
 var dialKatlcAgent = dialKatlcAgentTCP
-var wipeNodeKubectlRunner cluster.KubectlCommandRunner = execWipeNodeKubectlRunner{}
+var operatorKubectlRunner cluster.KubectlCommandRunner = execWipeNodeKubectlRunner{}
 var newWipeClusterConnector = func(token string) cluster.AgentConnector {
 	return cluster.TCPAgentConnector{AuthToken: strings.TrimSpace(token), AuthTokenForNode: agentTokenForNode}
 }
@@ -1070,7 +1070,7 @@ func cleanupWipeNodeKubernetes(ctx context.Context, kubeconfigPath string, node 
 	}
 	run := func(name string, args ...string) bool {
 		argv := append([]string{"kubectl", "--kubeconfig", kubeconfigPath}, args...)
-		output, err := wipeNodeKubectlRunner.Run(ctx, argv)
+		output, err := operatorKubectlRunner.Run(ctx, argv)
 		if err != nil {
 			diagnostic("%s failed: %v", name, err)
 			return false

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1103,12 +1103,12 @@ func TestClusterWipeNodeSubmitsWithNodeActor(t *testing.T) {
 	newWipeClusterConnector = func(token string) cluster.AgentConnector {
 		return connector
 	}
-	oldKubectl := wipeNodeKubectlRunner
+	oldKubectl := operatorKubectlRunner
 	kubectl := &fakeKubectlRunner{}
-	wipeNodeKubectlRunner = kubectl
+	operatorKubectlRunner = kubectl
 	t.Cleanup(func() {
 		newWipeClusterConnector = oldConnector
-		wipeNodeKubectlRunner = oldKubectl
+		operatorKubectlRunner = oldKubectl
 	})
 
 	var stdout, stderr bytes.Buffer
@@ -1150,12 +1150,12 @@ func TestWipeNodePlanPrintsUnknownKubernetesCleanupWithoutKubeconfig(t *testing.
 	newWipeClusterConnector = func(token string) cluster.AgentConnector {
 		return connector
 	}
-	oldKubectl := wipeNodeKubectlRunner
+	oldKubectl := operatorKubectlRunner
 	kubectl := &fakeKubectlRunner{}
-	wipeNodeKubectlRunner = kubectl
+	operatorKubectlRunner = kubectl
 	t.Cleanup(func() {
 		newWipeClusterConnector = oldConnector
-		wipeNodeKubectlRunner = oldKubectl
+		operatorKubectlRunner = oldKubectl
 	})
 
 	var stdout, stderr bytes.Buffer
@@ -1198,12 +1198,12 @@ func TestWipeNodeSubmitsAfterKubernetesCleanup(t *testing.T) {
 	newWipeClusterConnector = func(token string) cluster.AgentConnector {
 		return connector
 	}
-	oldKubectl := wipeNodeKubectlRunner
+	oldKubectl := operatorKubectlRunner
 	kubectl := &fakeKubectlRunner{}
-	wipeNodeKubectlRunner = kubectl
+	operatorKubectlRunner = kubectl
 	t.Cleanup(func() {
 		newWipeClusterConnector = oldConnector
-		wipeNodeKubectlRunner = oldKubectl
+		operatorKubectlRunner = oldKubectl
 	})
 
 	var stdout, stderr bytes.Buffer
@@ -1257,16 +1257,16 @@ func TestWipeNodeReportsRecoveryRequiredBeforeLocalReset(t *testing.T) {
 	newWipeClusterConnector = func(token string) cluster.AgentConnector {
 		return connector
 	}
-	oldKubectl := wipeNodeKubectlRunner
+	oldKubectl := operatorKubectlRunner
 	kubectl := &fakeKubectlRunner{results: []readiness.CommandResult{
 		{ExitStatus: 0},
 		{ExitStatus: 1, Stderr: "drain timed out with token abcdef.abcdefghijklmnop"},
 		{ExitStatus: 1, Stderr: "delete failed with Bearer secret-token"},
 	}}
-	wipeNodeKubectlRunner = kubectl
+	operatorKubectlRunner = kubectl
 	t.Cleanup(func() {
 		newWipeClusterConnector = oldConnector
-		wipeNodeKubectlRunner = oldKubectl
+		operatorKubectlRunner = oldKubectl
 	})
 
 	var stdout, stderr bytes.Buffer
@@ -1307,12 +1307,12 @@ func TestWipeNodeRefusesControlPlaneBeforeMutation(t *testing.T) {
 	newWipeClusterConnector = func(token string) cluster.AgentConnector {
 		return connector
 	}
-	oldKubectl := wipeNodeKubectlRunner
+	oldKubectl := operatorKubectlRunner
 	kubectl := &fakeKubectlRunner{}
-	wipeNodeKubectlRunner = kubectl
+	operatorKubectlRunner = kubectl
 	t.Cleanup(func() {
 		newWipeClusterConnector = oldConnector
-		wipeNodeKubectlRunner = oldKubectl
+		operatorKubectlRunner = oldKubectl
 	})
 
 	var stdout, stderr bytes.Buffer

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -359,9 +359,10 @@ scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
 
 The upgrade row pins the published source and target OCI references in the
 workflow matrix. It proves etcd snapshot capture, control-plane-first kubeadm
-upgrade, generation selection across reboot, worker upgrade, and final cluster
-health. Update those pins deliberately when promoting a newly published bundle
-pair into the compatibility gate.
+upgrade, live sysext replacement with a kubelet-only restart, durable generation
+promotion without reboot, worker upgrade, and final cluster health. Update those
+pins deliberately when promoting a newly published bundle pair into the
+compatibility gate.
 
 The runtime artifact set is intentionally limited to direct-runtime tests.
 Installed-runtime tests consume the KatlOS install image and reject

--- a/docs/internal/kubernetes-upgrade-operations.md
+++ b/docs/internal/kubernetes-upgrade-operations.md
@@ -305,9 +305,8 @@ snapshot/restore VM tests before Katl claims snapshot recovery support
 
 ## Post-Decision Execution Sketches
 
-The following role flows are the intended shape after the selected target
-kubeadm access mode and kubelet activation gate have implementation and VM
-coverage. They are not supported execution paths before that gate is closed.
+The following role flows define the supported target-kubeadm and kubelet
+activation sequence. Release claims require the matching VM coverage.
 
 Control-plane apply node:
 
@@ -317,11 +316,12 @@ make target kubeadm available to the operation
 run kubeadm upgrade plan
 record the selected target version
 run kubeadm upgrade apply <target-version>
-drain policy is operator-controlled or explicitly requested by the operation
+leave the node schedulable by default; optional client-side cordon is explicit
+stop the source kubelet
+refresh the globally selected Kubernetes sysext
 restart kubelet using the target Kubernetes payload
 run local post-upgrade health checks
-commit the candidate host generation or leave boot health pending according to
-  the operation result
+promote the live candidate as the healthy persistent boot default
 ```
 
 Additional control-plane nodes:
@@ -330,10 +330,11 @@ Additional control-plane nodes:
 stage target Kubernetes sysext in a candidate generation
 make target kubeadm available to the operation
 run kubeadm upgrade node
+stop the source kubelet
+refresh the globally selected Kubernetes sysext
 restart kubelet using the target Kubernetes payload
 run local post-upgrade health checks
-commit the candidate host generation or leave boot health pending according to
-  the operation result
+promote the live candidate as the healthy persistent boot default
 ```
 
 Worker nodes:
@@ -342,16 +343,17 @@ Worker nodes:
 stage target Kubernetes sysext in a candidate generation
 make target kubeadm available to the operation
 run kubeadm upgrade node
+stop the source kubelet
+refresh the globally selected Kubernetes sysext
 restart kubelet using the target Kubernetes payload
 run local post-upgrade health checks
-commit the candidate host generation or leave boot health pending according to
-  the operation result
+promote the live candidate as the healthy persistent boot default
 ```
 
-Drain and uncordon are intentionally not hidden inside generation activation.
-Katl may offer an explicit operation flag or a higher-level control-client flow
-for those steps, but the operation status must show whether they were requested,
-skipped, or left to the operator.
+Drain is intentionally not hidden inside generation activation. The normal
+home-lab path keeps running pods in place. `katlctl --cordon` optionally prevents
+new scheduling during each node operation and restores scheduling afterward;
+it does not drain or evict workloads.
 
 ## State And Status
 
@@ -603,7 +605,8 @@ VM release gates cover:
 single-control-plane patch upgrade through kubeadm apply
 worker upgrade after the control plane
 real stacked-etcd snapshot evidence before control-plane mutation
-candidate generation staging, commit, reboot activation, and node readiness
+candidate generation staging, live activation without reboot, durable boot
+  default promotion, and node readiness
 pre-mutation failure and post-mutation repair-required operation semantics
 ```
 

--- a/docs/operations/upgrade-kubernetes.md
+++ b/docs/operations/upgrade-kubernetes.md
@@ -1,9 +1,10 @@
 # Upgrade Kubernetes
 
 Katl upgrades Kubernetes as an explicit, non-interactive cluster rollout.
-`katlctl` validates every pending node, then upgrades and reboots control planes
-before workers, one node at a time. The first control plane runs `kubeadm
-upgrade apply`; remaining control planes and workers run `kubeadm upgrade node`.
+`katlctl` validates every pending node, then upgrades control planes before
+workers, one node at a time, without rebooting the host. The first control plane
+runs `kubeadm upgrade apply`; remaining control planes and workers run `kubeadm
+upgrade node`.
 
 ## Preconditions
 
@@ -56,15 +57,29 @@ prompt. It validates every pending operation, then processes every eligible
 node serially. Each node fetches and verifies the OCI bundle before mutation.
 Control-plane nodes capture a local pre-upgrade etcd snapshot and member-list
 digest. The target sysext is mounted privately so target `kubeadm` runs while
-the source kubelet remains active. Katl releases the target kubelet only after
-kubeadm succeeds, performs local health checks, and commits the candidate
-generation.
+the source kubelet remains active. After kubeadm succeeds, Katl stops kubelet,
+switches and refreshes the Kubernetes sysext, then restarts kubelet. Running pod
+containers remain owned by containerd during this short window. Katl checks the
+target kubelet and local API health, promotes the live candidate as the
+persistent boot default, and continues the rollout without rebooting.
 
-After each node-local operation succeeds, `katlctl` requests a reboot through
-the authenticated agent, waits for the agent to restart, and requires the
-target generation and Kubernetes payload to pass boot health before continuing.
-The command stops immediately on the first failed, rolled-back, or
-recovery-required node and does not touch the remaining nodes.
+The default path neither cordons nor drains nodes. To prevent new pods from
+being scheduled onto the node during its upgrade, opt into temporary cordoning:
+
+```sh
+katlctl kubernetes upgrade v1.36.1-katl.1 \
+  --cordon --kubeconfig ./kubeconfig
+```
+
+This flag cordons before the node operation and uncordons afterward; it does not
+evict running pods. [Kubernetes upstream recommends draining before minor
+kubelet upgrades](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
+Katl's no-drain default deliberately favors uninterrupted home-lab workloads;
+use an external maintenance workflow if your workloads or support policy
+require the conservative upstream procedure.
+
+The command stops immediately on the first failed or recovery-required node and
+does not touch the remaining nodes.
 
 After a successful rollout, check workload-level health with your normal
 Kubernetes tooling, for example `kubectl get nodes` and `kubectl get pods -A`.

--- a/internal/installer/generation/live_promotion.go
+++ b/internal/installer/generation/live_promotion.go
@@ -1,0 +1,120 @@
+package generation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type LivePromotionRequest struct {
+	Root           string
+	GenerationID   string
+	OperationID    string
+	Reason         string
+	Now            time.Time
+	SetBootDefault BootDefaultSetter
+}
+
+type LivePromotionResult struct {
+	GenerationID       string
+	PreviousGeneration string
+	DefaultBootEntry   string
+	BootDefaultSet     bool
+}
+
+// PromoteLiveGeneration records a candidate that is already active and healthy
+// as both the effective runtime generation and the persistent boot default.
+func PromoteLiveGeneration(request LivePromotionRequest) (LivePromotionResult, error) {
+	now := request.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	root := cleanRoot(request.Root)
+	generationID := strings.TrimSpace(request.GenerationID)
+	if generationID == "" {
+		return LivePromotionResult{}, fmt.Errorf("live promotion generationID is required")
+	}
+	spec, status, err := ReadGeneration(root, generationID)
+	if err != nil {
+		return LivePromotionResult{}, err
+	}
+	if status.CommitState != CommitStateCandidate {
+		return LivePromotionResult{}, fmt.Errorf("generation %s commitState %s cannot be promoted live", generationID, status.CommitState)
+	}
+	entry := strings.TrimSpace(spec.Boot.LoaderEntryPath)
+	if entry == "" {
+		return LivePromotionResult{}, fmt.Errorf("generation %s loaderEntryPath is required for live promotion", generationID)
+	}
+	selection, err := ReadBootSelection(root)
+	if err != nil {
+		return LivePromotionResult{}, err
+	}
+	previousID := strings.TrimSpace(selection.DefaultGenerationID)
+	if previousID == "" {
+		return LivePromotionResult{}, fmt.Errorf("live promotion requires a current default generation")
+	}
+	if previous := strings.TrimSpace(spec.PreviousGenerationID); previous != "" && previous != previousID {
+		return LivePromotionResult{}, fmt.Errorf("generation %s previousGenerationID %s does not match current default %s", generationID, previous, previousID)
+	}
+	bootDefaultSet := false
+	if strings.TrimSpace(selection.DefaultBootEntry) != entry {
+		if request.SetBootDefault == nil {
+			return LivePromotionResult{}, fmt.Errorf("boot default update required for %s but no updater is configured", entry)
+		}
+		if err := request.SetBootDefault(root, entry); err != nil {
+			return LivePromotionResult{}, fmt.Errorf("set boot default %s: %w", entry, err)
+		}
+		bootDefaultSet = true
+	}
+
+	status.CommitState = CommitStateCommitted
+	status.BootState = BootStateGood
+	status.HealthState = HealthStateHealthy
+	status.UpdatedAt = now
+	status.CommittedAt = &now
+	status.CommittedByOperation = strings.TrimSpace(request.OperationID)
+	status.StatusTransitions = append(status.StatusTransitions, StatusTransition{
+		At:          now,
+		OperationID: strings.TrimSpace(request.OperationID),
+		Reason:      transitionReason(request.Reason, "live generation activation passed health checks"),
+		CommitState: status.CommitState,
+		BootState:   status.BootState,
+		HealthState: status.HealthState,
+	})
+	if err := WriteGenerationStatus(root, spec, status); err != nil {
+		return LivePromotionResult{}, err
+	}
+
+	previousEntry := strings.TrimSpace(selection.DefaultBootEntry)
+	selection.DefaultGenerationID = generationID
+	selection.TargetBootGenerationID = ""
+	selection.TrialGenerationID = ""
+	selection.PreviousKnownGoodGenerationID = previousID
+	selection.BootedGenerationID = generationID
+	selection.FailedBootGenerationID = ""
+	selection.DefaultBootEntry = entry
+	selection.TargetBootEntry = ""
+	selection.TrialBootEntry = ""
+	selection.PreviousKnownGoodBootEntry = previousEntry
+	selection.BootedBootEntry = entry
+	selection.BootCountedTrialPath = ""
+	selection.PendingTransactionID = ""
+	selection.PendingHealthValidation = false
+	selection.PersistentDefaultPromotion = DefaultPromotionDone
+	selection.RecoveryRequired = false
+	selection.UpdatedAt = now
+	if err := WriteBootSelection(root, selection); err != nil {
+		return LivePromotionResult{}, err
+	}
+	if previousID != generationID {
+		if err := supersedePreviousGeneration(root, previousID, generationID, now); err != nil {
+			return LivePromotionResult{}, err
+		}
+	}
+	return LivePromotionResult{
+		GenerationID:       generationID,
+		PreviousGeneration: previousID,
+		DefaultBootEntry:   entry,
+		BootDefaultSet:     bootDefaultSet,
+	}, nil
+}

--- a/internal/installer/generation/live_promotion_test.go
+++ b/internal/installer/generation/live_promotion_test.go
@@ -1,0 +1,66 @@
+package generation
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPromoteLiveGenerationMakesCandidateCurrentAndBootDefault(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 13, 21, 0, 0, 0, time.UTC)
+	writeBootHealthGeneration(t, root, "gen0", "", CommitStateCommitted, BootStateGood, HealthStateHealthy, now.Add(-time.Hour))
+	writeBootHealthGeneration(t, root, "gen1", "gen0", CommitStateCandidate, BootStatePending, HealthStateUnknown, now.Add(-time.Minute))
+	writeBootHealthSelection(t, root, BootSelectionRecord{
+		APIVersion:          APIVersion,
+		Kind:                BootSelectionKind,
+		DefaultGenerationID: "gen0",
+		BootedGenerationID:  "gen0",
+		DefaultBootEntry:    "loader/entries/katl-gen0.conf",
+		BootedBootEntry:     "loader/entries/katl-gen0.conf",
+		UpdatedAt:           now.Add(-time.Minute),
+	})
+
+	result, err := PromoteLiveGeneration(LivePromotionRequest{
+		Root: root, GenerationID: "gen1", OperationID: "upgrade-1", Reason: "online Kubernetes upgrade passed health checks", Now: now,
+		SetBootDefault: bootHealthDefaultRecorder(t, "loader/entries/katl-gen1.conf"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PreviousGeneration != "gen0" || !result.BootDefaultSet || result.DefaultBootEntry != "loader/entries/katl-gen1.conf" {
+		t.Fatalf("result = %#v", result)
+	}
+	selection, err := ReadBootSelection(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.DefaultGenerationID != "gen1" || selection.BootedGenerationID != "gen1" || selection.PendingHealthValidation || selection.PreviousKnownGoodGenerationID != "gen0" {
+		t.Fatalf("selection = %#v", selection)
+	}
+	_, current, err := ReadGeneration(root, "gen1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.CommitState != CommitStateCommitted || current.BootState != BootStateGood || current.HealthState != HealthStateHealthy || current.CommittedByOperation != "upgrade-1" {
+		t.Fatalf("current status = %#v", current)
+	}
+	_, previous, err := ReadGeneration(root, "gen0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if previous.CommitState != CommitStateSuperseded {
+		t.Fatalf("previous commitState = %s", previous.CommitState)
+	}
+}
+
+func TestPromoteLiveGenerationRequiresBootDefaultUpdater(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 13, 21, 0, 0, 0, time.UTC)
+	writeBootHealthGeneration(t, root, "gen0", "", CommitStateCommitted, BootStateGood, HealthStateHealthy, now.Add(-time.Hour))
+	writeBootHealthGeneration(t, root, "gen1", "gen0", CommitStateCandidate, BootStatePending, HealthStateUnknown, now.Add(-time.Minute))
+	writeBootHealthSelection(t, root, BootSelectionRecord{APIVersion: APIVersion, Kind: BootSelectionKind, DefaultGenerationID: "gen0", DefaultBootEntry: "loader/entries/katl-gen0.conf", UpdatedAt: now})
+
+	if _, err := PromoteLiveGeneration(LivePromotionRequest{Root: root, GenerationID: "gen1", Now: now}); err == nil {
+		t.Fatal("PromoteLiveGeneration() error = nil, want missing boot default updater")
+	}
+}

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -59,6 +59,7 @@ type Executor struct {
 	RunPostHealth        ToolRunner
 	MountBootRoot        BootRootMounter
 	SetBootOneshot       BootEntrySetter
+	SetBootDefault       BootEntrySetter
 	ConfigApplyRunner    configapply.CommandRunner
 	ConfigApplyActivator configapply.ConfextActivator
 	BundleClient         *http.Client
@@ -90,6 +91,7 @@ func NewExecutor(root string, store operation.Store, agentStartID string) *Execu
 	}
 	if runtimeRoot(executor.Root) == "/" {
 		executor.SetBootOneshot = setBootOneshot
+		executor.SetBootDefault = setBootDefault
 	}
 	return executor
 }
@@ -624,47 +626,9 @@ func (e *Executor) commitCandidateGeneration(ctx context.Context, record operati
 	if candidate == "" {
 		return fmt.Errorf("candidate generation id is required")
 	}
-	spec, status, err := generation.ReadGeneration(e.Root, candidate)
-	if err != nil {
-		return fmt.Errorf("read candidate generation: %w", err)
-	}
-	if status.CommitState != generation.CommitStateCandidate {
-		return fmt.Errorf("candidate generation %s commitState is %s, want candidate", candidate, status.CommitState)
-	}
-	entry := strings.TrimSpace(spec.Boot.LoaderEntryPath)
-	if entry == "" {
-		return fmt.Errorf("candidate generation %s loader entry path is required", candidate)
-	}
-	machineID, err := runtimeMachineID(e.Root)
+	spec, status, entry, err := e.writeCandidateLoaderEntry(ctx, candidate)
 	if err != nil {
 		return err
-	}
-	bootRoot := filepath.Join(runtimeRoot(e.Root), "efi")
-	entryPath, err := generation.WriteEntry(bootRoot, generation.LoaderRequest{
-		Record:    generation.RecordFromSplit(spec, status),
-		MachineID: machineID,
-	})
-	if err != nil && errors.Is(err, syscall.EROFS) {
-		if e.MountBootRoot == nil {
-			return fmt.Errorf("write candidate loader entry: %w", err)
-		}
-		if mountErr := e.MountBootRoot(ctx, bootRoot); mountErr != nil {
-			return fmt.Errorf("write candidate loader entry: %w; mount boot root: %v", err, mountErr)
-		}
-		entryPath, err = generation.WriteEntry(bootRoot, generation.LoaderRequest{
-			Record:    generation.RecordFromSplit(spec, status),
-			MachineID: machineID,
-		})
-	}
-	if err != nil {
-		return fmt.Errorf("write candidate loader entry: %w", err)
-	}
-	relativeEntry, err := bootRelativePath(bootRoot, entryPath)
-	if err != nil {
-		return err
-	}
-	if relativeEntry != entry {
-		return fmt.Errorf("candidate loader entry %s does not match generation metadata %s", relativeEntry, entry)
 	}
 	committedAt := now.UTC()
 	selection, err := generation.ReadBootSelection(e.Root)
@@ -719,6 +683,46 @@ func (e *Executor) commitCandidateGeneration(ctx context.Context, record operati
 		return fmt.Errorf("commit candidate generation: %w", err)
 	}
 	return nil
+}
+
+func (e *Executor) writeCandidateLoaderEntry(ctx context.Context, candidate string) (generation.GenerationSpec, generation.GenerationStatus, string, error) {
+	spec, status, err := generation.ReadGeneration(e.Root, candidate)
+	if err != nil {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("read candidate generation: %w", err)
+	}
+	if status.CommitState != generation.CommitStateCandidate {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("candidate generation %s commitState is %s, want candidate", candidate, status.CommitState)
+	}
+	entry := strings.TrimSpace(spec.Boot.LoaderEntryPath)
+	if entry == "" {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("candidate generation %s loader entry path is required", candidate)
+	}
+	machineID, err := runtimeMachineID(e.Root)
+	if err != nil {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", err
+	}
+	bootRoot := filepath.Join(runtimeRoot(e.Root), "efi")
+	entryPath, err := generation.WriteEntry(bootRoot, generation.LoaderRequest{Record: generation.RecordFromSplit(spec, status), MachineID: machineID})
+	if err != nil && errors.Is(err, syscall.EROFS) {
+		if e.MountBootRoot == nil {
+			return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("write candidate loader entry: %w", err)
+		}
+		if mountErr := e.MountBootRoot(ctx, bootRoot); mountErr != nil {
+			return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("write candidate loader entry: %w; mount boot root: %v", err, mountErr)
+		}
+		entryPath, err = generation.WriteEntry(bootRoot, generation.LoaderRequest{Record: generation.RecordFromSplit(spec, status), MachineID: machineID})
+	}
+	if err != nil {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("write candidate loader entry: %w", err)
+	}
+	relativeEntry, err := bootRelativePath(bootRoot, entryPath)
+	if err != nil {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", err
+	}
+	if relativeEntry != entry {
+		return generation.GenerationSpec{}, generation.GenerationStatus{}, "", fmt.Errorf("candidate loader entry %s does not match generation metadata %s", relativeEntry, entry)
+	}
+	return spec, status, entry, nil
 }
 
 func (e *Executor) operationStoreRoot() string {
@@ -1027,6 +1031,14 @@ func bootRootIsMountpoint(ctx context.Context, bootRoot string) (bool, error) {
 }
 
 func setBootOneshot(ctx context.Context, root string, bootEntry string) error {
+	return setBootEntry(ctx, root, "set-oneshot", bootEntry)
+}
+
+func setBootDefault(ctx context.Context, root string, bootEntry string) error {
+	return setBootEntry(ctx, root, "set-default", bootEntry)
+}
+
+func setBootEntry(ctx context.Context, root, verb, bootEntry string) error {
 	bootEntry = filepath.Base(strings.TrimSpace(bootEntry))
 	if bootEntry == "." || bootEntry == "" {
 		return fmt.Errorf("boot entry is required")
@@ -1036,7 +1048,7 @@ func setBootOneshot(ctx context.Context, root string, bootEntry string) error {
 	if root != "/" {
 		args = append(args, "--esp-path="+filepath.Join(root, "efi"))
 	}
-	args = append(args, "set-oneshot", bootEntry)
+	args = append(args, verb, bootEntry)
 	bootCtx, cancel := context.WithTimeout(ctx, bootRootMountTimeout)
 	defer cancel()
 	result := runChildProcess(bootCtx, args, nil)

--- a/internal/katlc/agent/kubeadm_upgrade_executor.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor.go
@@ -135,8 +135,9 @@ func (e *Executor) executeKubeadmUpgrade(ctx context.Context, record operation.O
 		}
 	}
 
-	if _, err := e.Store.Update(record.OperationID, "release-target-kubelet", "kubelet-restart-running", func(current operation.OperationRecord) (operation.OperationRecord, error) {
-		current.Phase = "kubelet-restart-running"
+	if _, err := e.Store.Update(record.OperationID, "stop-source-kubelet", "kubelet-stop-running", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "kubelet-stop-running"
+		current.ActivationState = operation.ActivationStateActivating
 		current.KubeadmUpgradeEvidence.KubeletGateState = "released"
 		current.UpdatedAt = e.clock()
 		return current, nil
@@ -144,12 +145,33 @@ func (e *Executor) executeKubeadmUpgrade(ctx context.Context, record operation.O
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(rootedRuntimePath(e.Root, gatePath)), 0o700); err != nil {
-		return e.failKubeadmUpgrade(record, "kubelet-restart-running", err, true)
+		return e.failKubeadmUpgrade(record, "kubelet-stop-running", err, true)
 	}
 	if err := os.WriteFile(rootedRuntimePath(e.Root, gatePath), []byte(record.OperationID+"\n"), 0o600); err != nil {
-		return e.failKubeadmUpgrade(record, "kubelet-restart-running", err, true)
+		return e.failKubeadmUpgrade(record, "kubelet-stop-running", err, true)
+	}
+	if result := e.toolRunner()(ctx, []string{"systemctl", "stop", "kubelet.service"}, nil); result.Err != nil || result.ExitStatus != 0 {
+		return e.failKubeadmUpgrade(record, "kubelet-stop-running", fmt.Errorf("stop source kubelet: %s", toolFailure(result)), true)
+	}
+	if _, err := e.Store.Update(record.OperationID, "refresh-kubernetes-sysext", "sysext-refresh-running", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "sysext-refresh-running"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "kubelet-stop-running")
+		current.PhaseIndex = len(current.CompletedPhases)
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return e.failKubeadmUpgrade(record, "sysext-refresh-running", err, true)
 	}
 	if err := e.activateKubernetesCandidate(ctx, currentRef, candidateRef); err != nil {
+		return e.failKubeadmUpgrade(record, "sysext-refresh-running", err, true)
+	}
+	if _, err := e.Store.Update(record.OperationID, "restart-target-kubelet", "kubelet-restart-running", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "kubelet-restart-running"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "sysext-refresh-running")
+		current.PhaseIndex = len(current.CompletedPhases)
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
 		return e.failKubeadmUpgrade(record, "kubelet-restart-running", err, true)
 	}
 	if result := e.toolRunner()(ctx, []string{"systemctl", "restart", "kubelet.service"}, nil); result.Err != nil || result.ExitStatus != 0 {
@@ -448,23 +470,33 @@ func (e *Executor) completeKubeadmUpgrade(ctx context.Context, record operation.
 	if err := e.removeKubeletGate(ctx, record); err != nil {
 		return e.failKubeadmUpgrade(record, "health-check-running", err, true)
 	}
-	if err := e.commitCandidateGeneration(ctx, record, now, "Kubernetes upgrade passed local health checks"); err != nil {
+	if _, _, _, err := e.writeCandidateLoaderEntry(ctx, record.CandidateGenerationID); err != nil {
+		return e.failKubeadmUpgrade(record, "health-check-running", err, true)
+	}
+	if e.SetBootDefault == nil {
+		return e.failKubeadmUpgrade(record, "health-check-running", fmt.Errorf("persistent boot default updater is not configured"), true)
+	}
+	if _, err := generation.PromoteLiveGeneration(generation.LivePromotionRequest{
+		Root: e.Root, GenerationID: record.CandidateGenerationID, OperationID: record.OperationID,
+		Reason: "Kubernetes sysext activated live and passed local health checks", Now: now,
+		SetBootDefault: func(root, entry string) error { return e.SetBootDefault(ctx, root, entry) },
+	}); err != nil {
 		return e.failKubeadmUpgrade(record, "health-check-running", err, true)
 	}
 	_, err := e.Store.Update(record.OperationID, "kubeadm-upgrade-healthy", "healthy", func(current operation.OperationRecord) (operation.OperationRecord, error) {
 		current.Phase = "healthy"
-		current.CompletedPhases = appendMissing(current.CompletedPhases, "kubelet-restart-running", "health-check-running", "healthy")
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "kubelet-stop-running", "sysext-refresh-running", "kubelet-restart-running", "health-check-running", "healthy")
 		current.PhaseIndex = len(current.CompletedPhases)
 		current.KubeadmUpgradeEvidence.KubeletGateState = "target-observed"
 		current.ActivationState = operation.ActivationStateActiveLive
 		current.GenerationCommitState = operation.GenerationCommitCommitted
 		current.PostKubeadmHealthState = operation.PostKubeadmHealthPassed
-		current.BootHealthPending = true
+		current.BootHealthPending = false
 		current.Terminal = true
 		current.Result = operation.ResultSucceeded
 		current.CompletedAt = &now
 		current.UpdatedAt = now
-		current.NextAction = "reboot into the committed candidate for boot health validation before continuing the serialized rollout"
+		current.NextAction = "continue the serialized online rollout"
 		return current, nil
 	})
 	return err
@@ -520,6 +552,7 @@ func (e *Executor) failKubeadmUpgrade(record operation.OperationRecord, phase st
 
 func (e *Executor) restoreSourceKubernetesAfterFailure(record operation.OperationRecord) error {
 	var restoreErr error
+	restartKubelet := record.ActivationState == operation.ActivationStateActivating || record.ActivationState == operation.ActivationStateFailed
 	previous := strings.TrimSpace(record.PreviousGenerationID)
 	if previous != "" {
 		spec, _, err := generation.ReadGeneration(e.Root, previous)
@@ -560,6 +593,12 @@ func (e *Executor) restoreSourceKubernetesAfterFailure(record operation.Operatio
 	}
 	if record.KubeadmUpgradeEvidence != nil && strings.TrimSpace(record.KubeadmUpgradeEvidence.KubeletGateTokenPath) != "" {
 		_ = os.Remove(rootedRuntimePath(e.Root, record.KubeadmUpgradeEvidence.KubeletGateTokenPath))
+	}
+	if restartKubelet {
+		result := e.toolRunner()(context.Background(), []string{"systemctl", "restart", "kubelet.service"}, nil)
+		if result.Err != nil || result.ExitStatus != 0 {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restart source kubelet after failed live activation: %s", toolFailure(result)))
+		}
 	}
 	return restoreErr
 }

--- a/internal/katlc/agent/kubeadm_upgrade_executor_test.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor_test.go
@@ -22,6 +22,12 @@ func TestExecutorRunsApplyUpgradeWithPrivateKubeadmAndGate(t *testing.T) {
 	executor := NewExecutor(root, store, "agent-test")
 	executor.Async = false
 	executor.Now = func() time.Time { return now.Add(time.Minute) }
+	executor.SetBootDefault = func(_ context.Context, _ string, entry string) error {
+		if entry != "loader/entries/katl-gen1.conf" {
+			t.Fatalf("boot default entry = %q", entry)
+		}
+		return nil
+	}
 	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
 		commands = append(commands, append([]string(nil), argv...))
 		joined := strings.Join(argv, " ")
@@ -50,13 +56,23 @@ func TestExecutorRunsApplyUpgradeWithPrivateKubeadmAndGate(t *testing.T) {
 	if completed.KubeadmUpgradeEvidence.TargetKubeadmAccessMode != kubeadmAccessOperationPrivate || completed.KubeadmUpgradeEvidence.KubeletGateState != "target-observed" || completed.KubeadmUpgradeEvidence.GlobalTargetActiveBeforeKubeadm {
 		t.Fatalf("upgrade evidence = %+v", completed.KubeadmUpgradeEvidence)
 	}
-	assertCommandOrder(t, commands, "kubeadm upgrade plan v1.36.2", "kubeadm upgrade apply --yes v1.36.2", "systemd-sysext refresh", "systemctl restart kubelet.service")
+	assertCommandOrder(t, commands, "kubeadm upgrade plan v1.36.2", "kubeadm upgrade apply --yes v1.36.2", "systemctl stop kubelet.service", "systemd-sysext refresh", "systemctl restart kubelet.service")
 	spec, status, err := generation.ReadGeneration(root, "gen1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.CommitState != generation.CommitStateCommitted || status.BootState != generation.BootStateTrying || spec.Sysexts[0].PayloadVersion != "v1.36.2" {
+	if status.CommitState != generation.CommitStateCommitted || status.BootState != generation.BootStateGood || status.HealthState != generation.HealthStateHealthy || spec.Sysexts[0].PayloadVersion != "v1.36.2" {
 		t.Fatalf("candidate = spec %+v status %+v", spec, status)
+	}
+	if completed.BootHealthPending || completed.ActivationMode != operation.ActivationModeLive || completed.ActivationState != operation.ActivationStateActiveLive {
+		t.Fatalf("online lifecycle = mode %q state %q bootPending %v", completed.ActivationMode, completed.ActivationState, completed.BootHealthPending)
+	}
+	selection, err := generation.ReadBootSelection(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.DefaultGenerationID != "gen1" || selection.BootedGenerationID != "gen1" || selection.PendingHealthValidation {
+		t.Fatalf("live selection = %#v", selection)
 	}
 	if len(spec.Confexts) != 1 || spec.Confexts[0].Path != "/var/lib/katl/generations/gen1/confext" {
 		t.Fatalf("candidate confext refs = %+v", spec.Confexts)
@@ -132,6 +148,48 @@ func TestExecutorKeepsRecoveryRequiredAfterKubeadmMutationFailure(t *testing.T) 
 	}
 	if sawUnmount {
 		t.Fatal("operation-private target kubeadm repair view was removed after mutation failure")
+	}
+}
+
+func TestExecutorRestoresSourceSysextAndKubeletWhenLiveActivationFails(t *testing.T) {
+	root, store, record, now := kubeadmUpgradeFixture(t, "worker")
+	executor := NewExecutor(root, store, "agent-test")
+	executor.Async = false
+	executor.Now = func() time.Time { return now.Add(time.Minute) }
+	restarts := 0
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		joined := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(joined, "/usr/bin/kubeadm version"):
+			return ToolResult{Stdout: []byte("v1.36.2\n")}
+		case joined == "systemctl restart kubelet.service":
+			restarts++
+			if restarts == 1 {
+				return ToolResult{Err: errors.New("target kubelet failed"), ExitStatus: 1}
+			}
+		}
+		return ToolResult{}
+	}
+	if err := executor.Execute(context.Background(), record); err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if restarts != 2 {
+		t.Fatalf("kubelet restarts = %d, want failed target restart and source recovery restart", restarts)
+	}
+	activation := filepath.Join(root, "run/extensions/katl-kubernetes.raw")
+	target, err := os.Readlink(activation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "/var/lib/katl/generations/gen0/sysext/kubernetes.raw" {
+		t.Fatalf("restored sysext target = %q", target)
+	}
+	failed, err := store.Read(record.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !failed.RecoveryRequired || failed.Result != operation.ResultFailedNeedsRepair {
+		t.Fatalf("failed operation = %+v", failed)
 	}
 }
 
@@ -247,7 +305,7 @@ func TestExecutorCapturesUpgradeSnapshotInsideNode(t *testing.T) {
 func createUnresolvedUpgradeRecord(t *testing.T, store operation.Store, id string, request *operation.KubernetesSysextUpdate) operation.OperationRecord {
 	t.Helper()
 	now := time.Date(2026, 7, 12, 11, 0, 0, 0, time.UTC)
-	record, err := store.Create(operation.OperationRecord{OperationID: id, OperationKind: OperationKindKubeadmUpgrade, Scope: "kubeadm-state", Actor: "katlctl", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", PhasePlan: kubeadmUpgradePhasePlan(request.UpgradeRole), CompletedPhases: []string{"accepted"}, PhaseIndex: 1, CandidateGenerationID: request.CandidateGenerationID, KubernetesSysextUpdate: request, KubeadmUpgradeEvidence: &operation.KubeadmUpgradeEvidence{TargetKubeadmAccessMode: kubeadmAccessOperationPrivate, KubeletActivationGate: kubeletGateOperationReleased, KubeletGateState: "locked", SourceKubeletPolicy: "keep-running"}, ActivationMode: operation.ActivationModeNextBoot, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCandidate, PostKubeadmHealthState: operation.PostKubeadmHealthNotRun, ResourceLocks: []string{"generation-state.lock", "kubeadm-state.lock"}}, "accepted", now)
+	record, err := store.Create(operation.OperationRecord{OperationID: id, OperationKind: OperationKindKubeadmUpgrade, Scope: "kubeadm-state", Actor: "katlctl", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", PhasePlan: kubeadmUpgradePhasePlan(request.UpgradeRole), CompletedPhases: []string{"accepted"}, PhaseIndex: 1, CandidateGenerationID: request.CandidateGenerationID, KubernetesSysextUpdate: request, KubeadmUpgradeEvidence: &operation.KubeadmUpgradeEvidence{TargetKubeadmAccessMode: kubeadmAccessOperationPrivate, KubeletActivationGate: kubeletGateOperationReleased, KubeletGateState: "locked", SourceKubeletPolicy: "keep-running"}, ActivationMode: operation.ActivationModeLive, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCandidate, PostKubeadmHealthState: operation.PostKubeadmHealthNotRun, ResourceLocks: []string{"generation-state.lock", "kubeadm-state.lock"}}, "accepted", now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +417,7 @@ func kubeadmUpgradeFixture(t *testing.T, role string) (string, operation.Store, 
 	if err := generation.WriteGeneration(root, previous, status); err != nil {
 		t.Fatal(err)
 	}
-	if err := generation.WriteBootSelection(root, generation.BootSelectionRecord{APIVersion: generation.APIVersion, Kind: generation.BootSelectionKind, DefaultGenerationID: "gen0", BootedGenerationID: "gen0", Generation0FallbackID: "gen0", UpdatedAt: now}); err != nil {
+	if err := generation.WriteBootSelection(root, generation.BootSelectionRecord{APIVersion: generation.APIVersion, Kind: generation.BootSelectionKind, DefaultGenerationID: "gen0", BootedGenerationID: "gen0", Generation0FallbackID: "gen0", DefaultBootEntry: "loader/entries/katl-gen0.conf", BootedBootEntry: "loader/entries/katl-gen0.conf", UpdatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
@@ -367,7 +425,7 @@ func kubeadmUpgradeFixture(t *testing.T, role string) (string, operation.Store, 
 		t.Fatal(err)
 	}
 	request := &operation.KubernetesSysextUpdate{TargetPayloadVersion: "v1.36.2", TargetSysextPath: "/var/lib/katl/artifacts/kubernetes.raw", TargetSysextSHA256: targetSHA, TargetSysextSize: uint64(len(target)), CandidateGenerationID: "gen1", UpgradeRole: role, SourcePayloadVersion: "v1.36.1", SnapshotRef: "snapshot-1", SnapshotDigest: snapshotSHA, SnapshotCreatedAt: now.Format(time.RFC3339), CapturedMemberListDigest: strings.Repeat("c", 64), SnapshotStorageLocation: "/var/lib/katl/etcd-snapshots/snapshot-1.db", SnapshotOperatorIdentity: "operator-a"}
-	record, err := store.Create(operation.OperationRecord{OperationID: "kubeadm-upgrade-1", OperationKind: OperationKindKubeadmUpgrade, Scope: "kubeadm-state", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", PhasePlan: kubeadmUpgradePhasePlan(role), CompletedPhases: []string{"accepted"}, PhaseIndex: 1, CandidateGenerationID: "gen1", KubernetesSysextUpdate: request, KubeadmUpgradeEvidence: &operation.KubeadmUpgradeEvidence{TargetKubeadmAccessMode: kubeadmAccessOperationPrivate, KubeletActivationGate: kubeletGateOperationReleased, KubeletGateState: "locked", SourceKubeletPolicy: "keep-running"}, ActivationMode: operation.ActivationModeNextBoot, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCandidate, PostKubeadmHealthState: operation.PostKubeadmHealthNotRun, ResourceLocks: []string{"generation-state.lock", "kubeadm-state.lock"}}, "accepted", now)
+	record, err := store.Create(operation.OperationRecord{OperationID: "kubeadm-upgrade-1", OperationKind: OperationKindKubeadmUpgrade, Scope: "kubeadm-state", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", PhasePlan: kubeadmUpgradePhasePlan(role), CompletedPhases: []string{"accepted"}, PhaseIndex: 1, CandidateGenerationID: "gen1", KubernetesSysextUpdate: request, KubeadmUpgradeEvidence: &operation.KubeadmUpgradeEvidence{TargetKubeadmAccessMode: kubeadmAccessOperationPrivate, KubeletActivationGate: kubeletGateOperationReleased, KubeletGateState: "locked", SourceKubeletPolicy: "keep-running"}, ActivationMode: operation.ActivationModeLive, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCandidate, PostKubeadmHealthState: operation.PostKubeadmHealthNotRun, ResourceLocks: []string{"generation-state.lock", "kubeadm-state.lock"}}, "accepted", now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/katlc/agent/kubernetes_sysext_update.go
+++ b/internal/katlc/agent/kubernetes_sysext_update.go
@@ -109,7 +109,7 @@ func (s *Server) planKubernetesSysextUpdateOperation(req *agentapi.SubmitOperati
 			KubeletGateState:        "locked",
 			SourceKubeletPolicy:     "keep-running",
 		},
-		ActivationMode:         operation.ActivationModeNextBoot,
+		ActivationMode:         operation.ActivationModeLive,
 		ActivationState:        operation.ActivationStatePending,
 		GenerationCommitState:  operation.GenerationCommitAbandoned,
 		PostKubeadmHealthState: operation.PostKubeadmHealthNotRun,
@@ -282,7 +282,7 @@ func kubeadmUpgradePhasePlan(role string) []string {
 	} else {
 		plan = append(plan, "kubeadm-node-running")
 	}
-	return append(plan, "kubelet-restart-running", "health-check-running", "healthy")
+	return append(plan, "kubelet-stop-running", "sysext-refresh-running", "kubelet-restart-running", "health-check-running", "healthy")
 }
 
 func validateKubernetesUpgradeVersions(source, target string) error {

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -611,8 +611,12 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-before-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
 		return fmt.Errorf("wait for cluster readiness after bootstrap generation reboot: %w", err)
 	}
+	bootIDs, err := captureNodeBootIDs(ctx, cpNode, workerNode)
+	if err != nil {
+		return err
+	}
 	if bundle := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE")); bundle != "" {
-		return runPublishedKubernetesUpgradeCLIProof(ctx, katlRepoRoot(t), bundle, cpNode, workerNode, cpAddress, workerAddress, cpTokenPath, workerTokenPath, cniFixtures, kubeconfigPath, evidenceDir)
+		return runPublishedKubernetesUpgradeCLIProof(ctx, katlRepoRoot(t), bundle, cpNode, workerNode, cpAddress, workerAddress, cpTokenPath, workerTokenPath, kubeconfigPath, evidenceDir, bootIDs)
 	}
 	targetHost := filepath.Join(katlRepoRoot(t), "_build/mkosi/katl-kubernetes-upgrade.raw")
 	metadataHost := targetHost + ".json"
@@ -681,12 +685,6 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 	if err := assertSuccessfulUpgradeStatus(cpStatus, "upgrade-v1361-cp"); err != nil {
 		return err
 	}
-	if err := rebootIntoGeneration(ctx, cpNode, cpStatus.CandidateGenerationId); err != nil {
-		return fmt.Errorf("reboot upgraded control plane: %w", err)
-	}
-	if err := activateNodeCNIFixture(ctx, cpNode, cniFixtures[cpNode.Name]); err != nil {
-		return fmt.Errorf("reactivate control-plane CNI fixture after upgrade reboot: %w", err)
-	}
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-after-control-plane-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
 		return err
 	}
@@ -699,13 +697,10 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 	if err := assertSuccessfulUpgradeStatus(workerStatus, "upgrade-v1361-worker"); err != nil {
 		return err
 	}
-	if err := rebootIntoGeneration(ctx, workerNode, workerStatus.CandidateGenerationId); err != nil {
-		return fmt.Errorf("reboot upgraded worker: %w", err)
-	}
-	if err := activateNodeCNIFixture(ctx, workerNode, cniFixtures[workerNode.Name]); err != nil {
-		return fmt.Errorf("reactivate worker CNI fixture after upgrade reboot: %w", err)
-	}
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-after-worker-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
+		return err
+	}
+	if err := assertNodeBootIDsUnchanged(ctx, bootIDs, cpNode, workerNode); err != nil {
 		return err
 	}
 	for _, item := range []struct {
@@ -734,7 +729,7 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 	return nil
 }
 
-func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle string, cpNode, workerNode vmtest.RunningInstalledRuntimeNode, cpAddress, workerAddress, cpTokenPath, workerTokenPath string, cniFixtures map[string]nodeCNIFixture, kubeconfigPath, evidenceDir string) error {
+func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle string, cpNode, workerNode vmtest.RunningInstalledRuntimeNode, cpAddress, workerAddress, cpTokenPath, workerTokenPath, kubeconfigPath, evidenceDir string, bootIDs map[string]string) error {
 	configPath := filepath.Join(evidenceDir, "katlctl-upgrade.yaml")
 	config := fmt.Sprintf("currentContext: vmtest\ncontexts:\n  - name: vmtest\n    cluster: upgrade\nclusters:\n  - name: upgrade\n    controlPlaneEndpoint: %s:6443\n    nodes:\n      - name: cp-1\n        managementEndpoint: %s:9443\n        systemRole: control-plane\n        credentialRef: file:%s\n      - name: worker-1\n        managementEndpoint: %s:9443\n        systemRole: worker\n        credentialRef: file:%s\n", cpAddress, cpAddress, cpTokenPath, workerAddress, workerTokenPath)
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
@@ -773,16 +768,14 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 		return fmt.Errorf("unexpected katlctl Kubernetes upgrade report: %+v", report)
 	}
 	for i, want := range []string{"cp-1", "worker-1"} {
-		if report.Nodes[i].Name != want || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "boot-healthy" {
+		if report.Nodes[i].Name != want || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "healthy" {
 			return fmt.Errorf("unexpected katlctl Kubernetes upgrade node report %d: %+v", i, report.Nodes[i])
 		}
 	}
-	for _, node := range []vmtest.RunningInstalledRuntimeNode{cpNode, workerNode} {
-		if err := activateNodeCNIFixture(ctx, node, cniFixtures[node.Name]); err != nil {
-			return fmt.Errorf("reactivate %s CNI fixture after upgrade reboot: %w", node.Name, err)
-		}
-	}
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-after-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
+		return err
+	}
+	if err := assertNodeBootIDsUnchanged(ctx, bootIDs, cpNode, workerNode); err != nil {
 		return err
 	}
 	for _, item := range []vmtest.RunningInstalledRuntimeNode{cpNode, workerNode} {
@@ -890,10 +883,48 @@ func submitKubeadmUpgrade(ctx context.Context, address, token string, request ag
 }
 
 func assertSuccessfulUpgradeStatus(status *agentapi.OperationStatus, candidate string) error {
-	if status == nil || !status.Terminal || status.Result != operation.ResultSucceeded || status.RecoveryRequired || status.CandidateGenerationId != candidate || status.GenerationCommitState != operation.GenerationCommitCommitted || status.PostKubeadmHealthState != operation.PostKubeadmHealthPassed || !status.BootHealthPending {
+	if status == nil || !status.Terminal || status.Result != operation.ResultSucceeded || status.RecoveryRequired || status.CandidateGenerationId != candidate || status.GenerationCommitState != operation.GenerationCommitCommitted || status.PostKubeadmHealthState != operation.PostKubeadmHealthPassed || status.BootHealthPending || status.ActivationState != operation.ActivationStateActiveLive {
 		return fmt.Errorf("upgrade operation did not commit healthy candidate %s: %+v", candidate, status)
 	}
 	return nil
+}
+
+func captureNodeBootIDs(ctx context.Context, nodes ...vmtest.RunningInstalledRuntimeNode) (map[string]string, error) {
+	result := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		bootID, err := nodeBootID(ctx, node)
+		if err != nil {
+			return nil, fmt.Errorf("read %s boot id before Kubernetes upgrade: %w", node.Name, err)
+		}
+		result[node.Name] = bootID
+	}
+	return result, nil
+}
+
+func assertNodeBootIDsUnchanged(ctx context.Context, before map[string]string, nodes ...vmtest.RunningInstalledRuntimeNode) error {
+	for _, node := range nodes {
+		after, err := nodeBootID(ctx, node)
+		if err != nil {
+			return fmt.Errorf("read %s boot id after Kubernetes upgrade: %w", node.Name, err)
+		}
+		if after == "" || after != before[node.Name] {
+			return fmt.Errorf("node %s rebooted during online Kubernetes upgrade: boot id %q -> %q", node.Name, before[node.Name], after)
+		}
+	}
+	return nil
+}
+
+func nodeBootID(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) (string, error) {
+	health, err := retryDirectAgentOp(ctx, node, 10*time.Second, func(opCtx context.Context, client *vmtest.AgentClient) (*vmtestpb.HealthResponse, error) {
+		return client.Health(opCtx)
+	})
+	if err != nil {
+		return "", err
+	}
+	if bootID := strings.TrimSpace(health.BootId); bootID != "" {
+		return bootID, nil
+	}
+	return "", fmt.Errorf("vmtest agent returned an empty boot id")
 }
 
 func rebootIntoGeneration(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, generationID string) error {


### PR DESCRIPTION
Upgrade Kubernetes control planes and workers online by running target kubeadm before a kubelet-only sysext refresh, then promote the healthy live generation as the boot default. Nodes remain schedulable by default, with temporary cordoning available as an explicit option.