### PR TITLE
build: automate Fedora package-lock updates

### DIFF
--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -1,6 +1,7 @@
 name: Fast Checks
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -49,6 +50,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             range="origin/${{ github.base_ref }}...HEAD"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            range="origin/main...HEAD"
           elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
             range="${{ github.event.before }}..HEAD"
           else

--- a/.github/workflows/fedora-package-lock.yml
+++ b/.github/workflows/fedora-package-lock.yml
@@ -1,0 +1,147 @@
+name: Fedora Package Lock
+
+on:
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: fedora-package-lock
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update Fedora Package Lock
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    env:
+      GOTOOLCHAIN: auto
+      KATL_ARCHITECTURE: x86_64
+      KATL_CONTAINER_RUNTIME: docker
+      KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
+      KATL_VERSION: 0.0.0-package-lock
+      KATL_VMTEST_IMAGE_SUPPORT: "0"
+
+    steps:
+      - name: Check for an open package-lock update
+        id: existing
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const exists = pulls.some((pull) =>
+              pull.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}` &&
+              pull.head.ref.startsWith("automation/fedora-package-lock-")
+            );
+            core.setOutput("exists", exists ? "true" : "false");
+
+      - name: Check out repository
+        if: steps.existing.outputs.exists != 'true'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        if: steps.existing.outputs.exists != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Restore Katl Go build caches
+        if: steps.existing.outputs.exists != 'true'
+        uses: actions/cache@v6
+        with:
+          path: |
+            _build/go-mod
+            _build/go-cache
+          key: fedora-lock-go-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: |
+            fedora-lock-go-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-
+
+      - name: Restore mkosi package cache
+        if: steps.existing.outputs.exists != 'true'
+        uses: actions/cache@v6
+        with:
+          path: _build/mkosi/package-cache
+          key: fedora-lock-mkosi-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-44-${{ github.run_id }}
+          restore-keys: |
+            fedora-lock-mkosi-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-44-
+            katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
+
+      - name: Rebuild and refresh package lock
+        if: steps.existing.outputs.exists != 'true'
+        run: scripts/update-fedora-package-lock
+
+      - name: Detect package changes
+        if: steps.existing.outputs.exists != 'true'
+        id: changes
+        shell: bash
+        run: |
+          if git diff --quiet -- mkosi.profiles/resource-package-lock.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify generated lock
+        if: steps.changes.outputs.changed == 'true'
+        run: go test ./cmd/katl-resource-lock ./internal/resourcetest ./internal/scriptstest
+
+      - name: Commit package-lock update
+        if: steps.changes.outputs.changed == 'true'
+        id: branch
+        shell: bash
+        run: |
+          branch="automation/fedora-package-lock-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add mkosi.profiles/resource-package-lock.json
+          git commit -m "build: update Fedora package lock"
+          git push --set-upstream origin "$branch"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open ready pull request and enable auto-merge
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/github-script@v8
+        env:
+          HEAD_BRANCH: ${{ steps.branch.outputs.name }}
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: "main",
+              head: process.env.HEAD_BRANCH,
+              title: "build: update Fedora package lock",
+              body: "Updates the committed Fedora 44 package identities to the current stable repositories. The lock continues to block release builds from consuming unreviewed repository drift.",
+              draft: false,
+            });
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "fast-checks.yml",
+              ref: process.env.HEAD_BRANCH,
+            });
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH
+                }) {
+                  pullRequest { number }
+                }
+              }
+            `, { pullRequestId: pull.node_id });

--- a/cmd/katl-resource-lock/main.go
+++ b/cmd/katl-resource-lock/main.go
@@ -242,6 +242,13 @@ func runPrepareMkosi(args []string, stdout, stderr io.Writer) error {
 	if *gitRevision == "" {
 		*gitRevision = "unknown"
 	}
+	selectedSets, err := packageSetNames(packageSets)
+	if err != nil {
+		return err
+	}
+	includePackageSet := func(name string) bool {
+		return len(selectedSets) == 0 || selectedSets[name]
+	}
 
 	manifest := resourcetest.NewManifest(*runID, resourcetest.GitState{Revision: *gitRevision})
 	mkosiVersion, err := resolveMkosiVersion(*mkosiVersionFlag)
@@ -258,31 +265,43 @@ func runPrepareMkosi(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := addInstallerPackageSet(&manifest, filepath.Join(*mkosiDir, "katl-installer.packages.tsv"), repo, ""); err != nil {
-		return err
-	}
-	if err := addRuntimePackageSet(&manifest, *runtimeRoot, repo, ""); err != nil {
-		return err
-	}
-	if err := addKubernetesPackageSet(&manifest, filepath.Join(*mkosiDir, "katl-kubernetes.raw.json"), repo, ""); err != nil {
-		return err
-	}
-	katlosImage, err := findKatlOSImage(*mkosiDir)
-	if err != nil {
-		return err
-	}
-	if katlosImage != "" {
-		if err := addKatlOSPackageSet(&manifest, katlosImage, ""); err != nil {
+	if includePackageSet("installer-image") {
+		if err := addInstallerPackageSet(&manifest, filepath.Join(*mkosiDir, "katl-installer.packages.tsv"), repo, ""); err != nil {
 			return err
+		}
+	}
+	if includePackageSet("runtime") {
+		if err := addRuntimePackageSet(&manifest, *runtimeRoot, repo, ""); err != nil {
+			return err
+		}
+	}
+	if includePackageSet("kubernetes-sysext") {
+		if err := addKubernetesPackageSet(&manifest, filepath.Join(*mkosiDir, "katl-kubernetes.raw.json"), repo, ""); err != nil {
+			return err
+		}
+	}
+	if includePackageSet("katlos-install-image") {
+		katlosImage, err := findKatlOSImage(*mkosiDir)
+		if err != nil {
+			return err
+		}
+		if katlosImage != "" {
+			if err := addKatlOSPackageSet(&manifest, katlosImage, ""); err != nil {
+				return err
+			}
+		}
+	}
+	if *mode == "refresh" && len(selectedSets) > 0 {
+		for name := range selectedSets {
+			if !hasPackageSet(manifest.PackageSets, name) {
+				return fmt.Errorf("selected package set %q is missing from generated artifacts", name)
+			}
 		}
 	}
 	lockDigest := ""
 	switch *mode {
 	case "refresh":
-		if len(packageSets) != 0 {
-			return errors.New("--package-set requires --mode strict")
-		}
-		lock, err := resourcetest.PackageLockFromManifest(manifest)
+		lock, err := refreshedPackageLock(*lockPath, manifest, packageSets)
 		if err != nil {
 			return err
 		}
@@ -329,6 +348,111 @@ func runPrepareMkosi(args []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stdout, "lockSHA256: %s\n", lockDigest)
 	}
 	return nil
+}
+
+func hasPackageSet(sets []resourcetest.PackageSet, name string) bool {
+	for _, set := range sets {
+		if set.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func refreshedPackageLock(lockPath string, manifest resourcetest.Manifest, packageSets []string) (resourcetest.PackageLock, error) {
+	fresh, err := resourcetest.PackageLockFromManifest(manifest)
+	if err != nil {
+		return resourcetest.PackageLock{}, err
+	}
+	selected, err := packageSetNames(packageSets)
+	if err != nil {
+		return resourcetest.PackageLock{}, err
+	}
+	if len(selected) == 0 {
+		return fresh, nil
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return resourcetest.PackageLock{}, fmt.Errorf("read package lock %s for partial refresh: %w", lockPath, err)
+	}
+	existing, err := resourcetest.DecodePackageLock(bytes.NewReader(data))
+	if err != nil {
+		return resourcetest.PackageLock{}, fmt.Errorf("decode package lock %s for partial refresh: %w", lockPath, err)
+	}
+
+	freshSets := make(map[string]resourcetest.PackageLockPackageSet, len(fresh.PackageSets))
+	for _, set := range fresh.PackageSets {
+		freshSets[set.Name] = set
+	}
+	for name := range selected {
+		if _, ok := freshSets[name]; !ok {
+			return resourcetest.PackageLock{}, fmt.Errorf("selected package set %q is missing from generated package lock", name)
+		}
+	}
+
+	updatedSets := make([]resourcetest.PackageLockPackageSet, 0, len(existing.PackageSets)+len(selected))
+	replacedSets := make(map[string]bool, len(selected))
+	for _, set := range existing.PackageSets {
+		if replacement, ok := freshSets[set.Name]; ok && selected[set.Name] {
+			updatedSets = append(updatedSets, replacement)
+			replacedSets[set.Name] = true
+			continue
+		}
+		updatedSets = append(updatedSets, set)
+	}
+	for _, set := range fresh.PackageSets {
+		if selected[set.Name] && !replacedSets[set.Name] {
+			updatedSets = append(updatedSets, set)
+		}
+	}
+
+	freshProfiles := make(map[string]resourcetest.PackageLockProfile, len(fresh.MkosiProfiles))
+	for _, profile := range fresh.MkosiProfiles {
+		if selected[profile.PackageSetRef] {
+			freshProfiles[profile.Name] = profile
+		}
+	}
+	updatedProfiles := make([]resourcetest.PackageLockProfile, 0, len(existing.MkosiProfiles)+len(freshProfiles))
+	replacedProfiles := make(map[string]bool, len(freshProfiles))
+	for _, profile := range existing.MkosiProfiles {
+		if !selected[profile.PackageSetRef] {
+			updatedProfiles = append(updatedProfiles, profile)
+			continue
+		}
+		if replacement, ok := freshProfiles[profile.Name]; ok {
+			updatedProfiles = append(updatedProfiles, replacement)
+			replacedProfiles[profile.Name] = true
+		}
+	}
+	for _, profile := range fresh.MkosiProfiles {
+		if selected[profile.PackageSetRef] && !replacedProfiles[profile.Name] {
+			updatedProfiles = append(updatedProfiles, profile)
+		}
+	}
+
+	existing.Tools = fresh.Tools
+	existing.PackageSets = updatedSets
+	existing.MkosiProfiles = updatedProfiles
+	if err := resourcetest.ValidatePackageLock(existing); err != nil {
+		return resourcetest.PackageLock{}, err
+	}
+	return existing, nil
+}
+
+func packageSetNames(values []string) (map[string]bool, error) {
+	selected := make(map[string]bool, len(values))
+	for _, value := range values {
+		name := strings.TrimSpace(value)
+		if name == "" {
+			return nil, errors.New("selected package set must not be empty")
+		}
+		if selected[name] {
+			return nil, fmt.Errorf("selected package set %q is duplicated", name)
+		}
+		selected[name] = true
+	}
+	return selected, nil
 }
 
 func runRefresh(args []string, stdout, stderr io.Writer) error {

--- a/cmd/katl-resource-lock/main_test.go
+++ b/cmd/katl-resource-lock/main_test.go
@@ -296,6 +296,74 @@ func TestRunPrepareMkosiRefreshAndStrict(t *testing.T) {
 	}
 }
 
+func TestRunPrepareMkosiPartialRefreshPreservesUnselectedSets(t *testing.T) {
+	oldQuery := queryRPMPackages
+	t.Cleanup(func() { queryRPMPackages = oldQuery })
+	queryRPMPackages = func(root string) ([]resourcetest.Package, error) {
+		t.Fatalf("runtime package inventory should use the generated package list: %s", root)
+		return nil, nil
+	}
+
+	dir := t.TempDir()
+	mkosiDir := filepath.Join(dir, "_build", "mkosi")
+	runtimeRoot := filepath.Join(mkosiDir, "katl-runtime-root")
+	if err := os.MkdirAll(runtimeRoot, 0o755); err != nil {
+		t.Fatalf("mkdir runtime root: %v", err)
+	}
+	writeFile(t, filepath.Join(mkosiDir, "katl-runtime-root.squashfs"), "runtime")
+	writeKubernetesMetadata(t, filepath.Join(mkosiDir, "katl-kubernetes.raw.json"), "0:1.36.0-150500.1.1")
+	installerPackages := filepath.Join(mkosiDir, "katl-installer.packages.tsv")
+	writeInstallerPackages(t, installerPackages, "systemd-0:259.6-1.fc44.x86_64")
+	writeInstallerPackages(t, filepath.Join(mkosiDir, "katl-runtime.packages.tsv"), "systemd-0:259.6-1.fc44.x86_64")
+
+	manifestPath := filepath.Join(dir, "resource-manifest.json")
+	lockPath := filepath.Join(dir, "resource-package-lock.json")
+	baseArgs := []string{
+		"prepare-mkosi",
+		"--manifest", manifestPath,
+		"--lock", lockPath,
+		"--mkosi-dir", mkosiDir,
+		"--runtime-root", runtimeRoot,
+		"--mode", "refresh",
+		"--run-id", "run-1",
+		"--git-revision", "test",
+		"--mkosi-version", "26",
+	}
+	if err := run(baseArgs, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("initial refresh error = %v", err)
+	}
+
+	oldReadKatlOSIndex := readKatlOSIndex
+	t.Cleanup(func() { readKatlOSIndex = oldReadKatlOSIndex })
+	writeFile(t, filepath.Join(mkosiDir, "katlos-install-stale-x86_64.squashfs"), "stale")
+	readKatlOSIndex = func(path string) (katlosIndex, error) {
+		t.Fatalf("partial Fedora refresh inspected unrelated KatlOS image: %s", path)
+		return katlosIndex{}, nil
+	}
+	writeInstallerPackages(t, installerPackages, "systemd-0:259.7-1.fc44.x86_64")
+	partialArgs := append(append([]string(nil), baseArgs...), "--package-set", "installer-image")
+	if err := run(partialArgs, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("partial refresh error = %v", err)
+	}
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read partial lock: %v", err)
+	}
+	lock, err := resourcetest.DecodePackageLock(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode partial lock: %v", err)
+	}
+	if got := lockedPackageNEVRA(lock, "installer-image", "systemd"); got != "systemd-0:259.7-1.fc44.x86_64" {
+		t.Fatalf("installer systemd = %q", got)
+	}
+	if got := lockedPackageNEVRA(lock, "runtime", "systemd"); got != "systemd-0:259.6-1.fc44.x86_64" {
+		t.Fatalf("runtime systemd = %q, want unselected package preserved", got)
+	}
+	if got := lockedPackageNEVRA(lock, "kubernetes-sysext", "kubeadm"); got != "kubeadm-0:1.36.0-150500.1.1.x86_64" {
+		t.Fatalf("Kubernetes kubeadm = %q, want unselected package set preserved", got)
+	}
+}
+
 func TestRunPrepareMkosiStrictRejectsKubernetesDrift(t *testing.T) {
 	oldQuery := queryRPMPackages
 	t.Cleanup(func() { queryRPMPackages = oldQuery })
@@ -793,6 +861,20 @@ func packageNEVRA(packages []resourcetest.Package, name string) string {
 	for _, pkg := range packages {
 		if pkg.Name == name {
 			return pkg.NEVRA
+		}
+	}
+	return ""
+}
+
+func lockedPackageNEVRA(lock resourcetest.PackageLock, setName, packageName string) string {
+	for _, set := range lock.PackageSets {
+		if set.Name != setName {
+			continue
+		}
+		for _, pkg := range set.Packages {
+			if pkg.Name == packageName {
+				return pkg.NEVRA
+			}
 		}
 	}
 	return ""

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -218,6 +218,31 @@ It intentionally skips mkosi builds, libvirt/KVM setup, VM scenarios, and
 publishing. Those host-specific gates belong to the capable-host vmtest workflow
 and release gates.
 
+## Fedora Package Lock
+
+Fedora 44 is the selected base release. Fedora's release repository is frozen,
+but its stable updates repository advances. The committed resource package lock
+is therefore a review gate, not a repository snapshot: release and VM gates
+reject package identities that were not deliberately accepted, while Fedora's
+mirrors remain responsible for serving packages.
+
+Refresh every Fedora-backed profile and update the existing lock with:
+
+```sh
+scripts/update-fedora-package-lock
+```
+
+The command forces fresh runtime, installer, and Kubernetes sysext builds, then
+updates only those package sets; unrelated lock entries are preserved. Use
+`--from-build` only when those three outputs were already rebuilt against the
+repositories being accepted.
+
+`.github/workflows/fedora-package-lock.yml` runs this path weekly and on manual
+dispatch. When package identities change, it opens a ready pull request,
+dispatches the required fast check for that branch, and enables auto-merge. No
+PR is opened when Fedora's selected package set is unchanged or another lock
+update is already open.
+
 ## GitHub Release Artifacts
 
 `.github/workflows/release-artifacts.yml` builds Katl artifacts for pushes to

--- a/internal/scriptstest/fedora_package_lock_test.go
+++ b/internal/scriptstest/fedora_package_lock_test.go
@@ -1,0 +1,61 @@
+package scriptstest
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFedoraPackageLockUpdateContract(t *testing.T) {
+	repo := repoRoot(t)
+	scriptPath := repo + "/scripts/update-fedora-package-lock"
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("stat Fedora package-lock updater: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatal("Fedora package-lock updater is not executable")
+	}
+	script := string(mustReadFile(t, scriptPath))
+	for _, want := range []string{
+		"scripts/mkosi build-runtime",
+		"scripts/mkosi build-installer",
+		"scripts/mkosi build-kubernetes-sysext",
+		"--package-set installer-image",
+		"--package-set runtime",
+		"--package-set kubernetes-sysext",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("Fedora package-lock updater missing %q", want)
+		}
+	}
+	mkosi := string(mustReadFile(t, repo+"/scripts/mkosi"))
+	if !strings.Contains(mkosi, "installer_cache_root=/mkosi-build/cache/fedora~44~x86-64~main.cache") {
+		t.Fatal("containerized mkosi build does not record the installer package set inside the builder")
+	}
+
+	workflow := string(mustReadFile(t, repo+"/.github/workflows/fedora-package-lock.yml"))
+	var document any
+	if err := yaml.Unmarshal([]byte(workflow), &document); err != nil {
+		t.Fatalf("parse Fedora package-lock workflow: %v", err)
+	}
+	for _, want := range []string{
+		"schedule:",
+		"workflow_dispatch:",
+		"scripts/update-fedora-package-lock",
+		"draft: false",
+		"createWorkflowDispatch",
+		"enablePullRequestAutoMerge",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("Fedora package-lock workflow missing %q", want)
+		}
+	}
+
+	fastChecks := string(mustReadFile(t, repo+"/.github/workflows/fast-checks.yml"))
+	if !strings.Contains(fastChecks, "workflow_dispatch:") || !strings.Contains(fastChecks, `range="origin/main...HEAD"`) {
+		t.Fatal("fast checks do not support package-lock branch dispatch")
+	}
+}

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -155,9 +155,6 @@ func TestMkosiPodmanSkipsRecursiveBuildChown(t *testing.T) {
 fi
 printf '%s\n' "$@" > "$KATL_FAKE_PODMAN_ARGS"
 `)
-	writeFakeExecutable(t, bin, "rpm", "printf 'systemd\\t0:259.6-1.fc44.x86_64\\n'\n")
-	seedInstallerRPMCache(t, repo)
-
 	cmd := exec.Command(filepath.Join(repo, "scripts", "mkosi"), "build-installer", "--debug")
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(),

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -225,15 +225,15 @@
         },
         {
           "name": "kernel-core",
-          "nevra": "0:7.1.3-200.fc44.x86_64"
+          "nevra": "0:7.1.3-201.fc44.x86_64"
         },
         {
           "name": "kernel-modules",
-          "nevra": "0:7.1.3-200.fc44.x86_64"
+          "nevra": "0:7.1.3-201.fc44.x86_64"
         },
         {
           "name": "kernel-modules-core",
-          "nevra": "0:7.1.3-200.fc44.x86_64"
+          "nevra": "0:7.1.3-201.fc44.x86_64"
         },
         {
           "name": "keyutils-libs",
@@ -823,15 +823,15 @@
         },
         {
           "name": "kernel-core",
-          "nevra": "0:7.1.3-200.fc44.x86_64"
+          "nevra": "0:7.1.3-201.fc44.x86_64"
         },
         {
           "name": "kernel-modules",
-          "nevra": "0:7.1.3-200.fc44.x86_64"
+          "nevra": "0:7.1.3-201.fc44.x86_64"
         },
         {
           "name": "kernel-modules-core",
-          "nevra": "0:7.1.3-200.fc44.x86_64"
+          "nevra": "0:7.1.3-201.fc44.x86_64"
         },
         {
           "name": "keyutils-libs",

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -26,6 +26,14 @@ case "$vmtest_image_support" in
         ;;
 esac
 mkosi_env+=(--environment "KATL_VMTEST_IMAGE_SUPPORT=$vmtest_image_support")
+package_lock_refresh="${KATL_PACKAGE_LOCK_REFRESH:-0}"
+case "$package_lock_refresh" in
+    0|1) ;;
+    *)
+        echo "error: KATL_PACKAGE_LOCK_REFRESH must be 0 or 1" >&2
+        exit 2
+        ;;
+esac
 emit_runtime_artifact=0
 emit_kubernetes_sysext=0
 emit_installer_iso=0
@@ -452,6 +460,10 @@ store_target_cache() {
 
 prepare_cached_target() {
     local target="$1"
+    if [[ "$package_lock_refresh" == 1 ]]; then
+        printf 'mkosi package-lock refresh: rebuilding %s against current repositories\n' "$target" >&2
+        return
+    fi
     if target_cache_hit "$target"; then
         printf 'mkosi cache hit: %s artifacts match the current repo\n' "$target" >&2
         exit 0
@@ -814,6 +826,21 @@ set +e
     mkosi_artifacts() {
         go run ./cmd/katl-mkosi-artifacts "$@"
     }
+    if [[ "$status" -eq 0 && -n "${KATL_INSTALLER_PACKAGE_SET:-}" ]]; then
+        installer_cache_root=/mkosi-build/cache/fedora~44~x86-64~main.cache
+        if [[ ! -d "$installer_cache_root/usr/lib/sysimage/rpm" ]]; then
+            echo "error: installer RPM database not found: $installer_cache_root/usr/lib/sysimage/rpm" >&2
+            status=1
+        elif ! rpm \
+            --root "$installer_cache_root" \
+            --dbpath /usr/lib/sysimage/rpm \
+            -qa \
+            --queryformat "%{NAME}\t%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n" \
+            | sort >"$KATL_INSTALLER_PACKAGE_SET"; then
+            echo "error: record installer package set" >&2
+            status=1
+        fi
+    fi
     if [[ "$status" -eq 0 && "${KATL_EMIT_RUNTIME_ARTIFACT:-0}" == 1 ]]; then
         root=_build/mkosi/katl-runtime-root
         artifact=_build/mkosi/katl-runtime-root.squashfs
@@ -975,9 +1002,6 @@ set +e
 ' bash "${container_mkosi_storage_args[@]}" "${mkosi_env[@]}" "$@"
 status=$?
 set -e
-if [[ "$status" -eq 0 && -n "$installer_package_set" ]]; then
-    write_installer_package_set || status=1
-fi
 if [[ "$status" -eq 0 && -n "$cache_target" ]]; then
     store_target_cache "$cache_target"
 fi

--- a/scripts/update-fedora-package-lock
+++ b/scripts/update-fedora-package-lock
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+lock="$repo_root/mkosi.profiles/resource-package-lock.json"
+manifest="$repo_root/_build/fedora-package-lock-manifest.json"
+from_build=0
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/update-fedora-package-lock [--from-build] [--lock PATH] [--manifest PATH]
+
+Rebuild the Fedora-backed mkosi profiles against current Fedora repositories
+and update their package identities in the committed resource package lock.
+
+  --from-build    Refresh from existing _build/mkosi outputs without rebuilding.
+  --lock PATH     Package lock to update.
+  --manifest PATH Generated resource-test manifest path.
+EOF
+}
+
+while (($# > 0)); do
+    case "$1" in
+        --from-build)
+            from_build=1
+            shift
+            ;;
+        --lock)
+            [[ $# -ge 2 ]] || { echo "error: --lock requires a path" >&2; exit 2; }
+            lock="$2"
+            shift 2
+            ;;
+        --manifest)
+            [[ $# -ge 2 ]] || { echo "error: --manifest requires a path" >&2; exit 2; }
+            manifest="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unsupported argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$repo_root"
+
+if [[ "$from_build" == 0 ]]; then
+    export KATL_PACKAGE_LOCK_REFRESH=1
+    scripts/mkosi build-runtime
+    scripts/mkosi build-installer
+    scripts/mkosi build-kubernetes-sysext
+fi
+
+mkosi_version="$(scripts/mkosi builder-version)"
+git_revision="$(git rev-parse HEAD)"
+
+go run ./cmd/katl-resource-lock prepare-mkosi \
+    --manifest "$manifest" \
+    --lock "$lock" \
+    --mode refresh \
+    --run-id "fedora-lock-$(date -u +%Y%m%dT%H%M%SZ)" \
+    --git-revision "$git_revision" \
+    --mkosi-version "$mkosi_version" \
+    --package-set installer-image \
+    --package-set runtime \
+    --package-set kubernetes-sysext
+
+printf 'updated Fedora package lock: %s\n' "$lock"


### PR DESCRIPTION
The package lock detected Fedora repository drift only after a build and had no supported update path. This adds a one-command rebuild and partial refresh, plus weekly/manual automation that opens a ready PR and enables auto-merge. Installer package inventory is now captured inside the builder, and the committed Fedora 44 lock is refreshed to the currently selected packages. The lock remains a release drift gate; immutable repository inputs are tracked separately.