### PR TITLE
install: accept generated config directly

### DIFF
--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -16,7 +16,6 @@ import (
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/handoff"
 	"github.com/katl-dev/katl/internal/installer/manifest"
-	"github.com/katl-dev/katl/internal/katlctl/workstation"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -128,10 +127,6 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 	if len(opts.nodes) == 0 {
 		return fmt.Errorf("at least one --node or --installer is required")
 	}
-	configPath, err := workstation.ConfigPath()
-	if err != nil {
-		return err
-	}
 	sshKeys, notices, err := configSSHKeys(opts.sshKeyPath)
 	if err != nil {
 		return err
@@ -185,17 +180,13 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 			return fmt.Errorf("duplicate node name %q", node.name)
 		}
 		seen[node.name] = struct{}{}
-		credentialPath, err := workstation.CredentialPath(configPath, source.Metadata.Name, node.name)
-		if err != nil {
-			return err
-		}
 		targetDisk := node.disk
 		source.Spec.Nodes = append(source.Spec.Nodes, configbundle.SourceNode{
 			Name: node.name, SystemRole: node.role,
 			Overrides: configbundle.SourceNodeLayer{
 				Identity:  configbundle.SourceIdentity{Hostname: node.name},
 				Install:   configbundle.SourceInstallLayer{TargetDisk: &targetDisk},
-				Bootstrap: clusterplan.BootstrapLayer{Address: node.address, Access: inventory.Access{Method: "agent", CredentialRef: "file:" + credentialPath}},
+				Bootstrap: clusterplan.BootstrapLayer{Address: node.address, Access: inventory.Access{Method: "agent", CredentialRef: "agent/" + node.name}},
 			},
 		})
 	}

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -67,7 +68,7 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 		},
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL; discovers a unique waiting installer when omitted")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from the cluster config")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name or configured address; inferred when the config contains one node")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
@@ -95,18 +96,11 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	endpoint, err := resolveInstallerEndpoint(ctx, opts.endpoint, opts.timeout)
-	if err != nil {
-		return err
-	}
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
 	if strings.TrimSpace(opts.sourcePath) == "" {
 		return fmt.Errorf("source config path is required")
-	}
-	if strings.TrimSpace(opts.nodeName) == "" {
-		return fmt.Errorf("--node is required")
 	}
 	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
 		SourcePath:     opts.sourcePath,
@@ -120,13 +114,21 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if len(archive) > maxInstallBundleSize {
 		return fmt.Errorf("compiled config bundle size %d exceeds %d bytes", len(archive), maxInstallBundleSize)
 	}
+	nodeName, err := resolveInstallNode(archive, result.Digest, opts.nodeName)
+	if err != nil {
+		return err
+	}
 	selected, err := configbundle.ReadSelectedNode(bytes.NewReader(archive), configbundle.ReadOptions{
 		ExpectedDigest:          result.Digest,
-		NodeName:                opts.nodeName,
+		NodeName:                nodeName,
 		AllowMissingKatlosImage: true,
 	})
 	if err != nil {
 		return fmt.Errorf("select node from compiled cluster config: %w", err)
+	}
+	endpoint, err := resolveInstallerEndpoint(ctx, installEndpointHint(opts.endpoint, opts.nodeName, nodeName), opts.timeout)
+	if err != nil {
+		return err
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, opts.timeout)
@@ -160,6 +162,71 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 		return fmt.Errorf("installer finished in %s: %s", status.InstallStatus.State, installFailure(status.InstallStatus))
 	}
 	return nil
+}
+
+func installEndpointHint(endpoint, selector, nodeName string) string {
+	if endpoint = strings.TrimSpace(endpoint); endpoint != "" {
+		return endpoint
+	}
+	selector = strings.TrimSpace(selector)
+	if selector != "" && selector != nodeName {
+		return selector
+	}
+	return ""
+}
+
+func resolveInstallNode(archive []byte, digest, selector string) (string, error) {
+	bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), digest)
+	if err != nil {
+		return "", fmt.Errorf("read compiled cluster config: %w", err)
+	}
+	return selectInstallNode(bundle.Manifest, selector)
+}
+
+func selectInstallNode(manifest configbundle.BundleManifest, selector string) (string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		if len(manifest.Nodes) == 1 {
+			return manifest.Nodes[0].Name, nil
+		}
+		return "", fmt.Errorf("--node is required because the cluster config contains %d nodes (%s)", len(manifest.Nodes), installNodeChoices(manifest))
+	}
+	for _, node := range manifest.Nodes {
+		if node.Name == selector {
+			return node.Name, nil
+		}
+	}
+	var matches []string
+	for _, node := range manifest.Cluster.BootstrapInventory.Nodes {
+		if strings.TrimSpace(node.Address) == selector {
+			matches = append(matches, node.Name)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		sort.Strings(matches)
+		return "", fmt.Errorf("--node address %q matches multiple nodes (%s); use a node name", selector, strings.Join(matches, ", "))
+	}
+	return "", fmt.Errorf("--node %q does not match a configured node name or address; choose %s", selector, installNodeChoices(manifest))
+}
+
+func installNodeChoices(manifest configbundle.BundleManifest) string {
+	addresses := make(map[string]string, len(manifest.Cluster.BootstrapInventory.Nodes))
+	for _, node := range manifest.Cluster.BootstrapInventory.Nodes {
+		addresses[node.Name] = strings.TrimSpace(node.Address)
+	}
+	choices := make([]string, 0, len(manifest.Nodes))
+	for _, node := range manifest.Nodes {
+		choice := node.Name
+		if address := addresses[node.Name]; address != "" {
+			choice += " (" + address + ")"
+		}
+		choices = append(choices, choice)
+	}
+	sort.Strings(choices)
+	return strings.Join(choices, ", ")
 }
 
 func runInstallStatus(ctx context.Context, opts installStatusOptions, stdout, stderr io.Writer) error {

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/handoff"
+	"github.com/katl-dev/katl/internal/installer/manifest"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
 
@@ -252,7 +253,6 @@ func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
 	err := run(context.Background(), []string{
 		"install", "apply", sourcePath,
 		"--endpoint", ts.URL,
-		"--node", "cp-1",
 		"--no-wait",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -268,6 +268,113 @@ func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
 	payload := server.Bundle()
 	if payload.NodeName != "cp-1" || len(payload.Data) == 0 {
 		t.Fatalf("server bundle = node=%q bytes=%d", payload.NodeName, len(payload.Data))
+	}
+}
+
+func TestInstallApplyAcceptsGeneratedConfigByAddress(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "cluster.yaml")
+	keyPath := filepath.Join(dir, "id_ed25519.pub")
+	if err := os.WriteFile(keyPath, []byte(uxTestSSHKey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{
+		"config", "init", outputPath,
+		"--ssh-authorized-key", keyPath,
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-cp-root",
+	}, &stdout, &stderr); err != nil {
+		t.Fatalf("config init error = %v, stderr=%s", err, stderr.String())
+	}
+
+	server := handoff.NewHandoffServerWithDefaultImage(nil, manifest.KatlosImage{
+		LocalRef:         "katlos-install.raw",
+		SHA256:           strings.Repeat("a", 64),
+		SizeBytes:        1,
+		Version:          "test",
+		Architecture:     "x86_64",
+		RuntimeInterface: "katl-runtime-1",
+		Role:             "install",
+	})
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+	stdout.Reset()
+	stderr.Reset()
+	if err := run(context.Background(), []string{
+		"install", "apply", outputPath,
+		"--endpoint", ts.URL,
+		"--node", "192.0.2.11",
+		"--no-wait",
+	}, &stdout, &stderr); err != nil {
+		t.Fatalf("install apply error = %v, stderr=%s", err, stderr.String())
+	}
+	if payload := server.Bundle(); payload.NodeName != "cp-1" || len(payload.Data) == 0 {
+		t.Fatalf("server bundle = node=%q bytes=%d", payload.NodeName, len(payload.Data))
+	}
+}
+
+func TestSelectInstallNode(t *testing.T) {
+	manifest := configbundle.BundleManifest{
+		Nodes: []configbundle.NodeRecord{{Name: "cp-1"}, {Name: "worker-1"}},
+		Cluster: configbundle.ClusterRecord{BootstrapInventory: inventory.Inventory{Nodes: []inventory.Node{
+			{Name: "cp-1", Address: "192.0.2.11"},
+			{Name: "worker-1", Address: "192.0.2.21"},
+		}}},
+	}
+	for _, test := range []struct {
+		name     string
+		selector string
+		want     string
+		wantErr  string
+	}{
+		{name: "name", selector: "cp-1", want: "cp-1"},
+		{name: "address", selector: "192.0.2.21", want: "worker-1"},
+		{name: "required for multiple", wantErr: "contains 2 nodes"},
+		{name: "unknown", selector: "192.0.2.99", wantErr: "cp-1 (192.0.2.11)"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := selectInstallNode(manifest, test.selector)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("selectInstallNode() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("selectInstallNode() = %q, %v, want %q", got, err, test.want)
+			}
+		})
+	}
+
+	single := manifest
+	single.Nodes = single.Nodes[:1]
+	if got, err := selectInstallNode(single, ""); err != nil || got != "cp-1" {
+		t.Fatalf("single-node selection = %q, %v", got, err)
+	}
+	manifest.Cluster.BootstrapInventory.Nodes[1].Address = "192.0.2.11"
+	if _, err := selectInstallNode(manifest, "192.0.2.11"); err == nil || !strings.Contains(err.Error(), "matches multiple nodes") {
+		t.Fatalf("ambiguous address error = %v", err)
+	}
+}
+
+func TestInstallEndpointHint(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		endpoint string
+		selector string
+		nodeName string
+		want     string
+	}{
+		{name: "explicit endpoint", endpoint: "http://installer.test:8080", selector: "192.0.2.11", nodeName: "cp-1", want: "http://installer.test:8080"},
+		{name: "address selector", selector: "192.0.2.11", nodeName: "cp-1", want: "192.0.2.11"},
+		{name: "node name discovers", selector: "cp-1", nodeName: "cp-1"},
+		{name: "inferred node discovers", nodeName: "cp-1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := installEndpointHint(test.endpoint, test.selector, test.nodeName); got != test.want {
+				t.Fatalf("installEndpointHint() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -46,7 +46,7 @@ func TestConfigInitEmitsStarterClusterConfig(t *testing.T) {
 	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "192.0.2.11:6443" || len(source.Spec.Nodes) != 2 {
 		t.Fatalf("generated source = %#v", source)
 	}
-	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Access.CredentialRef; !strings.Contains(got, "/credentials/homelab/cp-1.token") {
+	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Access.CredentialRef; got != "agent/cp-1" {
 		t.Fatalf("credentialRef = %q", got)
 	}
 }

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -103,6 +103,7 @@ func Compile(request CompileRequest) (Plan, error) {
 		if err != nil {
 			return Plan{}, fmt.Errorf("node %q: %w", name, err)
 		}
+		layer.Bootstrap.Access = portableBootstrapAccess(name, layer.Bootstrap.Access)
 		layer = applyTargetDiskDefaults(layer)
 		material, invNode, err := compileNode(config, name, role, layer, kubernetes, request.KubeadmConfigs, controlPlaneEndpoint, endpointPlan)
 		if err != nil {
@@ -311,6 +312,16 @@ func manifestAccess(access inventory.Access) manifest.BootstrapAccess {
 		User:          strings.TrimSpace(access.User),
 		CredentialRef: strings.TrimSpace(access.CredentialRef),
 	}
+}
+
+func portableBootstrapAccess(node string, access inventory.Access) inventory.Access {
+	access.Method = strings.TrimSpace(access.Method)
+	access.User = strings.TrimSpace(access.User)
+	access.CredentialRef = strings.TrimSpace(access.CredentialRef)
+	if access.Method == "agent" && strings.HasPrefix(access.CredentialRef, "file:") {
+		access.CredentialRef = "agent/" + node
+	}
+	return access
 }
 
 func copyLabels(labels map[string]string) map[string]string {

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -78,6 +78,24 @@ func TestCompileClusterPlan(t *testing.T) {
 	}
 }
 
+func TestCompileMakesWorkstationCredentialRefPortable(t *testing.T) {
+	config := validConfig()
+	config.Spec.Nodes[0].Overrides.Bootstrap.Access = inventory.Access{
+		Method:        "agent",
+		CredentialRef: "file:/home/operator/.config/katl/credentials/lab/cp-1.token",
+	}
+	plan, err := Compile(CompileRequest{Config: config, KubeadmConfigs: validKubeadmConfigs("v1.36.1")})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if got := plan.Nodes[0].InstallManifest.Node.Bootstrap.Access.CredentialRef; got != "agent/cp-1" {
+		t.Fatalf("install credentialRef = %q", got)
+	}
+	if got := plan.BootstrapInventory.Nodes[0].Access.CredentialRef; got != "agent/cp-1" {
+		t.Fatalf("inventory credentialRef = %q", got)
+	}
+}
+
 func TestCompileNodeClassGoldenScenarios(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Fixes config init leaking a workstation credential path into node-bound install material. Generated configs now use portable agent references, while install apply accepts a node name or configured address, infers a single node, and routes directly to an address supplied by the operator.