### PR TITLE
cli: streamline ClusterConfig initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,28 @@ and kubeadm-ready starting point; repeat `--node` for the intended topology:
 
 ```sh
 katlctl config init ./cluster.yaml \
-  --ssh-authorized-key ~/.ssh/id_ed25519.pub \
   --node cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-KATL_CP_1_ROOT \
   --node worker-1=worker,192.0.2.21,/dev/disk/by-id/ata-KATL_WORKER_1_ROOT
 ```
 
+By default, config generation imports supported public keys from the active SSH
+agent, including the 1Password SSH agent, and then tries
+`~/.ssh/id_ed25519.pub`. Use `--ssh-authorized-key PATH` to select one key
+explicitly. If no key is available, Katl still writes the editable config with
+a warning; add an authorized key before `install apply`.
+
 Review the generated disk identities, addresses, Kubernetes selection, and
 network configuration before installing.
+
+When an installer address is already known, `config init` can fetch its live
+status and disk inventory instead of requiring the full node tuple. Repeat the
+flag to build a multi-node starter config in the supplied order:
+
+```sh
+katlctl config init ./cluster.yaml \
+  --installer 192.0.2.11 \
+  --installer 192.0.2.21
+```
 
 If the nodes are already booted into the installer, skip the manual `--node`
 arguments and generate this same file from live discovery in the next step.

--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/clusterplan"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/handoff"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/katl-dev/katl/internal/katlctl/workstation"
 	"github.com/spf13/cobra"
@@ -21,6 +26,10 @@ const (
 	defaultKubernetesBundle  = "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1"
 )
 
+var sshAgentPublicKeys = func() ([]byte, error) {
+	return exec.Command("ssh-add", "-L").Output()
+}
+
 type configInitOptions struct {
 	outputPath        string
 	clusterName       string
@@ -29,6 +38,8 @@ type configInitOptions struct {
 	kubernetesBundle  string
 	sshKeyPath        string
 	nodes             initNodeSpecs
+	installers        stringList
+	installerTimeout  time.Duration
 	force             bool
 }
 
@@ -65,7 +76,7 @@ func (values *initNodeSpecs) Set(value string) error {
 	return nil
 }
 
-func newConfigInitCommand(stdout, stderr io.Writer) *cobra.Command {
+func newConfigInitCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := defaultConfigInitOptions()
 	cmd := &cobra.Command{
 		Use:   "init [PATH]",
@@ -75,11 +86,13 @@ func newConfigInitCommand(stdout, stderr io.Writer) *cobra.Command {
 			if len(args) == 1 {
 				opts.outputPath = args[0]
 			}
-			return runConfigInit(opts, stdout, stderr)
+			return runConfigInit(ctx, opts, stdout, stderr)
 		},
 	}
 	addConfigInitFlags(cmd, &opts)
 	cmd.Flags().Var(&opts.nodes, "node", "node as name=role,address,/dev/disk/by-id/... (repeatable)")
+	cmd.Flags().Var(&opts.installers, "installer", "waiting installer IP, hostname, host:port, or base URL (repeatable)")
+	cmd.Flags().DurationVar(&opts.installerTimeout, "installer-timeout", opts.installerTimeout, "overall timeout for reading installer status")
 	return cmd
 }
 
@@ -88,6 +101,7 @@ func defaultConfigInitOptions() configInitOptions {
 		clusterName:       "katl-lab",
 		kubernetesVersion: defaultKubernetesVersion,
 		kubernetesBundle:  defaultKubernetesBundle,
+		installerTimeout:  15 * time.Second,
 	}
 }
 
@@ -96,34 +110,34 @@ func addConfigInitFlags(cmd *cobra.Command, opts *configInitOptions) {
 	cmd.Flags().StringVar(&opts.controlPlane, "control-plane-endpoint", "", "stable Kubernetes API endpoint host:port; defaults to the first control-plane address")
 	cmd.Flags().StringVar(&opts.kubernetesVersion, "kubernetes-version", opts.kubernetesVersion, "Kubernetes payload version")
 	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", opts.kubernetesBundle, "Kubernetes bundle image")
-	cmd.Flags().StringVar(&opts.sshKeyPath, "ssh-authorized-key", "", "public SSH key file; defaults to ~/.ssh/id_ed25519.pub")
+	cmd.Flags().StringVar(&opts.sshKeyPath, "ssh-authorized-key", "", "public SSH key file; otherwise uses the active SSH agent or ~/.ssh/id_ed25519.pub")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "replace an existing output file")
 }
 
-func runConfigInit(opts configInitOptions, stdout, stderr io.Writer) error {
-	_ = stderr
+func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr io.Writer) error {
+	if len(opts.nodes) > 0 && len(opts.installers.values) > 0 {
+		return fmt.Errorf("--node and --installer cannot be used together")
+	}
+	if len(opts.installers.values) > 0 {
+		var err error
+		opts.nodes, err = initNodesFromInstallers(ctx, opts.installers.values, opts.installerTimeout)
+		if err != nil {
+			return err
+		}
+	}
 	if len(opts.nodes) == 0 {
-		return fmt.Errorf("at least one --node is required")
+		return fmt.Errorf("at least one --node or --installer is required")
 	}
 	configPath, err := workstation.ConfigPath()
 	if err != nil {
 		return err
 	}
-	sshKeyPath := strings.TrimSpace(opts.sshKeyPath)
-	if sshKeyPath == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("locate default SSH public key: %w", err)
-		}
-		sshKeyPath = home + "/.ssh/id_ed25519.pub"
-	}
-	keyData, err := os.ReadFile(sshKeyPath)
+	sshKeys, notices, err := configSSHKeys(opts.sshKeyPath)
 	if err != nil {
-		return fmt.Errorf("read SSH public key %s: %w (use --ssh-authorized-key)", sshKeyPath, err)
+		return err
 	}
-	sshKey := strings.TrimSpace(string(keyData))
-	if sshKey == "" || strings.ContainsAny(sshKey, "\r\n") {
-		return fmt.Errorf("SSH public key %s must contain one non-empty key", sshKeyPath)
+	for _, notice := range notices {
+		fmt.Fprintln(stderr, notice)
 	}
 
 	controlPlane := strings.TrimSpace(opts.controlPlane)
@@ -151,7 +165,7 @@ func runConfigInit(opts configInitOptions, stdout, stderr io.Writer) error {
 				Bundle:  strings.TrimSpace(opts.kubernetesBundle),
 			},
 			Defaults: configbundle.SourceNodeLayer{
-				Identity: configbundle.SourceIdentity{SSH: manifest.SSHIdentity{AuthorizedKeys: []string{sshKey}}},
+				Identity: configbundle.SourceIdentity{SSH: manifest.SSHIdentity{AuthorizedKeys: sshKeys}},
 				Install:  configbundle.SourceInstallLayer{WipeTarget: &wipe},
 				Networkd: manifest.NetworkdConfig{Files: []manifest.NetworkdFile{{Name: "10-lan.network", Content: "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n"}}},
 			},
@@ -215,6 +229,112 @@ func runConfigInit(opts configInitOptions, stdout, stderr io.Writer) error {
 	}
 	fmt.Fprintf(stdout, "created %s\n", opts.outputPath)
 	return nil
+}
+
+func initNodesFromInstallers(ctx context.Context, addresses []string, timeout time.Duration) (initNodeSpecs, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("--installer-timeout must be positive")
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	client := &http.Client{Timeout: requestTimeout(timeout)}
+	installers := make([]discoveredInstaller, 0, len(addresses))
+	seen := make(map[string]struct{}, len(addresses))
+	for _, address := range addresses {
+		endpoint, err := normalizeInstallerAddress(address)
+		if err != nil {
+			return nil, fmt.Errorf("--installer %q: %w", address, err)
+		}
+		if _, ok := seen[endpoint]; ok {
+			return nil, fmt.Errorf("duplicate --installer endpoint %s", endpoint)
+		}
+		seen[endpoint] = struct{}{}
+		status, err := fetchInstallStatus(requestCtx, client, endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("read installer %s: %w", endpoint, err)
+		}
+		if status.State != handoff.HandoffWaiting {
+			return nil, fmt.Errorf("installer %s is not waiting for config: state=%s", endpoint, status.State)
+		}
+		installers = append(installers, discoveredInstaller{Endpoint: endpoint, Status: status})
+	}
+	return discoveredInitNodes(installers)
+}
+
+func configSSHKeys(explicitPath string) ([]string, []string, error) {
+	explicitPath = strings.TrimSpace(explicitPath)
+	if explicitPath != "" {
+		key, err := readConfigSSHKey(explicitPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		return []string{key}, nil, nil
+	}
+
+	var notices []string
+	if data, err := sshAgentPublicKeys(); err == nil {
+		keys, ignored := supportedSSHKeys(data)
+		if len(keys) > 0 {
+			notices = append(notices, fmt.Sprintf("using %d SSH public key(s) from the active SSH agent", len(keys)))
+			if ignored > 0 {
+				notices = append(notices, fmt.Sprintf("warning: ignored %d SSH agent key(s) not supported by KatlOS", ignored))
+			}
+			return keys, notices, nil
+		}
+		if ignored > 0 {
+			notices = append(notices, fmt.Sprintf("warning: ignored %d SSH agent key(s) not supported by KatlOS", ignored))
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		path := home + "/.ssh/id_ed25519.pub"
+		if _, err := os.Stat(path); err == nil {
+			key, err := readConfigSSHKey(path)
+			if err == nil {
+				return []string{key}, append(notices, "using SSH public key "+path), nil
+			}
+			return nil, append(notices,
+				"warning: "+err.Error(),
+				"warning: generated ClusterConfig has no SSH authorized keys; add one before install apply",
+			), nil
+		}
+	}
+
+	return nil, append(notices, "warning: generated ClusterConfig has no SSH authorized keys; add one before install apply"), nil
+}
+
+func readConfigSSHKey(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read SSH public key %s: %w", path, err)
+	}
+	key := strings.TrimSpace(string(data))
+	if key == "" || strings.ContainsAny(key, "\r\n") || !manifest.ValidAuthorizedKey(key) {
+		return "", fmt.Errorf("SSH public key %s must contain one supported public key", path)
+	}
+	return key, nil
+}
+
+func supportedSSHKeys(data []byte) ([]string, int) {
+	var keys []string
+	seen := map[string]struct{}{}
+	ignored := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		key := strings.TrimSpace(line)
+		if key == "" {
+			continue
+		}
+		if !manifest.ValidAuthorizedKey(key) {
+			ignored++
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys, ignored
 }
 
 func validHostname(value string) bool {

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -208,6 +209,26 @@ func normalizeInstallerEndpoint(value string) (string, error) {
 	}
 	parsed.Path = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func normalizeInstallerAddress(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("address is required")
+	}
+	if strings.Contains(value, "://") {
+		return normalizeInstallerEndpoint(value)
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		return normalizeInstallerEndpoint("http://" + net.JoinHostPort(ip.String(), "8080"))
+	}
+	if host, port, err := net.SplitHostPort(value); err == nil && host != "" && port != "" {
+		return normalizeInstallerEndpoint("http://" + value)
+	}
+	if strings.Contains(value, ":") {
+		return "", fmt.Errorf("address %q must be an IP, hostname, host:port, or HTTP base URL", value)
+	}
+	return normalizeInstallerEndpoint("http://" + net.JoinHostPort(value, "8080"))
 }
 
 func fetchInstallStatus(ctx context.Context, client *http.Client, endpoint string) (handoff.HandoffStatus, error) {

--- a/cmd/katlctl/install_discover.go
+++ b/cmd/katlctl/install_discover.go
@@ -68,7 +68,7 @@ func runInstallDiscover(ctx context.Context, opts installDiscoverOptions, stdout
 		if err != nil {
 			return err
 		}
-		return runConfigInit(opts.configInit, stdout, stderr)
+		return runConfigInit(ctx, opts.configInit, stdout, stderr)
 	}
 	report := installDiscoveryReport{APIVersion: "katl.dev/v1alpha1", Kind: "InstallerDiscovery", Installers: installers}
 	data, err := json.MarshalIndent(report, "", "  ")

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -78,17 +78,15 @@ func TestInstallDiscoverWritesClusterConfig(t *testing.T) {
 	t.Cleanup(func() { installerDiscoveryProbe = oldProbe })
 
 	dir := t.TempDir()
-	keyPath := filepath.Join(dir, "id_ed25519.pub")
-	if err := os.WriteFile(keyPath, []byte(uxTestSSHKey+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	oldAgent := sshAgentPublicKeys
+	sshAgentPublicKeys = func() ([]byte, error) { return []byte(uxTestSSHKey + "\n"), nil }
+	t.Cleanup(func() { sshAgentPublicKeys = oldAgent })
 	t.Setenv("KATLCTL_CONFIG", filepath.Join(dir, "katlctl.yaml"))
 	outputPath := filepath.Join(dir, "cluster.yaml")
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "discover", outputPath,
 		"--name", "homelab",
-		"--ssh-authorized-key", keyPath,
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
@@ -103,6 +101,9 @@ func TestInstallDiscoverWritesClusterConfig(t *testing.T) {
 	}
 	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "192.0.2.11:6443" || len(source.Spec.Nodes) != 2 {
 		t.Fatalf("generated source = %#v", source)
+	}
+	if keys := source.Spec.Defaults.Identity.SSH.AuthorizedKeys; len(keys) != 1 || keys[0] != uxTestSSHKey {
+		t.Fatalf("authorized keys = %#v", keys)
 	}
 	cp, worker := source.Spec.Nodes[0], source.Spec.Nodes[1]
 	if cp.Name != "cp-1" || cp.SystemRole != inventory.RoleControlPlane || cp.Overrides.Bootstrap.Address != "192.0.2.11" || cp.Overrides.Install.TargetDisk == nil || cp.Overrides.Install.TargetDisk.ByID != "/dev/disk/by-id/ata-cp-root" {
@@ -159,6 +160,66 @@ func TestDiscoveredInitNodesRejectsUnsafeInference(t *testing.T) {
 				t.Fatalf("discoveredInitNodes() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestConfigInitFromInstallerAddress(t *testing.T) {
+	status := installTestStatus(handoff.HandoffWaiting, installstatus.StateWaitingForConfig, "")
+	status.Disks = []handoff.HandoffDisk{{
+		Path: "/dev/vda", ByID: []string{"/dev/disk/by-id/virtio-root"}, Selectable: true,
+	}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(status)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(dir, "katlctl.yaml"))
+	oldAgent := sshAgentPublicKeys
+	sshAgentPublicKeys = func() ([]byte, error) { return []byte(uxTestSSHKey + "\n"), nil }
+	t.Cleanup(func() { sshAgentPublicKeys = oldAgent })
+
+	address := strings.TrimPrefix(server.URL, "http://")
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "init",
+		"--name", "direct-lab",
+		"--installer", address,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	source, err := configbundle.DecodeSource(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Fatalf("DecodeSource() error = %v\n%s", err, stdout.String())
+	}
+	if len(source.Spec.Nodes) != 1 || source.Spec.Nodes[0].Name != "cp-1" || source.Spec.Nodes[0].Overrides.Install.TargetDisk == nil || source.Spec.Nodes[0].Overrides.Install.TargetDisk.ByID != "/dev/disk/by-id/virtio-root" {
+		t.Fatalf("generated source = %#v", source)
+	}
+	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Address; got != "127.0.0.1" {
+		t.Fatalf("bootstrap address = %q", got)
+	}
+}
+
+func TestConfigInitInstallerInputValidation(t *testing.T) {
+	endpoint, err := normalizeInstallerAddress("192.0.2.11")
+	if err != nil || endpoint != "http://192.0.2.11:8080" {
+		t.Fatalf("normalizeInstallerAddress() = %q, %v", endpoint, err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{
+		"config", "init",
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-root",
+		"--installer", "192.0.2.11",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "--node and --installer cannot be used together") {
+		t.Fatalf("run() error = %v", err)
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -117,7 +117,7 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	cmd.AddCommand(kubernetesCmd)
 
 	configCmd := &cobra.Command{Use: "config", Short: "Katl configuration operations"}
-	configCmd.AddCommand(newConfigInitCommand(stdout, stderr))
+	configCmd.AddCommand(newConfigInitCommand(ctx, stdout, stderr))
 	configCmd.AddCommand(newConfigPathCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigTopologyCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigValidateCommand(stdout, stderr))

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,6 +48,84 @@ func TestConfigInitEmitsStarterClusterConfig(t *testing.T) {
 	}
 	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Access.CredentialRef; !strings.Contains(got, "/credentials/homelab/cp-1.token") {
 		t.Fatalf("credentialRef = %q", got)
+	}
+}
+
+func TestConfigInitUsesSSHAgentKeys(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(dir, "katlctl.yaml"))
+	oldAgent := sshAgentPublicKeys
+	sshAgentPublicKeys = func() ([]byte, error) {
+		return []byte(uxTestSSHKey + "\n" + uxTestSSHKey + "\n"), nil
+	}
+	t.Cleanup(func() { sshAgentPublicKeys = oldAgent })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "init",
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-cp-root",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	source, err := configbundle.DecodeSource(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := source.Spec.Defaults.Identity.SSH.AuthorizedKeys
+	if len(keys) != 1 || keys[0] != uxTestSSHKey {
+		t.Fatalf("authorized keys = %#v", keys)
+	}
+	if !strings.Contains(stderr.String(), "using 1 SSH public key(s) from the active SSH agent") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestConfigInitWithoutSSHKeysWritesEditableConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(dir, "katlctl.yaml"))
+	oldAgent := sshAgentPublicKeys
+	sshAgentPublicKeys = func() ([]byte, error) { return nil, errors.New("no agent") }
+	t.Cleanup(func() { sshAgentPublicKeys = oldAgent })
+
+	outputPath := filepath.Join(dir, "cluster.yaml")
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "init", outputPath,
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-cp-root",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := configbundle.DecodeSource(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if keys := source.Spec.Defaults.Identity.SSH.AuthorizedKeys; len(keys) != 0 {
+		t.Fatalf("authorized keys = %#v", keys)
+	}
+	if !strings.Contains(stderr.String(), "generated ClusterConfig has no SSH authorized keys") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestConfigInitExplicitSSHKeyDoesNotFallBack(t *testing.T) {
+	oldAgent := sshAgentPublicKeys
+	sshAgentPublicKeys = func() ([]byte, error) {
+		t.Fatal("SSH agent was queried for an explicit key path")
+		return nil, nil
+	}
+	t.Cleanup(func() { sshAgentPublicKeys = oldAgent })
+
+	_, _, err := configSSHKeys(filepath.Join(t.TempDir(), "missing.pub"))
+	if err == nil || !strings.Contains(err.Error(), "read SSH public key") {
+		t.Fatalf("configSSHKeys() error = %v", err)
 	}
 }
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -88,10 +88,10 @@ direnv allow
 Use `direnv` plus `nix-direnv` if you want the flake shell loaded
 automatically when entering the repository.
 
-That shell provides the Go and protobuf toolchain, Git, `jq`, `curl`, and Podman.
-Image construction stays behind `scripts/mkosi`; mkosi, Fedora package tools,
-UKI tooling, filesystem tools, and compression tools run inside its builder
-container instead of being installed on the host.
+That shell provides the Go and protobuf toolchain, Git, OpenSSH, `jq`, `curl`,
+and Podman. Image construction stays behind `scripts/mkosi`; mkosi, Fedora
+package tools, UKI tooling, filesystem tools, and compression tools run inside
+its builder container instead of being installed on the host.
 
 `katlctl` is also available in both development shells. It runs from the current
 checkout so local source changes are used immediately:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -322,6 +322,19 @@ Discover waiting installers and their disk inventory from the workstation:
 katlctl install discover
 ```
 
+If the installer addresses are already known, query them directly while
+creating the config instead of scanning the local subnet:
+
+```sh
+katlctl config init ./cluster.yaml \
+  --installer 192.0.2.11 \
+  --installer 192.0.2.21
+```
+
+Bare addresses use HTTP port 8080. A hostname, `host:port`, or complete HTTP(S)
+base URL is also accepted. The first supplied installer becomes `cp-1`; later
+installers become workers.
+
 The report marks a disk `selectable` only when it is a writable whole disk, is
 not mounted, and has a stable by-id, WWN, or serial selector. To turn all waiting
 installers into an editable cluster source directly, provide an output path:
@@ -329,6 +342,12 @@ installers into an editable cluster source directly, provide an output path:
 ```sh
 katlctl install discover ./cluster.yaml
 ```
+
+Config generation imports supported public keys from the active SSH agent,
+including the 1Password SSH agent, and falls back to
+`~/.ssh/id_ed25519.pub`. Pass `--ssh-authorized-key PATH` to choose a key file
+explicitly. If neither source provides a key, discovery still writes the file
+and warns that an authorized key must be added before `install apply`.
 
 The first discovered endpoint becomes `cp-1`; subsequent endpoints become
 workers. Katl writes a target selector only when an installer reports exactly

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -55,6 +55,12 @@ The command connects as `root` using the workstation's normal SSH agent. Use
 - verifies authenticated access to TCP port `9443`; and
 - writes or updates the selected cluster in `katlctl.yaml`.
 
+`katlctl config init` and `katlctl install discover CLUSTER_CONFIG` also read
+supported public keys from the active SSH agent when creating the initial SSH
+authorization. This works with agent-only keys such as 1Password. An explicit
+`--ssh-authorized-key PATH` remains available when only one key should be
+authorized.
+
 `katlctl config init` generates the matching credential references. In a
 hand-authored `ClusterConfig`, use workstation paths rather than secret values:
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
               git
               go
               jq
+              openssh
               podman
               protobuf
               protoc-gen-go


### PR DESCRIPTION
Lets config init derive nodes from waiting installer addresses and obtain supported public keys from the active SSH agent, including 1Password. Missing automatic keys now produce an editable config and warning instead of blocking generation, while install validation remains strict.