### PR TITLE
katlctl: add routine host status and reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,20 @@ Supported changes compile into generation-scoped confext/sysext state and are
 applied live or on next boot according to the domain policy. See
 [Apply runtime configuration](docs/installing.md#apply-runtime-configuration).
 
+Routine host management uses the enrolled workstation context. The current
+context selects a single-node lab automatically; pass a node name in a larger
+cluster:
+
+```sh
+katlctl host status cp-1
+katlctl host reboot cp-1
+```
+
+Status and reboot results are concise text by default. Add `--output json` for
+automation. Reboot honors any generation already staged for the next boot and
+waits for a new agent instance to report healthy; `--no-wait` deliberately
+detaches after the reboot is scheduled.
+
 Host upgrades take a release version and a node from the current workstation
 context. `katlctl` resolves the published image, stages it, reboots the node,
 and waits for the new generation to pass boot health:

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/spf13/cobra"
+)
+
+const (
+	hostOutputText = "text"
+	hostOutputJSON = "json"
+)
+
+type hostStatusOptions struct {
+	target  managementTargetOptions
+	timeout time.Duration
+	output  string
+}
+
+type hostRebootOptions struct {
+	target  managementTargetOptions
+	timeout time.Duration
+	noWait  bool
+	output  string
+}
+
+type hostStatusReport struct {
+	Node          string `json:"node"`
+	Endpoint      string `json:"endpoint"`
+	Health        string `json:"health"`
+	Generation    string `json:"generation"`
+	KatlOSVersion string `json:"katlosVersion,omitempty"`
+	NextBoot      string `json:"nextBoot,omitempty"`
+	Activity      string `json:"activity"`
+}
+
+type hostRebootReport struct {
+	Node       string `json:"node"`
+	Result     string `json:"result"`
+	Generation string `json:"generation"`
+	Health     string `json:"health,omitempty"`
+}
+
+func newHostStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := hostStatusOptions{timeout: 15 * time.Second, output: hostOutputText}
+	cmd := &cobra.Command{
+		Use:   "status [NODE]",
+		Short: "Show the current state of one KatlOS host",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := selectHostNode(&opts.target.nodeName, args); err != nil {
+				return err
+			}
+			return runHostStatus(ctx, opts, stdout, stderr)
+		},
+	}
+	addManagementTargetFlags(cmd, &opts.target)
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "management request timeout")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
+	return cmd
+}
+
+func newHostRebootCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := hostRebootOptions{timeout: 10 * time.Minute, output: hostOutputText}
+	cmd := &cobra.Command{
+		Use:   "reboot [NODE]",
+		Short: "Reboot one KatlOS host and wait for it to return healthy",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := selectHostNode(&opts.target.nodeName, args); err != nil {
+				return err
+			}
+			return runHostReboot(ctx, opts, stdout, stderr)
+		},
+	}
+	addManagementTargetFlags(cmd, &opts.target)
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "time to wait for the host to return healthy")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the host schedules the reboot")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
+	return cmd
+}
+
+func selectHostNode(selected *string, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	if strings.TrimSpace(*selected) != "" {
+		return fmt.Errorf("NODE cannot be combined with --node")
+	}
+	*selected = args[0]
+	return nil
+}
+
+func runHostStatus(ctx context.Context, opts hostStatusOptions, stdout, stderr io.Writer) error {
+	_ = stderr
+	if err := validateHostOutput(opts.output); err != nil {
+		return err
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	target, err := resolveManagementTarget(opts.target)
+	if err != nil {
+		return err
+	}
+	node := hostTargetName(target)
+	requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+	defer cancel()
+	conn, err := dialKatlcAgent(requestCtx, target.endpoint, target.token)
+	if err != nil {
+		return fmt.Errorf("connect to %s at %s: %w", node, target.endpoint, err)
+	}
+	defer conn.Close()
+
+	status, current, err := readHostState(requestCtx, conn.Client, node)
+	if err != nil {
+		return err
+	}
+	report := newHostStatusReport(node, target.endpoint, status, current)
+	return writeHostStatus(stdout, opts.output, report)
+}
+
+func runHostReboot(ctx context.Context, opts hostRebootOptions, stdout, stderr io.Writer) error {
+	if err := validateHostOutput(opts.output); err != nil {
+		return err
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	target, err := resolveManagementTarget(opts.target)
+	if err != nil {
+		return err
+	}
+	node := hostTargetName(target)
+	requestCtx, cancelRequest := context.WithTimeout(ctx, opts.timeout)
+	conn, err := dialKatlcAgent(requestCtx, target.endpoint, target.token)
+	if err != nil {
+		cancelRequest()
+		return fmt.Errorf("connect to %s at %s: %w", node, target.endpoint, err)
+	}
+
+	status, _, err := readHostState(requestCtx, conn.Client, node)
+	if err != nil {
+		_ = conn.Close()
+		cancelRequest()
+		return err
+	}
+	generationID := strings.TrimSpace(status.GetBootTargetGenerationId())
+	if generationID == "" {
+		generationID = strings.TrimSpace(status.GetCurrentGenerationId())
+	}
+	previousAgentStart := status.GetAgentStartId()
+	if err := requestNodeReboot(requestCtx, conn.Client, "katlctl host reboot", status.GetMachineId(), generationID); err != nil {
+		_ = conn.Close()
+		cancelRequest()
+		return fmt.Errorf("schedule reboot for %s: %w", node, err)
+	}
+	_ = conn.Close()
+	cancelRequest()
+
+	report := hostRebootReport{Node: node, Result: "scheduled", Generation: generationID}
+	if opts.noWait {
+		return writeHostReboot(stdout, opts.output, report)
+	}
+	_, _ = fmt.Fprintf(stderr, "Reboot scheduled for %s; waiting for KatlOS to return healthy...\n", node)
+	waitCtx, cancelWait := context.WithTimeout(ctx, opts.timeout)
+	verifiedConn, verified, err := waitNodeBootHealth(waitCtx, node, target.endpoint, target.token, previousAgentStart, generationID, io.Discard)
+	cancelWait()
+	if err != nil {
+		return err
+	}
+	_ = verifiedConn.Close()
+	report.Result = "rebooted"
+	report.Health = displayHostHealth(verified.Generation)
+	return writeHostReboot(stdout, opts.output, report)
+}
+
+func readHostState(ctx context.Context, client agentapi.KatlcAgentClient, node string) (*agentapi.NodeStatus, *agentapi.Generation, error) {
+	status, err := client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("read status from %s: %w", node, err)
+	}
+	generationID := strings.TrimSpace(status.GetCurrentGenerationId())
+	if generationID == "" {
+		return nil, nil, fmt.Errorf("%s did not report a current KatlOS generation", node)
+	}
+	current, err := client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: generationID})
+	if err != nil {
+		return nil, nil, fmt.Errorf("read current generation from %s: %w", node, err)
+	}
+	return status, current, nil
+}
+
+func newHostStatusReport(node, endpoint string, status *agentapi.NodeStatus, current *agentapi.Generation) hostStatusReport {
+	activity := "idle"
+	if status.GetOperationLockHeld() {
+		activity = "busy"
+	}
+	report := hostStatusReport{
+		Node:          node,
+		Endpoint:      endpoint,
+		Health:        displayHostHealth(current),
+		Generation:    current.GetGenerationId(),
+		KatlOSVersion: strings.TrimSpace(current.GetRuntimeVersion()),
+		Activity:      activity,
+	}
+	if target := strings.TrimSpace(status.GetBootTargetGenerationId()); target != "" && target != current.GetGenerationId() {
+		report.NextBoot = target
+	}
+	return report
+}
+
+func displayHostHealth(current *agentapi.Generation) string {
+	if current.GetCommitState() == generation.CommitStateCommitted && current.GetBootState() == generation.BootStateGood && current.GetHealthState() == generation.HealthStateHealthy {
+		return "OK"
+	}
+	if health := strings.TrimSpace(current.GetHealthState()); health != "" {
+		return health
+	}
+	return "unknown"
+}
+
+func writeHostStatus(stdout io.Writer, output string, report hostStatusReport) error {
+	if output == hostOutputJSON {
+		return writeJSON(stdout, report)
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "NODE\tHEALTH\tKATLOS\tGENERATION\tNEXT BOOT\tACTIVITY"); err != nil {
+		return err
+	}
+	version := report.KatlOSVersion
+	if version == "" {
+		version = "unknown"
+	}
+	nextBoot := report.NextBoot
+	if nextBoot == "" {
+		nextBoot = "-"
+	}
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", report.Node, report.Health, version, report.Generation, nextBoot, report.Activity); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func writeHostReboot(stdout io.Writer, output string, report hostRebootReport) error {
+	if output == hostOutputJSON {
+		return writeJSON(stdout, report)
+	}
+	if report.Result == "scheduled" {
+		_, err := fmt.Fprintf(stdout, "%s reboot scheduled\n", report.Node)
+		return err
+	}
+	_, err := fmt.Fprintf(stdout, "%s rebooted successfully; health %s\n", report.Node, report.Health)
+	return err
+}
+
+func validateHostOutput(output string) error {
+	switch output {
+	case hostOutputText, hostOutputJSON:
+		return nil
+	default:
+		return fmt.Errorf("--output = %q, want text or json", output)
+	}
+}
+
+func hostTargetName(target managementTarget) string {
+	if node := strings.TrimSpace(target.nodeName); node != "" {
+		return node
+	}
+	return target.endpoint
+}

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+func TestHostStatusUsesContextAndPrintsOperatorView(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "cp-1.token")
+	if err := os.WriteFile(tokenPath, []byte("node-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := writeKatlctlConfig(t, fmt.Sprintf(`currentContext: lab
+contexts:
+- name: lab
+  cluster: homelab
+clusters:
+- name: homelab
+  nodes:
+  - name: cp-1
+    managementEndpoint: 192.0.2.10:9443
+    systemRole: control-plane
+    credentialRef: file:%s
+`, tokenPath))
+	fake := healthyHostClient("machine-secret", "agent-secret", "generation-0")
+	fake.nodeStatus.OperationLockHeld = true
+	fake.nodeStatus.ActiveOperationIds = []string{"operation-secret"}
+	fake.nodeStatus.BootTargetGenerationId = "generation-staged"
+	fake.generation.RuntimeVersion = "2026.7.0-alpha.10"
+	installKatlcDial(t, func(endpoint, token string) {
+		if endpoint != "192.0.2.10:9443" || token != "node-token" {
+			t.Fatalf("dial endpoint=%q token=%q", endpoint, token)
+		}
+	}, fake)
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"host", "status", "cp-1", "--config", configPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"NODE", "HEALTH", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	for _, internal := range []string{"machine-secret", "agent-secret", "operation-secret"} {
+		if strings.Contains(output, internal) {
+			t.Fatalf("output exposes %q:\n%s", internal, output)
+		}
+	}
+}
+
+func TestHostStatusJSON(t *testing.T) {
+	fake := healthyHostClient("machine-a", "agent-a", "generation-0")
+	installKatlcDial(t, nil, fake)
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"host", "status", "node-a", "--endpoint", "node-a.test:9443", "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	var report hostStatusReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode status: %v\n%s", err, stdout.String())
+	}
+	if report.Node != "node-a" || report.Endpoint != "node-a.test:9443" || report.Health != "OK" || report.Generation != "generation-0" || report.Activity != "idle" {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestHostRebootHonorsBootTargetAndWaits(t *testing.T) {
+	fake := healthyHostClient("machine-a", "before", "generation-0")
+	fake.nodeStatus.BootTargetGenerationId = "generation-staged"
+	fake.onReboot = func(req *agentapi.RebootRequest) {
+		fake.nodeStatus.AgentStartId = "after"
+		fake.nodeStatus.CurrentGenerationId = req.GetTargetGenerationId()
+		fake.generation.GenerationId = req.GetTargetGenerationId()
+	}
+	installKatlcDial(t, nil, fake)
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if len(fake.rebootRequests) != 1 {
+		t.Fatalf("reboot requests = %d, want 1", len(fake.rebootRequests))
+	}
+	request := fake.rebootRequests[0]
+	if request.GetActor() != "katlctl host reboot" || request.GetExpectedMachineId() != "machine-a" || request.GetTargetGenerationId() != "generation-staged" {
+		t.Fatalf("reboot request = %#v", request)
+	}
+	if got := stdout.String(); got != "node-a rebooted successfully; health OK\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "Reboot scheduled for node-a") || strings.Contains(got, "agent=") {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestHostRebootNoWaitJSON(t *testing.T) {
+	fake := healthyHostClient("machine-a", "before", "generation-0")
+	installKatlcDial(t, nil, fake)
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	var report hostRebootReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode reboot: %v\n%s", err, stdout.String())
+	}
+	if report.Node != "node-a" || report.Result != "scheduled" || report.Generation != "generation-0" || report.Health != "" {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestHostRebootReportsUnhealthyReturn(t *testing.T) {
+	fake := healthyHostClient("machine-a", "before", "generation-0")
+	fake.onReboot = func(*agentapi.RebootRequest) {
+		fake.nodeStatus.AgentStartId = "after"
+		fake.generation.HealthState = generation.HealthStateUnhealthy
+	}
+	installKatlcDial(t, nil, fake)
+
+	err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "reported generation generation-0 unhealthy after reboot") {
+		t.Fatalf("run() error = %v, want unhealthy boot error", err)
+	}
+}
+
+func TestHostRebootTimesOutWhenAgentDoesNotRestart(t *testing.T) {
+	fake := healthyHostClient("machine-a", "before", "generation-0")
+	installKatlcDial(t, nil, fake)
+	oldInterval := upgradeRebootPollInterval
+	upgradeRebootPollInterval = time.Millisecond
+	t.Cleanup(func() { upgradeRebootPollInterval = oldInterval })
+
+	err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "10ms"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "node node-a did not return healthy") {
+		t.Fatalf("run() error = %v, want reboot timeout", err)
+	}
+}
+
+func TestHostManagementRejectsDuplicateNodeSelection(t *testing.T) {
+	err := run(context.Background(), []string{"host", "status", "cp-1", "--node", "worker-1"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "NODE cannot be combined with --node") {
+		t.Fatalf("run() error = %v", err)
+	}
+}
+
+func healthyHostClient(machineID, agentStartID, generationID string) *fakeKatlcAgentClient {
+	return &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           machineID,
+			AgentStartId:        agentStartID,
+			CurrentGenerationId: generationID,
+		},
+		generation: &agentapi.Generation{
+			GenerationId: generationID,
+			CommitState:  generation.CommitStateCommitted,
+			BootState:    generation.BootStateGood,
+			HealthState:  generation.HealthStateHealthy,
+		},
+	}
+}
+
+func installKatlcDial(t *testing.T, inspect func(endpoint, token string), client agentapi.KatlcAgentClient) {
+	t.Helper()
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(_ context.Context, endpoint, token string) (katlcAgentConnection, error) {
+		if inspect != nil {
+			inspect(endpoint, token)
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+}

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -130,6 +130,8 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	cmd.AddCommand(newOperationCommand(ctx, stdout, stderr))
 
 	hostCmd := &cobra.Command{Use: "host", Short: "KatlOS host lifecycle operations"}
+	hostCmd.AddCommand(newHostStatusCommand(ctx, stdout, stderr))
+	hostCmd.AddCommand(newHostRebootCommand(ctx, stdout, stderr))
 	hostCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))
 	cmd.AddCommand(hostCmd)
 
@@ -320,7 +322,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 			return err
 		}
 		agentStart := status.GetAgentStartId()
-		if err := requestNodeReboot(ctx, conn.Client, status.GetMachineId(), request.CandidateGenerationID); err != nil {
+		if err := requestNodeReboot(ctx, conn.Client, opts.actor, status.GetMachineId(), request.CandidateGenerationID); err != nil {
 			report.Result = "staged"
 			_ = writeJSON(stdout, report)
 			return fmt.Errorf("reboot node %s: %w", report.Node, err)

--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -18,11 +18,11 @@ type verifiedNodeBoot struct {
 	Generation *agentapi.Generation
 }
 
-func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, machineID, targetGeneration string) error {
+func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, actor, machineID, targetGeneration string) error {
 	accepted, err := client.Reboot(ctx, &agentapi.RebootRequest{
 		ApiVersion:         generation.APIVersion,
 		Kind:               "RebootRequest",
-		Actor:              "katlctl upgrade rollout",
+		Actor:              strings.TrimSpace(actor),
 		ExpectedMachineId:  strings.TrimSpace(machineID),
 		TargetGenerationId: strings.TrimSpace(targetGeneration),
 	})
@@ -52,7 +52,10 @@ func waitNodeBootHealth(ctx context.Context, nodeName, endpoint, token, previous
 					if generationErr == nil {
 						if candidate.GetHealthState() == generation.HealthStateUnhealthy {
 							_ = conn.Close()
-							return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s rejected generation %s during boot health and rolled back", nodeName, targetGeneration)
+							if current := status.GetCurrentGenerationId(); current != "" && current != targetGeneration {
+								return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s rejected generation %s during boot health and returned on generation %s", nodeName, targetGeneration, current)
+							}
+							return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s reported generation %s unhealthy after reboot", nodeName, targetGeneration)
 						}
 						if status.GetCurrentGenerationId() == targetGeneration && candidate.GetCommitState() == generation.CommitStateCommitted && candidate.GetBootState() == generation.BootStateGood && candidate.GetHealthState() == generation.HealthStateHealthy {
 							return conn, verifiedNodeBoot{Status: status, Generation: candidate}, nil

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -18,6 +18,7 @@ networks.
 | Bare or disposable machine | Install generation 0 | [Install KatlOS](../installing.md) |
 | Generation 0 booted | Establish node management access | [Access installed nodes](access.md) |
 | All intended nodes installed | Create the kubeadm cluster | [Bootstrap Kubernetes](bootstrap-kubernetes.md) |
+| Installed node | Inspect or reboot one host | [Access installed nodes](access.md#routine-host-management) |
 | Installed or bootstrapped node | Change supported runtime configuration | [Apply node configuration](configure-nodes.md) |
 | Healthy installed node | Stage a new KatlOS release | [Upgrade a KatlOS host](upgrade-host.md) |
 | Cluster is intentionally being discarded | Reset boot state and reinstall | [Wipe and reinstall](wipe-reinstall.md) |

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -94,12 +94,38 @@ Inspect the resolved context after enrollment:
 
 ```sh
 katlctl config topology
-katlctl operations list --node cp-1
+katlctl host status cp-1
 ```
 
 Enrollment has already performed the authenticated agent health check. Normal
 management commands now need only `--node`; `--context` selects a non-current
 cluster. Explicit `--endpoint` and `--agent-token-file` remain expert overrides.
+
+## Routine Host Management
+
+Show the current KatlOS version, generation, any staged next boot, health, and
+whether the node is busy without exposing machine identity or operation IDs:
+
+```sh
+katlctl host status cp-1
+```
+
+Reboot a node and wait for it to return healthy:
+
+```sh
+katlctl host reboot cp-1
+```
+
+The reboot command does not require a confirmation flag. It honors the node's
+selected boot target, including a generation already staged for next boot, and
+verifies that a new agent instance returns on that generation with good boot
+health.
+Use `--no-wait` only when intentionally detaching, and `--output json` when a
+script needs structured output.
+
+Use SSH for an interactive shell and arbitrary system administration. The
+KatlOS management API intentionally exposes bounded lifecycle operations rather
+than remote command execution.
 
 There is no supported alpha token-rotation workflow. If a token is exposed,
 isolate the node and treat the evaluation identity as compromised; do not

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -135,7 +135,7 @@ func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agen
 		return nil, status.Errorf(codes.Internal, "read operation locks: %v", err)
 	}
 	if len(active) > 0 {
-		return nil, status.Errorf(codes.FailedPrecondition, "cannot reboot while operation %s is active", strings.Join(active, ","))
+		return nil, status.Error(codes.FailedPrecondition, "cannot reboot while another operation is active")
 	}
 	if s.RunReboot == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node reboot runner is not configured")
@@ -160,6 +160,14 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
 	}
 	currentGenerationID, _ := currentGenerationID(s.Root)
+	bootTargetGenerationID := currentGenerationID
+	if selection, selectionErr := generation.ReadBootSelection(s.Root); selectionErr == nil {
+		if target := strings.TrimSpace(selection.TargetBootGenerationID); target != "" {
+			bootTargetGenerationID = target
+		} else if selected := strings.TrimSpace(selection.DefaultGenerationID); selected != "" {
+			bootTargetGenerationID = selected
+		}
+	}
 	return &agentapi.NodeStatus{
 		ApiVersion:              APIVersion,
 		MachineId:               machineID,
@@ -170,6 +178,7 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 		OperationLockHeld:       len(ids) > 0,
 		ActiveOperationIds:      ids,
 		CurrentGenerationId:     currentGenerationID,
+		BootTargetGenerationId:  bootTargetGenerationID,
 	}, nil
 }
 

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -122,6 +122,46 @@ func TestRebootSchedulesCommittedSelectedGeneration(t *testing.T) {
 	}
 }
 
+func TestNodeStatusReportsSelectedBootTarget(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	selection, err := generation.ReadBootSelection(server.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection.TargetBootGenerationID = "generation-staged"
+	selection.TargetBootEntry = "loader/entries/katl-generation-staged.conf"
+	if err := generation.WriteBootSelection(server.Root, selection); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeStatus, err := server.GetNodeStatus(context.Background(), &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodeStatus.GetCurrentGenerationId() != "generation-0" || nodeStatus.GetBootTargetGenerationId() != "generation-staged" {
+		t.Fatalf("node status generations = current %q target %q", nodeStatus.GetCurrentGenerationId(), nodeStatus.GetBootTargetGenerationId())
+	}
+}
+
+func TestRebootRefusesActiveOperationWithoutExposingID(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	createAgentOperation(t, server.Store, "operation-secret")
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.Reboot(context.Background(), &agentapi.RebootRequest{
+		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
+		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
+	})
+	if status.Code(err) != codes.FailedPrecondition || !strings.Contains(err.Error(), "another operation is active") || strings.Contains(err.Error(), "operation-secret") {
+		t.Fatalf("Reboot() error = %v", err)
+	}
+}
+
 func TestSubmitOperationRecordsDestructiveReset(t *testing.T) {
 	server := newTestServer(t)
 	var dispatched atomic.Int32

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -68,6 +68,7 @@ type NodeStatus struct {
 	OperationLockHeld       bool                   `protobuf:"varint,7,opt,name=operation_lock_held,json=operationLockHeld,proto3" json:"operation_lock_held,omitempty"`
 	ActiveOperationIds      []string               `protobuf:"bytes,8,rep,name=active_operation_ids,json=activeOperationIds,proto3" json:"active_operation_ids,omitempty"`
 	CurrentGenerationId     string                 `protobuf:"bytes,9,opt,name=current_generation_id,json=currentGenerationId,proto3" json:"current_generation_id,omitempty"`
+	BootTargetGenerationId  string                 `protobuf:"bytes,10,opt,name=boot_target_generation_id,json=bootTargetGenerationId,proto3" json:"boot_target_generation_id,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -161,6 +162,13 @@ func (x *NodeStatus) GetActiveOperationIds() []string {
 func (x *NodeStatus) GetCurrentGenerationId() string {
 	if x != nil {
 		return x.CurrentGenerationId
+	}
+	return ""
+}
+
+func (x *NodeStatus) GetBootTargetGenerationId() string {
+	if x != nil {
+		return x.BootTargetGenerationId
 	}
 	return ""
 }
@@ -3166,7 +3174,7 @@ var File_internal_katlc_agentapi_agent_proto protoreflect.FileDescriptor
 const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\n" +
 	"#internal/katlc/agentapi/agent.proto\x12\rkatl.agent.v1\"\x16\n" +
-	"\x14GetNodeStatusRequest\"\xa4\x03\n" +
+	"\x14GetNodeStatusRequest\"\xdf\x03\n" +
 	"\n" +
 	"NodeStatus\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
@@ -3179,7 +3187,9 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x19supported_operation_kinds\x18\x06 \x03(\tR\x17supportedOperationKinds\x12.\n" +
 	"\x13operation_lock_held\x18\a \x01(\bR\x11operationLockHeld\x120\n" +
 	"\x14active_operation_ids\x18\b \x03(\tR\x12activeOperationIds\x122\n" +
-	"\x15current_generation_id\x18\t \x01(\tR\x13currentGenerationId\"\x8d\b\n" +
+	"\x15current_generation_id\x18\t \x01(\tR\x13currentGenerationId\x129\n" +
+	"\x19boot_target_generation_id\x18\n" +
+	" \x01(\tR\x16bootTargetGenerationId\"\x8d\b\n" +
 	"\x16SubmitOperationRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -31,6 +31,7 @@ message NodeStatus {
   bool operation_lock_held = 7;
   repeated string active_operation_ids = 8;
   string current_generation_id = 9;
+  string boot_target_generation_id = 10;
 }
 
 message SubmitOperationRequest {

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -355,7 +355,15 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 		t.Fatalf("boot selection did not change after staged config apply")
 	}
 
-	guest, client = restartGuestAndReconnect(t, ctx, node, guest, client)
+	previousBootID := guestBootID(t, ctx, client)
+	runKatlctl(t, ctx, result, katlctl, "host-reboot-staged-generation",
+		"host", "reboot", "cp-1",
+		"--endpoint", endpoint,
+		"--agent-token-file", tokenFile,
+		"--timeout", "3m",
+	)
+	_ = client.Close()
+	guest, client = reconnectGuestAfterBoot(t, ctx, node, previousBootID)
 	if got := currentGenerationFromGuest(t, ctx, guest); got != stagedGeneration {
 		t.Fatalf("booted generation = %q, want staged networkd generation %q", got, stagedGeneration)
 	}
@@ -432,6 +440,16 @@ func restartGuestAndReconnect(t *testing.T, ctx context.Context, node *RunningIn
 	if node == nil || node.handle == nil {
 		t.Fatal("running installed runtime node handle is required")
 	}
+	previousBootID := guestBootID(t, ctx, client)
+	if err := requestGuestReboot(ctx, guest); err != nil {
+		t.Fatalf("request guest reboot for staged generation restart: %v", err)
+	}
+	_ = client.Close()
+	return reconnectGuestAfterBoot(t, ctx, node, previousBootID)
+}
+
+func guestBootID(t *testing.T, ctx context.Context, client *AgentClient) string {
+	t.Helper()
 	health, err := client.Health(ctx)
 	if err != nil {
 		t.Fatalf("vmtest agent health before staged generation restart: %v", err)
@@ -440,12 +458,11 @@ func restartGuestAndReconnect(t *testing.T, ctx context.Context, node *RunningIn
 	if previousBootID == "" {
 		t.Fatal("vmtest agent health returned empty boot ID before staged generation restart")
 	}
+	return previousBootID
+}
 
-	if err := requestGuestReboot(ctx, guest); err != nil {
-		t.Fatalf("request guest reboot for staged generation restart: %v", err)
-	}
-	_ = client.Close()
-
+func reconnectGuestAfterBoot(t *testing.T, ctx context.Context, node *RunningInstalledRuntimeNode, previousBootID string) (*GuestControl, *AgentClient) {
+	t.Helper()
 	deadline := time.Now().Add(3 * time.Minute)
 	var lastErr error
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
Adds context-aware host status and host reboot workflows with readable defaults and JSON output. Reboot honors staged boot targets and waits for the restarted node to report healthy; routine output omits machine and operation identities.