### PR TITLE
config: simplify generated starter config

### DIFF
--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -20,11 +20,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	defaultKubernetesVersion = "v1.36.1"
-	defaultKubernetesBundle  = "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1"
-)
-
 var sshAgentPublicKeys = func() ([]byte, error) {
 	return exec.Command("ssh-add", "-L").Output()
 }
@@ -98,8 +93,7 @@ func newConfigInitCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.
 func defaultConfigInitOptions() configInitOptions {
 	return configInitOptions{
 		clusterName:       "katl-lab",
-		kubernetesVersion: defaultKubernetesVersion,
-		kubernetesBundle:  defaultKubernetesBundle,
+		kubernetesVersion: configbundle.DefaultKubernetesVersion,
 		installerTimeout:  15 * time.Second,
 	}
 }
@@ -107,8 +101,8 @@ func defaultConfigInitOptions() configInitOptions {
 func addConfigInitFlags(cmd *cobra.Command, opts *configInitOptions) {
 	cmd.Flags().StringVar(&opts.clusterName, "name", opts.clusterName, "cluster name")
 	cmd.Flags().StringVar(&opts.controlPlane, "control-plane-endpoint", "", "stable Kubernetes API endpoint host:port; defaults to the first control-plane address")
-	cmd.Flags().StringVar(&opts.kubernetesVersion, "kubernetes-version", opts.kubernetesVersion, "Kubernetes payload version")
-	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", opts.kubernetesBundle, "Kubernetes bundle image")
+	cmd.Flags().StringVar(&opts.kubernetesVersion, "kubernetes-version", opts.kubernetesVersion, "override the default Kubernetes payload version")
+	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", opts.kubernetesBundle, "override the default Kubernetes bundle image")
 	cmd.Flags().StringVar(&opts.sshKeyPath, "ssh-authorized-key", "", "public SSH key file; otherwise uses the active SSH agent or ~/.ssh/id_ed25519.pub")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "replace an existing output file")
 }
@@ -135,42 +129,29 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 		fmt.Fprintln(stderr, notice)
 	}
 
-	controlPlane := strings.TrimSpace(opts.controlPlane)
-	if controlPlane == "" {
-		for _, node := range opts.nodes {
-			if node.role == inventory.RoleControlPlane {
-				controlPlane = net.JoinHostPort(node.address, "6443")
-				break
-			}
+	hasControlPlane := false
+	for _, node := range opts.nodes {
+		if node.role == inventory.RoleControlPlane {
+			hasControlPlane = true
+			break
 		}
 	}
-	if controlPlane == "" {
+	if !hasControlPlane {
 		return fmt.Errorf("at least one control-plane --node is required")
 	}
 
-	wipe := true
 	source := configbundle.SourceConfig{
 		APIVersion: configbundle.APIVersion,
 		Kind:       configbundle.Kind,
 		Metadata:   configbundle.Metadata{Name: strings.TrimSpace(opts.clusterName)},
 		Spec: configbundle.SourceSpec{
-			ControlPlaneEndpoint: controlPlane,
+			ControlPlaneEndpoint: strings.TrimSpace(opts.controlPlane),
 			Kubernetes: configbundle.SourceKubernetesCluster{
 				Version: strings.TrimSpace(opts.kubernetesVersion),
 				Bundle:  strings.TrimSpace(opts.kubernetesBundle),
 			},
 			Defaults: configbundle.SourceNodeLayer{
 				Identity: configbundle.SourceIdentity{SSH: manifest.SSHIdentity{AuthorizedKeys: sshKeys}},
-				Install:  configbundle.SourceInstallLayer{WipeTarget: &wipe},
-				Networkd: manifest.NetworkdConfig{Files: []manifest.NetworkdFile{{Name: "10-lan.network", Content: "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n"}}},
-			},
-			SystemRoleDefaults: map[inventory.SystemRole]configbundle.SourceNodeLayer{
-				inventory.RoleControlPlane: {Kubernetes: configbundle.SourceKubernetesLayer{Kubeadm: configbundle.SourceKubeadmRef{ConfigRef: "control-plane"}}},
-				inventory.RoleWorker:       {Kubernetes: configbundle.SourceKubernetesLayer{Kubeadm: configbundle.SourceKubeadmRef{ConfigRef: "worker"}}},
-			},
-			KubeadmConfigs: map[string]configbundle.SourceKubeadmConfig{
-				"control-plane": {Config: kubeadmInitConfig(opts.kubernetesVersion)},
-				"worker":        {Config: kubeadmJoinConfig()},
 			},
 		},
 	}
@@ -184,9 +165,8 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 		source.Spec.Nodes = append(source.Spec.Nodes, configbundle.SourceNode{
 			Name: node.name, SystemRole: node.role,
 			Overrides: configbundle.SourceNodeLayer{
-				Identity:  configbundle.SourceIdentity{Hostname: node.name},
 				Install:   configbundle.SourceInstallLayer{TargetDisk: &targetDisk},
-				Bootstrap: clusterplan.BootstrapLayer{Address: node.address, Access: inventory.Access{Method: "agent", CredentialRef: "agent/" + node.name}},
+				Bootstrap: clusterplan.BootstrapLayer{Address: node.address},
 			},
 		})
 	}
@@ -194,6 +174,7 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 	if err != nil {
 		return fmt.Errorf("encode starter ClusterConfig: %w", err)
 	}
+	data = annotateStarterConfig(data, len(sshKeys) == 0, source.Spec.Kubernetes.Version == configbundle.DefaultKubernetesVersion && source.Spec.Kubernetes.Bundle == "")
 	if _, err := configbundle.DecodeSource(strings.NewReader(string(data))); err != nil {
 		return fmt.Errorf("validate generated ClusterConfig: %w", err)
 	}
@@ -220,6 +201,27 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 	}
 	fmt.Fprintf(stdout, "created %s\n", opts.outputPath)
 	return nil
+}
+
+func annotateStarterConfig(data []byte, missingSSHKeys, showBundleOverride bool) []byte {
+	comments := "spec:\n" +
+		"    # Stable Kubernetes API endpoint for multi-control-plane clusters.\n" +
+		"    # controlPlaneEndpoint: api.home.arpa:6443\n" +
+		"    # Nodes use DHCP by default; native systemd-networkd files can be set under defaults or node overrides.\n"
+	if missingSSHKeys {
+		comments += "    # Add an SSH public key here if console-only access is not sufficient.\n" +
+			"    # defaults:\n" +
+			"    #     identity:\n" +
+			"    #         ssh:\n" +
+			"    #             authorizedKeys:\n" +
+			"    #                 - ssh-ed25519 AAAA... operator@home\n"
+	}
+	comments += "\n"
+	rendered := strings.Replace(string(data), "spec:\n", comments, 1)
+	if showBundleOverride {
+		rendered = strings.Replace(rendered, "    kubernetes:\n", "    kubernetes:\n        # Override the bundle selected for this Kubernetes version.\n        # bundle: "+configbundle.DefaultKubernetesBundle+"\n", 1)
+	}
+	return []byte(rendered)
 }
 
 func initNodesFromInstallers(ctx context.Context, addresses []string, timeout time.Duration) (initNodeSpecs, error) {
@@ -338,12 +340,4 @@ func validHostname(value string) bool {
 		}
 	}
 	return true
-}
-
-func kubeadmInitConfig(version string) string {
-	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: " + strings.TrimSpace(version) + "\n"
-}
-
-func kubeadmJoinConfig() string {
-	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n"
 }

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -100,7 +100,7 @@ func TestInstallDiscoverWritesClusterConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeSource() error = %v\n%s", err, data)
 	}
-	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "192.0.2.11:6443" || len(source.Spec.Nodes) != 2 {
+	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "" || source.Spec.Kubernetes.Version != configbundle.DefaultKubernetesVersion || len(source.Spec.Nodes) != 2 {
 		t.Fatalf("generated source = %#v", source)
 	}
 	if keys := source.Spec.Defaults.Identity.SSH.AuthorizedKeys; len(keys) != 1 || keys[0] != uxTestSSHKey {

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -43,11 +43,48 @@ func TestConfigInitEmitsStarterClusterConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeSource() error = %v\n%s", err, stdout.String())
 	}
-	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "192.0.2.11:6443" || len(source.Spec.Nodes) != 2 {
+	if source.Metadata.Name != "homelab" || source.Spec.ControlPlaneEndpoint != "" || source.Spec.Kubernetes.Version != configbundle.DefaultKubernetesVersion || source.Spec.Kubernetes.Bundle != "" || len(source.Spec.Nodes) != 2 {
 		t.Fatalf("generated source = %#v", source)
 	}
-	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Access.CredentialRef; got != "agent/cp-1" {
-		t.Fatalf("credentialRef = %q", got)
+	if got := source.Spec.Nodes[0].Overrides.Bootstrap.Access; got != (inventory.Access{}) {
+		t.Fatalf("generated access = %#v", got)
+	}
+	rendered := stdout.String()
+	for _, internalDefault := range []string{"katlosImage:", "wipeTarget:", "systemRoleDefaults:", "kubeadmConfigs:", "hostname:", "access:"} {
+		if strings.Contains(rendered, internalDefault) {
+			t.Fatalf("generated config contains internal default %q:\n%s", internalDefault, rendered)
+		}
+	}
+	for _, guidance := range []string{"# controlPlaneEndpoint:", "# bundle:", "# Nodes use DHCP by default"} {
+		if !strings.Contains(rendered, guidance) {
+			t.Fatalf("generated config is missing guidance %q:\n%s", guidance, rendered)
+		}
+	}
+}
+
+func TestConfigInitRendersExplicitOverrides(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519.pub")
+	if err := os.WriteFile(keyPath, []byte(uxTestSSHKey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "init",
+		"--ssh-authorized-key", keyPath,
+		"--control-plane-endpoint", "api.home.arpa:6443",
+		"--kubernetes-bundle", configbundle.DefaultKubernetesBundle,
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-cp-root",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
+	}
+	source, err := configbundle.DecodeSource(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.Spec.ControlPlaneEndpoint != "api.home.arpa:6443" || source.Spec.Kubernetes.Bundle != configbundle.DefaultKubernetesBundle {
+		t.Fatalf("explicit overrides = %#v", source.Spec)
 	}
 }
 
@@ -112,6 +149,9 @@ func TestConfigInitWithoutSSHKeysWritesEditableConfig(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "generated ClusterConfig has no SSH authorized keys") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if !strings.Contains(string(data), "# defaults:") || !strings.Contains(string(data), "#             authorizedKeys:") {
+		t.Fatalf("generated config has no commented SSH key guidance:\n%s", data)
 	}
 }
 

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -20,6 +20,8 @@ import (
 
 const validationActivationPath = "/run/extensions/katl-kubernetes.raw"
 
+const defaultNetworkdFile = "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n"
+
 type selectedKubernetes struct {
 	version        string
 	catalogRef     string
@@ -104,6 +106,9 @@ func Compile(request CompileRequest) (Plan, error) {
 			return Plan{}, fmt.Errorf("node %q: %w", name, err)
 		}
 		layer.Bootstrap.Access = portableBootstrapAccess(name, layer.Bootstrap.Access)
+		if len(layer.Networkd.Files) == 0 {
+			layer.Networkd.Files = []manifest.NetworkdFile{{Name: "10-lan.network", Content: defaultNetworkdFile}}
+		}
 		layer = applyTargetDiskDefaults(layer)
 		material, invNode, err := compileNode(config, name, role, layer, kubernetes, request.KubeadmConfigs, controlPlaneEndpoint, endpointPlan)
 		if err != nil {
@@ -318,6 +323,9 @@ func portableBootstrapAccess(node string, access inventory.Access) inventory.Acc
 	access.Method = strings.TrimSpace(access.Method)
 	access.User = strings.TrimSpace(access.User)
 	access.CredentialRef = strings.TrimSpace(access.CredentialRef)
+	if access.Method == "" && access.User == "" && access.CredentialRef == "" {
+		return inventory.Access{Method: "agent", CredentialRef: "agent/" + node}
+	}
 	if access.Method == "agent" && strings.HasPrefix(access.CredentialRef, "file:") {
 		access.CredentialRef = "agent/" + node
 	}

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -31,6 +32,9 @@ const (
 
 	BundleManifestMediaType = "application/vnd.katl.config.bundle.v1+json"
 	BundleArtifactType      = "application/vnd.katl.config.bundle.v1"
+
+	DefaultKubernetesVersion = "v1.36.1"
+	DefaultKubernetesBundle  = "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1"
 )
 
 type BuildRequest struct {
@@ -61,7 +65,7 @@ type SourceSpec struct {
 	ControlPlaneEndpoint string                                   `yaml:"controlPlaneEndpoint,omitempty" json:"controlPlaneEndpoint,omitempty"`
 	PlatformAPIEndpoint  *platformendpoint.Config                 `yaml:"platformAPIEndpoint,omitempty" json:"platformAPIEndpoint,omitempty"`
 	Kubernetes           SourceKubernetesCluster                  `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty"`
-	KatlosImage          manifest.KatlosImage                     `yaml:"katlosImage" json:"katlosImage"`
+	KatlosImage          manifest.KatlosImage                     `yaml:"katlosImage,omitempty" json:"katlosImage,omitempty"`
 	Defaults             SourceNodeLayer                          `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 	NodeClasses          map[string]SourceNodeLayer               `yaml:"nodeClasses,omitempty" json:"nodeClasses,omitempty"`
 	SystemRoleDefaults   map[inventory.SystemRole]SourceNodeLayer `yaml:"systemRoleDefaults,omitempty" json:"systemRoleDefaults,omitempty"`
@@ -228,6 +232,7 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 	if err != nil {
 		return nil, Result{}, err
 	}
+	source = defaultSource(source)
 	repoRoot := filepath.Dir(sourcePath)
 	normalized, err := marshalCanonical(source)
 	if err != nil {
@@ -333,6 +338,7 @@ func DecodeSource(reader io.Reader) (SourceConfig, error) {
 }
 
 func LowerSource(source SourceConfig) (clusterplan.Config, error) {
+	source = defaultSource(source)
 	wipe := source.Spec.Defaults.Install.WipeTarget
 	if wipe == nil || !*wipe {
 		return clusterplan.Config{}, fmt.Errorf("spec.defaults.install.wipeTarget must be true")
@@ -450,7 +456,89 @@ func selectedKubernetesVersion(source SourceConfig) string {
 	if value := strings.TrimSpace(source.Spec.Kubernetes.Version); value != "" {
 		return value
 	}
+	if bundle := strings.TrimSpace(source.Spec.Kubernetes.Bundle); bundle != "" {
+		if image, err := kubernetesbundle.ParseImageReference(bundle); err == nil {
+			return image.PayloadVersion
+		}
+	}
 	return strings.TrimSpace(source.Spec.Defaults.Kubernetes.Version)
+}
+
+func defaultSource(source SourceConfig) SourceConfig {
+	spec := source.Spec
+	spec.Nodes = append([]SourceNode(nil), spec.Nodes...)
+	if strings.TrimSpace(spec.ControlPlaneEndpoint) == "" && spec.PlatformAPIEndpoint == nil {
+		for _, node := range spec.Nodes {
+			if node.SystemRole == inventory.RoleControlPlane {
+				if address := strings.TrimSpace(node.Overrides.Bootstrap.Address); address != "" {
+					spec.ControlPlaneEndpoint = net.JoinHostPort(address, "6443")
+					break
+				}
+			}
+		}
+	}
+	version := strings.TrimSpace(spec.Kubernetes.Version)
+	bundle := strings.TrimSpace(spec.Kubernetes.Bundle)
+	catalog := strings.TrimSpace(spec.Kubernetes.CatalogRef)
+	if version == "" && bundle == "" && catalog == "" {
+		spec.Kubernetes.Version = DefaultKubernetesVersion
+		spec.Kubernetes.Bundle = DefaultKubernetesBundle
+	} else if version == DefaultKubernetesVersion && bundle == "" && catalog == "" {
+		spec.Kubernetes.Bundle = DefaultKubernetesBundle
+	}
+	if spec.Defaults.Install.WipeTarget == nil {
+		wipe := true
+		spec.Defaults.Install.WipeTarget = &wipe
+	}
+	spec.SystemRoleDefaults = cloneRoleDefaults(spec.SystemRoleDefaults)
+	cp := spec.SystemRoleDefaults[inventory.RoleControlPlane]
+	if strings.TrimSpace(cp.Kubernetes.Kubeadm.ConfigRef) == "" {
+		cp.Kubernetes.Kubeadm.ConfigRef = "control-plane"
+		spec.SystemRoleDefaults[inventory.RoleControlPlane] = cp
+	}
+	worker := spec.SystemRoleDefaults[inventory.RoleWorker]
+	if strings.TrimSpace(worker.Kubernetes.Kubeadm.ConfigRef) == "" {
+		worker.Kubernetes.Kubeadm.ConfigRef = "worker"
+		spec.SystemRoleDefaults[inventory.RoleWorker] = worker
+	}
+	spec.KubeadmConfigs = cloneKubeadmConfigs(spec.KubeadmConfigs)
+	version = selectedKubernetesVersion(SourceConfig{Spec: spec})
+	if _, ok := spec.KubeadmConfigs["control-plane"]; !ok {
+		spec.KubeadmConfigs["control-plane"] = SourceKubeadmConfig{Config: defaultKubeadmInitConfig(version)}
+	}
+	if _, ok := spec.KubeadmConfigs["worker"]; !ok {
+		spec.KubeadmConfigs["worker"] = SourceKubeadmConfig{Config: defaultKubeadmJoinConfig()}
+	}
+	source.Spec = spec
+	return source
+}
+
+func cloneRoleDefaults(source map[inventory.SystemRole]SourceNodeLayer) map[inventory.SystemRole]SourceNodeLayer {
+	cloned := make(map[inventory.SystemRole]SourceNodeLayer, len(source)+2)
+	for role, layer := range source {
+		cloned[role] = layer
+	}
+	return cloned
+}
+
+func cloneKubeadmConfigs(source map[string]SourceKubeadmConfig) map[string]SourceKubeadmConfig {
+	cloned := make(map[string]SourceKubeadmConfig, len(source)+2)
+	for name, config := range source {
+		cloned[name] = config
+	}
+	return cloned
+}
+
+func defaultKubeadmInitConfig(version string) string {
+	config := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n"
+	if version != "" {
+		config += "kubernetesVersion: " + version + "\n"
+	}
+	return config
+}
+
+func defaultKubeadmJoinConfig() string {
+	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n"
 }
 
 func resolveKubeadmConfigs(repoRoot string, source SourceConfig, kubernetesVersion string) (map[string]kubeadmconfig.Plan, error) {

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -88,6 +88,54 @@ func TestBuildArchiveWritesDeterministicBundle(t *testing.T) {
 	}
 }
 
+func TestBuildArchiveDefaultsMinimalSource(t *testing.T) {
+	sourcePath := writeSource(t, `apiVersion: config.katl.dev/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: lab
+spec:
+  kubernetes:
+    version: v1.36.1
+  defaults:
+    identity:
+      ssh:
+        authorizedKeys:
+          - `+testSSHKey+`
+  nodes:
+    - name: cp-1
+      systemRole: control-plane
+      overrides:
+        install:
+          targetDisk:
+            byID: /dev/disk/by-id/ata-cp-root
+        bootstrap:
+          address: 192.0.2.11
+`)
+	archive, result, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	if result.Manifest.Cluster.BootstrapInventory.ControlPlaneEndpoint != "192.0.2.11:6443" {
+		t.Fatalf("bootstrap inventory = %#v", result.Manifest.Cluster.BootstrapInventory)
+	}
+	if len(result.Manifest.Cluster.KubernetesPayloads) != 1 || result.Manifest.Cluster.KubernetesPayloads[0].Ref != DefaultKubernetesBundle {
+		t.Fatalf("Kubernetes payloads = %#v", result.Manifest.Cluster.KubernetesPayloads)
+	}
+	selected, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode() error = %v", err)
+	}
+	if selected.InstallManifest.Node.Identity.Hostname != "cp-1" || selected.InstallManifest.Node.Bootstrap.Access.CredentialRef != "agent/cp-1" {
+		t.Fatalf("defaulted install manifest = %#v", selected.InstallManifest)
+	}
+	if len(selected.InstallManifest.Node.Networkd.Files) != 1 || !strings.Contains(selected.InstallManifest.Node.Networkd.Files[0].Content, "DHCP=yes") {
+		t.Fatalf("defaulted networkd = %#v", selected.InstallManifest.Node.Networkd)
+	}
+	if selected.NodeMaterial.KubeadmConfig.Ref != "control-plane" || selected.KubeadmConfigs["control-plane"].Config.RenderPath == "" {
+		t.Fatalf("defaulted kubeadm = material %#v configs %#v", selected.NodeMaterial.KubeadmConfig, selected.KubeadmConfigs)
+	}
+}
+
 func TestBuildArchiveDefersKatlosImageToInstallMedia(t *testing.T) {
 	source := validSourceConfig()
 	start := strings.Index(source, "  katlosImage:\n")


### PR DESCRIPTION
Keeps the Kubernetes version visible while reducing generated ClusterConfig YAML to operator-owned choices. Katl now supplies the matching bundle, DHCP, kubeadm, wipe, endpoint, hostname, and access defaults internally, while concise comments show the common overrides.