### PR TITLE
dev: slim the Nix development shells

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -28,13 +28,12 @@ dependency and should not be required by automated tests.
 The current local boot contract proves only the installer OS
 build/boot/test loop.
 
-- Build tool: `mkosi 26`.
+- Build tool: `mkosi 26`, run inside the project's containerized builder.
 - Base distribution: Fedora, chosen for current systemd and mkosi support.
 - Output format: a bootable `disk` image with systemd-boot/UKI support.
 - Output directory: `_build/mkosi/`.
 - Primary artifact name: `katl-installer.raw`.
-- Build command: `mkosi -f build`.
-- Interactive boot command: `mkosi vm --firmware uefi --console console`.
+- Build command: `scripts/mkosi build-installer`.
 - Required smoke path: `scripts/vmtest-run` with libvirt system VM execution
   and deterministic serial capture.
 - Firmware expectation: the runner is given readable OVMF/edk2 pflash images.
@@ -74,7 +73,7 @@ the public developer interface.
 
 ## Nix Dev Shell
 
-On NixOS or any host with flakes enabled, enter the minimum mkosi build shell:
+On NixOS or any host with flakes enabled, enter the default development shell:
 
 ```sh
 nix develop
@@ -89,21 +88,22 @@ direnv allow
 Use `direnv` plus `nix-direnv` if you want the flake shell loaded
 automatically when entering the repository.
 
-That shell provides mkosi, Fedora package tooling (`dnf5` and `rpm`), UKI
-tooling, filesystem tools, compression tools, crypto tools, and CA
-certificates needed by the current Fedora-based `mkosi.conf`.
+That shell provides the Go and protobuf toolchain, Git, `jq`, `curl`, and Podman.
+Image construction stays behind `scripts/mkosi`; mkosi, Fedora package tools,
+UKI tooling, filesystem tools, and compression tools run inside its builder
+container instead of being installed on the host.
 
-Check the mkosi tool view from inside the shell:
+`katlctl` is also available in both development shells. It runs from the current
+checkout so local source changes are used immediately:
 
 ```sh
-nix develop --command mkosi dependencies
-nix develop --command mkosi summary
+nix develop --command katlctl --help
 ```
 
-Build the current installer image:
+Build current artifacts through the supported container wrapper:
 
 ```sh
-nix develop --command mkosi -f build
+nix develop --command scripts/mkosi build-installer
 ```
 
 For manual VM work and VM tests, use the optional VM shell:

--- a/flake.nix
+++ b/flake.nix
@@ -14,60 +14,48 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       pkgsFor = system: import nixpkgs { inherit system; };
-      shellFor =
+      katlctlFor =
         pkgs:
-        let
-          dnfCompat = pkgs.writeShellScriptBin "dnf" ''
-            state_home="''${XDG_STATE_HOME:-}"
-            if [ -z "$state_home" ]; then
-              state_home="''${TMPDIR:-/tmp}/katl-xdg-state"
-            fi
-            logdir="$state_home/dnf5"
-            mkdir -p "$logdir"
-            exec ${pkgs.dnf5}/bin/dnf5 --setopt=logdir="$logdir" "$@"
-          '';
-        in
+        pkgs.writeShellScriptBin "katlctl" ''
+          repo_root="$(${pkgs.git}/bin/git rev-parse --show-toplevel 2>/dev/null)" || {
+            echo "error: katlctl must be run from the Katl checkout" >&2
+            exit 1
+          }
+          exec ${pkgs.go}/bin/go run "$repo_root/cmd/katlctl" "$@"
+        '';
+      shellFor =
+        pkgs: vmTools:
         pkgs.mkShell {
-          packages = with pkgs; [
-            bashInteractive
-            cacert
-            coreutils
-            cpio
-            cryptsetup
-            curl
-            dnf5
-            dosfstools
-            e2fsprogs
-            erofs-utils
-            findutils
-            gawk
-            git
-            go
-            iproute2
-            jq
-            kubectl
-            libvirt
-            virt-manager
-            mkosi
-            mtools
-            openssl
-            OVMFFull
-            podman
-            protobuf
-            protoc-gen-go
-            protoc-gen-go-grpc
-            qemu_kvm
-            rpm
-            squashfsTools
-            systemd
-            util-linux
-            xz
-            zstd
-            dnfCompat
-          ];
+          packages =
+            (with pkgs; [
+              bashInteractive
+              cacert
+              curl
+              git
+              go
+              jq
+              podman
+              protobuf
+              protoc-gen-go
+              protoc-gen-go-grpc
+            ])
+            ++ [ (katlctlFor pkgs) ]
+            ++ pkgs.lib.optionals vmTools (
+              with pkgs;
+              [
+                kubectl
+                libvirt
+                mtools
+                OVMFFull
+                qemu_kvm
+                util-linux
+              ]
+            );
 
           shellHook = ''
             export TMPDIR="''${TMPDIR:-/tmp}"
+          ''
+          + pkgs.lib.optionalString vmTools ''
             export KATL_OVMF_CODE="''${KATL_OVMF_CODE:-${pkgs.OVMFFull.fd}/FV/OVMF_CODE.fd}"
             export KATL_OVMF_VARS="''${KATL_OVMF_VARS:-${pkgs.OVMFFull.fd}/FV/OVMF_VARS.fd}"
             export KATL_VMTEST_IMAGE_TOOL="''${KATL_VMTEST_IMAGE_TOOL:-${pkgs.qemu_kvm}/bin/qemu-img}"
@@ -85,8 +73,8 @@
           pkgs = pkgsFor system;
         in
         {
-          default = shellFor pkgs;
-          vm = shellFor pkgs;
+          default = shellFor pkgs false;
+          vm = shellFor pkgs true;
         }
       );
     };


### PR DESCRIPTION
Removes obsolete host-native mkosi and image-building dependencies from the Nix shell, keeps VM tooling isolated in .#vm, and provides a source-backed katlctl command. This aligns local development with the containerized image builder while retaining the supported libvirt test path.