### PR TITLE
config: restore bounded native kubeadm input

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -35,11 +35,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
+      actions: write
       artifact-metadata: write
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
+      pull-requests: write
 
     env:
       DISPATCH_ARTIFACT_VERSION: ${{ inputs.artifact_version }}
@@ -359,3 +361,71 @@ jobs:
           subject-name: ${{ env.OCI_REPOSITORY }}
           subject-digest: ${{ steps.publish.outputs.manifest-digest }}
           push-to-registry: true
+
+      - name: Record published compatibility
+        if: ${{ env.PUBLISH == 'true' }}
+        id: compatibility
+        shell: bash
+        env:
+          BUNDLE_DIR: ${{ steps.bundle.outputs.bundle-dir }}
+          MANIFEST_DIGEST: ${{ steps.publish.outputs.manifest-digest }}
+        run: |
+          runtime_interfaces="$(jq -r '.supportedRuntimeInterfaces | join(",")' "${BUNDLE_DIR}/catalog-entry.json")"
+          go run ./cmd/katl-kubernetes-release record-compatibility \
+            --payload-version "$PAYLOAD_VERSION" \
+            --artifact-version "$ARTIFACT_VERSION" \
+            --manifest-digest "$MANIFEST_DIGEST" \
+            --architecture "$KATL_ARCHITECTURE" \
+            --runtime-interfaces "$runtime_interfaces"
+          if git diff --quiet -- internal/installer/kubernetescompat/catalog.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish compatibility update branch
+        if: ${{ steps.compatibility.outputs.changed == 'true' }}
+        id: compatibility-branch
+        shell: bash
+        run: |
+          branch="automation/kubernetes-compatibility-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add internal/installer/kubernetescompat/catalog.json
+          git commit -m "release: record Kubernetes ${PAYLOAD_VERSION} compatibility"
+          git push --set-upstream origin "$branch"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open compatibility pull request
+        if: ${{ steps.compatibility.outputs.changed == 'true' }}
+        uses: actions/github-script@v8
+        env:
+          HEAD_BRANCH: ${{ steps.compatibility-branch.outputs.name }}
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: "main",
+              head: process.env.HEAD_BRANCH,
+              title: `release: select Kubernetes ${process.env.PAYLOAD_VERSION}`,
+              body: "Selects the newly published immutable Kubernetes bundle and records its KatlOS runtime compatibility for version-only install and upgrade resolution.",
+              draft: false,
+            });
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "fast-checks.yml",
+              ref: process.env.HEAD_BRANCH,
+            });
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH
+                }) {
+                  pullRequest { number }
+                }
+              }
+            `, { pullRequestId: pull.node_id });

--- a/README.md
+++ b/README.md
@@ -255,18 +255,19 @@ Add `--plan` to check the upgrade without changing or rebooting the node. The
 node calculates and records image identity internally before changing the
 inactive root slot.
 
-Kubernetes upgrades use the workstation cluster context and a readable bundle
-reference. Plan the whole control-plane-first rollout without supplying bundle
+Kubernetes upgrades use the workstation cluster context and an exact Kubernetes
+version. Plan the whole control-plane-first rollout without supplying bundle
 digests, artifact paths, snapshot metadata, generation IDs, or operation IDs:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1-katl.1 --plan
+katlctl kubernetes upgrade v1.36.1 --plan
 ```
 
 Remove `--plan` to run the complete control-plane-first, worker-second rollout.
-The command upgrades and reboots one node at a time, requires boot health before
-continuing, and stops on the first failure. Each node fetches the selected
-bundle itself; control-plane nodes capture pre-mutation etcd snapshot evidence.
+Katl resolves the release-owned immutable bundle and runtime compatibility,
+upgrades one node online at a time, and stops on the first failure. Each node
+fetches the selected bundle itself; control-plane nodes capture pre-mutation
+etcd snapshot evidence.
 See [Upgrade Kubernetes](docs/operations/upgrade-kubernetes.md).
 
 Mutating commands follow the node's durable operation to completion by default.

--- a/cmd/katl-generation-activate/main.go
+++ b/cmd/katl-generation-activate/main.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"golang.org/x/sys/unix"
 )
 
 func main() {
@@ -52,8 +55,48 @@ func run(_ context.Context, args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if filepath.Clean(*root) == "/" {
+		hostname, err := activateHostname(*root, plan, unix.Sethostname)
+		if err != nil {
+			return err
+		}
+		if stdout != nil && hostname != "" {
+			fmt.Fprintf(stdout, "katl-generation-activate hostname=%s\n", hostname)
+		}
+	}
 	if stdout != nil {
 		fmt.Fprintf(stdout, "katl-generation-activate generation=%s sysexts=%d confexts=%d\n", plan.GenerationID, len(plan.Sysexts), len(plan.Confexts))
 	}
 	return nil
+}
+
+func activateHostname(root string, plan generation.ActivationPlan, setHostname func([]byte) error) (string, error) {
+	var hostname string
+	for _, confext := range plan.Confexts {
+		path := filepath.Join(filepath.Clean(root), strings.TrimPrefix(confext.SourcePath, "/"), "etc/hostname")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("read selected hostname: %w", err)
+		}
+		candidate := strings.TrimSpace(string(data))
+		if candidate == "" || strings.ContainsAny(candidate, " \t\r\n") {
+			return "", fmt.Errorf("selected hostname in %s is invalid", confext.SourcePath)
+		}
+		if hostname != "" && hostname != candidate {
+			return "", fmt.Errorf("selected confexts disagree on hostname: %q and %q", hostname, candidate)
+		}
+		hostname = candidate
+	}
+	if hostname == "" {
+		// Generations written before hostname became native configuration remain
+		// bootable; their base-image hostname is retained until config is applied.
+		return "", nil
+	}
+	if err := setHostname([]byte(hostname)); err != nil {
+		return "", fmt.Errorf("activate hostname %q: %w", hostname, err)
+	}
+	return hostname, nil
 }

--- a/cmd/katl-generation-activate/main_test.go
+++ b/cmd/katl-generation-activate/main_test.go
@@ -57,6 +57,36 @@ func TestGenerationActivateRejectsMismatchedMetadata(t *testing.T) {
 	}
 }
 
+func TestActivateHostnameUsesSelectedVerifiedConfext(t *testing.T) {
+	root := t.TempDir()
+	confext := "/var/lib/katl/generations/1/confext"
+	writeCommandFile(t, filepath.Join(root, strings.TrimPrefix(confext, "/"), "etc/hostname"), "cp-1\n")
+	var selected string
+	hostname, err := activateHostname(root, generation.ActivationPlan{
+		Confexts: []generation.ActivationLink{{Name: "katl-node", SourcePath: confext}},
+	}, func(value []byte) error {
+		selected = string(value)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("activateHostname() error = %v", err)
+	}
+	if hostname != "cp-1" || selected != "cp-1" {
+		t.Fatalf("hostname = %q, selected = %q", hostname, selected)
+	}
+}
+
+func TestActivateHostnameKeepsBaseHostnameForOlderGeneration(t *testing.T) {
+	called := false
+	hostname, err := activateHostname(t.TempDir(), generation.ActivationPlan{}, func([]byte) error {
+		called = true
+		return nil
+	})
+	if err != nil || hostname != "" || called {
+		t.Fatalf("activateHostname() hostname = %q, called = %t, error = %v", hostname, called, err)
+	}
+}
+
 func commandActivationRecord(t *testing.T, root string, id string) generation.Record {
 	t.Helper()
 	sysextContent := "selected sysext\n"

--- a/cmd/katl-kubernetes-release/main.go
+++ b/cmd/katl-kubernetes-release/main.go
@@ -13,9 +13,14 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/kubernetescompat"
 )
 
-const defaultManifest = "mkosi.profiles/kubernetes-sysext/kubernetes.env"
+const (
+	defaultManifest             = "mkosi.profiles/kubernetes-sysext/kubernetes.env"
+	defaultCompatibilityCatalog = "internal/installer/kubernetescompat/catalog.json"
+)
 
 var payloadPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
 
@@ -36,16 +41,115 @@ func main() {
 
 func run(args []string, stdout, stderr io.Writer, query packageQuery) error {
 	if len(args) == 0 {
-		return errors.New("command is required: identity or prepare")
+		return errors.New("command is required: identity, prepare, or record-compatibility")
 	}
 	switch args[0] {
 	case "identity":
 		return runIdentity(args[1:], stdout, stderr)
 	case "prepare":
 		return runPrepare(args[1:], stdout, stderr, query)
+	case "record-compatibility":
+		return runRecordCompatibility(args[1:], stdout, stderr)
 	default:
 		return fmt.Errorf("unsupported command %q", args[0])
 	}
+}
+
+func runRecordCompatibility(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release record-compatibility", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	catalogPath := flags.String("catalog", defaultCompatibilityCatalog, "release compatibility catalog to update")
+	payload := flags.String("payload-version", "", "exact Kubernetes payload version")
+	artifact := flags.String("artifact-version", "", "immutable Katl bundle build version")
+	manifestDigest := flags.String("manifest-digest", "", "published OCI manifest digest")
+	architecture := flags.String("architecture", "x86_64", "supported architecture")
+	runtimeInterfaces := flags.String("runtime-interfaces", "katl-runtime-1", "comma-separated supported KatlOS runtime interfaces")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if payloadPattern.FindStringSubmatch(strings.TrimSpace(*payload)) == nil {
+		return fmt.Errorf("--payload-version must look like v1.36.1")
+	}
+	wantArtifactPrefix := strings.TrimSpace(*payload) + "-katl."
+	if !strings.HasPrefix(strings.TrimSpace(*artifact), wantArtifactPrefix) {
+		return fmt.Errorf("--artifact-version must look like %s1", wantArtifactPrefix)
+	}
+	if !regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(strings.TrimSpace(*manifestDigest)) {
+		return fmt.Errorf("--manifest-digest must be a sha256 OCI manifest digest")
+	}
+	interfaces := splitNonEmpty(*runtimeInterfaces)
+	if len(interfaces) == 0 {
+		return fmt.Errorf("--runtime-interfaces must contain at least one value")
+	}
+	data, err := os.ReadFile(*catalogPath)
+	if err != nil {
+		return fmt.Errorf("read compatibility catalog: %w", err)
+	}
+	catalog, err := kubernetescompat.Decode(data)
+	if err != nil {
+		return err
+	}
+	entry := kubernetescompat.Entry{
+		KubernetesVersion: strings.TrimSpace(*payload),
+		Bundle:            "ghcr.io/katl-dev/kubernetes:" + strings.TrimSpace(*artifact) + "@" + strings.TrimSpace(*manifestDigest),
+		Architectures:     []string{strings.TrimSpace(*architecture)},
+		RuntimeInterfaces: interfaces,
+	}
+	catalog, err = kubernetescompat.Upsert(catalog, entry)
+	if err != nil {
+		return err
+	}
+	updated, err := kubernetescompat.Marshal(catalog)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(data, updated) {
+		fmt.Fprintf(stdout, "compatibility already records %s as %s\n", entry.KubernetesVersion, entry.Bundle)
+		return nil
+	}
+	info, err := os.Stat(*catalogPath)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(*catalogPath), ".kubernetes-compatibility-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(updated); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, *catalogPath); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "recorded %s as %s\n", entry.KubernetesVersion, entry.Bundle)
+	return nil
+}
+
+func splitNonEmpty(value string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	return out
 }
 
 func runIdentity(args []string, stdout, stderr io.Writer) error {

--- a/cmd/katl-kubernetes-release/main_test.go
+++ b/cmd/katl-kubernetes-release/main_test.go
@@ -69,6 +69,50 @@ func TestIdentity(t *testing.T) {
 	}
 }
 
+func TestRecordCompatibility(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.json")
+	if err := os.WriteFile(path, []byte(`{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesCompatibilityCatalog",
+  "entries": [{
+    "kubernetesVersion": "v1.36.0",
+    "bundle": "ghcr.io/katl-dev/kubernetes:v1.36.0-katl.1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "architectures": ["x86_64"],
+    "runtimeInterfaces": ["katl-runtime-1"]
+  }]
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	digest := "sha256:" + strings.Repeat("b", 64)
+	if err := run([]string{
+		"record-compatibility",
+		"--catalog", path,
+		"--payload-version", "v1.36.1",
+		"--artifact-version", "v1.36.1-katl.2",
+		"--manifest-digest", digest,
+		"--architecture", "x86_64",
+		"--runtime-interfaces", "katl-runtime-1, katl-runtime-legacy",
+	}, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"kubernetesVersion": "v1.36.0"`,
+		`"kubernetesVersion": "v1.36.1"`,
+		`"bundle": "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.2@` + digest + `"`,
+		`"katl-runtime-legacy"`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("updated catalog missing %q:\n%s", want, data)
+		}
+	}
+}
+
 func TestPrepareRejectsPackageMismatch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "kubernetes.env")
 	if err := os.WriteFile(path, []byte(testManifest), 0o644); err != nil {

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
+	"github.com/katl-dev/katl/internal/installer/kubernetescompat"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"github.com/katl-dev/katl/internal/katlctl/workstation"
@@ -292,11 +293,14 @@ func kubernetesUpgradeBundle(version, explicit string) (string, error) {
 	if version == "" {
 		return "", fmt.Errorf("VERSION is required")
 	}
-	version = strings.TrimPrefix(version, "v")
-	if !strings.Contains(version, "-katl.") {
-		version += "-katl.1"
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
 	}
-	return "ghcr.io/katl-dev/kubernetes:v" + version, nil
+	selection, err := kubernetescompat.Resolve(kubernetescompat.Request{KubernetesVersion: version})
+	if err != nil {
+		return "", fmt.Errorf("resolve Kubernetes upgrade version: %w", err)
+	}
+	return selection.Bundle, nil
 }
 
 func waitKubernetesUpgrade(ctx context.Context, client agentapi.KatlcAgentClient, operationID, nodeName string, stderr io.Writer) (*agentapi.OperationStatus, error) {

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -64,7 +64,7 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 	kubernetesUpgradeNow = func() time.Time { return time.Unix(42, 0).UTC() }
 	dialKubernetesEndpoint = func(context.Context, string) error { return nil }
 	var stdout bytes.Buffer
-	if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{configPath: configPath, version: "v1.36.1-katl.1", timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
+	if err := runKubernetesUpgrade(context.Background(), kubernetesUpgradeOptions{configPath: configPath, version: "v1.36.1", timeout: time.Minute, output: "json"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(stdout.String(), "internal-") || strings.Contains(strings.ToLower(stdout.String()), "digest") {
@@ -99,6 +99,19 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 	}
 	if want := []string{"cp-1", "cp-2", "worker-1"}; !reflect.DeepEqual(executionOrder, want) {
 		t.Fatalf("execution order = %v, want %v", executionOrder, want)
+	}
+}
+
+func TestKubernetesUpgradeBundleUsesReleaseCompatibility(t *testing.T) {
+	bundle, err := kubernetesUpgradeBundle("1.36.1", "")
+	if err != nil {
+		t.Fatalf("kubernetesUpgradeBundle() error = %v", err)
+	}
+	if !strings.Contains(bundle, "v1.36.1-katl.1@sha256:") {
+		t.Fatalf("bundle = %q", bundle)
+	}
+	if _, err := kubernetesUpgradeBundle("v1.36.2", ""); err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("unavailable version error = %v", err)
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1471,6 +1471,7 @@ func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) 
 	return configapply.RenderNodeConfigurationChange(configapply.RenderNodeRequest{
 		NodeName:       selected.Node.Name,
 		Manifest:       selected.InstallManifest,
+		KubeadmConfigs: selected.KubeadmConfigs,
 		SourceID:       sourceID,
 		DesiredVersion: opts.desiredVersion,
 		ApplyMode:      mode,

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -327,7 +327,11 @@ artifact.
 Set `publish: true` only for a reviewed bundle identity. The workflow refuses
 to replace either immutable GHCR tag, publishes the Katl custom bundle manifest
 as the OCI config with the sysext and metadata as layers, pulls the config back
-for byte verification, and creates a GitHub build-provenance attestation. The
+for byte verification, and creates a GitHub build-provenance attestation. It
+then records the exact version, manifest digest, architecture, and runtime
+interfaces in the embedded compatibility catalog through a ready auto-merged
+pull request. Install and upgrade clients consume that mapping; they never
+construct a `katl.1` tag from an operator-supplied Kubernetes version. The
 canonical package is `ghcr.io/katl-dev/kubernetes`. Its readable tags use the
 bundle build identity directly, for example `v1.36.0-katl.1`, while a
 second `sha256-<bundle-manifest-digest>` tag supports exact Katl resolution.
@@ -339,9 +343,11 @@ GitHub creates a new container package as private. After the first publication,
 an organization owner must make the `kubernetes` package public in its package
 settings so uncredentialed KatlOS nodes can fetch it. This is a one-time GHCR
 namespace operation. The workflow summary prints the readable and digest-pinned
-OCI bundle references for install/bootstrap manifests. Published development
-bundles remain unsigned until the signing policy lands; the GitHub attestation
-records build provenance but is not yet a trust decision enforced by `katlc`.
+OCI bundle references for release audit and expert diagnostics; ordinary
+ClusterConfig continues to contain only the Kubernetes version. Published
+development bundles remain unsigned until the signing policy lands; the GitHub
+attestation records build provenance but is not yet a trust decision enforced
+by `katlc`.
 
 The scheduled public-bundle workflow derives the selected readable tag from
 the same committed release manifest, resolves its immutable digest

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -135,7 +135,7 @@ enforcement remain separate work.
 Normal installation starts from one `config.katl.dev/v1alpha1` `ClusterConfig`.
 It describes operator choices: the Kubernetes version and the desired identity,
 role, networking, and install target of each node. Katl selects release
-artifacts and kubeadm profiles and handles bundle and operation metadata
+artifacts and role-dependent Kubernetes bootstrap state and handles bundle and operation metadata
 internally.
 
 `katlctl config init` generates this minimal form. It uses DHCP and the KatlOS
@@ -176,8 +176,28 @@ spec:
 ```
 
 The release ISO supplies the KatlOS image. ClusterConfig never contains image
-URLs, bundle references, credentials, kubeadm profiles, node classes, or other
-compiler mechanisms.
+URLs, bundle references, credentials, named kubeadm profiles, node classes, or
+other compiler mechanisms.
+
+Advanced users can keep native kubeadm settings without waiting for Katl to add
+a typed field for each upstream option:
+
+```yaml
+spec:
+  kubernetes:
+    version: v1.36.1
+    kubeadm:
+      configFile: ./kubeadm.yaml
+      patchesDir: ./kubeadm-patches
+```
+
+Both paths are relative to `cluster.yaml`. Katl validates the native document
+kinds and API versions, rejects unsafe host paths and filesystem escapes,
+supplies its required role defaults, and embeds the resulting files into the
+compiled `.katlcfg`. It selects control-plane and worker documents internally
+and injects bootstrap tokens and certificate material only when the explicit
+bootstrap operation runs. Omit the entire `kubeadm` block for Katl's complete
+defaults.
 
 The ISO flow consumes this source directly: `katlctl install apply` and
 `katlctl cluster bootstrap` compile the internal bundle automatically. Produce
@@ -380,34 +400,13 @@ Installation does not run `kubeadm`, fetch Kubernetes payloads, or bundle a
 Kubernetes sysext. It stores the node role and bootstrap intent needed for a
 later explicit operator action.
 
-The Kubernetes bundle is one ordinary OCI image reference. During the explicit
-bootstrap operation, `katlc` resolves and fetches that bundle, checks its
-contents internally, stages the sysext locally, and selects it for generation
-1. The selected alpha reference above supplies the `v1.36.1`
-payload; a different Kubernetes version requires its matching bundle reference
-and a KatlOS runtime compatible with that bundle.
-
-Katl publishes development Kubernetes bundles as custom OCI artifacts in the
-public `ghcr.io/katl-dev/kubernetes` package. A tag-only reference is accepted:
-
-```text
-ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1
-```
-
-An immutable OCI manifest pin is optional when exact byte-for-byte
-reproducibility matters:
-
-```text
-ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537
-```
-
-`katlc` verifies the resolved OCI manifest, the Katl bundle config, every layer
-digest and size, and
-Katl runtime compatibility, and only then stages the sysext. The readable
-`ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1` tag is suitable for Renovate's
-Docker datasource; the full patch precision lets Renovate propose Kubernetes
-patch updates. An unpinned tag is resolved once for the operation record; a
-digest pin prevents the tag from selecting different content before that point.
+During explicit bootstrap, Katl resolves `spec.kubernetes.version` through the
+release compatibility catalog to an immutable bundle digest and compatible
+KatlOS runtime interface. It fails before mutation when the version is not
+available for this Katl release. `katlc` then fetches the selected public
+`ghcr.io/katl-dev/kubernetes` artifact, verifies every OCI layer and its runtime
+compatibility, stages the sysext, and selects it for generation 1. Operators do
+not supply a bundle tag or digest on the normal path.
 
 After all nodes are installed and reachable through their node-local `katlc`
 management endpoints, bootstrap directly from the same source:
@@ -449,9 +448,8 @@ distribution or add-on manager.
 ## Apply Runtime Configuration
 
 `ClusterConfig` is the user-authored source for installation and supported
-node runtime configuration. `NodeConfigurationChange` is the node-agent
-operation envelope; normal users do not need to reverse-engineer or maintain it
-by hand.
+node runtime configuration. `katlctl` compiles and submits the node-agent
+request internally; operators do not maintain a second configuration schema.
 
 Optionally plan the exact per-node runtime request through the node agent:
 
@@ -480,34 +478,15 @@ Keep the same configuration inputs when submitting. `katlctl` generates the
 idempotency key and follows the accepted operation to its terminal result.
 
 The renderer carries the node's desired identity and systemd-networkd files as
-well as operation-only system-role and internally selected kubeadm state. The
+well as operation-only system role and role-dependent Kubernetes bootstrap state. The
 planner applies runtime-safe changes and reports when a lifecycle operation is
 required; it does not silently discard operation-only differences. Disk install
 selection and Kubernetes version changes use their dedicated install and
-upgrade workflows. `--file` remains available for an advanced,
-pre-rendered `NodeConfigurationChange`, with `--node` selecting any
-`nodeOverrides` entry it contains. An advanced request may carry a named
-desired kubeadm input and select it atomically:
-
-```yaml
-spec:
-  kubeadmConfigs:
-    control-plane-profiled:
-      config: |
-        apiVersion: kubeadm.k8s.io/v1beta4
-        kind: ClusterConfiguration
-        kubernetesVersion: v1.36.1
-  clusterDefaults:
-    kubernetes:
-      kubeadm:
-        configRef: control-plane-profiled
-```
-
-Inline `patches` may also map single file names to native kubeadm patch YAML.
-Applying the request renders the named desired input and records that a
-kubeadm-aware action is required; normal config apply still does not mutate
-kubeadm-owned cluster state. Run the explicit Katl kubeadm operation after the
-candidate generation is committed.
+upgrade workflows. A change to bounded native kubeadm input records that a
+kubeadm-aware action is required; normal config apply does not mutate
+kubeadm-owned cluster state. Use the dedicated operation for a supported live
+change. The node-agent request envelope is an internal API and is documented
+separately from the operator installation flow.
 
 ## Upgrades
 

--- a/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
+++ b/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
@@ -6,9 +6,9 @@ Date: 2026-07-11.
 
 ## Context
 
-Katl renders desired native kubeadm input under
-`/etc/katl/kubeadm/<name>/config.yaml`, but normal generation activation must
-not rewrite kubeadm-owned state. A running control plane has derived state in
+Katl compiles default or bounded operator-supplied native kubeadm input into
+role-dependent state under `/etc/katl/kubeadm/<name>/config.yaml`, but normal
+generation activation must not rewrite kubeadm-owned state. A running control plane has derived state in
 the `kube-system/kubeadm-config` ConfigMap and in static Pod manifests under
 `/etc/kubernetes/manifests`. Changing the desired file is therefore not the
 same action as changing the live cluster.
@@ -74,7 +74,8 @@ cannot be combined with this operation.
 
 ## Source Of Truth
 
-Desired state is the selected `KubeadmConfig` in one committed Katl generation:
+Desired state is the internally selected, generated kubeadm config in one
+committed Katl generation:
 
 ```text
 desired generation ID
@@ -82,6 +83,10 @@ selected KubeadmConfig name
 /etc/katl/kubeadm/<name>/config.yaml
 canonical desired config SHA-256
 ```
+
+The name is compiled from `systemRole`; it is not an operator-authored
+ClusterConfig reference. When `spec.kubernetes.kubeadm` is present, the desired
+digest includes its validated and role-selected native documents and patches.
 
 The operation accepts only a config selected by the active generation. It does
 not accept an arbitrary path or inline replacement YAML. Every participating

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -37,7 +37,9 @@ There are two authoring levels:
 
 There are no node classes, system-role default layers, or `overrides` wrapper.
 Katl selects its control-plane and worker kubeadm profiles internally from
-`systemRole`.
+`systemRole`. Operators who need a native kubeadm setting that Katl does not
+model may supply one bounded cluster-wide kubeadm file and optional patch
+directory. They never name or select the generated profiles.
 
 ## Supported Shape
 
@@ -52,6 +54,10 @@ spec:
 
   kubernetes:
     version: v1.36.1
+    # Advanced native input, resolved relative to this ClusterConfig.
+    # kubeadm:
+    #   configFile: ./kubeadm.yaml
+    #   patchesDir: ./kubeadm-patches
 
   defaults:
     identity:
@@ -92,6 +98,12 @@ spec:
 `name` is also the node hostname. A separate hostname alias is deliberately not
 part of the contract.
 
+`bootstrap.address` is the operator-reachable address used for installation,
+enrollment, initial Kubernetes bootstrap, and the initial workstation context.
+It need not be a permanent node identity, but it must remain reachable through
+those steps. For DHCP nodes, use a reservation or update the workstation
+context after enrollment when the address changes.
+
 Nodes use a generated DHCP systemd-networkd profile when neither defaults nor
 the node supplies native networkd files. Default and node files merge by file
 name and conflicting content is rejected.
@@ -118,7 +130,7 @@ The following are not ClusterConfig fields:
 
 - KatlOS image URLs, checksums, local paths, or release descriptors;
 - Kubernetes OCI bundle references, catalogs, resolver inputs, or digests;
-- kubeadm configuration documents or profile references;
+- named kubeadm profiles, maps, render paths, or config references;
 - bootstrap access methods, tokens, or credential references;
 - node classes, platform API endpoint helpers, or role-default layers;
 - generation IDs, operation IDs, source digests, or validation bookkeeping.
@@ -128,14 +140,28 @@ compiler provide these inputs at the operation boundary. For example, PXE
 bundle compilation takes KatlOS artifact metadata as command flags while the
 same ClusterConfig remains usable for ISO installation.
 
+The bounded exception is `spec.kubernetes.kubeadm`. `configFile` and
+`patchesDir` are repository-relative operator inputs that `katlctl` validates
+and embeds into the compiled bundle. Katl supplies missing role documents, the
+selected Kubernetes version, the containerd CRI socket, safe rendered paths,
+and dynamic bootstrap credentials. It rejects unsupported API kinds, unsafe
+host paths, symlinks, traversal, and a kubeadm version that conflicts with
+`spec.kubernetes.version`.
+
 ## Runtime Planning
 
 When a ClusterConfig is rendered for an installed node, Katl includes every
 supported desired field in the node change request. Runtime-live fields such as
 SSH keys and networkd files can be applied directly. Operation-only fields such
-as system role and the internally selected kubeadm profile remain visible to
+as system role and role-dependent Kubernetes bootstrap state remain visible to
 the planner and produce an explicit lifecycle action or refusal; the renderer
 must not silently omit them.
+
+Changing bounded native kubeadm input updates desired role-dependent bootstrap
+state. Normal config apply may stage and report that state, but making a running
+cluster match it requires the dedicated kubeadm-aware operation. Native input
+acceptance does not imply that every kubeadm change has a supported live
+transition.
 
 Disk installation fields are consumed by installation and are not runtime
 configuration. Kubernetes version changes are handled by the Kubernetes
@@ -152,7 +178,7 @@ spec.nodeClasses and nodes[].nodeClass
 spec.platformAPIEndpoint
 spec.katlosImage
 spec.kubernetes.bundle and spec.kubernetes.catalogRef
-spec.kubeadmConfigs and kubeadm config references
+spec.kubeadmConfigs, named kubeadm maps, and kubeadm config references
 bootstrap access or credential fields
 identity.hostname
 install.wipeTarget

--- a/docs/internal/kubeadm-config-input-design.md
+++ b/docs/internal/kubeadm-config-input-design.md
@@ -14,33 +14,24 @@ generations and then coordinate kubeadm init/join.
 
 ## Decision
 
-Kubeadm configuration is an implementation-native Katl configuration object
-that points to native kubeadm YAML files in the user's config repository.
-
-User-facing node intent references a Katl bootstrap profile, not a kubeadm
-command or flag shape:
+The ordinary path is Katl-owned complete kubeadm configuration selected from a
+node's `systemRole`. The bounded advanced path adds one native input to
+`ClusterConfig` without exposing Katl's internal names or references:
 
 ```yaml
-kubernetes:
-  bootstrap:
-    profileRef: control-plane
-```
-
-The bootstrap profile resolves to a native `KubeadmConfig` object for the
-current kubeadm backend. That referenced object owns file locations in the
-config repository:
-
-```yaml
-apiVersion: config.katl.dev/v1alpha1
-kind: KubeadmConfig
-metadata:
-  name: control-plane
 spec:
-  configFile: kubeadm/control-plane.yaml
-  patchesDir: kubeadm/patches/control-plane
+  kubernetes:
+    version: v1.36.1
+    kubeadm:
+      configFile: ./kubeadm.yaml
+      patchesDir: ./kubeadm-patches
 ```
 
-`kubeadm/control-plane.yaml` is native kubeadm YAML, not YAML embedded as a
+The paths are resolved relative to the `ClusterConfig` file and embedded into
+the compiled `.katlcfg`. They are not runtime host paths. `patchesDir` is
+optional; setting it requires `configFile`.
+
+`kubeadm.yaml` is native kubeadm YAML, not YAML embedded as a
 string inside Katl YAML:
 
 ```yaml
@@ -64,16 +55,20 @@ cgroupDriver: systemd
 Katl renders the selected config into generated confext under:
 
 ```text
-/etc/katl/kubeadm/<name>/config.yaml
-/etc/katl/kubeadm/<name>/patches/
-```
-
-For the example above:
-
-```text
 /etc/katl/kubeadm/control-plane/config.yaml
 /etc/katl/kubeadm/control-plane/patches/
+/etc/katl/kubeadm/worker/config.yaml
+/etc/katl/kubeadm/worker/patches/
 ```
+
+Katl splits the native documents by role. Control-plane input contains
+`InitConfiguration`, `ClusterConfiguration`, and any common kubelet or
+kube-proxy document. Worker input contains `JoinConfiguration` and common
+documents. Missing role documents, the selected Kubernetes version, the
+containerd CRI socket, and safe patch paths are supplied by Katl. Control-plane
+join material is derived from the selected init input. Tokens, discovery
+hashes, and certificate keys are injected only by the accepted bootstrap
+operation and are never read from ClusterConfig.
 
 The rendered path is stable for node-local `katlc` operation wrappers:
 
@@ -100,9 +95,9 @@ generation activation, or the kubeadm-ready target.
 Katl owns:
 
 ```text
-bootstrap profile naming and references
-KubeadmConfig object resolution for the kubeadm backend
-repository-local file resolution
+complete default control-plane and worker kubeadm input
+internal profile naming and role selection
+ClusterConfig-relative file resolution and bundle embedding
 kubeadm config parsing and compatibility validation
 safe render paths under /etc/katl/kubeadm/
 generated confext staging and generation selection
@@ -126,6 +121,7 @@ bootstrap is defined in
 The operator owns:
 
 ```text
+optional native kubeadm settings and patches
 when to run kubeadm init or join
 when to run kubeadm upgrade or other cluster reconfiguration
 cluster add-ons, CNI, GitOps, workloads, and ongoing Kubernetes lifecycle after
@@ -134,7 +130,7 @@ bootstrap
 
 ## Validation
 
-Katl should parse the referenced kubeadm YAML as multi-document YAML and reject
+Katl parses the referenced kubeadm YAML as multi-document YAML and rejects
 inputs that violate the runtime OS boundary.
 
 Allowed document families for the first implementation:
@@ -181,11 +177,13 @@ immutable, or kubeadm-output paths. Denied host paths include:
 Kubeadm may create output under `/etc/kubernetes` at runtime. Katl-generated
 confext must not pre-create or overwrite that output.
 
-For kubeadm patches, Katl should copy only regular files from the declared
-`patchesDir`, reject path traversal and symlinks, and render them under the
-selected config directory. If the kubeadm YAML declares an explicit patch
-directory, it must either match the rendered `/etc/katl/kubeadm/<name>/patches`
-path or fail validation. Katl should not allow arbitrary patch directories.
+For kubeadm patches, Katl copies only regular files from the declared
+`patchesDir`, rejects path traversal and symlinks, and renders them under the
+selected role directory. Operator input omits `patches.directory`; Katl writes
+the role-specific `/etc/katl/kubeadm/<role>/patches` path while compiling the
+bundle. Control-plane profiles receive the full patch set; worker profiles
+receive only `kubeletconfiguration` patches. Arbitrary patch directories are
+not accepted.
 
 For kubeadm `extraVolumes` or other host-path-like fields, Katl should allow
 only paths that are already part of the kubeadm contract or explicitly
@@ -197,9 +195,9 @@ is present and conflicts with the selected Kubernetes sysext payload version,
 validation must fail before install or runtime config activation. For first
 install, the selected payload version comes from Katl bootstrap intent and the
 exact matching Kubernetes payload bundle fetched and verified by `katlc`. Katl
-may normalize manifest `1.36.0` to kubeadm's `v1.36.0` form for comparison, but
-it must not use sentinel values or a day-one catalog resolver inside native
-kubeadm YAML.
+may normalize manifest `1.36.0` to kubeadm's `v1.36.0` form for comparison.
+Release compatibility resolution selects the bundle outside native kubeadm
+YAML; no catalog references or sentinel values are written into it.
 
 The CRI socket should default to containerd's socket. A different CRI socket is
 deferred until Katl intentionally supports another runtime.
@@ -210,8 +208,8 @@ Generated confext renders kubeadm input files as regular read-only config under
 `/etc/katl`:
 
 ```text
-/etc/katl/kubeadm/<name>/config.yaml
-/etc/katl/kubeadm/<name>/patches/<patch-files>
+/etc/katl/kubeadm/<role>/config.yaml
+/etc/katl/kubeadm/<role>/patches/<patch-files>
 ```
 
 Suggested modes:
@@ -233,9 +231,9 @@ A runtime configuration update can change the desired kubeadm input:
 
 ```text
 new Katl YAML/configuration
-katlc validates KubeadmConfig
+katlctl validates and compiles the bounded native kubeadm input
 katlc renders a new generated confext generation
-/etc/katl/kubeadm/<name>/config.yaml changes after activation
+/etc/katl/kubeadm/<role>/config.yaml changes after activation
 ```
 
 That does not reconfigure a running cluster by itself.
@@ -281,15 +279,15 @@ The supported v0.1 live control-plane reconfiguration surface, serial rollout,
 and rollback boundary are defined by
 `docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md`.
 
-Rolling back rendered `/etc/katl/kubeadm/<name>/config.yaml` restores desired
+Rolling back rendered `/etc/katl/kubeadm/<role>/config.yaml` restores desired
 input only. It does not restore kubeadm output, kubelet runtime config, etcd
 contents, or kubeadm-managed ConfigMaps. Applying or undoing those live changes
 requires an explicit kubeadm-aware operation.
 
 ## Test Harness Use
 
-The single-node API smoke should use a test fixture `KubeadmConfig` and then
-drive the same explicit bootstrap path used by operators:
+The single-node API smoke should use a ClusterConfig with bounded native
+kubeadm input and then drive the same explicit bootstrap path used by operators:
 
 ```text
 run katlctl cluster bootstrap against the installed generation 0 node
@@ -306,25 +304,13 @@ This keeps the smoke test honest: Katl proves it can deliver validated kubeadm
 input and a kubeadm-ready OS; `katlctl` proves the explicit control-client
 boundary; kubeadm proves it can bootstrap the control plane.
 
-## Open Questions
+## Deliberate Boundaries
 
-1. Should `katlc` allow multiple `KubeadmConfig` objects to be installed on one
-   node?
-
-   Initial recommendation: yes, as long as node config selects one default
-   bootstrap `profileRef`. Installing multiple named configs is useful for test
-   fixtures and for operators who want both init and join material available,
-   but Katl should not choose the action.
-
-2. Should Katl rewrite `kubernetesVersion: sysext` in native kubeadm YAML?
-
-   Initial recommendation: avoid sentinel values inside kubeadm YAML. Prefer
-   omitting `kubernetesVersion` or writing the concrete selected sysext version
-   during `katlc` generation. If a shorthand is needed, make it a Katl wrapper
-   field on `KubeadmConfig`, not a fake kubeadm value.
-
-3. How should sensitive kubeadm bootstrap values be supplied?
-
-   Initial recommendation: keep them out of the first API. Operator-run
-   bootstrap tools can pass tokens and certificate keys at action time. A later
-   secret design can add encrypted or external secret references.
+- ClusterConfig exposes one cluster-wide native file and patch directory, not
+  multiple named objects or per-node references.
+- Katl writes the concrete selected Kubernetes version; native sentinel values
+  are not accepted.
+- Bootstrap tokens, discovery hashes, and certificate keys remain operation
+  inputs and are never stored in source configuration.
+- Accepting desired native input does not expand the supported live
+  reconfiguration allowlist in ADR-010.

--- a/docs/internal/kubernetes-sysext-delivery.md
+++ b/docs/internal/kubernetes-sysext-delivery.md
@@ -862,22 +862,32 @@ OCI in GHCR is the canonical publication shape. Each project-minted bundle kind
 uses a clearly named package; Kubernetes is `ghcr.io/katl-dev/kubernetes`. A
 Kubernetes bundle has a human-facing `vMAJOR.MINOR.PATCH-katl.BUILD` tag and a
 mandatory `sha256-<bundle-manifest-digest>` resolver tag. End users provide the
-readable OCI image reference, optionally pinned to its OCI manifest digest;
-`katlc` requires the Katl bundle manifest to be the resolved config. GitHub Releases or a static HTTPS
-layout may mirror the same bytes later, but they are not the primary store.
+Kubernetes version; the matching Katl release resolves it to a readable OCI tag
+and immutable manifest digest. Expert operation APIs may still carry an
+explicit reference. `katlc` requires the Katl bundle manifest to be the resolved
+config. GitHub Releases or a static HTTPS layout may mirror the same bytes
+later, but they are not the primary store.
 
 The readable tag deliberately retains the exact Kubernetes patch version.
 Renovate's Docker datasource preserves tag precision and treats the hyphenated
 suffix as compatibility, so `v1.36.0-katl.1` can advance to
-`v1.36.1-katl.1`. Consumers should pair that readable dependency with a digest
-pin. Katl separately verifies and records the custom bundle manifest digest.
+`v1.36.1-katl.1`. The release catalog pairs that readable identity with its
+digest pin. Katl separately verifies and records the custom bundle manifest
+digest.
 
 The OCI manifest digest is the distribution digest. The sysext payload digest is
 still recorded as the activation digest in bundle metadata, catalog data, and
 generation records after `katlc` stages the payload locally.
 
+The release-owned compatibility catalog maps exact Kubernetes version to OCI
+bundle identity, manifest digest, architectures, and supported KatlOS runtime
+interfaces. It is embedded in `katlctl`, is not a ClusterConfig input, and is
+updated by a ready auto-merged PR after the producer publishes and verifies a
+new immutable bundle. Missing versions and incompatible runtimes fail before an
+install or upgrade operation is accepted.
+
 The catalog is authoritative for discovery, not for trust by itself. Consumers
-must still verify the referenced sysext digest and, once signing is enabled,
+still verify the referenced OCI and sysext digests and, once signing is enabled,
 verify the catalog or artifact signatures before staging or activation.
 
 ## Version Bumps

--- a/docs/internal/north-star.md
+++ b/docs/internal/north-star.md
@@ -95,7 +95,10 @@ User input should describe Katl-owned domains and preserve native syntax where
 that is the clearest interface. A network domain may accept `.network`,
 `.netdev`, and `.link` content. Kubeadm input remains native kubeadm YAML.
 Katl adds validation, ownership, render paths, apply mode, trust handling, and
-rollback behavior around those native artifacts.
+rollback behavior around those native artifacts. The common path is complete
+Katl-owned role defaults; a bounded advanced ClusterConfig file reference keeps
+legitimate upstream kubeadm settings available without exposing internal
+profiles or references.
 
 Katl configuration is applied to KatlOS nodes.
 

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -8,14 +8,14 @@ an explicit mutation of node-local kubeadm state and the Kubernetes API.
 - every intended node completed [generation 0 handoff](access.md);
 - the same `ClusterConfig` source used for installation is available;
 - `katlctl cluster enroll ./cluster.yaml` completed successfully;
-- the Kubernetes bundle reference names a version compatible with the KatlOS
-  runtime;
+- `spec.kubernetes.version` is available in this Katl release's compatibility
+  catalog;
 - the control-plane endpoint resolves or routes as designed; and
 - independent recovery/backup expectations are understood.
 
-Katl fetches the Kubernetes bundle during this operation. Nodes need registry
-and CA access to `ghcr.io` unless the bundle is supplied through an explicitly
-supported local mechanism.
+Katl resolves and fetches the immutable Kubernetes bundle during this
+operation. Nodes need registry and CA access to `ghcr.io` unless the bundle is
+supplied through an explicitly supported local mechanism.
 
 ## Review Changed Intent
 
@@ -41,9 +41,9 @@ The enrolled `file:` credential references are read automatically. Use
 `--node-address node=address` only for an observed address that differs from the
 compiled source.
 
-Review the plan, selected init node, node order, control-plane endpoint,
-Kubernetes version, and bundle reference. A dry run must not create generation
-1 or invoke kubeadm.
+Review the plan, selected init node, node order, control-plane endpoint, and
+Kubernetes version. Katl records the resolved bundle identity internally. A dry
+run must not create generation 1 or invoke kubeadm.
 
 ## Execute Bootstrap
 

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -10,12 +10,17 @@ renderer carries:
 
 - SSH authorized keys;
 - systemd-networkd files; and
-- operation-only system role and internally selected kubeadm profile state.
+- operation-only system role and role-dependent Kubernetes bootstrap state.
 
 Runtime-safe fields can apply normally. Operation-only differences are planned
 and reported as requiring an explicit lifecycle action; config apply does not
 run kubeadm. Disk/install selection and Kubernetes version changes use the
 dedicated install and Kubernetes upgrade workflows.
+
+If `spec.kubernetes.kubeadm` changes, planning reports a kubeadm-aware action.
+Normal config apply does not rewrite live kubeadm or Kubernetes state; use the
+dedicated operation for a supported change, or follow the reported manual
+boundary when Katl does not support that transition.
 
 ## Plan an Apply
 

--- a/docs/operations/upgrade-kubernetes.md
+++ b/docs/operations/upgrade-kubernetes.md
@@ -14,22 +14,23 @@ upgrade node`.
 - per-node `credentialRef` values point to protected token files;
 - no other mutating Katl operation is active;
 - workloads tolerate a serial control-plane-first rollout; and
-- the selected bundle represents a newer patch or the next Kubernetes minor.
+- the selected Kubernetes version represents a newer patch or the next minor.
 
 Nodes fetch the bundle directly. They need registry and CA access to `ghcr.io`.
-An immutable `@sha256:` suffix is recommended but not required.
+Katl resolves the version to an immutable digest compatible with this KatlOS
+release; operators do not supply the bundle identity.
 
 ## Plan
 
 ```sh
 katlctl cluster upgrade kubernetes \
-  v1.36.1-katl.1 --plan
+  v1.36.1 --plan
 ```
 
 The shorter top-level form is equivalent:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1-katl.1 --plan
+katlctl kubernetes upgrade v1.36.1 --plan
 ```
 
 By default, `katlctl` uses the current context in its workstation configuration.
@@ -40,16 +41,17 @@ Kubernetes payload, derives the control-plane/worker order, and asks every
 pending node to validate its operation. It does not fetch a bundle, create a
 candidate generation, take a snapshot, or run kubeadm.
 
-Operators provide only the cluster selection and bundle version. Katl derives
-and records bundle digests, sysext paths and sizes, candidate generation IDs,
-operation IDs, and snapshot evidence internally.
+Operators provide only the cluster selection and Kubernetes version. Katl
+selects the release-owned compatible bundle and records its digest, sysext paths
+and sizes, candidate generation IDs, operation IDs, and snapshot evidence
+internally. An unavailable version fails before any node operation is accepted.
 
 ## Execute
 
 Run the same command without `--plan`:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1-katl.1
+katlctl kubernetes upgrade v1.36.1
 ```
 
 The command itself authorizes the rollout; there is no additional confirmation
@@ -67,7 +69,7 @@ The default path neither cordons nor drains nodes. To prevent new pods from
 being scheduled onto the node during its upgrade, opt into temporary cordoning:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1-katl.1 \
+katlctl kubernetes upgrade v1.36.1 \
   --cordon --kubeconfig ./kubeconfig
 ```
 

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -1312,6 +1312,9 @@ func synthesizeJoinConfig(initDoc map[string]any) map[string]any {
 	if nodeRegistration, ok := initDoc["nodeRegistration"].(map[string]any); ok {
 		doc["nodeRegistration"] = nodeRegistration
 	}
+	if patches, ok := initDoc["patches"].(map[string]any); ok {
+		doc["patches"] = patches
+	}
 	return doc
 }
 

--- a/internal/bootstrap/cluster/cluster_test.go
+++ b/internal/bootstrap/cluster/cluster_test.go
@@ -1520,6 +1520,30 @@ cgroupDriver: systemd
 `
 }
 
+func TestRenderControlPlaneJoinCarriesOperatorPatchDirectory(t *testing.T) {
+	base := []byte(`apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+patches:
+  directory: /etc/katl/kubeadm/control-plane/patches
+`)
+	material := JoinMaterial{Argv: []string{
+		"kubeadm", "join", "api.katl.test:6443",
+		"--token", "abcdef.0123456789abcdef",
+		"--discovery-token-ca-cert-hash", testDiscoveryHash,
+		"--control-plane",
+		"--certificate-key", strings.Repeat("a", 64),
+	}}
+	rendered, err := RenderControlPlaneJoinConfig(base, material)
+	if err != nil {
+		t.Fatalf("RenderControlPlaneJoinConfig() error = %v", err)
+	}
+	if !strings.Contains(string(rendered), "directory: /etc/katl/kubeadm/control-plane/patches") {
+		t.Fatalf("rendered join config did not retain patches directory:\n%s", rendered)
+	}
+}
+
 func adminKubeconfig() string {
 	return `apiVersion: v1
 kind: Config

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/artifact"
+	"github.com/katl-dev/katl/internal/installer/confext"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/katl-dev/katl/internal/installer/sysextcatalog"
@@ -49,11 +50,13 @@ func TestCompileClusterPlan(t *testing.T) {
 	if len(cp.InstallManifest.Node.Networkd.Files) != 2 {
 		t.Fatalf("networkd files = %#v", cp.InstallManifest.Node.Networkd.Files)
 	}
-	if len(cp.NativeEtcFiles) != 4 {
-		t.Fatalf("native /etc files = %#v", cp.NativeEtcFiles)
+	hostname := nativeFile(cp.NativeEtcFiles, "/etc/hostname")
+	if hostname == nil || hostname.Content != "cp-1-host\n" {
+		t.Fatalf("hostname confext = %#v", hostname)
 	}
-	if cp.NativeEtcFiles[1].Path != "/etc/ssh/authorized_keys/katl" || cp.NativeEtcFiles[1].Mode != 0o600 || cp.NativeEtcFiles[1].Content != sshKey+"\n" {
-		t.Fatalf("authorized keys confext = %#v", cp.NativeEtcFiles[1])
+	authorizedKeys := nativeFile(cp.NativeEtcFiles, "/etc/ssh/authorized_keys/katl")
+	if authorizedKeys == nil || authorizedKeys.Mode != 0o600 || authorizedKeys.Content != sshKey+"\n" {
+		t.Fatalf("authorized keys confext = %#v", authorizedKeys)
 	}
 	if len(cp.InstallManifest.Node.Identity.SSH.AuthorizedKeys) != 1 {
 		t.Fatalf("ssh keys were not de-duplicated: %#v", cp.InstallManifest.Node.Identity.SSH.AuthorizedKeys)
@@ -76,6 +79,15 @@ func TestCompileClusterPlan(t *testing.T) {
 	if string(data) != string(want) {
 		t.Fatalf("compiled plan mismatch\nwant:\n%s\ngot:\n%s", want, data)
 	}
+}
+
+func nativeFile(files []confext.NativeEtcFile, path string) *confext.NativeEtcFile {
+	for index := range files {
+		if files[index].Path == path {
+			return &files[index]
+		}
+	}
+	return nil
 }
 
 func TestCompileMakesWorkstationCredentialRefPortable(t *testing.T) {

--- a/internal/installer/clusterplan/testdata/basic.golden.json
+++ b/internal/installer/clusterplan/testdata/basic.golden.json
@@ -99,6 +99,11 @@
       },
       "nativeEtcFiles": [
         {
+          "path": "/etc/hostname",
+          "content": "cp-1-host\n",
+          "mode": 420
+        },
+        {
           "path": "/etc/katl/node.json",
           "content": "{\n  \"apiVersion\": \"katl.dev/v1alpha1\",\n  \"kind\": \"NodeMetadata\",\n  \"identity\": {\n    \"hostname\": \"cp-1-host\"\n  },\n  \"systemRole\": \"control-plane\",\n  \"kubeadm\": {\n    \"configRef\": \"control-plane\",\n    \"configPath\": \"/etc/katl/kubeadm/control-plane/config.yaml\",\n    \"intent\": \"control-plane\"\n  },\n  \"kubernetes\": {\n    \"payloadVersion\": \"v1.36.1\",\n    \"activationPath\": \"/run/extensions/katl-kubernetes.raw\"\n  }\n}\n",
           "mode": 420
@@ -212,6 +217,11 @@
         }
       },
       "nativeEtcFiles": [
+        {
+          "path": "/etc/hostname",
+          "content": "worker-1\n",
+          "mode": 420
+        },
         {
           "path": "/etc/katl/node.json",
           "content": "{\n  \"apiVersion\": \"katl.dev/v1alpha1\",\n  \"kind\": \"NodeMetadata\",\n  \"identity\": {\n    \"hostname\": \"worker-1\"\n  },\n  \"systemRole\": \"worker\",\n  \"kubeadm\": {\n    \"configRef\": \"worker\",\n    \"configPath\": \"/etc/katl/kubeadm/worker/config.yaml\",\n    \"intent\": \"worker\"\n  },\n  \"kubernetes\": {\n    \"payloadVersion\": \"v1.36.1\",\n    \"activationPath\": \"/run/extensions/katl-kubernetes.raw\"\n  }\n}\n",

--- a/internal/installer/configapply/render.go
+++ b/internal/installer/configapply/render.go
@@ -2,8 +2,10 @@ package configapply
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -11,6 +13,7 @@ import (
 type RenderNodeRequest struct {
 	NodeName       string
 	Manifest       manifest.Manifest
+	KubeadmConfigs map[string]kubeadmconfig.Plan
 	SourceID       string
 	DesiredVersion string
 	ApplyMode      string
@@ -30,7 +33,8 @@ type renderedNodeConfigurationMetadata struct {
 }
 
 type renderedNodeConfigurationChangeSpec struct {
-	NodeOverrides map[string]renderedNodeConfigurationOverlay `yaml:"nodeOverrides"`
+	NodeOverrides  map[string]renderedNodeConfigurationOverlay `yaml:"nodeOverrides"`
+	KubeadmConfigs map[string]inlineKubeadmConfig              `yaml:"kubeadmConfigs,omitempty"`
 }
 
 type renderedNodeConfigurationOverlay struct {
@@ -64,6 +68,10 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 	}
 
 	node := request.Manifest.Node
+	kubeadmConfigs, err := renderKubeadmConfigs(node.Kubernetes.Kubeadm.ConfigRef, request.KubeadmConfigs)
+	if err != nil {
+		return nil, err
+	}
 	document := renderedNodeConfigurationChange{
 		APIVersion: NodeConfigurationChangeAPIVersion,
 		Kind:       NodeConfigurationChangeKind,
@@ -73,6 +81,7 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 		},
 		Apply: Apply{Mode: applyMode},
 		Spec: renderedNodeConfigurationChangeSpec{
+			KubeadmConfigs: kubeadmConfigs,
 			NodeOverrides: map[string]renderedNodeConfigurationOverlay{
 				nodeName: {
 					Identity: renderedNodeIdentity{
@@ -91,4 +100,29 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 		return nil, fmt.Errorf("marshal node configuration change: %w", err)
 	}
 	return data, nil
+}
+
+func renderKubeadmConfigs(ref string, configs map[string]kubeadmconfig.Plan) (map[string]inlineKubeadmConfig, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || len(configs) == 0 {
+		return nil, nil
+	}
+	plan, ok := configs[ref]
+	if !ok {
+		return nil, fmt.Errorf("selected kubeadm config %q was not resolved", ref)
+	}
+	patches := make(map[string]string, len(plan.Patches))
+	for _, patch := range plan.Patches {
+		name := filepath.Base(patch.RenderPath)
+		if _, exists := patches[name]; exists {
+			return nil, fmt.Errorf("selected kubeadm config %q contains duplicate patch name %q", ref, name)
+		}
+		patches[name] = string(patch.Content)
+	}
+	if len(patches) == 0 {
+		patches = nil
+	}
+	return map[string]inlineKubeadmConfig{
+		ref: {Config: string(plan.Config.Content), Patches: patches},
+	}, nil
 }

--- a/internal/installer/configapply/render_test.go
+++ b/internal/installer/configapply/render_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
@@ -52,6 +53,47 @@ func TestRenderNodeConfigurationChange(t *testing.T) {
 	}
 	if strings.Contains(string(data), "install:") {
 		t.Fatalf("rendered change contains install fields:\n%s", data)
+	}
+}
+
+func TestRenderNodeConfigurationChangeCarriesSelectedKubeadmInput(t *testing.T) {
+	plan, err := kubeadmconfig.PlanFromRenderedFiles("control-plane", []kubeadmconfig.File{
+		{
+			RenderPath: "/etc/katl/kubeadm/control-plane/config.yaml",
+			Content:    []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\n"),
+		},
+		{
+			RenderPath: "/etc/katl/kubeadm/control-plane/patches/kube-apiserver0+merge.yaml",
+			Content:    []byte("metadata:\n  labels:\n    katl.dev/profile: homelab\n"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
+		NodeName: "cp-1",
+		Manifest: manifest.Manifest{Node: manifest.NodeConfig{
+			Identity:   manifest.NodeIdentity{Hostname: "cp-1"},
+			SystemRole: "control-plane",
+			Kubernetes: manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: "control-plane"}},
+		}},
+		KubeadmConfigs: map[string]kubeadmconfig.Plan{"control-plane": plan},
+		SourceID:       "lab",
+		DesiredVersion: "2",
+	})
+	if err != nil {
+		t.Fatalf("RenderNodeConfigurationChange() error = %v", err)
+	}
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(string(data)), TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() error = %v\n%s", err, data)
+	}
+	resolved := request.KubeadmConfigs["control-plane"]
+	if !strings.Contains(string(resolved.Config.Content), "kubernetesVersion: v1.36.1") || len(resolved.Patches) != 1 {
+		t.Fatalf("resolved kubeadm input = %#v", resolved)
+	}
+	if !request.NodeOverrides["cp-1"].KubeadmChanged {
+		t.Fatal("rendered kubeadm input was not planned as an operation-only change")
 	}
 }
 

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/clusterplan"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
+	"github.com/katl-dev/katl/internal/installer/kubernetescompat"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -33,7 +34,6 @@ const (
 	BundleArtifactType      = "application/vnd.katl.config.bundle.v1"
 
 	DefaultKubernetesVersion = "v1.36.1"
-	DefaultKubernetesBundle  = "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1"
 )
 
 type BuildRequest struct {
@@ -108,7 +108,13 @@ type SourceInstallLayer struct {
 }
 
 type SourceKubernetesCluster struct {
-	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	Version string              `yaml:"version,omitempty" json:"version,omitempty"`
+	Kubeadm *SourceKubeadmInput `yaml:"kubeadm,omitempty" json:"kubeadm,omitempty"`
+}
+
+type SourceKubeadmInput struct {
+	ConfigFile string `yaml:"configFile,omitempty" json:"configFile,omitempty"`
+	PatchesDir string `yaml:"patchesDir,omitempty" json:"patchesDir,omitempty"`
 }
 
 type SourceKubernetesLayer struct {
@@ -223,14 +229,22 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 	if err != nil {
 		return nil, Result{}, err
 	}
-	sourceDigest := digestBytes(normalized)
-	kubeadmConfigs, err := resolveKubeadmConfigs(selectedKubernetesVersion(source))
+	kubeadmConfigs, kubeadmSourceInputs, err := resolveKubeadmConfigs(filepath.Dir(sourcePath), source.Spec.Kubernetes.Kubeadm, selectedKubernetesVersion(source))
 	if err != nil {
 		return nil, Result{}, err
 	}
+	sourceDigest := digestSourceInputs(normalized, kubeadmSourceInputs)
 	planning := request.Planning
 	if strings.TrimSpace(planning.KubernetesBundle) == "" {
-		planning.KubernetesBundle = defaultKubernetesBundle(selectedKubernetesVersion(source))
+		selection, err := kubernetescompat.Resolve(kubernetescompat.Request{
+			KubernetesVersion: selectedKubernetesVersion(source),
+			Architecture:      planning.KatlosImage.Architecture,
+			RuntimeInterface:  planning.KatlosImage.RuntimeInterface,
+		})
+		if err != nil {
+			return nil, Result{}, fmt.Errorf("resolve spec.kubernetes.version: %w", err)
+		}
+		planning.KubernetesBundle = selection.Bundle
 	}
 	config, err := LowerSource(source, planning)
 	if err != nil {
@@ -273,14 +287,6 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 		return nil, Result{}, err
 	}
 	return archive, Result{Digest: manifestDigest, Manifest: manifest, ArchiveSize: int64(len(archive))}, nil
-}
-
-func defaultKubernetesBundle(version string) string {
-	version = strings.TrimSpace(version)
-	if version == "" {
-		version = DefaultKubernetesVersion
-	}
-	return "ghcr.io/katl-dev/kubernetes:" + version + "-katl.1"
 }
 
 func WriteArchive(path string, request BuildRequest) (Result, error) {
@@ -460,7 +466,7 @@ func defaultKubeadmJoinConfig() string {
 	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n"
 }
 
-func resolveKubeadmConfigs(kubernetesVersion string) (map[string]kubeadmconfig.Plan, error) {
+func defaultKubeadmConfigs(kubernetesVersion string) (map[string]kubeadmconfig.Plan, error) {
 	inputs := map[string]string{
 		"control-plane": defaultKubeadmInitConfig(kubernetesVersion),
 		"worker":        defaultKubeadmJoinConfig(),
@@ -598,6 +604,14 @@ func buildMembers(source SourceConfig, normalized []byte, sourceDigest string, p
 			CreatedBy:             firstNonEmpty(request.CreatedBy, "katlctl config bundle"),
 		},
 	}
+	if len(payloads) == 1 {
+		if len(manifest.Compatibility.SupportedArchitectures) == 0 {
+			manifest.Compatibility.SupportedArchitectures = nonEmptyStrings(payloads[0].Architecture)
+		}
+		if len(manifest.Compatibility.SupportedKatlOSRuntimeInterfaces) == 0 {
+			manifest.Compatibility.SupportedKatlOSRuntimeInterfaces = append([]string(nil), payloads[0].SupportedRuntimeInterfaces...)
+		}
+	}
 	return members, manifest, nil
 }
 
@@ -648,6 +662,13 @@ func kubernetesPayloads(plan clusterplan.Plan) []KubernetesPayloadRecord {
 		Architecture:               plan.KatlosImage.Architecture,
 		SupportedRuntimeInterfaces: nonEmptyStrings(plan.KatlosImage.RuntimeInterface),
 		ResolverVersion:            "config-bundle-v1",
+	}
+	if selected, err := kubernetescompat.Resolve(kubernetescompat.Request{KubernetesVersion: plan.KubernetesVersion}); err == nil && selected.Bundle == plan.KubernetesBundleRef {
+		record.ResolverVersion = "release-compatibility-v1"
+		record.SupportedRuntimeInterfaces = append([]string(nil), selected.RuntimeInterfaces...)
+		if record.Architecture == "" && len(selected.Architectures) == 1 {
+			record.Architecture = selected.Architectures[0]
+		}
 	}
 	if image, err := kubernetesbundle.ParseImageReference(plan.KubernetesBundleRef); err == nil {
 		record.ArtifactVersion = image.ArtifactVersion
@@ -749,6 +770,22 @@ func marshalCanonical(value any) ([]byte, error) {
 func digestBytes(data []byte) string {
 	sum := sha256.Sum256(data)
 	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func digestSourceInputs(config []byte, kubeadmInputs []kubeadmSourceInput) string {
+	if len(kubeadmInputs) == 0 {
+		return digestBytes(config)
+	}
+	inputs := append([]kubeadmSourceInput(nil), kubeadmInputs...)
+	sort.Slice(inputs, func(i, j int) bool { return inputs[i].Name < inputs[j].Name })
+	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "cluster-config:%d\n", len(config))
+	_, _ = hash.Write(config)
+	for _, input := range inputs {
+		_, _ = fmt.Fprintf(hash, "kubeadm-input:%d:%s:%d\n", len(input.Name), input.Name, len(input.Content))
+		_, _ = hash.Write(input.Content)
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
 }
 
 func copyLabels(labels map[string]string) map[string]string {

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -56,8 +56,11 @@ func TestBuildArchiveWritesDeterministicBundle(t *testing.T) {
 	if len(bundle.Nodes[0].KubeadmInputs) != 1 || bundle.Nodes[0].KubeadmInputs[0].Annotations["dev.katl.kubeadm.resolved-id"] != "control-plane" {
 		t.Fatalf("control-plane kubeadm inputs = %#v", bundle.Nodes[0].KubeadmInputs)
 	}
-	if bundle.Cluster.KubernetesPayloads[0].OCIManifestDigest != "" || bundle.Cluster.KubernetesPayloads[0].ArtifactVersion != "v1.36.1-katl.1" {
+	if bundle.Cluster.KubernetesPayloads[0].OCIManifestDigest != "sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537" || bundle.Cluster.KubernetesPayloads[0].ArtifactVersion != "v1.36.1-katl.1" {
 		t.Fatalf("kubernetes payloads = %#v", bundle.Cluster.KubernetesPayloads)
+	}
+	if payload := bundle.Cluster.KubernetesPayloads[0]; payload.ResolverVersion != "release-compatibility-v1" || payload.Architecture != "x86_64" || len(payload.SupportedRuntimeInterfaces) != 1 || payload.SupportedRuntimeInterfaces[0] != "katl-runtime-1" {
+		t.Fatalf("resolved Kubernetes compatibility = %#v", payload)
 	}
 	if !hasDescriptor(bundle.Descriptors, "source-normalized", "source/cluster.normalized.yaml") ||
 		!hasDescriptor(bundle.Descriptors, "node-install-material", "nodes/cp-1/install/material.json") ||
@@ -69,6 +72,104 @@ func TestBuildArchiveWritesDeterministicBundle(t *testing.T) {
 		if _, ok := files[blobPath]; !ok {
 			t.Fatalf("descriptor %s missing blob %s", desc.FileName, blobPath)
 		}
+	}
+}
+
+func TestBuildArchiveCompilesBoundedNativeKubeadmInputByRole(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "kubeadm.yaml")
+	writeFile(t, configPath, `apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    - name: profiling
+      value: "false"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+shutdownGracePeriod: 45s
+`)
+	patchesDir := filepath.Join(dir, "kubeadm-patches")
+	if err := os.MkdirAll(patchesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(patchesDir, "kube-apiserver0+merge.yaml"), "metadata:\n  labels:\n    katl.dev/profile: homelab\n")
+	writeFile(t, filepath.Join(patchesDir, "kubeletconfiguration0+merge.yaml"), "shutdownGracePeriod: 45s\n")
+	source := strings.Replace(validSourceConfig(), "    version: v1.36.1", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml\n      patchesDir: ./kubeadm-patches", 1)
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	writeFile(t, sourcePath, source)
+	archive, result, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+
+	controlPlane, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode(control-plane) error = %v", err)
+	}
+	cp := controlPlane.KubeadmConfigs["control-plane"]
+	cpConfig := string(cp.Config.Content)
+	for _, want := range []string{"kind: InitConfiguration", "kind: ClusterConfiguration", "kubernetesVersion: v1.36.1", "name: profiling", "kind: KubeletConfiguration", "directory: /etc/katl/kubeadm/control-plane/patches"} {
+		if !strings.Contains(cpConfig, want) {
+			t.Fatalf("control-plane kubeadm input missing %q:\n%s", want, cpConfig)
+		}
+	}
+	if len(cp.Patches) != 2 || cp.Patches[0].RenderPath != "/etc/katl/kubeadm/control-plane/patches/kube-apiserver0+merge.yaml" {
+		t.Fatalf("control-plane patches = %#v", cp.Patches)
+	}
+
+	worker, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "worker-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode(worker) error = %v", err)
+	}
+	workerPlan := worker.KubeadmConfigs["worker"]
+	workerConfig := string(workerPlan.Config.Content)
+	for _, want := range []string{"kind: JoinConfiguration", "kind: KubeletConfiguration", "directory: /etc/katl/kubeadm/worker/patches"} {
+		if !strings.Contains(workerConfig, want) {
+			t.Fatalf("worker kubeadm input missing %q:\n%s", want, workerConfig)
+		}
+	}
+	if strings.Contains(workerConfig, "kind: ClusterConfiguration") || strings.Contains(workerConfig, "name: profiling") {
+		t.Fatalf("worker kubeadm input contains control-plane documents:\n%s", workerConfig)
+	}
+	if len(workerPlan.Patches) != 1 || workerPlan.Patches[0].RenderPath != "/etc/katl/kubeadm/worker/patches/kubeletconfiguration0+merge.yaml" {
+		t.Fatalf("worker patches = %#v", workerPlan.Patches)
+	}
+
+	writeFile(t, filepath.Join(patchesDir, "kubeletconfiguration0+merge.yaml"), "shutdownGracePeriod: 60s\n")
+	_, changed, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive(changed kubeadm input) error = %v", err)
+	}
+	if changed.Manifest.Source.SourceDigest == result.Manifest.Source.SourceDigest {
+		t.Fatalf("source digest did not change with referenced kubeadm input: %s", changed.Manifest.Source.SourceDigest)
+	}
+}
+
+func TestBuildArchiveRejectsUnsafeAdvancedKubeadmInput(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "kubeadm.yaml"), `apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+apiServer:
+  extraVolumes:
+    - name: host-ssh
+      hostPath: /etc/ssh
+      mountPath: /safe/in-container
+`)
+	source := strings.Replace(validSourceConfig(), "    version: v1.36.1", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml", 1)
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	writeFile(t, sourcePath, source)
+	_, _, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err == nil || !strings.Contains(err.Error(), "host path /etc/ssh is denied") {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+}
+
+func TestBuildArchiveRejectsEmptyAdvancedKubeadmInput(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), "    version: v1.36.1", "    version: v1.36.1\n    kubeadm: {}", 1)
+	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+	if err == nil || !strings.Contains(err.Error(), "spec.kubernetes.kubeadm.configFile is required") {
+		t.Fatalf("BuildArchive() error = %v", err)
 	}
 }
 
@@ -101,7 +202,7 @@ spec:
 	if result.Manifest.Cluster.BootstrapInventory.ControlPlaneEndpoint != "192.0.2.11:6443" {
 		t.Fatalf("bootstrap inventory = %#v", result.Manifest.Cluster.BootstrapInventory)
 	}
-	if len(result.Manifest.Cluster.KubernetesPayloads) != 1 || result.Manifest.Cluster.KubernetesPayloads[0].Ref != DefaultKubernetesBundle {
+	if len(result.Manifest.Cluster.KubernetesPayloads) != 1 || !strings.Contains(result.Manifest.Cluster.KubernetesPayloads[0].Ref, "v1.36.1-katl.1@sha256:") {
 		t.Fatalf("Kubernetes payloads = %#v", result.Manifest.Cluster.KubernetesPayloads)
 	}
 	selected, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
@@ -346,7 +447,7 @@ func TestSourceSchemaGolden(t *testing.T) {
 		}
 	}
 	got := fmt.Sprintf("%x", sha256.Sum256(data))
-	const want = "14d55c950a63f6c195faec4846f78eebb0119a3a923b811d80ce642031d3b68f"
+	const want = "a131b02e81d1b2cf68cd7d55b032fb714a597e01d03b99892611c0370d1679c7"
 	if got != want {
 		t.Fatalf("schema SHA-256 = %s, want %s; review the authoring contract before accepting a new golden", got, want)
 	}

--- a/internal/installer/configbundle/kubeadm.go
+++ b/internal/installer/configbundle/kubeadm.go
@@ -1,0 +1,243 @@
+package configbundle
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
+	"gopkg.in/yaml.v3"
+)
+
+const kubeadmCRISocket = "unix:///run/containerd/containerd.sock"
+
+type kubeadmSourceInput struct {
+	Name    string
+	Content []byte
+}
+
+func resolveKubeadmConfigs(sourceRoot string, input *SourceKubeadmInput, kubernetesVersion string) (map[string]kubeadmconfig.Plan, []kubeadmSourceInput, error) {
+	if input == nil {
+		configs, err := defaultKubeadmConfigs(kubernetesVersion)
+		return configs, nil, err
+	}
+	configFile := strings.TrimSpace(input.ConfigFile)
+	patchesDir := strings.TrimSpace(input.PatchesDir)
+	if configFile == "" {
+		return nil, nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile is required")
+	}
+	resolved, err := kubeadmconfig.Resolve(kubeadmconfig.ResolveRequest{
+		RepoRoot: filepath.Clean(sourceRoot),
+		Object: kubeadmconfig.Object{
+			APIVersion: kubeadmconfig.APIVersion,
+			Kind:       kubeadmconfig.Kind,
+			Metadata:   kubeadmconfig.Metadata{Name: "operator-input"},
+			Spec: kubeadmconfig.Spec{
+				ConfigFile: configFile,
+				PatchesDir: patchesDir,
+			},
+		},
+		KubernetesVersion: kubernetesVersion,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("spec.kubernetes.kubeadm: %w", err)
+	}
+	plans, err := splitKubeadmPlans(resolved, kubernetesVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	inputs := []kubeadmSourceInput{{Name: configFile, Content: resolved.Config.Content}}
+	for _, patch := range resolved.Patches {
+		inputs = append(inputs, kubeadmSourceInput{
+			Name:    filepath.ToSlash(filepath.Join(patchesDir, filepath.Base(patch.SourcePath))),
+			Content: patch.Content,
+		})
+	}
+	return plans, inputs, nil
+}
+
+func splitKubeadmPlans(input kubeadmconfig.Plan, kubernetesVersion string) (map[string]kubeadmconfig.Plan, error) {
+	documents, err := decodeKubeadmDocuments(input.Config.Content)
+	if err != nil {
+		return nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile: %w", err)
+	}
+	byKind := make(map[string]map[string]any, len(documents))
+	for index, document := range documents {
+		kind, _ := document["kind"].(string)
+		if _, exists := byKind[kind]; exists {
+			return nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile contains duplicate %s documents", kind)
+		}
+		if kind == "JoinConfiguration" {
+			if _, controlPlane := document["controlPlane"]; controlPlane {
+				return nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile document %d must not set JoinConfiguration.controlPlane; Katl derives control-plane join credentials and state", index+1)
+			}
+		}
+		if kind == "InitConfiguration" || kind == "JoinConfiguration" {
+			if patches, ok := document["patches"].(map[string]any); ok {
+				if directory, _ := patches["directory"].(string); strings.TrimSpace(directory) != "" {
+					return nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile document %d must omit patches.directory; Katl sets the bundled role-specific path", index+1)
+				}
+			}
+		}
+		byKind[kind] = document
+	}
+
+	defaults, err := defaultKubeadmDocuments(kubernetesVersion)
+	if err != nil {
+		return nil, err
+	}
+	for kind, document := range defaults {
+		if _, ok := byKind[kind]; !ok {
+			byKind[kind] = document
+		}
+	}
+	if err := provideKubeadmDefaults(byKind, kubernetesVersion); err != nil {
+		return nil, err
+	}
+
+	commonKinds := []string{"KubeletConfiguration", "KubeProxyConfiguration"}
+	controlPlaneDocs := []map[string]any{byKind["InitConfiguration"], byKind["ClusterConfiguration"]}
+	workerDocs := []map[string]any{byKind["JoinConfiguration"]}
+	for _, kind := range commonKinds {
+		if document, ok := byKind[kind]; ok {
+			controlPlaneDocs = append(controlPlaneDocs, document)
+			workerDocs = append(workerDocs, document)
+		}
+	}
+
+	plans := make(map[string]kubeadmconfig.Plan, 2)
+	for _, role := range []struct {
+		name      string
+		documents []map[string]any
+	}{
+		{name: "control-plane", documents: controlPlaneDocs},
+		{name: "worker", documents: workerDocs},
+	} {
+		patches := rolePatches(input, role.name)
+		content, err := encodeKubeadmDocuments(role.documents, role.name, len(patches) > 0)
+		if err != nil {
+			return nil, err
+		}
+		files := []kubeadmconfig.File{{
+			SourcePath: input.Config.SourcePath,
+			RenderPath: "/etc/katl/kubeadm/" + role.name + "/config.yaml",
+			Content:    content,
+			Mode:       0o644,
+		}}
+		files = append(files, patches...)
+		plan, err := kubeadmconfig.PlanFromRenderedFiles(role.name, files)
+		if err != nil {
+			return nil, fmt.Errorf("compile %s kubeadm input: %w", role.name, err)
+		}
+		plans[role.name] = plan
+	}
+	return plans, nil
+}
+
+func defaultKubeadmDocuments(kubernetesVersion string) (map[string]map[string]any, error) {
+	controlPlane, err := decodeKubeadmDocuments([]byte(defaultKubeadmInitConfig(kubernetesVersion)))
+	if err != nil {
+		return nil, err
+	}
+	worker, err := decodeKubeadmDocuments([]byte(defaultKubeadmJoinConfig()))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[string]any, len(controlPlane)+len(worker))
+	for _, document := range append(controlPlane, worker...) {
+		kind, _ := document["kind"].(string)
+		out[kind] = document
+	}
+	return out, nil
+}
+
+func provideKubeadmDefaults(documents map[string]map[string]any, kubernetesVersion string) error {
+	cluster := documents["ClusterConfiguration"]
+	version, _ := cluster["kubernetesVersion"].(string)
+	version = strings.TrimSpace(version)
+	if version != "" && version != kubernetesVersion {
+		return fmt.Errorf("spec.kubernetes.kubeadm.configFile Kubernetes version %q does not match spec.kubernetes.version %q", version, kubernetesVersion)
+	}
+	cluster["kubernetesVersion"] = kubernetesVersion
+	for _, kind := range []string{"InitConfiguration", "JoinConfiguration"} {
+		document := documents[kind]
+		nodeRegistration := childMapping(document, "nodeRegistration")
+		if value, _ := nodeRegistration["criSocket"].(string); strings.TrimSpace(value) == "" {
+			nodeRegistration["criSocket"] = kubeadmCRISocket
+		}
+		document["nodeRegistration"] = nodeRegistration
+	}
+	return nil
+}
+
+func encodeKubeadmDocuments(documents []map[string]any, role string, hasPatches bool) ([]byte, error) {
+	if hasPatches {
+		for _, document := range documents {
+			kind, _ := document["kind"].(string)
+			if kind != "InitConfiguration" && kind != "JoinConfiguration" {
+				continue
+			}
+			patches := childMapping(document, "patches")
+			patches["directory"] = "/etc/katl/kubeadm/" + role + "/patches"
+			document["patches"] = patches
+		}
+	}
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	for _, document := range documents {
+		if err := encoder.Encode(document); err != nil {
+			_ = encoder.Close()
+			return nil, fmt.Errorf("encode %s kubeadm input: %w", role, err)
+		}
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, fmt.Errorf("encode %s kubeadm input: %w", role, err)
+	}
+	return out.Bytes(), nil
+}
+
+func decodeKubeadmDocuments(data []byte) ([]map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var documents []map[string]any
+	for {
+		document := map[string]any{}
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(document) != 0 {
+			documents = append(documents, document)
+		}
+	}
+	return documents, nil
+}
+
+func childMapping(parent map[string]any, key string) map[string]any {
+	child, _ := parent[key].(map[string]any)
+	if child == nil {
+		child = map[string]any{}
+	}
+	return child
+}
+
+func rolePatches(input kubeadmconfig.Plan, role string) []kubeadmconfig.File {
+	base := "/etc/katl/kubeadm/" + input.Name + "/patches/"
+	out := make([]kubeadmconfig.File, 0, len(input.Patches))
+	for _, patch := range input.Patches {
+		rel := strings.TrimPrefix(filepath.ToSlash(patch.RenderPath), base)
+		if role == "worker" && !strings.HasPrefix(strings.ToLower(filepath.Base(rel)), "kubeletconfiguration") {
+			continue
+		}
+		copy := patch
+		copy.RenderPath = "/etc/katl/kubeadm/" + role + "/patches/" + rel
+		out = append(out, copy)
+	}
+	return out
+}

--- a/internal/installer/configdomain/configdomain.go
+++ b/internal/installer/configdomain/configdomain.go
@@ -24,6 +24,13 @@ type RenderRequest struct {
 func NativeEtcFiles(request RenderRequest) ([]confext.NativeEtcFile, error) {
 	files := networkdFiles(request.Manifest.Node.Networkd)
 	files = append(files, sysctlFiles(request.Manifest.Node.Sysctl)...)
+	files = append(files, confext.NativeEtcFile{
+		Path:    "/etc/hostname",
+		Content: request.Manifest.Node.Identity.Hostname + "\n",
+		Mode:    0o644,
+		UID:     0,
+		GID:     0,
+	})
 	identity, err := generation.RenderSSH(request.Manifest.Node.Identity.SSH.AuthorizedKeys)
 	if err != nil {
 		return nil, err

--- a/internal/installer/configdomain/configdomain_test.go
+++ b/internal/installer/configdomain/configdomain_test.go
@@ -40,6 +40,7 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 		t.Fatalf("NativeEtcFiles() error = %v", err)
 	}
 	want := []string{
+		"/etc/hostname",
 		"/etc/katl/kubeadm/control-plane/config.yaml",
 		"/etc/katl/node.json",
 		"/etc/ssh/authorized_keys/katl",
@@ -62,8 +63,11 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 		}
 	}
 	var metadata map[string]any
-	if err := json.Unmarshal([]byte(files[1].Content), &metadata); err != nil {
-		t.Fatalf("decode node metadata: %v\n%s", err, files[1].Content)
+	if files[0].Content != "lab-node-01\n" {
+		t.Fatalf("hostname content = %q", files[0].Content)
+	}
+	if err := json.Unmarshal([]byte(files[2].Content), &metadata); err != nil {
+		t.Fatalf("decode node metadata: %v\n%s", err, files[2].Content)
 	}
 	if metadata["apiVersion"] != "katl.dev/v1alpha1" || metadata["kind"] != "NodeMetadata" || metadata["systemRole"] != "control-plane" {
 		t.Fatalf("metadata = %#v", metadata)
@@ -76,11 +80,11 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 	if kubernetes["payloadVersion"] != "v1.36.1" || kubernetes["activationPath"] != "/run/extensions/katl-kubernetes.raw" {
 		t.Fatalf("metadata kubernetes = %#v", kubernetes)
 	}
-	if files[2].Mode != 0o600 || !strings.Contains(files[2].Content, "ssh-ed25519") {
-		t.Fatalf("authorized keys file = %#v", files[2])
+	if files[3].Mode != 0o600 || !strings.Contains(files[3].Content, "ssh-ed25519") {
+		t.Fatalf("authorized keys file = %#v", files[3])
 	}
-	if !strings.Contains(files[3].Content, "net.ipv4.ip_forward = 1") {
-		t.Fatalf("sysctl content = %q", files[3].Content)
+	if !strings.Contains(files[4].Content, "net.ipv4.ip_forward = 1") {
+		t.Fatalf("sysctl content = %q", files[4].Content)
 	}
 }
 

--- a/internal/installer/kubernetescompat/catalog.go
+++ b/internal/installer/kubernetescompat/catalog.go
@@ -1,0 +1,172 @@
+package kubernetescompat
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
+)
+
+const (
+	APIVersion = "katl.dev/v1alpha1"
+	Kind       = "KubernetesCompatibilityCatalog"
+)
+
+//go:embed catalog.json
+var defaultCatalog []byte
+
+type Catalog struct {
+	APIVersion string  `json:"apiVersion"`
+	Kind       string  `json:"kind"`
+	Entries    []Entry `json:"entries"`
+}
+
+type Entry struct {
+	KubernetesVersion string   `json:"kubernetesVersion"`
+	Bundle            string   `json:"bundle"`
+	Architectures     []string `json:"architectures"`
+	RuntimeInterfaces []string `json:"runtimeInterfaces"`
+}
+
+type Request struct {
+	KubernetesVersion string
+	Architecture      string
+	RuntimeInterface  string
+}
+
+func Resolve(request Request) (Entry, error) {
+	catalog, err := Decode(defaultCatalog)
+	if err != nil {
+		return Entry{}, fmt.Errorf("load embedded Kubernetes compatibility catalog: %w", err)
+	}
+	version := strings.TrimSpace(request.KubernetesVersion)
+	for _, entry := range catalog.Entries {
+		if entry.KubernetesVersion != version {
+			continue
+		}
+		if architecture := strings.TrimSpace(request.Architecture); architecture != "" && !contains(entry.Architectures, architecture) {
+			return Entry{}, fmt.Errorf("Kubernetes %s is not available for architecture %s", version, architecture)
+		}
+		if runtime := strings.TrimSpace(request.RuntimeInterface); runtime != "" && !contains(entry.RuntimeInterfaces, runtime) {
+			return Entry{}, fmt.Errorf("Kubernetes %s is not compatible with KatlOS runtime interface %s", version, runtime)
+		}
+		return copyEntry(entry), nil
+	}
+	return Entry{}, fmt.Errorf("Kubernetes %q is not available in this Katl release; choose a version listed by the release compatibility catalog", version)
+}
+
+func Decode(data []byte) (Catalog, error) {
+	var catalog Catalog
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&catalog); err != nil {
+		return Catalog{}, fmt.Errorf("decode catalog: %w", err)
+	}
+	if err := Validate(catalog); err != nil {
+		return Catalog{}, err
+	}
+	return catalog, nil
+}
+
+func Marshal(catalog Catalog) ([]byte, error) {
+	sort.Slice(catalog.Entries, func(i, j int) bool {
+		return catalog.Entries[i].KubernetesVersion < catalog.Entries[j].KubernetesVersion
+	})
+	if err := Validate(catalog); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal catalog: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func Upsert(catalog Catalog, entry Entry) (Catalog, error) {
+	updated := false
+	for i := range catalog.Entries {
+		if catalog.Entries[i].KubernetesVersion == entry.KubernetesVersion {
+			catalog.Entries[i] = copyEntry(entry)
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		catalog.Entries = append(catalog.Entries, copyEntry(entry))
+	}
+	if err := Validate(catalog); err != nil {
+		return Catalog{}, err
+	}
+	return catalog, nil
+}
+
+func Validate(catalog Catalog) error {
+	if catalog.APIVersion != APIVersion {
+		return fmt.Errorf("Kubernetes compatibility catalog apiVersion must be %s", APIVersion)
+	}
+	if catalog.Kind != Kind {
+		return fmt.Errorf("Kubernetes compatibility catalog kind must be %s", Kind)
+	}
+	if len(catalog.Entries) == 0 {
+		return fmt.Errorf("Kubernetes compatibility catalog requires at least one entry")
+	}
+	seen := map[string]bool{}
+	for index, entry := range catalog.Entries {
+		image, err := kubernetesbundle.ParseImageReference(entry.Bundle)
+		if err != nil {
+			return fmt.Errorf("Kubernetes compatibility entry %d bundle: %w", index, err)
+		}
+		if image.PayloadVersion != entry.KubernetesVersion {
+			return fmt.Errorf("Kubernetes compatibility entry %d bundle payload %q does not match version %q", index, image.PayloadVersion, entry.KubernetesVersion)
+		}
+		if image.ManifestDigest == "" {
+			return fmt.Errorf("Kubernetes compatibility entry %d bundle must include an immutable OCI manifest digest", index)
+		}
+		if seen[entry.KubernetesVersion] {
+			return fmt.Errorf("Kubernetes compatibility version %q is duplicated", entry.KubernetesVersion)
+		}
+		seen[entry.KubernetesVersion] = true
+		if err := validateValues("architectures", entry.Architectures); err != nil {
+			return fmt.Errorf("Kubernetes compatibility entry %d: %w", index, err)
+		}
+		if err := validateValues("runtimeInterfaces", entry.RuntimeInterfaces); err != nil {
+			return fmt.Errorf("Kubernetes compatibility entry %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+func validateValues(field string, values []string) error {
+	if len(values) == 0 {
+		return fmt.Errorf("%s must not be empty", field)
+	}
+	seen := map[string]bool{}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" || value != strings.TrimSpace(value) {
+			return fmt.Errorf("%s values must be non-empty and trimmed", field)
+		}
+		if seen[value] {
+			return fmt.Errorf("%s value %q is duplicated", field, value)
+		}
+		seen[value] = true
+	}
+	return nil
+}
+
+func contains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func copyEntry(entry Entry) Entry {
+	entry.Architectures = append([]string(nil), entry.Architectures...)
+	entry.RuntimeInterfaces = append([]string(nil), entry.RuntimeInterfaces...)
+	return entry
+}

--- a/internal/installer/kubernetescompat/catalog.json
+++ b/internal/installer/kubernetescompat/catalog.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesCompatibilityCatalog",
+  "entries": [
+    {
+      "kubernetesVersion": "v1.36.0",
+      "bundle": "ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:c974730cb3500dc4a82cb942138b9f32c1b2e9163469d5073dbedc83c8cd728b",
+      "architectures": [
+        "x86_64"
+      ],
+      "runtimeInterfaces": [
+        "katl-runtime-1"
+      ]
+    },
+    {
+      "kubernetesVersion": "v1.36.1",
+      "bundle": "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:1793f4aed888b48891e659cf286a88088f39a87311d5710c889341aff3f5c537",
+      "architectures": [
+        "x86_64"
+      ],
+      "runtimeInterfaces": [
+        "katl-runtime-1"
+      ]
+    }
+  ]
+}

--- a/internal/installer/kubernetescompat/catalog_test.go
+++ b/internal/installer/kubernetescompat/catalog_test.go
@@ -1,0 +1,56 @@
+package kubernetescompat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveReturnsImmutableCompatibleBundle(t *testing.T) {
+	entry, err := Resolve(Request{
+		KubernetesVersion: "v1.36.1",
+		Architecture:      "x86_64",
+		RuntimeInterface:  "katl-runtime-1",
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !strings.Contains(entry.Bundle, "v1.36.1-katl.1@sha256:") {
+		t.Fatalf("bundle = %q", entry.Bundle)
+	}
+}
+
+func TestResolveRejectsUnavailableOrIncompatibleSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		request Request
+		want    string
+	}{
+		{name: "version", request: Request{KubernetesVersion: "v1.36.2"}, want: "not available"},
+		{name: "architecture", request: Request{KubernetesVersion: "v1.36.1", Architecture: "aarch64"}, want: "not available for architecture"},
+		{name: "runtime", request: Request{KubernetesVersion: "v1.36.1", RuntimeInterface: "katl-runtime-2"}, want: "not compatible"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Resolve(test.request)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Resolve() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsMutableBundle(t *testing.T) {
+	catalog := Catalog{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Entries: []Entry{{
+			KubernetesVersion: "v1.36.1",
+			Bundle:            "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1",
+			Architectures:     []string{"x86_64"},
+			RuntimeInterfaces: []string{"katl-runtime-1"},
+		}},
+	}
+	if err := Validate(catalog); err == nil || !strings.Contains(err.Error(), "immutable OCI manifest digest") {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -40,6 +40,12 @@ func TestKubernetesBundleWorkflowContract(t *testing.T) {
 		`version_tag="$ARTIFACT_VERSION"`,
 		"immutable OCI tag already exists",
 		"actions/attest@v4",
+		"record-compatibility",
+		"internal/installer/kubernetescompat/catalog.json",
+		"automation/kubernetes-compatibility-",
+		"draft: false",
+		"createWorkflowDispatch",
+		"enablePullRequestAutoMerge",
 	}
 	for _, value := range required {
 		if !strings.Contains(workflow, value) {

--- a/internal/vmtest/first_install_world_test.go
+++ b/internal/vmtest/first_install_world_test.go
@@ -511,7 +511,7 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 
 	handoff, err := planFirstInstallWorldRun(world, "local mkosi handoff", repo, NodeSpec{Name: "cp-2", Role: ControlPlane}, firstInstallWorldInput{
 		Mode:              firstInstallWorldGuestHandoff,
-		KubernetesVersion: "v1.35.9",
+		KubernetesVersion: "v1.36.1",
 		TargetDiskSize:    "20G",
 	}, KVMOff)
 	if err != nil {
@@ -523,7 +523,7 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 	if handoff.Config.ConfigBundle == "" || handoff.Config.SelectedNode != "cp-2" {
 		t.Fatalf("handoff bundle input = %#v", handoff.Config)
 	}
-	if data, err := os.ReadFile(filepath.Join(filepath.Dir(handoff.Config.ManifestPath), "kubeadm", "control-plane.yaml")); err != nil || !strings.Contains(string(data), "kubernetesVersion: v1.35.9") {
+	if data, err := os.ReadFile(filepath.Join(filepath.Dir(handoff.Config.ManifestPath), "kubeadm", "control-plane.yaml")); err != nil || !strings.Contains(string(data), "kubernetesVersion: v1.36.1") {
 		t.Fatalf("handoff kubeadm version override = %q, err = %v", data, err)
 	}
 }


### PR DESCRIPTION
Restores an optional file-based native kubeadm interface without exposing Katl’s internal profiles or request envelopes. Kubernetes versions now resolve through a release-owned immutable compatibility catalog, with bundle publication opening an automatic catalog-update PR. Also materializes configured hostnames after the two-node bootstrap journey exposed duplicate base identities.