### PR TITLE
install: accept node address selectors

### DIFF
--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -126,7 +126,11 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if err != nil {
 		return fmt.Errorf("select node from compiled cluster config: %w", err)
 	}
-	endpoint, err := resolveInstallerEndpoint(ctx, installEndpointHint(opts.endpoint, opts.nodeName, nodeName), opts.timeout)
+	endpointHint, err := installEndpointHint(opts.endpoint, opts.nodeName, nodeName)
+	if err != nil {
+		return err
+	}
+	endpoint, err := resolveInstallerEndpoint(ctx, endpointHint, opts.timeout)
 	if err != nil {
 		return err
 	}
@@ -164,15 +168,15 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	return nil
 }
 
-func installEndpointHint(endpoint, selector, nodeName string) string {
+func installEndpointHint(endpoint, selector, nodeName string) (string, error) {
 	if endpoint = strings.TrimSpace(endpoint); endpoint != "" {
-		return endpoint
+		return normalizeInstallerEndpoint(endpoint)
 	}
 	selector = strings.TrimSpace(selector)
 	if selector != "" && selector != nodeName {
-		return selector
+		return normalizeInstallerAddress(selector)
 	}
-	return ""
+	return "", nil
 }
 
 func resolveInstallNode(archive []byte, digest, selector string) (string, error) {

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -366,15 +366,23 @@ func TestInstallEndpointHint(t *testing.T) {
 		want     string
 	}{
 		{name: "explicit endpoint", endpoint: "http://installer.test:8080", selector: "192.0.2.11", nodeName: "cp-1", want: "http://installer.test:8080"},
-		{name: "address selector", selector: "192.0.2.11", nodeName: "cp-1", want: "192.0.2.11"},
+		{name: "IPv4 address selector", selector: "192.0.2.11", nodeName: "cp-1", want: "http://192.0.2.11:8080"},
+		{name: "IPv6 address selector", selector: "2001:db8::11", nodeName: "cp-1", want: "http://[2001:db8::11]:8080"},
+		{name: "hostname selector", selector: "installer.home.arpa", nodeName: "cp-1", want: "http://installer.home.arpa:8080"},
+		{name: "address with port selector", selector: "192.0.2.11:9080", nodeName: "cp-1", want: "http://192.0.2.11:9080"},
 		{name: "node name discovers", selector: "cp-1", nodeName: "cp-1"},
 		{name: "inferred node discovers", nodeName: "cp-1"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if got := installEndpointHint(test.endpoint, test.selector, test.nodeName); got != test.want {
-				t.Fatalf("installEndpointHint() = %q, want %q", got, test.want)
+			got, err := installEndpointHint(test.endpoint, test.selector, test.nodeName)
+			if err != nil || got != test.want {
+				t.Fatalf("installEndpointHint() = %q, %v, want %q", got, err, test.want)
 			}
 		})
+	}
+
+	if _, err := installEndpointHint("installer.test:8080", "192.0.2.11", "cp-1"); err == nil || !strings.Contains(err.Error(), "scheme must be http or https") {
+		t.Fatalf("bare explicit endpoint error = %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes install apply when --node is a configured IP address or hostname. The address was selected correctly but then passed to strict URL validation; it is now normalized to the installer default endpoint while explicit --endpoint remains strict.