### PR TITLE
vmtest: gate release-critical lifecycle journeys

### DIFF
--- a/.github/workflows/vmtest.yml
+++ b/.github/workflows/vmtest.yml
@@ -51,26 +51,33 @@ jobs:
             go_timeout: 35m
             timeout_minutes: 70
           - id: installer-boot-media
-            name: Installer Boot Media VM
+            name: Installer Media Install VM
             artifact_set: default
             package: ./internal/vmtest/scenarios
-            run: ^(TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke)$
-            go_timeout: 15m
-            timeout_minutes: 45
+            run: ^(TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke|TestInstallerISOFirstInstallSmoke)$
+            go_timeout: 35m
+            timeout_minutes: 70
           - id: installed-runtime
-            name: Installed Runtime VM
+            name: Installed Runtime Config and Management VM
             artifact_set: default
             package: ./internal/vmtest
-            run: ^(TestInstalledRuntimeKubeadmReadySmoke|TestInstalledRuntimeConfigApplyModesSmoke)$
+            run: ^TestInstalledRuntimeConfigApplyModesSmoke$
             go_timeout: 45m
             timeout_minutes: 85
           - id: two-node-bootstrap
             name: Two-Node Bootstrap VM
             artifact_set: default
             package: ./internal/vmtest/scenarios
-            run: ^TestInstalledRuntimeTwoNodeKubeadmJoinSmoke$
+            run: ^TestInstalledRuntimeTwoNodeOperationBackedBootstrapSmoke$
             go_timeout: 60m
             timeout_minutes: 110
+          - id: host-upgrade-rollback
+            name: KatlOS Upgrade and Rollback VM
+            artifact_set: default
+            package: ./internal/vmtest
+            run: ^TestInstalledRuntimeSysupdateRootUKITransfer$
+            go_timeout: 45m
+            timeout_minutes: 90
           - id: kubernetes-upgrade
             name: Kubernetes Bundle Upgrade VM
             artifact_set: default
@@ -129,7 +136,7 @@ jobs:
           nix develop .#vm -c bash -s <<'EOF'
           set -euo pipefail
           missing=()
-          for tool in jq virsh qemu-img mformat mcopy truncate sfdisk sha256sum awk realpath kubectl; do
+          for tool in jq virsh qemu-img cpio mformat mcopy mkfs.vfat mksquashfs rpm truncate sfdisk sha256sum awk realpath kubectl ukify unsquashfs xorriso zstd; do
             if ! command -v "$tool" >/dev/null 2>&1; then
               missing+=("command:$tool")
             fi

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -335,7 +335,9 @@ the local VM shell, including `nix develop .#vm`, readable `KATL_OVMF_CODE`, and
 readable `KATL_OVMF_VARS`.
 
 The workflow runs a serialized matrix so fail-fast behavior does not leave many
-VMs active at once:
+VMs active at once. The installer-media row includes a complete ISO install and
+observes the installer's autonomous reboot into generation 0; the short ISO and
+PXE checks remain fast boot-media diagnostics:
 
 ```sh
 scripts/vmtest-run --artifact-set=runtime ./internal/vmtest \
@@ -344,12 +346,18 @@ scripts/vmtest-run --artifact-set=runtime ./internal/vmtest \
 scripts/vmtest-run --artifact-set=default ./internal/vmtest \
   -run '^TestFirstInstallTargetDiskSerialSmoke$' \
   -count=1 -failfast -timeout 35m
+scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
+  -run '^(TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke|TestInstallerISOFirstInstallSmoke)$' \
+  -count=1 -failfast -timeout 35m
 scripts/vmtest-run --artifact-set=default ./internal/vmtest \
-  -run '^(TestInstalledRuntimeKubeadmReadySmoke|TestInstalledRuntimeConfigApplyModesSmoke)$' \
+  -run '^TestInstalledRuntimeConfigApplyModesSmoke$' \
   -count=1 -failfast -timeout 45m
 scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \
-  -run '^TestInstalledRuntimeTwoNodeKubeadmJoinSmoke$' \
+  -run '^TestInstalledRuntimeTwoNodeOperationBackedBootstrapSmoke$' \
   -count=1 -failfast -timeout 60m
+scripts/vmtest-run --artifact-set=default ./internal/vmtest \
+  -run '^TestInstalledRuntimeSysupdateRootUKITransfer$' \
+  -count=1 -failfast -timeout 45m
 KATL_VMTEST_KUBERNETES_BUNDLE='<digest-pinned-source-bundle>' \
 KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE='<digest-pinned-target-bundle>' \
 scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios \

--- a/docs/internal/v0.1-release-gate-matrix.md
+++ b/docs/internal/v0.1-release-gate-matrix.md
@@ -20,8 +20,10 @@ Tier 1, single-node VM host:
 
 - Everything in Tier 0.
 - `scripts/vmtest-run`, `virsh`, and an image tool such as `qemu-img` in `PATH`.
-- Disk/image helper tools used by the VM harness: `mformat`, `mcopy`,
-  `truncate`, `sfdisk`, `sha256sum`, `awk`, and `realpath`.
+- Disk/image and inspection tools used by the VM harness and artifact builder:
+  `cpio`, `mformat`, `mcopy`, `mkfs.vfat`, `mksquashfs`, `rpm`, `truncate`,
+  `sfdisk`, `sha256sum`, `ukify`, `unsquashfs`, `xorriso`, `zstd`, `awk`, and
+  `realpath`.
 - Readable OVMF code and vars images, either discovered by the VM shell or set
   with `KATL_OVMF_CODE` and `KATL_OVMF_VARS`.
 - Access to `qemu:///system`, or an explicit `KATL_VMTEST_LIBVIRT_URI`.
@@ -81,7 +83,7 @@ unbounded run. When debugging hangs, prefer one scenario and one count:
 
 ```sh
 scripts/vmtest-run --debug-on-failure ./internal/vmtest/scenarios \
-  -run '^TestInstalledRuntimeTwoNodeKubeadmJoinSmoke$' \
+  -run '^TestInstalledRuntimeTwoNodeOperationBackedBootstrapSmoke$' \
   -count=1 -failfast -timeout 45m
 ```
 
@@ -116,10 +118,11 @@ The pull-request VM workflow runs for manual dispatches and, when the repository
 variable `KATL_VMTEST_PR_ENABLED=1` is set, same-repository non-draft pull
 requests. It uses self-hosted capable runners labeled for `katl-vmtest`,
 `libvirt`, `kvm`, `ovmf`, and `vsock`. It serializes the direct runtime,
-first-install, installed-runtime ready/config-apply, and two-node bootstrap
-gates through `nix develop .#vm` using the same `scripts/vmtest-run` commands
-documented below, each with `-count=1`, `-failfast`, and an explicit Go test
-`-timeout`.
+first-install, release-media install/reboot, runtime config/management,
+operation-backed two-node bootstrap, KatlOS upgrade/rollback, and Kubernetes
+upgrade gates through `nix develop .#vm` using the same `scripts/vmtest-run`
+commands documented below, each with `-count=1`, `-failfast`, and an explicit
+Go test `-timeout`.
 
 Expected artifacts: the uploaded vmtest run directory for each matrix entry,
 excluding large VM disk images, including `world.json`, `host-capabilities.json`,
@@ -218,24 +221,47 @@ install status.
 Failure mapping: installer state-machine, disk, boot, or artifact Bead depending
 on the failed phase.
 
-### Installed Runtime And Config Apply Gate
+### Installer Release Media Gate
+
+Command:
+
+```sh
+scripts/vmtest-run ./internal/vmtest/scenarios \
+  -run '^(TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke|TestInstallerISOFirstInstallSmoke)$' \
+  -count=1 -failfast -timeout 35m
+```
+
+Tier: 1.
+
+Required before: installer ISO, PXE boot artifacts, install completion, or
+installer reboot behavior can be considered releasable. The full ISO scenario
+must observe the installed generation-0 boot in the same VM after the installer
+requests reboot; a harness-started second VM is not equivalent evidence.
+
+Expected artifacts: ISO and PXE serial logs plus the completed ISO install,
+installed disk, reboot transition, and generation-0 serial evidence.
+
+Failure mapping: installer media, service, reboot, disk, or boot Beads depending
+on the failed phase.
+
+### Installed Runtime Config And Management Gate
 
 Command:
 
 ```sh
 scripts/vmtest-run ./internal/vmtest \
-  -run '^(TestInstalledRuntimeKubeadmReadySmoke|TestInstalledRuntimeKubeadmAPISmoke|TestInstalledRuntimeConfigApplyModesSmoke)$' \
+  -run '^TestInstalledRuntimeConfigApplyModesSmoke$' \
   -count=1 -failfast -timeout 45m
 ```
 
 Tier: 1.
 
-Required before: `katlc` agent, generation metadata, config apply, kubeadm
-projection, or installed-runtime fixture changes can be considered releasable.
+Required before: `katlc` agent, generation metadata, config apply, remote host
+reboot, or installed-runtime fixture changes can be considered releasable.
 
 Expected artifacts: installed runtime serial logs, operation records, generated
-confext/generation files, kubeadm readiness evidence, and config-apply
-diagnostic artifacts.
+confext/generation files, live and next-boot apply evidence, katlctl host reboot
+evidence, post-reboot health, and config-apply diagnostic artifacts.
 
 Failure mapping: generation/config apply/kubeadm projection Beads. Missing
 fixture publication maps back to the first-install fixture Bead.
@@ -269,7 +295,7 @@ Command:
 
 ```sh
 scripts/vmtest-run ./internal/vmtest/scenarios \
-  -run '^TestInstalledRuntimeTwoNodeKubeadmJoinSmoke$' \
+  -run '^TestInstalledRuntimeTwoNodeOperationBackedBootstrapSmoke$' \
   -count=1 -failfast -timeout 60m
 ```
 
@@ -312,24 +338,7 @@ control-plane inventory, etcd reports, and per-node bootstrap status.
 Failure mapping: etcd ownership/bootstrap Beads for product failures; VM harness
 Beads for missing evidence or fixture planning failures.
 
-## Conditional Gates
-
-### Operation-Backed Bootstrap Gate
-
-Command:
-
-```sh
-scripts/vmtest-run ./internal/vmtest/scenarios \
-  -run '^TestInstalledRuntimeTwoNodeOperationBackedBootstrapSmoke$' \
-  -count=1 -failfast -timeout 60m
-```
-
-Tier: 2.
-
-Mandatory when operation-backed bootstrap behavior changes. Deferred for Beads
-that only touch artifact format or single-node runtime behavior.
-
-### Sysupdate Gate
+### KatlOS Upgrade And Rollback Gate
 
 Command:
 
@@ -341,9 +350,13 @@ scripts/vmtest-run ./internal/vmtest \
 
 Tier: 1.
 
-Mandatory when root update, UKI transfer, boot selection, rollback, or
-systemd-sysupdate behavior changes. Deferred for pure Kubernetes/bootstrap
-Beads until the v0.1 update milestone.
+Required before: KatlOS update, UKI transfer, boot selection, health promotion,
+rollback, or systemd-sysupdate behavior can be considered releasable. The gate
+stages the alternate root and UKI, boots and promotes the trial generation,
+then returns to the previous known-good generation while proving persistent
+state survives both transitions.
+
+## Conditional Gates
 
 ### BIRD And BGP API VIP Extension Gate
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,14 @@
                 mtools
                 OVMFFull
                 qemu_kvm
+                cpio
+                dosfstools
+                rpm
+                squashfsTools
+                systemdUkify
                 util-linux
+                xorriso
+                zstd
               ]
             );
 

--- a/internal/installer/bootstrapplan/plan.go
+++ b/internal/installer/bootstrapplan/plan.go
@@ -300,14 +300,6 @@ func validateRequest(kind string, intent installer.ClusterIntent, request operat
 	if strings.TrimSpace(intent.Kubernetes.PayloadVersion) != "" && request.KubernetesPayloadVersion != intent.Kubernetes.PayloadVersion {
 		return fmt.Errorf("bootstrapRequest kubernetesPayloadVersion %q does not match stored intent %q", request.KubernetesPayloadVersion, intent.Kubernetes.PayloadVersion)
 	}
-	if strings.TrimSpace(intent.Kubernetes.BundleSource) != "" || strings.TrimSpace(intent.Kubernetes.BundleRef) != "" {
-		if request.KubernetesBundleSource != intent.Kubernetes.BundleSource {
-			return fmt.Errorf("bootstrapRequest kubernetesBundleSource does not match stored intent")
-		}
-		if request.KubernetesBundleRef != intent.Kubernetes.BundleRef {
-			return fmt.Errorf("bootstrapRequest kubernetesBundleRef does not match stored intent")
-		}
-	}
 	if request.BootstrapProfileRef != intent.BootstrapProfile.Ref {
 		return fmt.Errorf("bootstrapRequest bootstrapProfileRef %q does not match stored intent %q", request.BootstrapProfileRef, intent.BootstrapProfile.Ref)
 	}

--- a/internal/installer/bootstrapplan/plan_test.go
+++ b/internal/installer/bootstrapplan/plan_test.go
@@ -228,6 +228,35 @@ func TestCreateFetchesKubernetesBundleFromStoredIntent(t *testing.T) {
 	assertNoKubeadmMutation(t, root)
 }
 
+func TestCreateAcceptsMirroredKubernetesBundle(t *testing.T) {
+	root := cleanRoot(t, "control-plane")
+	fixture := writeKubernetesBundleFixture(t, "v1.36.1", "mirrored kubernetes sysext payload")
+	server := httptest.NewTLSServer(http.FileServer(http.Dir(fixture.root)))
+	t.Cleanup(server.Close)
+	editIntent(t, root, func(intent *installer.ClusterIntent) {
+		intent.Kubernetes.BundleSource = "https://ghcr.io/v2/katl-dev/kubernetes"
+		intent.Kubernetes.BundleRef = "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1"
+	})
+	req := controlPlaneRequest()
+	req.KubernetesBundleSource = server.URL
+	req.KubernetesBundleRef = fixture.ref
+
+	plan, err := Create(Request{
+		Root:         root,
+		OperationID:  "bootstrap-init-mirrored-bundle",
+		Kind:         OperationKindInit,
+		Bootstrap:    req,
+		BundleClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	selected := plan.RuntimeInputs.SelectedKubernetesSysext
+	if selected.BundleSource != server.URL || selected.BundleRef != fixture.ref || selected.BundleManifestDigest != fixture.bundleDigest {
+		t.Fatalf("selected mirrored bundle = %#v", selected)
+	}
+}
+
 func TestCreateFetchesKubernetesBundleFromOperationWhenStoredIntentUnpinned(t *testing.T) {
 	root := cleanRoot(t, "control-plane")
 	fixture := writeKubernetesBundleFixture(t, "v1.36.1", "operation selected kubernetes sysext payload")

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -52,8 +52,11 @@ func TestCompileClusterPlan(t *testing.T) {
 	if len(cp.InstallManifest.Node.Networkd.Files) != 2 {
 		t.Fatalf("networkd files = %#v", cp.InstallManifest.Node.Networkd.Files)
 	}
-	if len(cp.NativeEtcFiles) != 3 {
+	if len(cp.NativeEtcFiles) != 4 {
 		t.Fatalf("native /etc files = %#v", cp.NativeEtcFiles)
+	}
+	if cp.NativeEtcFiles[1].Path != "/etc/ssh/authorized_keys/katl" || cp.NativeEtcFiles[1].Mode != 0o600 || cp.NativeEtcFiles[1].Content != sshKey+"\n" {
+		t.Fatalf("authorized keys confext = %#v", cp.NativeEtcFiles[1])
 	}
 	if len(cp.InstallManifest.Node.Identity.SSH.AuthorizedKeys) != 1 {
 		t.Fatalf("ssh keys were not de-duplicated: %#v", cp.InstallManifest.Node.Identity.SSH.AuthorizedKeys)

--- a/internal/installer/clusterplan/testdata/all-same-hardware.golden.json
+++ b/internal/installer/clusterplan/testdata/all-same-hardware.golden.json
@@ -89,6 +89,11 @@
           "mode": 420
         },
         {
+          "path": "/etc/ssh/authorized_keys/katl",
+          "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
+          "mode": 384
+        },
+        {
           "path": "/etc/systemd/network/10-common.network",
           "content": "[Match]\nName=enp1s0\n\n[Network]\nDHCP=yes\n",
           "mode": 420
@@ -186,6 +191,11 @@
           "path": "/etc/katl/node.json",
           "content": "{\n  \"apiVersion\": \"katl.dev/v1alpha1\",\n  \"kind\": \"NodeMetadata\",\n  \"identity\": {\n    \"hostname\": \"worker-1\"\n  },\n  \"systemRole\": \"worker\",\n  \"kubeadm\": {\n    \"configRef\": \"worker\",\n    \"configPath\": \"/etc/katl/kubeadm/worker/config.yaml\",\n    \"intent\": \"worker\"\n  },\n  \"kubernetes\": {\n    \"payloadVersion\": \"v1.36.1\",\n    \"activationPath\": \"/run/extensions/katl-kubernetes.raw\"\n  }\n}\n",
           "mode": 420
+        },
+        {
+          "path": "/etc/ssh/authorized_keys/katl",
+          "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
+          "mode": 384
         },
         {
           "path": "/etc/systemd/network/10-common.network",

--- a/internal/installer/clusterplan/testdata/basic.golden.json
+++ b/internal/installer/clusterplan/testdata/basic.golden.json
@@ -104,6 +104,11 @@
           "mode": 420
         },
         {
+          "path": "/etc/ssh/authorized_keys/katl",
+          "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
+          "mode": 384
+        },
+        {
           "path": "/etc/systemd/network/10-common.network",
           "content": "[Match]\nName=enp1s0\n\n[Network]\nDHCP=yes\n",
           "mode": 420
@@ -211,6 +216,11 @@
           "path": "/etc/katl/node.json",
           "content": "{\n  \"apiVersion\": \"katl.dev/v1alpha1\",\n  \"kind\": \"NodeMetadata\",\n  \"identity\": {\n    \"hostname\": \"worker-1\"\n  },\n  \"systemRole\": \"worker\",\n  \"kubeadm\": {\n    \"configRef\": \"worker\",\n    \"configPath\": \"/etc/katl/kubeadm/worker/config.yaml\",\n    \"intent\": \"worker\"\n  },\n  \"kubernetes\": {\n    \"payloadVersion\": \"v1.36.1\",\n    \"activationPath\": \"/run/extensions/katl-kubernetes.raw\"\n  }\n}\n",
           "mode": 420
+        },
+        {
+          "path": "/etc/ssh/authorized_keys/katl",
+          "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
+          "mode": 384
         },
         {
           "path": "/etc/systemd/network/10-common.network",

--- a/internal/installer/clusterplan/testdata/mixed-node-classes.golden.json
+++ b/internal/installer/clusterplan/testdata/mixed-node-classes.golden.json
@@ -98,6 +98,11 @@
           "mode": 420
         },
         {
+          "path": "/etc/ssh/authorized_keys/katl",
+          "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
+          "mode": 384
+        },
+        {
           "path": "/etc/systemd/network/10-common.network",
           "content": "[Match]\nName=enp1s0\n\n[Network]\nDHCP=yes\n",
           "mode": 420
@@ -209,6 +214,11 @@
           "path": "/etc/katl/node.json",
           "content": "{\n  \"apiVersion\": \"katl.dev/v1alpha1\",\n  \"kind\": \"NodeMetadata\",\n  \"identity\": {\n    \"hostname\": \"worker-1\"\n  },\n  \"systemRole\": \"worker\",\n  \"kubeadm\": {\n    \"configRef\": \"worker\",\n    \"configPath\": \"/etc/katl/kubeadm/worker/config.yaml\",\n    \"intent\": \"worker\"\n  },\n  \"kubernetes\": {\n    \"payloadVersion\": \"v1.36.1\",\n    \"activationPath\": \"/run/extensions/katl-kubernetes.raw\"\n  }\n}\n",
           "mode": 420
+        },
+        {
+          "path": "/etc/ssh/authorized_keys/katl",
+          "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
+          "mode": 384
         },
         {
           "path": "/etc/systemd/network/10-common.network",

--- a/internal/installer/configdomain/configdomain.go
+++ b/internal/installer/configdomain/configdomain.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/confext"
+	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
@@ -23,6 +24,17 @@ type RenderRequest struct {
 func NativeEtcFiles(request RenderRequest) ([]confext.NativeEtcFile, error) {
 	files := networkdFiles(request.Manifest.Node.Networkd)
 	files = append(files, sysctlFiles(request.Manifest.Node.Sysctl)...)
+	identity, err := generation.RenderSSH(request.Manifest.Node.Identity.SSH.AuthorizedKeys)
+	if err != nil {
+		return nil, err
+	}
+	files = append(files, confext.NativeEtcFile{
+		Path:    "/etc/ssh/authorized_keys/katl",
+		Content: identity.AuthorizedKeys,
+		Mode:    0o600,
+		UID:     0,
+		GID:     0,
+	})
 	ref := request.Manifest.Node.Kubernetes.Kubeadm.ConfigRef
 	var kubeadm *kubeadmconfig.Plan
 	if ref != "" {

--- a/internal/installer/configdomain/configdomain_test.go
+++ b/internal/installer/configdomain/configdomain_test.go
@@ -2,6 +2,7 @@ package configdomain
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -41,6 +42,7 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 	want := []string{
 		"/etc/katl/kubeadm/control-plane/config.yaml",
 		"/etc/katl/node.json",
+		"/etc/ssh/authorized_keys/katl",
 		"/etc/sysctl.d/90-katl.conf",
 		"/etc/systemd/network/10-lan.network",
 	}
@@ -51,7 +53,11 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 		if files[i].Path != path {
 			t.Fatalf("files[%d].Path = %q, want %q", i, files[i].Path, path)
 		}
-		if files[i].Mode != 0o644 || files[i].UID != 0 || files[i].GID != 0 {
+		wantMode := os.FileMode(0o644)
+		if path == "/etc/ssh/authorized_keys/katl" {
+			wantMode = 0o600
+		}
+		if files[i].Mode != wantMode || files[i].UID != 0 || files[i].GID != 0 {
 			t.Fatalf("files[%d] mode/owner = %04o %d:%d", i, files[i].Mode, files[i].UID, files[i].GID)
 		}
 	}
@@ -70,8 +76,11 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 	if kubernetes["payloadVersion"] != "v1.36.1" || kubernetes["activationPath"] != "/run/extensions/katl-kubernetes.raw" {
 		t.Fatalf("metadata kubernetes = %#v", kubernetes)
 	}
-	if !strings.Contains(files[2].Content, "net.ipv4.ip_forward = 1") {
-		t.Fatalf("sysctl content = %q", files[2].Content)
+	if files[2].Mode != 0o600 || !strings.Contains(files[2].Content, "ssh-ed25519") {
+		t.Fatalf("authorized keys file = %#v", files[2])
+	}
+	if !strings.Contains(files[3].Content, "net.ipv4.ip_forward = 1") {
+		t.Fatalf("sysctl content = %q", files[3].Content)
 	}
 }
 

--- a/internal/installer/generation/identity.go
+++ b/internal/installer/generation/identity.go
@@ -17,11 +17,7 @@ type IdentityRequest struct {
 
 type IdentityAssets struct {
 	MachineID      string
-	SSHDConfig     string
 	AuthorizedKeys string
-	Sysusers       string
-	HostKeyService string
-	SSHDUnitDropIn string
 }
 
 func RenderSSH(keys []string) (IdentityAssets, error) {
@@ -31,40 +27,6 @@ func RenderSSH(keys []string) (IdentityAssets, error) {
 	}
 	return IdentityAssets{
 		AuthorizedKeys: strings.Join(append(cleaned, ""), "\n"),
-		SSHDConfig: strings.Join([]string{
-			"PasswordAuthentication no",
-			"KbdInteractiveAuthentication no",
-			"PubkeyAuthentication yes",
-			"PermitRootLogin no",
-			"AuthorizedKeysFile /etc/ssh/authorized_keys/%u",
-			"AllowUsers katl",
-			"HostKey /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key",
-			"",
-		}, "\n"),
-		Sysusers: strings.Join([]string{
-			"# Katl-owned host accounts",
-			"u katl - \"Katl operator\" /home/katl /usr/bin/bash",
-			"",
-		}, "\n"),
-		HostKeyService: strings.Join([]string{
-			"[Unit]",
-			"Description=Generate Katl SSH host keys",
-			"ConditionPathExists=!/var/lib/katl/ssh/host-keys/ssh_host_ed25519_key",
-			"RequiresMountsFor=/var/lib/katl/ssh/host-keys",
-			"After=var.mount",
-			"Before=sshd.service",
-			"",
-			"[Service]",
-			"Type=oneshot",
-			"ExecStart=/usr/bin/ssh-keygen -q -t ed25519 -N \"\" -f /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key",
-			"",
-		}, "\n"),
-		SSHDUnitDropIn: strings.Join([]string{
-			"[Unit]",
-			"Wants=katl-ssh-host-keys.service",
-			"After=katl-ssh-host-keys.service",
-			"",
-		}, "\n"),
 	}, nil
 }
 
@@ -81,25 +43,6 @@ func WriteIdentity(root string, request IdentityRequest) (IdentityAssets, error)
 		return IdentityAssets{}, err
 	}
 	assets.MachineID = machineID
-	files := []struct {
-		path    string
-		content string
-		mode    os.FileMode
-	}{
-		{path: "etc/ssh/authorized_keys/katl", content: assets.AuthorizedKeys, mode: 0o600},
-		{path: "etc/ssh/sshd_config.d/10-katl.conf", content: assets.SSHDConfig, mode: 0o600},
-		{path: "etc/sysusers.d/10-katl-users.conf", content: assets.Sysusers, mode: 0o644},
-		{path: "etc/systemd/system/katl-ssh-host-keys.service", content: assets.HostKeyService, mode: 0o644},
-		{path: "etc/systemd/system/sshd.service.d/10-katl-host-keys.conf", content: assets.SSHDUnitDropIn, mode: 0o644},
-	}
-	for _, file := range files {
-		if err := writeFile(root, file.path, file.content, file.mode); err != nil {
-			return IdentityAssets{}, err
-		}
-		if err := os.Chmod(filepath.Join(root, filepath.FromSlash(file.path)), file.mode); err != nil {
-			return IdentityAssets{}, fmt.Errorf("chmod %s: %w", file.path, err)
-		}
-	}
 	return assets, nil
 }
 

--- a/internal/installer/generation/identity_test.go
+++ b/internal/installer/generation/identity_test.go
@@ -63,24 +63,6 @@ func TestRenderSSH(t *testing.T) {
 	if strings.Count(assets.AuthorizedKeys, sshKey) != 1 {
 		t.Fatalf("authorized keys = %q", assets.AuthorizedKeys)
 	}
-	for _, want := range []string{
-		"PasswordAuthentication no",
-		"KbdInteractiveAuthentication no",
-		"PermitRootLogin no",
-		"AllowUsers katl",
-		"AuthorizedKeysFile /etc/ssh/authorized_keys/%u",
-		"HostKey /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key",
-	} {
-		if !strings.Contains(assets.SSHDConfig, want) {
-			t.Fatalf("sshd config missing %q:\n%s", want, assets.SSHDConfig)
-		}
-	}
-	if !strings.Contains(assets.Sysusers, "u katl") || strings.Contains(assets.Sysusers, "root") {
-		t.Fatalf("sysusers = %q", assets.Sysusers)
-	}
-	if !strings.Contains(assets.HostKeyService, "ssh-keygen") || !strings.Contains(assets.SSHDUnitDropIn, "katl-ssh-host-keys.service") {
-		t.Fatalf("host key service/drop-in = %q / %q", assets.HostKeyService, assets.SSHDUnitDropIn)
-	}
 }
 
 func TestWriteIdentity(t *testing.T) {
@@ -93,13 +75,6 @@ func TestWriteIdentity(t *testing.T) {
 		t.Fatalf("WriteIdentity() error = %v", err)
 	}
 	assertFile(t, filepath.Join(root, "var/lib/katl/identity/machine-id"), assets.MachineID+"\n")
-	assertFile(t, filepath.Join(root, "etc/ssh/authorized_keys/katl"), assets.AuthorizedKeys)
-	assertFile(t, filepath.Join(root, "etc/ssh/sshd_config.d/10-katl.conf"), assets.SSHDConfig)
-	assertFile(t, filepath.Join(root, "etc/sysusers.d/10-katl-users.conf"), assets.Sysusers)
-	assertFile(t, filepath.Join(root, "etc/systemd/system/katl-ssh-host-keys.service"), assets.HostKeyService)
-	assertFile(t, filepath.Join(root, "etc/systemd/system/sshd.service.d/10-katl-host-keys.conf"), assets.SSHDUnitDropIn)
-	assertMode(t, filepath.Join(root, "etc/ssh/authorized_keys/katl"), 0o600)
-	assertMode(t, filepath.Join(root, "etc/ssh/sshd_config.d/10-katl.conf"), 0o600)
 }
 
 func TestRenderSSHRejectsKey(t *testing.T) {

--- a/internal/installer/generation/state.go
+++ b/internal/installer/generation/state.go
@@ -468,6 +468,7 @@ func stateDirs() []StateDir {
 		{Path: KubernetesSource, Mode: 0o755},
 		{Path: "/var/lib/katl/ssh", Mode: 0o755},
 		{Path: "/var/lib/katl/ssh/host-keys", Mode: 0o700},
+		{Path: "/var/lib/katl/home/katl", Mode: 0o700},
 		{Path: "/var/lib/containerd", Mode: 0o755},
 		{Path: "/var/lib/etcd", Mode: 0o755},
 		{Path: "/var/lib/kubelet", Mode: 0o755},
@@ -479,11 +480,16 @@ func renderTmpfiles(dirs []StateDir) string {
 	lines := make([]string, 0, len(dirs)+1)
 	lines = append(lines, "# Katl writable state seed directories")
 	for _, dir := range dirs {
+		owner := "root"
 		group := "root"
-		if dir.Path == "/var/log/journal" {
+		switch dir.Path {
+		case "/var/lib/katl/home/katl":
+			owner = "katl"
+			group = "katl"
+		case "/var/log/journal":
 			group = "systemd-journal"
 		}
-		lines = append(lines, fmt.Sprintf("d %s %04o root %s -", dir.Path, dir.Mode, group))
+		lines = append(lines, fmt.Sprintf("d %s %04o %s %s -", dir.Path, dir.Mode, owner, group))
 	}
 	return strings.Join(append(lines, ""), "\n")
 }

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -1113,8 +1113,7 @@ func TestRunnerInstallsIdentity(t *testing.T) {
 
 	machineID := "30313233343536373839616263646566"
 	assertText(t, filepath.Join(targetRoot, "var/lib/katl/identity/machine-id"), machineID+"\n")
-	assertText(t, filepath.Join(targetRoot, "etc/ssh/authorized_keys/katl"), sshKey+"\n")
-	assertContains(t, filepath.Join(targetRoot, "etc/ssh/sshd_config.d/10-katl.conf"), "AllowUsers katl")
+	assertText(t, filepath.Join(targetRoot, "var/lib/katl/generations/2026.06.01-005/confext/etc/ssh/authorized_keys/katl"), sshKey+"\n")
 	assertContains(t, filepath.Join(bootRoot, "loader/entries/katl-2026.06.01-005.conf"), "systemd.machine_id="+machineID)
 	assertText(t, filepath.Join(targetRoot, "var/lib/katl/generations/2026.06.01-005/confext/etc/extension-release.d/extension-release.katl-node"), "ID=fedora\nVERSION_ID=0.1.0\nCONFEXT_LEVEL=1\n")
 }

--- a/internal/scriptstest/installer_iso_scripts_test.go
+++ b/internal/scriptstest/installer_iso_scripts_test.go
@@ -174,9 +174,49 @@ func TestInstallerConsoleAndVMGateContract(t *testing.T) {
 			t.Fatalf("installer dual-console journal routing missing %q", value)
 		}
 	}
-	for _, value := range []string{"Installer Boot Media VM", "TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke"} {
+	for _, value := range []string{"Installer Media Install VM", "TestInstallerISOBootSmoke|TestInstallerPXEBootSmoke|TestInstallerISOFirstInstallSmoke"} {
 		if !strings.Contains(workflow, value) {
 			t.Fatalf("installer ISO VM workflow missing %q", value)
+		}
+	}
+}
+
+func TestVMWorkflowCoversReleaseCriticalJourneys(t *testing.T) {
+	repo := repoRoot(t)
+	workflow := string(mustReadFile(t, filepath.Join(repo, ".github/workflows/vmtest.yml")))
+	flake := string(mustReadFile(t, filepath.Join(repo, "flake.nix")))
+
+	for _, value := range []string{
+		"^TestInstalledRuntimeConfigApplyModesSmoke$",
+		"^TestInstalledRuntimeTwoNodeOperationBackedBootstrapSmoke$",
+		"^TestInstalledRuntimeSysupdateRootUKITransfer$",
+	} {
+		if !strings.Contains(workflow, value) {
+			t.Fatalf("release-critical VM workflow missing %q", value)
+		}
+	}
+	for _, stale := range []string{
+		"TestInstalledRuntimeKubeadmReadySmoke",
+		"TestInstalledRuntimeTwoNodeKubeadmJoinSmoke",
+	} {
+		if strings.Contains(workflow, stale) {
+			t.Fatalf("VM workflow still selects stale pre-operation scenario %q", stale)
+		}
+	}
+	for _, dependency := range []string{"cpio", "dosfstools", "rpm", "squashfsTools", "systemdUkify", "xorriso", "zstd"} {
+		if !strings.Contains(flake, dependency) {
+			t.Fatalf("VM development shell does not provide %q", dependency)
+		}
+	}
+	for _, tool := range []string{"cpio", "mkfs.vfat", "mksquashfs", "rpm", "ukify", "unsquashfs", "xorriso", "zstd"} {
+		if !strings.Contains(workflow, tool) {
+			t.Fatalf("VM capable-host preflight does not require %q", tool)
+		}
+	}
+	runner := string(mustReadFile(t, filepath.Join(repo, "scripts/vmtest-run")))
+	for _, value := range []string{`scripts/mkosi" builder-version`, `-mkosi-version "$mkosi_version"`} {
+		if !strings.Contains(runner, value) {
+			t.Fatalf("VM resource lock does not record the containerized builder identity %q", value)
 		}
 	}
 }

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -109,6 +109,38 @@ func TestMkosiDirectRejectsRuntimePackaging(t *testing.T) {
 	}
 }
 
+func TestMkosiBuilderVersionUsesContainer(t *testing.T) {
+	repo := repoRoot(t)
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", bin, err)
+	}
+	writeFakeExecutable(t, bin, "podman", `if [[ "${1:-}" == "image" && "${2:-}" == "exists" ]]; then
+  exit 0
+fi
+if [[ "$*" == "run --rm localhost/katl-mkosi-builder:fedora-44-go-squashfs mkosi --version" ]]; then
+  printf 'mkosi 26\n'
+  exit 0
+fi
+exit 2
+`)
+
+	cmd := exec.Command(filepath.Join(repo, "scripts", "mkosi"), "builder-version")
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"KATL_CONTAINER_RUNTIME=podman",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scripts/mkosi builder-version failed: %v\n%s", err, output)
+	}
+	if got := strings.TrimSpace(string(output)); got != "26" {
+		t.Fatalf("builder version = %q, want 26", got)
+	}
+}
+
 func TestMkosiPodmanSkipsRecursiveBuildChown(t *testing.T) {
 	repo := repoRoot(t)
 	tmp := t.TempDir()

--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -112,6 +112,36 @@ func TestOperatorConsoleOwnsTTY1AndPreservesRecoveryAccess(t *testing.T) {
 	}
 }
 
+func TestRuntimeOwnsPersistentSSHIdentity(t *testing.T) {
+	repo := repoRoot(t)
+	extra := filepath.Join(repo, "mkosi.profiles", "runtime", "mkosi.extra")
+	sshd := string(mustReadFile(t, filepath.Join(extra, "etc", "ssh", "sshd_config.d", "10-katl.conf")))
+	assertTextContains(t, sshd,
+		"AuthorizedKeysFile /etc/ssh/authorized_keys/%u",
+		"AllowUsers katl",
+		"HostKey /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key",
+	)
+	hostKeys := string(mustReadFile(t, filepath.Join(extra, "usr", "lib", "systemd", "system", "katl-ssh-host-keys.service")))
+	assertTextContains(t, hostKeys,
+		"RequiresMountsFor=/var/lib/katl/ssh/host-keys",
+		"Before=sshd.service",
+		`ExecStart=/usr/bin/ssh-keygen -q -t ed25519 -N "" -f /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key`,
+	)
+	keygenDropIn := string(mustReadFile(t, filepath.Join(extra, "usr", "lib", "systemd", "system", "sshd-keygen@.service.d", "10-katl-persistent-host-key.conf")))
+	assertTextContains(t, keygenDropIn, "ConditionPathExists=/var/lib/katl/ssh/enable-distribution-host-key-generator")
+	sysusers := string(mustReadFile(t, filepath.Join(extra, "usr", "lib", "sysusers.d", "10-katl-users.conf")))
+	assertTextContains(t, sysusers, `u katl - "Katl operator" /var/lib/katl/home/katl /usr/bin/bash`)
+
+	runtimeCheck := string(mustReadFile(t, filepath.Join(repo, "scripts", "check-runtime-root")))
+	assertTextContains(t, runtimeCheck,
+		"/etc/ssh/sshd_config.d/10-katl.conf",
+		"/usr/lib/systemd/system/katl-ssh-host-keys.service",
+		"/usr/lib/systemd/system/sshd.service.d/10-katl-host-keys.conf",
+		"/usr/lib/systemd/system/sshd-keygen@.service.d/10-katl-persistent-host-key.conf",
+		"/usr/lib/sysusers.d/10-katl-users.conf",
+	)
+}
+
 func runRuntimeBuild(t *testing.T, repo, bin, dest, support string) {
 	t.Helper()
 	cmd := exec.Command(filepath.Join(repo, "mkosi.profiles", "runtime", "mkosi.build"))

--- a/internal/vmtest/installed.go
+++ b/internal/vmtest/installed.go
@@ -35,6 +35,7 @@ var runtimeConsoleOptions = []string{
 var runtimeVMTestOptions = append([]string{"katl.vmtest_agent=1"}, runtimeConsoleOptions...)
 
 const runtimeBootSignal = "Katl runtime reached systemd userspace"
+const runtimeKernelBootSignal = "katl.generation="
 const runtimeDebugShellOption = "katl.vmtest_debug_shell=1"
 
 type installedRuntimeRecord struct {
@@ -81,7 +82,11 @@ func RunInstalledRuntime(ctx context.Context, result Result, config InstalledRun
 	}
 	vm := config.VM
 	vm.Phase = "runtime"
-	vm.Expect = first(vm.Expect, config.Expect, runtimeBootSignal)
+	defaultSignal := runtimeBootSignal
+	if config.RequireVMTestAgent || vm.Agent.RequireHealth {
+		defaultSignal = runtimeKernelBootSignal
+	}
+	vm.Expect = first(vm.Expect, config.Expect, defaultSignal)
 	vm.Boot = VMBoot{
 		Image:         config.Disk,
 		ImageFormat:   diskFormat(config.DiskFormat),

--- a/internal/vmtest/installed_node.go
+++ b/internal/vmtest/installed_node.go
@@ -49,7 +49,7 @@ func StartInstalledRuntimeNode(ctx context.Context, parent Result, config Instal
 	}
 	vm := runtime.VM
 	vm.Phase = "runtime"
-	vm.Expect = first(vm.Expect, runtime.Expect, runtimeBootSignal)
+	vm.Expect = first(vm.Expect, runtime.Expect, runtimeKernelBootSignal)
 	vm.Boot = VMBoot{
 		Image:         runtime.Disk,
 		ImageFormat:   diskFormat(runtime.DiskFormat),

--- a/internal/vmtest/installed_test.go
+++ b/internal/vmtest/installed_test.go
@@ -109,7 +109,7 @@ func TestInstalledRuntimeWithVMTestAgent(t *testing.T) {
 	}
 	_, vmConfig := vmFixture(t)
 	runner := VMRunner{
-		Executor: vmExec{write: runtimeBootSignal},
+		Executor: vmExec{write: runtimeKernelBootSignal},
 		probe: probe{
 			lookPath: func(string) (string, error) { return "/usr/bin/virsh", nil },
 			stat:     os.Stat,

--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -1780,6 +1780,7 @@ func appendHostEnv(env []string, tools fakeHostTools, extra ...string) []string 
 		"KATL_VMTEST_VSOCK_DEVICE="+tools.vsock,
 		"KATL_VMTEST_KUBECTL="+tools.kubectl,
 		"KATL_VMTEST_RESOURCE_LOCK="+tools.resourceLock,
+		"KATL_VMTEST_MKOSI_VERSION=26",
 		"KATL_VMTEST_AUTO_REBUILD=0",
 		"KATL_FAKE_CHILD_WORLD_SCENARIO=fake vm scenario",
 		"KATL_VMTEST_KEEP=always",

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -129,6 +129,7 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 		"--candidate-generation", candidateGeneration,
 		"--client-request-id", "vmtest-host-upgrade-"+candidateGeneration,
 		"--actor", "installed runtime host upgrade vmtest",
+		"--no-wait",
 	)
 	var accepted agentapi.OperationAccepted
 	mustUnmarshalProtoJSON(t, acceptedData, &accepted)

--- a/internal/vmtest/world_scenario.go
+++ b/internal/vmtest/world_scenario.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 type NodeRole string
@@ -288,21 +290,25 @@ func lockLeaseFile(path string) (func(), error) {
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		return nil, err
 	}
-	var lock *os.File
-	var err error
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
 	for i := 0; i < 100; i++ {
-		lock, err = os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+		err = unix.Flock(int(lock.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 		if err == nil {
 			return func() {
+				_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
 				_ = lock.Close()
-				_ = os.Remove(lockPath)
 			}, nil
 		}
-		if !errors.Is(err, os.ErrExist) {
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			_ = lock.Close()
 			return nil, err
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	_ = lock.Close()
 	return nil, fmt.Errorf("timed out waiting for lease lock %s", lockPath)
 }
 

--- a/internal/vmtest/world_scenario_test.go
+++ b/internal/vmtest/world_scenario_test.go
@@ -95,6 +95,25 @@ func TestWorldScenarioRejectsReservedAndDuplicateAddresses(t *testing.T) {
 	}
 }
 
+func TestLeaseLockIgnoresStaleMarker(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "leases.json")
+	if err := os.WriteFile(path+".lock", nil, 0o600); err != nil {
+		t.Fatalf("write stale lock marker: %v", err)
+	}
+
+	unlock, err := lockLeaseFile(path)
+	if err != nil {
+		t.Fatalf("lockLeaseFile() with stale marker: %v", err)
+	}
+	unlock()
+
+	unlock, err = lockLeaseFile(path)
+	if err != nil {
+		t.Fatalf("lockLeaseFile() after release: %v", err)
+	}
+	unlock()
+}
+
 func TestWorldScenarioReportsExhaustedCIDR(t *testing.T) {
 	world := testWorld(t)
 	world.Network.CIDR = "10.77.0.1/32"

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -18,7 +18,7 @@
     {
       "name": "runtime",
       "path": "mkosi.profiles/runtime",
-      "configSHA256": "64e34b5a505b008e7861031323cd9af98230ae61526f404a02dbb4cb469df49e",
+      "configSHA256": "4357aa997da348d3957ae15e85cedaf05a63ad7d29760394dca7a159a33d3d8e",
       "packageSetRef": "runtime",
       "mkosiVersion": "26"
     },
@@ -1225,7 +1225,7 @@
       "name": "katlos-install-image",
       "source": "scripts/build-katlos-install-image",
       "distribution": "katl",
-      "release": "2026.7.0-alpha.1",
+      "release": "2026.7.0-dev.1",
       "architecture": "x86_64",
       "repositories": [
         {

--- a/mkosi.profiles/runtime/mkosi.extra/etc/ssh/sshd_config.d/10-katl.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/etc/ssh/sshd_config.d/10-katl.conf
@@ -1,0 +1,7 @@
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+PermitRootLogin no
+AuthorizedKeysFile /etc/ssh/authorized_keys/%u
+AllowUsers katl
+HostKey /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-ssh-host-keys.service
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-ssh-host-keys.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Generate Katl SSH host keys
+ConditionPathExists=!/var/lib/katl/ssh/host-keys/ssh_host_ed25519_key
+RequiresMountsFor=/var/lib/katl/ssh/host-keys
+After=var.mount
+Before=sshd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ssh-keygen -q -t ed25519 -N "" -f /var/lib/katl/ssh/host-keys/ssh_host_ed25519_key

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/sshd-keygen@.service.d/10-katl-persistent-host-key.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/sshd-keygen@.service.d/10-katl-persistent-host-key.conf
@@ -1,0 +1,3 @@
+[Unit]
+# Katl owns the persistent host key instead of writing host keys to immutable /etc.
+ConditionPathExists=/var/lib/katl/ssh/enable-distribution-host-key-generator

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/sshd.service.d/10-katl-host-keys.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/sshd.service.d/10-katl-host-keys.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=katl-ssh-host-keys.service
+After=katl-ssh-host-keys.service

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/sysusers.d/10-katl-users.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/sysusers.d/10-katl-users.conf
@@ -1,0 +1,2 @@
+# Katl-owned host accounts
+u katl - "Katl operator" /var/lib/katl/home/katl /usr/bin/bash

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/tmpfiles.d/katl-state.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/tmpfiles.d/katl-state.conf
@@ -16,6 +16,7 @@ d /var/lib/katl/kubernetes 0755 root root -
 d /var/lib/katl/kubernetes/etc-kubernetes 0755 root root -
 d /var/lib/katl/ssh 0755 root root -
 d /var/lib/katl/ssh/host-keys 0700 root root -
+d /var/lib/katl/home/katl 0700 katl katl -
 d /var/lib/containerd 0755 root root -
 d /var/lib/etcd 0755 root root -
 d /var/lib/kubelet 0755 root root -

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -181,6 +181,7 @@ for path in \
     /usr/bin/resolvectl \
     /usr/bin/sshd \
     /usr/bin/ssh-keygen \
+	/etc/ssh/sshd_config.d/10-katl.conf \
     /usr/bin/conntrack \
     /usr/bin/iptables-nft \
     /usr/bin/ipset \
@@ -207,6 +208,10 @@ for path in \
     /usr/lib/systemd/systemd-import \
     /usr/lib/systemd/systemd-sysupdate \
     /usr/lib/systemd/system/sshd.service \
+	/usr/lib/systemd/system/katl-ssh-host-keys.service \
+	/usr/lib/systemd/system/sshd.service.d/10-katl-host-keys.conf \
+	/usr/lib/systemd/system/sshd-keygen@.service.d/10-katl-persistent-host-key.conf \
+	/usr/lib/sysusers.d/10-katl-users.conf \
     /usr/lib/systemd/system/containerd.service \
     /usr/lib/systemd/system/var.mount \
     /usr/lib/systemd/system/etc-kubernetes.mount \

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -529,6 +529,25 @@ if ! image_exists; then
     "$runtime" "${build_flags[@]}" "$repo_root"
 fi
 
+if [[ "${1:-}" == builder-version ]]; then
+    if [[ $# -ne 1 ]]; then
+        echo "error: builder-version does not accept arguments" >&2
+        exit 2
+    fi
+    if [[ "$runtime" == direct ]]; then
+        version="$(mkosi --version)"
+    else
+        version="$("$runtime" run --rm "$image" mkosi --version)"
+    fi
+    version="${version#mkosi }"
+    [[ -n "$version" ]] || {
+        echo "error: mkosi builder returned an empty version" >&2
+        exit 1
+    }
+    printf '%s\n' "$version"
+    exit 0
+fi
+
 if [[ $# -eq 0 ]]; then
     cache_target=installer
     prepare_cached_target "$cache_target"

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -492,16 +492,22 @@ prepare_resource_manifest() {
         return 0
     fi
 
-    local revision
+	local revision mkosi_version
 	local -a lock_args
     revision="$(git_revision)"
+	mkosi_version="${KATL_VMTEST_MKOSI_VERSION:-}"
+	if [[ -z "$mkosi_version" ]] && ! mkosi_version="$("$repo_root/scripts/mkosi" builder-version)"; then
+		setup_failures+=("detect the containerized mkosi builder version")
+		return 1
+	fi
     printf 'vmtest validating current repo artifacts: katl-resource-lock prepare-mkosi --mode strict\n' >&2
 	lock_args=(prepare-mkosi \
         -manifest "$resource_manifest" \
         -lock "$package_lock" \
         -mode strict \
         -run-id "$run_id" \
-		-git-revision "$revision")
+		-git-revision "$revision" \
+		-mkosi-version "$mkosi_version")
 	if vmtest_requests_kubernetes_upgrade; then
 		# The committed lock names the selected release payload. Upgrade tests
 		# deliberately build a different source payload, so validate the KatlOS


### PR DESCRIPTION
Make complete install, config/management, operation-backed bootstrap, and KatlOS upgrade/rollback journeys mandatory in pull-request VM CI. Fix the runtime identity, bundle transport, readiness, lease locking, and stale harness assumptions those newly active gates exposed.