### PR TITLE
install: reboot after successful install

### DIFF
--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -373,7 +373,7 @@ func runWriteRuntimeRoot(args []string, stdout, stderr io.Writer, cfg config) er
 		CompatibleBoot: &bootCompat{
 			Kind:              "uki",
 			RuntimeInterface:  "katl-runtime-1",
-			KernelCommandLine: []string{"rootfstype=squashfs", "ro"},
+			KernelCommandLine: runtimeKernelCommandLine(),
 		},
 		Created: time.Now().UTC().Format(time.RFC3339),
 	}
@@ -429,7 +429,7 @@ func runWriteRuntimeUKI(args []string, stdout, stderr io.Writer, cfg config) err
 			ArtifactSHA256: *runtimeSHA,
 		},
 		KernelVersion:     *kernelVersion,
-		KernelCommandLine: []string{"rootfstype=squashfs", "ro"},
+		KernelCommandLine: runtimeKernelCommandLine(),
 		Created:           time.Now().UTC().Format(time.RFC3339),
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
@@ -437,6 +437,15 @@ func runWriteRuntimeUKI(args []string, stdout, stderr io.Writer, cfg config) err
 	}
 	fmt.Fprintln(stdout, digest)
 	return nil
+}
+
+func runtimeKernelCommandLine() []string {
+	return []string{
+		"rootfstype=squashfs",
+		"ro",
+		"console=ttyS0,115200n8",
+		"console=tty0",
+	}
 }
 
 func runWriteKubernetesSysext(args []string, stdout, stderr io.Writer, cfg config) error {

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -329,6 +329,9 @@ func TestMetadataWriters(t *testing.T) {
 	if rootMetadata.CompatibleBoot == nil || rootMetadata.CompatibleBoot.Kind != "uki" {
 		t.Fatalf("runtime root boot compatibility = %#v", rootMetadata.CompatibleBoot)
 	}
+	if got := strings.Join(rootMetadata.CompatibleBoot.KernelCommandLine, " "); !strings.Contains(got, "console=ttyS0,115200n8 console=tty0") {
+		t.Fatalf("runtime root kernel command line = %q", got)
+	}
 
 	stdout.Reset()
 	if err := run([]string{
@@ -350,6 +353,9 @@ func TestMetadataWriters(t *testing.T) {
 	}
 	if ukiMetadata.KernelVersion != "6.12.0" {
 		t.Fatalf("kernelVersion = %q", ukiMetadata.KernelVersion)
+	}
+	if got := strings.Join(ukiMetadata.KernelCommandLine, " "); !strings.Contains(got, "console=ttyS0,115200n8 console=tty0") {
+		t.Fatalf("runtime UKI kernel command line = %q", got)
 	}
 
 	stdout.Reset()

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -847,12 +847,16 @@ func (rebootStep) Run(ctx context.Context, install *Context) error {
 		return ctx.Err()
 	default:
 	}
-	if install.Commands != nil {
-		if err := install.Commands.Run(ctx, "sync"); err != nil {
-			return fmt.Errorf("sync target writes: %w", err)
-		}
+	if err := recordStep(ctx, install, Reboot); err != nil {
+		return fmt.Errorf("persist reboot status: %w", err)
 	}
-	return recordStep(ctx, install, Reboot)
+	if err := install.Commands.Run(ctx, "sync"); err != nil {
+		return fmt.Errorf("sync install state: %w", err)
+	}
+	if err := install.Commands.Run(ctx, "systemctl", "--no-block", "reboot"); err != nil {
+		return fmt.Errorf("request system reboot: %w", err)
+	}
+	return nil
 }
 
 type stubStep struct {

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -77,6 +78,54 @@ func TestPreseededManifestPlanSkipsLocalConfigWait(t *testing.T) {
 
 	if got := PreseededManifestPlan().IDs(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("PreseededManifestPlan IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestRebootPersistsStatusBeforeRequest(t *testing.T) {
+	store := &MemoryStateStore{}
+	commands := &rebootCommandRunner{store: store}
+	install := &Context{Commands: commands, Store: store}
+
+	if err := (rebootStep{}).Run(context.Background(), install); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	want := []CommandCall{
+		{Name: "sync"},
+		{Name: "systemctl", Args: []string{"--no-block", "reboot"}},
+	}
+	if !reflect.DeepEqual(commands.calls, want) {
+		t.Fatalf("command calls = %#v, want %#v", commands.calls, want)
+	}
+	if commands.statusAtReboot != installstatus.StateRebootRequested {
+		t.Fatalf("status at reboot request = %q, want %q", commands.statusAtReboot, installstatus.StateRebootRequested)
+	}
+	if commands.statusAtSync != installstatus.StateRebootRequested {
+		t.Fatalf("status at sync = %q, want persisted reboot status", commands.statusAtSync)
+	}
+}
+
+func TestRebootRequestFailureIsRecorded(t *testing.T) {
+	store := &MemoryStateStore{}
+	commands := &rebootCommandRunner{store: store, rebootErr: errors.New("reboot transaction rejected")}
+	install := &Context{
+		Commands:  commands,
+		Store:     store,
+		Completed: []StepID{PrepareDisk},
+	}
+
+	err := NewRunner(Plan{rebootStep{}}, install).Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "request system reboot: reboot transaction rejected") {
+		t.Fatalf("Run() error = %v, want reboot request failure", err)
+	}
+	if len(store.Statuses) != 2 {
+		t.Fatalf("status records = %d, want reboot request and failure", len(store.Statuses))
+	}
+	if store.Statuses[0].State != installstatus.StateRebootRequested {
+		t.Fatalf("first status = %q, want %q", store.Statuses[0].State, installstatus.StateRebootRequested)
+	}
+	if got := store.Statuses[1]; got.State != installstatus.StateFailedAfterMutation || !strings.Contains(got.LastError, "request system reboot") {
+		t.Fatalf("failure status = %#v", got)
 	}
 }
 
@@ -334,8 +383,8 @@ func TestRunnerRecordsCheckpointsWithoutCommands(t *testing.T) {
 	if targetStatus.State != installstatus.StateRebootRequested || targetStatus.InstalledGeneration != "2026.06.04-000" || !targetStatus.WipeTargetAccepted {
 		t.Fatalf("target status = %#v", targetStatus)
 	}
-	if got := commandNames(commands.Calls); got != "sync" {
-		t.Fatalf("command calls = %q, want sync", got)
+	if got := commandNames(commands.Calls); got != "sync systemctl" {
+		t.Fatalf("command calls = %q, want sync and reboot request", got)
 	}
 }
 
@@ -1577,6 +1626,28 @@ type recordingOutputRunner struct {
 	outputs     map[string][]byte
 	Inputs      map[string]string
 	OutputCalls []string
+}
+
+type rebootCommandRunner struct {
+	store          *MemoryStateStore
+	calls          []CommandCall
+	statusAtReboot string
+	statusAtSync   string
+	rebootErr      error
+}
+
+func (r *rebootCommandRunner) Run(_ context.Context, name string, args ...string) error {
+	r.calls = append(r.calls, CommandCall{Name: name, Args: append([]string(nil), args...)})
+	if len(r.store.Statuses) > 0 && name == "sync" {
+		r.statusAtSync = r.store.Statuses[len(r.store.Statuses)-1].State
+	}
+	if name != "systemctl" {
+		return nil
+	}
+	if len(r.store.Statuses) > 0 {
+		r.statusAtReboot = r.store.Statuses[len(r.store.Statuses)-1].State
+	}
+	return r.rebootErr
 }
 
 func (r *recordingOutputRunner) RunInput(_ context.Context, input string, name string, args ...string) error {

--- a/internal/vmtest/first_install.go
+++ b/internal/vmtest/first_install.go
@@ -23,23 +23,24 @@ import (
 )
 
 type FirstInstallConfig struct {
-	Installer       InstallerBootConfig
-	Runtime         InstalledRuntimeConfig
-	UseInstalledESP bool
-	ESPExtractor    InstalledESPExtractor
-	Manifest        []byte
-	ManifestPath    string
-	ConfigBundle    string
-	SelectedNode    string
-	GuestHandoff    bool
-	PreseedManifest bool
-	HandoffURL      string
-	HandoffPoster   func(context.Context, string, []byte) (int, string, error)
-	TargetDisk      DiskFixture
-	DiskRunner      DiskRunner
-	PreseedRunner   DiskRunner
-	InstallerRunner VMRunner
-	RuntimeRunner   VMRunner
+	Installer           InstallerBootConfig
+	Runtime             InstalledRuntimeConfig
+	UseInstalledESP     bool
+	ESPExtractor        InstalledESPExtractor
+	Manifest            []byte
+	ManifestPath        string
+	ConfigBundle        string
+	SelectedNode        string
+	GuestHandoff        bool
+	PreseedManifest     bool
+	RebootIntoInstalled bool
+	HandoffURL          string
+	HandoffPoster       func(context.Context, string, []byte) (int, string, error)
+	TargetDisk          DiskFixture
+	DiskRunner          DiskRunner
+	PreseedRunner       DiskRunner
+	InstallerRunner     VMRunner
+	RuntimeRunner       VMRunner
 }
 
 type InstalledESPExtractor func(context.Context, DiskPlan, string) (string, error)
@@ -96,6 +97,18 @@ func RunFirstInstall(ctx context.Context, runner Runner, scenario Scenario, conf
 			config.Installer.Expect = firstInstallCompletedSignal(config)
 		}
 	}
+	if config.RebootIntoInstalled {
+		if config.Installer.InstallerISO == "" {
+			return failFirst(runner, scenario, result, "installer", errors.New("observing the installed reboot requires installer ISO media"))
+		}
+		installedSignal := first(config.Runtime.VM.Expect, config.Runtime.Expect)
+		if installedSignal == "" {
+			return failFirst(runner, scenario, result, "installer", errors.New("observing the installed reboot requires an installed boot signal"))
+		}
+		config.Installer.Expect = installedSignal
+		config.Installer.VM.Expect = installedSignal
+		config.Installer.DiskFirst = true
+	}
 	if config.GuestHandoff {
 		preseed, err := writeGuestHandoffSeedMedia(ctx, result, config, manifest)
 		if err != nil {
@@ -138,6 +151,23 @@ func RunFirstInstall(ctx context.Context, runner Runner, scenario Scenario, conf
 		}
 		now := runner.time()
 		result.addPhase("local-handoff", StatusPassed, "", now, now)
+	}
+	if config.RebootIntoInstalled {
+		if err := copyArtifact(result.Artifacts.InstallerSerial, result.Artifacts.RuntimeSerial); err != nil {
+			return failFirst(runner, scenario, result, "installed-reboot", err)
+		}
+		if err := copyArtifact(result.Artifacts.LaunchCommand, result.Artifacts.RuntimeLaunchCommand); err != nil {
+			return failFirst(runner, scenario, result, "installed-reboot", err)
+		}
+		now := runner.time()
+		result.addPhase("installed-reboot", StatusPassed, "", now, now)
+		if err := CleanupDisks(result); err != nil {
+			return failFirst(runner, scenario, result, "cleanup", err)
+		}
+		if err := runner.Write(scenario, result); err != nil {
+			return result, err
+		}
+		return result, nil
 	}
 	if config.UseInstalledESP {
 		esp, err := extractInstalledESP(ctx, result, config)

--- a/internal/vmtest/first_install_test.go
+++ b/internal/vmtest/first_install_test.go
@@ -65,6 +65,53 @@ func TestFirstInstall(t *testing.T) {
 	}
 }
 
+func TestFirstInstallObservesInstalledReboot(t *testing.T) {
+	root := t.TempDir()
+	iso := writeFixture(t, root, "katl-installer.iso", "iso")
+	_, vmConfig := vmFixture(t)
+	const installedGenerationSignal = "katl.generation=0 katl.root-slot=root-a"
+	serial := preseedInstallerEvidence() + installerCompletedSignal + "/run/katl/preseed/install-manifest.json\n" + installedGenerationSignal + "\n"
+	result, err := RunFirstInstall(context.Background(), NewRunner(Options{
+		StateRoot: root,
+		RunID:     "run-1",
+	}), Scenario{Name: "first-install-reboot"}, FirstInstallConfig{
+		Installer: InstallerBootConfig{
+			InstallerISO: iso,
+			VM:           vmConfig,
+		},
+		Runtime: InstalledRuntimeConfig{
+			Expect: installedGenerationSignal,
+			VM:     vmConfig,
+		},
+		Manifest:            []byte(firstManifest()),
+		PreseedManifest:     true,
+		RebootIntoInstalled: true,
+		TargetDisk:          TargetDisk("root", string(DiskRaw), "64M"),
+		DiskRunner:          fileDiskRunner{},
+		PreseedRunner:       fakePreseedRunner{},
+		InstallerRunner:     fakeVM(serial),
+	})
+	if err != nil {
+		t.Fatalf("RunFirstInstall() error = %v", err)
+	}
+	if result.Status != StatusPassed {
+		t.Fatalf("Status = %q, failure = %q", result.Status, result.FailureSummary)
+	}
+	if !hasPhase(result, "installed-reboot") || hasPhase(result, "runtime") {
+		t.Fatalf("phases = %#v, want same-domain installed reboot", result.Phases)
+	}
+	domainXML := readDomainXML(t, result)
+	if !strings.Contains(domainXML, `<source file="`+result.Disks[0].HostPath+`"></source>`) ||
+		!strings.Contains(domainXML, `<boot order="1"></boot>`) ||
+		!strings.Contains(domainXML, `<source file="`+iso+`"></source>`) ||
+		!strings.Contains(domainXML, `<boot order="2"></boot>`) {
+		t.Fatalf("same-domain boot order missing from domain XML:\n%s", domainXML)
+	}
+	if serial, err := os.ReadFile(result.Artifacts.RuntimeSerial); err != nil || !strings.Contains(string(serial), installedGenerationSignal) {
+		t.Fatalf("runtime serial = %q, err = %v", serial, err)
+	}
+}
+
 func TestFirstInstallFailure(t *testing.T) {
 	root := t.TempDir()
 	uki := writeFixture(t, root, "katl-installer.efi", "uki")

--- a/internal/vmtest/installer.go
+++ b/internal/vmtest/installer.go
@@ -14,6 +14,7 @@ type InstallerBootConfig struct {
 	InstallerInitrd string
 	CommandLine     []string
 	RuntimeArtifact string
+	DiskFirst       bool
 	Expect          string
 	VM              VMConfig
 }
@@ -44,7 +45,7 @@ func BootInstaller(ctx context.Context, result Result, config InstallerBootConfi
 			CommandLine: config.CommandLine,
 		}
 	} else if config.InstallerISO != "" {
-		vm.Boot = VMBoot{ISO: config.InstallerISO}
+		vm.Boot = VMBoot{ISO: config.InstallerISO, DiskFirst: config.DiskFirst}
 	} else {
 		vm.Boot = VMBoot{UKI: config.InstallerUKI}
 	}
@@ -52,6 +53,9 @@ func BootInstaller(ctx context.Context, result Result, config InstallerBootConfi
 }
 
 func checkInstallerBoot(config InstallerBootConfig) error {
+	if config.DiskFirst && config.InstallerISO == "" {
+		return errors.New("disk-first installer boot requires an ISO")
+	}
 	modes := 0
 	if config.InstallerUKI != "" {
 		modes++

--- a/internal/vmtest/libvirt_vm.go
+++ b/internal/vmtest/libvirt_vm.go
@@ -20,6 +20,7 @@ import (
 type VMBoot struct {
 	UKI           string
 	ISO           string
+	DiskFirst     bool
 	Kernel        string
 	Initrd        string
 	CommandLine   []string
@@ -1402,6 +1403,10 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 			add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
 		}
 	} else if boot.ISO != "" {
+		isoBootOrder := 1
+		if boot.DiskFirst {
+			isoBootOrder = 2
+		}
 		disks = append(disks, libvirtDisk{
 			Path:      boot.ISO,
 			Format:    DiskRaw,
@@ -1409,7 +1414,7 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 			Device:    "cdrom",
 			Bus:       "sata",
 			ReadOnly:  true,
-			BootOrder: 1,
+			BootOrder: isoBootOrder,
 		})
 		if boot.Image != "" {
 			add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
@@ -1453,6 +1458,14 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 	}
 	if diskErr != nil {
 		return nil, "", "", "", "", diskErr
+	}
+	if boot.ISO != "" && boot.DiskFirst {
+		for i := range disks {
+			if disks[i].Device == "" {
+				disks[i].BootOrder = 1
+				break
+			}
+		}
 	}
 	return disks, efiTree, efiImage, preseedImage, preseedDir, nil
 }

--- a/internal/vmtest/scenarios/installer_iso_vmtest_test.go
+++ b/internal/vmtest/scenarios/installer_iso_vmtest_test.go
@@ -151,13 +151,13 @@ install:
 	result, err := vmtest.RunFirstInstall(ctx, vmtest.NewRunner(options), vmtest.Scenario{Name: "installer-iso-first-install"}, vmtest.FirstInstallConfig{
 		Installer: vmtest.InstallerBootConfig{InstallerISO: iso, VM: vm},
 		Runtime: vmtest.InstalledRuntimeConfig{
-			Expect: "katl-boot-health generation=0 result=success",
+			Expect: "katl.generation=0 katl.root-slot=root-a",
 			VM:     vm,
 		},
-		Manifest:        manifest,
-		PreseedManifest: true,
-		UseInstalledESP: true,
-		TargetDisk:      vmtest.TargetDisk("root", string(vmtest.DiskRaw), "32G"),
+		Manifest:            manifest,
+		PreseedManifest:     true,
+		RebootIntoInstalled: true,
+		TargetDisk:          vmtest.TargetDisk("root", string(vmtest.DiskRaw), "32G"),
 	})
 	if err != nil {
 		_ = worldScenario.WriteSetupFailure(err)


### PR DESCRIPTION
The installer recorded `reboot-requested` but never asked systemd to reboot, leaving real machines halted after userspace shutdown.

Persist and flush final install state before queueing a non-blocking reboot. The ISO regression now keeps one VM alive through the guest reboot and requires the installed generation 0 kernel to boot from disk.
