### PR TITLE
cli: write ClusterConfig from discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ katlctl config init ./cluster.yaml \
 Review the generated disk identities, addresses, Kubernetes selection, and
 network configuration before installing.
 
+If the nodes are already booted into the installer, skip the manual `--node`
+arguments and generate this same file from live discovery in the next step.
+
 Use the readable version tag on the normal path. Katl resolves the selected
 content once for the operation and checks what it downloads internally. An
 immutable digest pin remains available as an optional reproducibility control.
@@ -137,9 +140,21 @@ their stable disk identities:
 katlctl install discover
 ```
 
-Update the node's target disk if discovery shows a different stable identity,
-then apply the cluster source. When exactly one installer is waiting, no URL
-needs to be copied from the console:
+To create `cluster.yaml` directly from all waiting installers, give discovery
+the output path:
+
+```sh
+katlctl install discover ./cluster.yaml
+```
+
+Discovery assigns the first endpoint to `cp-1` and subsequent endpoints to
+`worker-1`, `worker-2`, and so on. It writes a disk selector only when each
+installer reports exactly one safe selectable disk; ambiguous disks produce an
+error instead of a guess. Review the generated node names, roles, addresses,
+disk identities, and Kubernetes selection before applying it.
+
+When exactly one installer is waiting, no URL needs to be copied from the
+console:
 
 ```sh
 katlctl install apply ./cluster.yaml --node cp-1

--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -36,7 +36,7 @@ type initNodeSpec struct {
 	name    string
 	role    inventory.SystemRole
 	address string
-	disk    string
+	disk    manifest.DiskSelector
 }
 
 type initNodeSpecs []initNodeSpec
@@ -61,16 +61,12 @@ func (values *initNodeSpecs) Set(value string) error {
 	if !strings.HasPrefix(disk, "/dev/disk/by-id/") {
 		return fmt.Errorf("node %q disk must be a stable /dev/disk/by-id path", name)
 	}
-	*values = append(*values, initNodeSpec{name: strings.TrimSpace(name), role: role, address: address, disk: disk})
+	*values = append(*values, initNodeSpec{name: strings.TrimSpace(name), role: role, address: address, disk: manifest.DiskSelector{ByID: disk}})
 	return nil
 }
 
 func newConfigInitCommand(stdout, stderr io.Writer) *cobra.Command {
-	opts := configInitOptions{
-		clusterName:       "katl-lab",
-		kubernetesVersion: defaultKubernetesVersion,
-		kubernetesBundle:  defaultKubernetesBundle,
-	}
+	opts := defaultConfigInitOptions()
 	cmd := &cobra.Command{
 		Use:   "init [PATH]",
 		Short: "Create an editable starter ClusterConfig",
@@ -82,14 +78,26 @@ func newConfigInitCommand(stdout, stderr io.Writer) *cobra.Command {
 			return runConfigInit(opts, stdout, stderr)
 		},
 	}
+	addConfigInitFlags(cmd, &opts)
+	cmd.Flags().Var(&opts.nodes, "node", "node as name=role,address,/dev/disk/by-id/... (repeatable)")
+	return cmd
+}
+
+func defaultConfigInitOptions() configInitOptions {
+	return configInitOptions{
+		clusterName:       "katl-lab",
+		kubernetesVersion: defaultKubernetesVersion,
+		kubernetesBundle:  defaultKubernetesBundle,
+	}
+}
+
+func addConfigInitFlags(cmd *cobra.Command, opts *configInitOptions) {
 	cmd.Flags().StringVar(&opts.clusterName, "name", opts.clusterName, "cluster name")
 	cmd.Flags().StringVar(&opts.controlPlane, "control-plane-endpoint", "", "stable Kubernetes API endpoint host:port; defaults to the first control-plane address")
 	cmd.Flags().StringVar(&opts.kubernetesVersion, "kubernetes-version", opts.kubernetesVersion, "Kubernetes payload version")
 	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", opts.kubernetesBundle, "Kubernetes bundle image")
 	cmd.Flags().StringVar(&opts.sshKeyPath, "ssh-authorized-key", "", "public SSH key file; defaults to ~/.ssh/id_ed25519.pub")
-	cmd.Flags().Var(&opts.nodes, "node", "node as name=role,address,/dev/disk/by-id/... (repeatable)")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "replace an existing output file")
-	return cmd
 }
 
 func runConfigInit(opts configInitOptions, stdout, stderr io.Writer) error {
@@ -167,11 +175,12 @@ func runConfigInit(opts configInitOptions, stdout, stderr io.Writer) error {
 		if err != nil {
 			return err
 		}
+		targetDisk := node.disk
 		source.Spec.Nodes = append(source.Spec.Nodes, configbundle.SourceNode{
 			Name: node.name, SystemRole: node.role,
 			Overrides: configbundle.SourceNodeLayer{
 				Identity:  configbundle.SourceIdentity{Hostname: node.name},
-				Install:   configbundle.SourceInstallLayer{TargetDisk: &manifest.DiskSelector{ByID: node.disk}},
+				Install:   configbundle.SourceInstallLayer{TargetDisk: &targetDisk},
 				Bootstrap: clusterplan.BootstrapLayer{Address: node.address, Access: inventory.Access{Method: "agent", CredentialRef: "file:" + credentialPath}},
 			},
 		})

--- a/cmd/katlctl/install_discover.go
+++ b/cmd/katlctl/install_discover.go
@@ -7,18 +7,21 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/handoff"
+	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/spf13/cobra"
 )
 
 type installDiscoverOptions struct {
-	timeout time.Duration
-	output  string
+	timeout    time.Duration
+	configInit configInitOptions
 }
 
 type discoveredInstaller struct {
@@ -38,28 +41,34 @@ var installerDiscoveryProbe = func(ctx context.Context, endpoint string, timeout
 }
 
 func newInstallDiscoverCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := installDiscoverOptions{timeout: 3 * time.Second, output: "json"}
+	opts := installDiscoverOptions{timeout: 3 * time.Second, configInit: defaultConfigInitOptions()}
 	cmd := &cobra.Command{
-		Use:   "discover",
-		Short: "Find waiting KatlOS installers and inspect their disks",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Use:   "discover [CLUSTER_CONFIG]",
+		Short: "Find waiting KatlOS installers and optionally create a ClusterConfig",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.configInit.outputPath = args[0]
+			}
 			return runInstallDiscover(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall local-network discovery timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	addConfigInitFlags(cmd, &opts.configInit)
 	return cmd
 }
 
 func runInstallDiscover(ctx context.Context, opts installDiscoverOptions, stdout, stderr io.Writer) error {
-	_ = stderr
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
-	}
 	installers, err := discoverInstallers(ctx, opts.timeout)
 	if err != nil {
 		return err
+	}
+	if strings.TrimSpace(opts.configInit.outputPath) != "" {
+		opts.configInit.nodes, err = discoveredInitNodes(installers)
+		if err != nil {
+			return err
+		}
+		return runConfigInit(opts.configInit, stdout, stderr)
 	}
 	report := installDiscoveryReport{APIVersion: "katl.dev/v1alpha1", Kind: "InstallerDiscovery", Installers: installers}
 	data, err := json.MarshalIndent(report, "", "  ")
@@ -68,6 +77,81 @@ func runInstallDiscover(ctx context.Context, opts installDiscoverOptions, stdout
 	}
 	_, err = stdout.Write(append(data, '\n'))
 	return err
+}
+
+func discoveredInitNodes(installers []discoveredInstaller) (initNodeSpecs, error) {
+	waiting := make([]discoveredInstaller, 0, len(installers))
+	for _, installer := range installers {
+		if installer.Status.State == handoff.HandoffWaiting {
+			waiting = append(waiting, installer)
+		}
+	}
+	if len(waiting) == 0 {
+		return nil, fmt.Errorf("no waiting KatlOS installer was discovered; boot the installation media and retry")
+	}
+
+	nodes := make(initNodeSpecs, 0, len(waiting))
+	worker := 1
+	for i, installer := range waiting {
+		address, err := installerAddress(installer.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+		disk, err := discoveredTargetDisk(installer)
+		if err != nil {
+			return nil, err
+		}
+		name := "cp-1"
+		role := inventory.RoleControlPlane
+		if i > 0 {
+			name = fmt.Sprintf("worker-%d", worker)
+			role = inventory.RoleWorker
+			worker++
+		}
+		nodes = append(nodes, initNodeSpec{name: name, role: role, address: address, disk: disk})
+	}
+	return nodes, nil
+}
+
+func installerAddress(endpoint string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Hostname() == "" {
+		return "", fmt.Errorf("discovered installer endpoint %q has no usable address", endpoint)
+	}
+	return parsed.Hostname(), nil
+}
+
+func discoveredTargetDisk(installer discoveredInstaller) (manifest.DiskSelector, error) {
+	selectable := make([]handoff.HandoffDisk, 0, len(installer.Status.Disks))
+	for _, disk := range installer.Status.Disks {
+		if disk.Selectable {
+			selectable = append(selectable, disk)
+		}
+	}
+	if len(selectable) != 1 {
+		paths := make([]string, 0, len(selectable))
+		for _, disk := range selectable {
+			paths = append(paths, disk.Path)
+		}
+		detail := "none"
+		if len(paths) > 0 {
+			detail = strings.Join(paths, ", ")
+		}
+		return manifest.DiskSelector{}, fmt.Errorf("installer %s reports %d selectable disks (%s); create the ClusterConfig with katlctl config init and choose the intended stable disk", installer.Endpoint, len(selectable), detail)
+	}
+	disk := selectable[0]
+	if len(disk.ByID) > 0 {
+		byID := append([]string(nil), disk.ByID...)
+		sort.Strings(byID)
+		return manifest.DiskSelector{ByID: byID[0]}, nil
+	}
+	if strings.TrimSpace(disk.WWN) != "" {
+		return manifest.DiskSelector{WWN: disk.WWN}, nil
+	}
+	if strings.TrimSpace(disk.Serial) != "" {
+		return manifest.DiskSelector{Serial: disk.Serial}, nil
+	}
+	return manifest.DiskSelector{}, fmt.Errorf("installer %s marked %s selectable without a stable disk identity", installer.Endpoint, disk.Path)
 }
 
 func resolveInstallerEndpoint(ctx context.Context, value string, timeout time.Duration) (string, error) {

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -9,11 +9,15 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/handoff"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
@@ -47,6 +51,114 @@ func TestInstallDiscoverFindsWaitingInstallerAndDisks(t *testing.T) {
 	endpoint, err := resolveInstallerEndpoint(context.Background(), "", time.Second)
 	if err != nil || endpoint != "http://192.0.2.42:8080" {
 		t.Fatalf("resolveInstallerEndpoint() = %q, %v", endpoint, err)
+	}
+}
+
+func TestInstallDiscoverWritesClusterConfig(t *testing.T) {
+	oldAddrs := installerInterfaceAddrs
+	installerInterfaceAddrs = func() ([]net.Addr, error) {
+		return []net.Addr{&net.IPNet{IP: net.ParseIP("192.0.2.5"), Mask: net.CIDRMask(24, 32)}}, nil
+	}
+	t.Cleanup(func() { installerInterfaceAddrs = oldAddrs })
+	oldProbe := installerDiscoveryProbe
+	installerDiscoveryProbe = func(_ context.Context, endpoint string, _ time.Duration) (handoff.HandoffStatus, error) {
+		status := handoff.HandoffStatus{State: handoff.HandoffWaiting}
+		switch endpoint {
+		case "http://192.0.2.11:8080":
+			status.Disks = []handoff.HandoffDisk{{
+				Path: "/dev/vda", ByID: []string{"/dev/disk/by-id/virtio-cp-root", "/dev/disk/by-id/ata-cp-root"}, Selectable: true,
+			}}
+		case "http://192.0.2.21:8080":
+			status.Disks = []handoff.HandoffDisk{{Path: "/dev/sda", WWN: "worker-root-wwn", Selectable: true}}
+		default:
+			return handoff.HandoffStatus{}, fmt.Errorf("not an installer")
+		}
+		return status, nil
+	}
+	t.Cleanup(func() { installerDiscoveryProbe = oldProbe })
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519.pub")
+	if err := os.WriteFile(keyPath, []byte(uxTestSSHKey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(dir, "katlctl.yaml"))
+	outputPath := filepath.Join(dir, "cluster.yaml")
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"install", "discover", outputPath,
+		"--name", "homelab",
+		"--ssh-authorized-key", keyPath,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := configbundle.DecodeSource(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("DecodeSource() error = %v\n%s", err, data)
+	}
+	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "192.0.2.11:6443" || len(source.Spec.Nodes) != 2 {
+		t.Fatalf("generated source = %#v", source)
+	}
+	cp, worker := source.Spec.Nodes[0], source.Spec.Nodes[1]
+	if cp.Name != "cp-1" || cp.SystemRole != inventory.RoleControlPlane || cp.Overrides.Bootstrap.Address != "192.0.2.11" || cp.Overrides.Install.TargetDisk == nil || cp.Overrides.Install.TargetDisk.ByID != "/dev/disk/by-id/ata-cp-root" {
+		t.Fatalf("control-plane node = %#v", cp)
+	}
+	if worker.Name != "worker-1" || worker.SystemRole != inventory.RoleWorker || worker.Overrides.Bootstrap.Address != "192.0.2.21" || worker.Overrides.Install.TargetDisk == nil || worker.Overrides.Install.TargetDisk.WWN != "worker-root-wwn" {
+		t.Fatalf("worker node = %#v", worker)
+	}
+	if !strings.Contains(stdout.String(), "created "+outputPath) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := run(context.Background(), []string{"config", "validate", outputPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("validate generated config: %v\nstderr=%s", err, stderr.String())
+	}
+}
+
+func TestDiscoveredInitNodesRejectsUnsafeInference(t *testing.T) {
+	tests := []struct {
+		name       string
+		installers []discoveredInstaller
+		want       string
+	}{
+		{
+			name:       "no waiting installer",
+			installers: []discoveredInstaller{{Endpoint: "http://192.0.2.11:8080", Status: handoff.HandoffStatus{State: handoff.HandoffAccepted}}},
+			want:       "no waiting KatlOS installer",
+		},
+		{
+			name: "no selectable disk",
+			installers: []discoveredInstaller{{
+				Endpoint: "http://192.0.2.11:8080",
+				Status:   handoff.HandoffStatus{State: handoff.HandoffWaiting, Disks: []handoff.HandoffDisk{{Path: "/dev/vda"}}},
+			}},
+			want: "0 selectable disks",
+		},
+		{
+			name: "ambiguous disks",
+			installers: []discoveredInstaller{{
+				Endpoint: "http://192.0.2.11:8080",
+				Status: handoff.HandoffStatus{State: handoff.HandoffWaiting, Disks: []handoff.HandoffDisk{
+					{Path: "/dev/vda", ByID: []string{"/dev/disk/by-id/virtio-a"}, Selectable: true},
+					{Path: "/dev/vdb", ByID: []string{"/dev/disk/by-id/virtio-b"}, Selectable: true},
+				}},
+			}},
+			want: "2 selectable disks (/dev/vda, /dev/vdb)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := discoveredInitNodes(tt.installers)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("discoveredInitNodes() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -323,9 +323,19 @@ katlctl install discover
 ```
 
 The report marks a disk `selectable` only when it is a writable whole disk, is
-not mounted, and has a stable by-id, WWN, or serial selector. Copy the intended
-stable selector into the matching node in `cluster.yaml`; never substitute the
-transient `/dev/vda` or `/dev/sda` path.
+not mounted, and has a stable by-id, WWN, or serial selector. To turn all waiting
+installers into an editable cluster source directly, provide an output path:
+
+```sh
+katlctl install discover ./cluster.yaml
+```
+
+The first discovered endpoint becomes `cp-1`; subsequent endpoints become
+workers. Katl writes a target selector only when an installer reports exactly
+one selectable disk and refuses to guess when multiple disks are eligible.
+Review and adjust the generated node names, roles, addresses, disk identities,
+and Kubernetes selection before applying it. Never substitute a transient
+`/dev/vda` or `/dev/sda` path.
 
 Apply the cluster source directly:
 


### PR DESCRIPTION
Adds a direct `katlctl install discover ./cluster.yaml` path that turns waiting installers and their live disk inventory into an editable ClusterConfig. It reuses config-init defaults and refuses to guess when an installer has zero or multiple selectable disks.