### PR TITLE
cli: organize katlctl around operator resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ kubeconfig to the operator.
 optional plan contacts the selected node but does not accept an operation:
 
 ```sh
-katlctl config apply ./cluster.yaml --node cp-1 --plan
+katlctl node apply ./cluster.yaml --node cp-1 --plan
 ```
 
 Run the command without `--plan` to apply it. `katlctl` derives config versions,
@@ -234,8 +234,8 @@ context selects a single-node lab automatically; pass a node name in a larger
 cluster:
 
 ```sh
-katlctl host status cp-1
-katlctl host reboot cp-1
+katlctl node status cp-1
+katlctl node reboot cp-1
 ```
 
 Status and reboot results are concise text by default. Add `--output json` for
@@ -248,7 +248,7 @@ context. `katlctl` resolves the published image, stages it, reboots the node,
 and waits for the new generation to pass boot health:
 
 ```sh
-katlctl host upgrade v2026.7.0-alpha.9 --node cp-1
+katlctl node upgrade v2026.7.0-alpha.9 --node cp-1
 ```
 
 Add `--plan` to check the upgrade without changing or rebooting the node. The

--- a/cmd/katlctl/enroll.go
+++ b/cmd/katlctl/enroll.go
@@ -74,7 +74,7 @@ func newClusterEnrollCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 			return runClusterEnroll(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "context name; defaults to the cluster name")
 	cmd.Flags().StringVar(&opts.sshUser, "ssh-user", opts.sshUser, "installed-node SSH user")
 	cmd.Flags().StringVar(&opts.identityFile, "identity-file", "", "SSH private key file")

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -52,7 +52,7 @@ func newHostStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.
 	opts := hostStatusOptions{timeout: 15 * time.Second, output: hostOutputText}
 	cmd := &cobra.Command{
 		Use:   "status [NODE]",
-		Short: "Show the current state of one KatlOS host",
+		Short: "Show the current state of one KatlOS node",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := selectHostNode(&opts.target.nodeName, args); err != nil {
@@ -71,7 +71,7 @@ func newHostRebootCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.
 	opts := hostRebootOptions{timeout: 10 * time.Minute, output: hostOutputText}
 	cmd := &cobra.Command{
 		Use:   "reboot [NODE]",
-		Short: "Reboot one KatlOS host and wait for it to return healthy",
+		Short: "Reboot one KatlOS node and wait for it to return healthy",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := selectHostNode(&opts.target.nodeName, args); err != nil {
@@ -157,7 +157,7 @@ func runHostReboot(ctx context.Context, opts hostRebootOptions, stdout, stderr i
 		generationID = strings.TrimSpace(status.GetCurrentGenerationId())
 	}
 	previousAgentStart := status.GetAgentStartId()
-	if err := requestNodeReboot(requestCtx, conn.Client, "katlctl host reboot", status.GetMachineId(), generationID); err != nil {
+	if err := requestNodeReboot(requestCtx, conn.Client, "katlctl node reboot", status.GetMachineId(), generationID); err != nil {
 		_ = conn.Close()
 		cancelRequest()
 		return fmt.Errorf("schedule reboot for %s: %w", node, err)

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -44,7 +44,7 @@ clusters:
 	}, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"host", "status", "cp-1", "--config", configPath}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "status", "cp-1", "--context-file", configPath}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	output := stdout.String()
@@ -65,7 +65,7 @@ func TestHostStatusJSON(t *testing.T) {
 	installKatlcDial(t, nil, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"host", "status", "node-a", "--endpoint", "node-a.test:9443", "--output", "json"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "status", "node-a", "--endpoint", "node-a.test:9443", "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	var report hostStatusReport
@@ -88,14 +88,14 @@ func TestHostRebootHonorsBootTargetAndWaits(t *testing.T) {
 	installKatlcDial(t, nil, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	if len(fake.rebootRequests) != 1 {
 		t.Fatalf("reboot requests = %d, want 1", len(fake.rebootRequests))
 	}
 	request := fake.rebootRequests[0]
-	if request.GetActor() != "katlctl host reboot" || request.GetExpectedMachineId() != "machine-a" || request.GetTargetGenerationId() != "generation-staged" {
+	if request.GetActor() != "katlctl node reboot" || request.GetExpectedMachineId() != "machine-a" || request.GetTargetGenerationId() != "generation-staged" {
 		t.Fatalf("reboot request = %#v", request)
 	}
 	if got := stdout.String(); got != "node-a rebooted successfully; health OK\n" {
@@ -111,7 +111,7 @@ func TestHostRebootNoWaitJSON(t *testing.T) {
 	installKatlcDial(t, nil, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	var report hostRebootReport
@@ -131,7 +131,7 @@ func TestHostRebootReportsUnhealthyReturn(t *testing.T) {
 	}
 	installKatlcDial(t, nil, fake)
 
-	err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &bytes.Buffer{}, &bytes.Buffer{})
+	err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "reported generation generation-0 unhealthy after reboot") {
 		t.Fatalf("run() error = %v, want unhealthy boot error", err)
 	}
@@ -144,14 +144,14 @@ func TestHostRebootTimesOutWhenAgentDoesNotRestart(t *testing.T) {
 	upgradeRebootPollInterval = time.Millisecond
 	t.Cleanup(func() { upgradeRebootPollInterval = oldInterval })
 
-	err := run(context.Background(), []string{"host", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "10ms"}, &bytes.Buffer{}, &bytes.Buffer{})
+	err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "10ms"}, &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "node node-a did not return healthy") {
 		t.Fatalf("run() error = %v, want reboot timeout", err)
 	}
 }
 
 func TestHostManagementRejectsDuplicateNodeSelection(t *testing.T) {
-	err := run(context.Background(), []string{"host", "status", "cp-1", "--node", "worker-1"}, &bytes.Buffer{}, &bytes.Buffer{})
+	err := run(context.Background(), []string{"node", "status", "cp-1", "--node", "worker-1"}, &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "NODE cannot be combined with --node") {
 		t.Fatalf("run() error = %v", err)
 	}

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -78,10 +78,9 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 func newInstallStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := installStatusOptions{timeout: 15 * time.Second, output: "json"}
 	cmd := &cobra.Command{
-		Use:     "status",
-		Aliases: []string{"inspect"},
-		Short:   "Report a waiting or running KatlOS installer",
-		Args:    cobra.NoArgs,
+		Use:   "status",
+		Short: "Report a waiting or running KatlOS installer",
+		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runInstallStatus(ctx, opts, stdout, stderr)
 		},

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -23,7 +23,7 @@ type kubeadmControlPlaneConfigOptions struct {
 
 func newKubeadmControlPlaneConfigCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := kubeadmControlPlaneConfigOptions{}
-	cmd := &cobra.Command{Use: "kubeadm-control-plane-config", Short: "Roll out the bounded kubeadm control-plane configuration change", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runKubeadmControlPlaneConfig(ctx, opts, stdout) }}
+	cmd := &cobra.Command{Use: "apply-config", Short: "Apply staged kubeadm configuration across control planes", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runKubeadmControlPlaneConfig(ctx, opts, stdout) }}
 	f := cmd.Flags()
 	f.StringVar(&opts.inventoryPath, "inventory", "", "three-control-plane inventory")
 	f.StringVar(&opts.coordinator, "coordinator", "", "coordinator control-plane node changed last")
@@ -108,7 +108,7 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 	var summary []map[string]string
 	for i, t := range targets {
 		body := kubeadmControlPlaneConfigBody(opts, t.node, uint32(i+1))
-		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-dry-run-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster kubeadm-control-plane-config", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: opts.generationID, DryRun: true, KubeadmControlPlaneConfig: body})
+		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-dry-run-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl kubernetes apply-config", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: opts.generationID, DryRun: true, KubeadmControlPlaneConfig: body})
 		if err != nil {
 			return fmt.Errorf("dry-run %s: %w", t.node.Name, err)
 		}
@@ -118,7 +118,7 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 	}
 	for i, t := range targets {
 		body := kubeadmControlPlaneConfigBody(opts, t.node, uint32(i+1))
-		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster kubeadm-control-plane-config", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: opts.generationID, KubeadmControlPlaneConfig: body})
+		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl kubernetes apply-config", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: opts.generationID, KubeadmControlPlaneConfig: body})
 		if err != nil {
 			return fmt.Errorf("submit %s: %w", t.node.Name, err)
 		}

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -79,7 +79,7 @@ var dialKubernetesEndpoint = func(ctx context.Context, endpoint string) error {
 func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := kubernetesUpgradeOptions{timeout: 25 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "kubernetes VERSION",
+		Use:   "upgrade VERSION",
 		Short: "Upgrade Kubernetes control planes and workers online",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -89,7 +89,7 @@ func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) 
 			return runKubernetesUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl config path (defaults to the selected workstation context)")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl config context name")
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "cluster inventory instead of a workstation context")
 	cmd.Flags().StringVar(&opts.bundle, "bundle", "", "Kubernetes bundle image, for example ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1")
@@ -156,7 +156,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 		accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
 			ClientRequestId: "katlctl-plan-" + target.candidate, OperationKind: "kubeadm-upgrade",
-			Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
+			Actor: "katlctl kubernetes upgrade", ExpectedMachineId: target.machineID,
 			ExpectedCurrentGenerationId: target.generation, DryRun: true, KubernetesSysextUpdate: body,
 		})
 		if err != nil {
@@ -210,7 +210,7 @@ func runKubernetesUpgradeTarget(ctx context.Context, topology workstation.Resolv
 	accepted, err := target.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 		ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
 		ClientRequestId: "katlctl-" + target.candidate, OperationKind: "kubeadm-upgrade",
-		Actor: "katlctl cluster upgrade kubernetes", ExpectedMachineId: target.machineID,
+		Actor: "katlctl kubernetes upgrade", ExpectedMachineId: target.machineID,
 		ExpectedCurrentGenerationId: target.generation, OperationTimeout: opts.timeout.String(),
 		KubernetesSysextUpdate: kubernetesUpgradeBody(target, image),
 	})
@@ -333,7 +333,7 @@ func resolveKubernetesUpgradeTopology(opts kubernetesUpgradeOptions) (workstatio
 	request := workstation.ResolveRequest{ConfigPath: strings.TrimSpace(opts.configPath), ContextName: strings.TrimSpace(opts.contextName)}
 	if strings.TrimSpace(opts.inventoryPath) != "" {
 		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
-			return workstation.ResolvedTopology{}, fmt.Errorf("--inventory cannot be combined with --config or --context")
+			return workstation.ResolvedTopology{}, fmt.Errorf("--inventory cannot be combined with --context-file or --context")
 		}
 		inv, err := loadInventory(opts.inventoryPath)
 		if err != nil {

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -58,7 +58,6 @@ const (
 	configBundleCreator      = "katlctl config bundle"
 	clusterBootstrapCreator  = "katlctl cluster bootstrap"
 	wipeClusterOperationKind = "destructive-reset"
-	wipeAcknowledgementText  = "I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity."
 )
 
 func main() {
@@ -76,15 +75,19 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 
 func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "katlctl",
-		Short:         "KatlOS operator client",
+		Use:   "katlctl",
+		Short: "Install and manage KatlOS clusters",
+		Long: `katlctl installs and manages KatlOS nodes and their Kubernetes cluster.
+
+Start with "katlctl install discover" for a waiting installer or
+"katlctl context show" to inspect the currently enrolled cluster.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("command is required")
+		RunE: func(command *cobra.Command, _ []string) error {
+			return command.Help()
 		},
 	}
 	cmd.SetOut(stdout)
@@ -104,49 +107,42 @@ func newKatlctlCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 	clusterCmd := &cobra.Command{Use: "cluster", Short: "Cluster lifecycle operations"}
 	clusterCmd.AddCommand(newClusterEnrollCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newClusterBootstrapCommand(ctx, stdout, stderr))
-	clusterUpgradeCmd := &cobra.Command{Use: "upgrade", Short: "Cluster upgrade operations"}
-	clusterUpgradeCmd.AddCommand(newKubernetesUpgradeCommand(ctx, stdout, stderr))
-	clusterCmd.AddCommand(clusterUpgradeCmd)
-	clusterCmd.AddCommand(newKubeadmControlPlaneConfigCommand(ctx, stdout, stderr))
-	clusterWipeCmd := newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe")
-	clusterWipeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl cluster wipe node"))
-	clusterCmd.AddCommand(clusterWipeCmd)
+	clusterCmd.AddCommand(newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe"))
 	cmd.AddCommand(clusterCmd)
+
 	kubernetesCmd := &cobra.Command{Use: "kubernetes", Short: "Kubernetes lifecycle operations"}
-	kubernetesUpgradeCmd := newKubernetesUpgradeCommand(ctx, stdout, stderr)
-	kubernetesUpgradeCmd.Use = "upgrade VERSION"
-	kubernetesCmd.AddCommand(kubernetesUpgradeCmd)
+	kubernetesCmd.AddCommand(newKubernetesUpgradeCommand(ctx, stdout, stderr))
+	kubernetesCmd.AddCommand(newKubeadmControlPlaneConfigCommand(ctx, stdout, stderr))
 	cmd.AddCommand(kubernetesCmd)
 
-	configCmd := &cobra.Command{Use: "config", Short: "Katl configuration operations"}
+	configCmd := &cobra.Command{Use: "config", Short: "Create and compile ClusterConfig"}
 	configCmd.AddCommand(newConfigInitCommand(ctx, stdout, stderr))
-	configCmd.AddCommand(newConfigPathCommand(stdout, stderr))
-	configCmd.AddCommand(newConfigTopologyCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigValidateCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigSchemaCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigBundleCommand(stdout, stderr))
-	configCmd.AddCommand(newConfigRenderNodeCommand(stdout, stderr))
-	configCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
+	renderNodeCmd := newConfigRenderNodeCommand(stdout, stderr)
+	renderNodeCmd.Hidden = true
+	configCmd.AddCommand(renderNodeCmd)
 	cmd.AddCommand(configCmd)
+
+	contextCmd := &cobra.Command{Use: "context", Short: "Inspect enrolled workstation context"}
+	contextCmd.AddCommand(newConfigPathCommand(stdout, stderr))
+	topologyCmd := newConfigTopologyCommand(stdout, stderr)
+	topologyCmd.Use = "show"
+	topologyCmd.Short = "Show the selected cluster and its nodes"
+	contextCmd.AddCommand(topologyCmd)
+	cmd.AddCommand(contextCmd)
+
 	cmd.AddCommand(newInstallCommand(ctx, stdout, stderr))
 	cmd.AddCommand(newOperationCommand(ctx, stdout, stderr))
 
-	hostCmd := &cobra.Command{Use: "host", Short: "KatlOS host lifecycle operations"}
-	hostCmd.AddCommand(newHostStatusCommand(ctx, stdout, stderr))
-	hostCmd.AddCommand(newHostRebootCommand(ctx, stdout, stderr))
-	hostCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))
-	cmd.AddCommand(hostCmd)
-
-	wipeCmd := &cobra.Command{
-		Use:   "wipe",
-		Short: "Compatibility aliases for destructive wipe commands",
-	}
-	legacyClusterWipeCmd := newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe")
-	legacyClusterWipeCmd.Use = "cluster"
-	legacyClusterWipeCmd.Short = "Compatibility alias for katlctl cluster wipe"
-	wipeCmd.AddCommand(legacyClusterWipeCmd)
-	wipeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl wipe node"))
-	cmd.AddCommand(wipeCmd)
+	nodeCmd := &cobra.Command{Use: "node", Short: "Manage individual KatlOS nodes"}
+	nodeCmd.AddCommand(newHostStatusCommand(ctx, stdout, stderr))
+	nodeCmd.AddCommand(newHostRebootCommand(ctx, stdout, stderr))
+	nodeCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))
+	nodeCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
+	nodeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl node wipe"))
+	cmd.AddCommand(nodeCmd)
 
 	return cmd
 }
@@ -181,10 +177,10 @@ type hostUpgradeReport struct {
 var katlOSReleasePattern = regexp.MustCompile(`^[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 
 func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := hostUpgradeOptions{actor: "katlctl host upgrade", waitTimeout: 30 * time.Minute, output: "json"}
+	opts := hostUpgradeOptions{actor: "katlctl node upgrade", waitTimeout: 30 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
 		Use:   "upgrade VERSION",
-		Short: "Upgrade one KatlOS host and verify its next boot",
+		Short: "Upgrade one KatlOS node and verify its next boot",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 1 {
@@ -195,7 +191,7 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
-	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.imageURL, "image-url", "", "HTTPS KatlOS upgrade image URL")
@@ -400,8 +396,6 @@ type wipeClusterOptions struct {
 	contextName       string
 	all               bool
 	allowPartial      bool
-	confirm           bool
-	acknowledgement   string
 	clientRequestID   string
 	agentTokenFile    string
 	planOnly          bool
@@ -415,6 +409,7 @@ func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, comman
 	cmd := &cobra.Command{
 		Use:   "wipe [SOURCE]",
 		Short: "Destructively reset cluster nodes for installer-media reinstall",
+		Long:  "Erase KatlOS boot artifacts from the selected cluster nodes. Every wiped node must boot installer media or PXE before it can be used again.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 1 {
@@ -425,12 +420,10 @@ func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, comman
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
 	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
-	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "select every node in the inventory")
 	cmd.Flags().BoolVar(&opts.allowPartial, "allow-partial-cluster", false, "allow a partial cluster target set")
-	cmd.Flags().BoolVar(&opts.confirm, "confirm-destructive-wipe", false, "confirm destructive wipe")
-	cmd.Flags().StringVar(&opts.acknowledgement, "acknowledge", "", "required destructive acknowledgement text")
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
@@ -447,14 +440,6 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 	if opts.output != "json" {
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
-	if !opts.planOnly {
-		if !opts.confirm {
-			return fmt.Errorf("--confirm-destructive-wipe is required")
-		}
-		if opts.acknowledgement != wipeAcknowledgementText {
-			return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
-		}
-	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
 		return err
@@ -467,24 +452,11 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 		return fmt.Errorf("--all and --node cannot be combined")
 	}
 
-	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
-	if err != nil {
-		return err
-	}
-	inv, err = overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
-	if err != nil {
-		return err
-	}
-	plan, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv})
-	if err != nil {
-		return err
-	}
-	targets, partial, err := wipeClusterTargets(plan, opts.all, opts.selectedNodes.values)
+	targets, partial, err := resolveWipeClusterTargets(opts)
 	if err != nil {
 		return err
 	}
 	report := newWipeClusterReport(opts.planOnly, partial, targets)
-	report.AcknowledgementAccepted = opts.confirm && opts.acknowledgement == wipeAcknowledgementText
 	report.Command = opts.command
 	if partial && !opts.allowPartial {
 		report.Refusals = append(report.Refusals, "partial cluster wipe requires --allow-partial-cluster")
@@ -519,6 +491,47 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 	return submitErr
 }
 
+func resolveWipeClusterTargets(opts wipeClusterOptions) ([]inventory.PlannedNode, bool, error) {
+	hasExplicitTopology := strings.TrimSpace(opts.sourcePath) != "" || strings.TrimSpace(opts.configBundlePath) != "" || strings.TrimSpace(opts.inventoryPath) != ""
+	if !hasExplicitTopology {
+		topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
+			ConfigPath:  strings.TrimSpace(opts.workstationConfig),
+			ContextName: strings.TrimSpace(opts.contextName),
+		})
+		if err != nil {
+			return nil, false, fmt.Errorf("resolve cluster from workstation context: %w", err)
+		}
+		plan := inventory.Plan{Nodes: make([]inventory.PlannedNode, 0, len(topology.Nodes))}
+		for _, node := range topology.Nodes {
+			host, _, err := net.SplitHostPort(node.ManagementEndpoint)
+			if err != nil {
+				return nil, false, fmt.Errorf("node %q management endpoint: %w", node.Name, err)
+			}
+			plan.Nodes = append(plan.Nodes, inventory.PlannedNode{
+				Name:       node.Name,
+				Address:    host,
+				SystemRole: node.SystemRole,
+				Access:     inventory.Access{Method: "agent", CredentialRef: node.CredentialRef},
+			})
+		}
+		return wipeClusterTargets(plan, opts.all, opts.selectedNodes.values)
+	}
+
+	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	if err != nil {
+		return nil, false, err
+	}
+	inv, err = overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
+	if err != nil {
+		return nil, false, err
+	}
+	plan, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv})
+	if err != nil {
+		return nil, false, err
+	}
+	return wipeClusterTargets(plan, opts.all, opts.selectedNodes.values)
+}
+
 type wipeNodeOptions struct {
 	command           string
 	selectedNodes     stringList
@@ -528,8 +541,6 @@ type wipeNodeOptions struct {
 	workstationConfig string
 	contextName       string
 	kubeconfigPath    string
-	confirm           bool
-	acknowledgement   string
 	clientRequestID   string
 	agentTokenFile    string
 	planOnly          bool
@@ -541,23 +552,23 @@ type wipeNodeOptions struct {
 func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
 	opts := wipeNodeOptions{command: commandName, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "node [SOURCE]",
-		Short: "Destructively reset one node for installer-media reinstall",
-		Args:  cobra.MaximumNArgs(1),
+		Use:   "wipe NODE [SOURCE]",
+		Short: "Remove one node and reset it for installer-media reinstall",
+		Long:  "Remove one worker from Kubernetes and erase its KatlOS boot artifacts. The node must boot installer media or PXE before it can be used again.",
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) == 1 {
-				opts.sourcePath = args[0]
+			opts.selectedNodes.values = []string{args[0]}
+			if len(args) == 2 {
+				opts.sourcePath = args[1]
 			}
 			return runWipeNodeOptions(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
 	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
-	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.kubeconfigPath, "kubeconfig", "", "path to operator kubeconfig")
-	cmd.Flags().BoolVar(&opts.confirm, "confirm-destructive-wipe", false, "confirm destructive wipe")
-	cmd.Flags().StringVar(&opts.acknowledgement, "acknowledge", "", "required destructive acknowledgement text")
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
@@ -565,7 +576,6 @@ func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandNa
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
 	cmd.Flags().StringVar(&opts.timeout, "timeout", "30m", "operation and wait timeout duration")
 	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
-	cmd.Flags().Var(&opts.selectedNodes, "node", "inventory node name to wipe")
 	return cmd
 }
 
@@ -580,14 +590,6 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 	if !opts.planOnly && strings.TrimSpace(opts.kubeconfigPath) == "" {
 		return fmt.Errorf("--kubeconfig is required")
 	}
-	if !opts.planOnly {
-		if !opts.confirm {
-			return fmt.Errorf("--confirm-destructive-wipe is required")
-		}
-		if opts.acknowledgement != wipeAcknowledgementText {
-			return fmt.Errorf("--acknowledge must exactly match the destructive wipe acknowledgement text")
-		}
-	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
 		return err
@@ -597,25 +599,11 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return fmt.Errorf("--timeout must be a positive duration")
 	}
 
-	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	target, partial, err := resolveWipeNodeTarget(opts)
 	if err != nil {
 		return err
 	}
-	inv, err = overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
-	if err != nil {
-		return err
-	}
-	plan, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv})
-	if err != nil {
-		return err
-	}
-	targets, partial, err := wipeClusterTargets(plan, false, opts.selectedNodes.values)
-	if err != nil {
-		return err
-	}
-	target := targets[0]
 	report := newWipeNodeReport(opts.planOnly, partial, target)
-	report.AcknowledgementAccepted = opts.confirm && opts.acknowledgement == wipeAcknowledgementText
 	report.Command = opts.command
 	if target.SystemRole == inventory.RoleControlPlane {
 		report.KubernetesCleanup = "refused"
@@ -663,6 +651,53 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return printErr
 	}
 	return submitErr
+}
+
+func resolveWipeNodeTarget(opts wipeNodeOptions) (inventory.PlannedNode, bool, error) {
+	hasExplicitTopology := strings.TrimSpace(opts.sourcePath) != "" || strings.TrimSpace(opts.configBundlePath) != "" || strings.TrimSpace(opts.inventoryPath) != ""
+	if !hasExplicitTopology {
+		topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
+			ConfigPath:  strings.TrimSpace(opts.workstationConfig),
+			ContextName: strings.TrimSpace(opts.contextName),
+		})
+		if err != nil {
+			return inventory.PlannedNode{}, false, fmt.Errorf("resolve node from workstation context: %w", err)
+		}
+		for _, node := range topology.Nodes {
+			if node.Name != opts.selectedNodes.values[0] {
+				continue
+			}
+			host, _, err := net.SplitHostPort(node.ManagementEndpoint)
+			if err != nil {
+				return inventory.PlannedNode{}, false, fmt.Errorf("node %q management endpoint: %w", node.Name, err)
+			}
+			return inventory.PlannedNode{
+				Name:       node.Name,
+				Address:    host,
+				SystemRole: node.SystemRole,
+				Access:     inventory.Access{Method: "agent", CredentialRef: node.CredentialRef},
+			}, len(topology.Nodes) > 1, nil
+		}
+		return inventory.PlannedNode{}, false, fmt.Errorf("node %q is not in context %q", opts.selectedNodes.values[0], topology.ContextName)
+	}
+
+	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	if err != nil {
+		return inventory.PlannedNode{}, false, err
+	}
+	inv, err = overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
+	if err != nil {
+		return inventory.PlannedNode{}, false, err
+	}
+	plan, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv})
+	if err != nil {
+		return inventory.PlannedNode{}, false, err
+	}
+	targets, partial, err := wipeClusterTargets(plan, false, opts.selectedNodes.values)
+	if err != nil {
+		return inventory.PlannedNode{}, false, err
+	}
+	return targets[0], partial, nil
 }
 
 func loadWipeInventory(sourcePath, bundlePath, inventoryPath string) (inventory.Inventory, error) {
@@ -726,19 +761,18 @@ func overlayWipeContext(inv inventory.Inventory, configPath, contextName string)
 }
 
 type wipeClusterReport struct {
-	APIVersion              string                          `json:"apiVersion"`
-	Kind                    string                          `json:"kind"`
-	Command                 string                          `json:"command"`
-	Plan                    bool                            `json:"plan"`
-	PartialCluster          bool                            `json:"partialCluster"`
-	AcknowledgementAccepted bool                            `json:"acknowledgementAccepted"`
-	Targets                 []wipeClusterTarget             `json:"targets"`
-	KubernetesCleanup       string                          `json:"kubernetesCleanup"`
-	NodeLocalOperations     []wipeClusterNodeLocalOperation `json:"nodeLocalOperations"`
-	WipedState              []string                        `json:"wipedState"`
-	PreservedState          []string                        `json:"preservedState"`
-	Refusals                []string                        `json:"refusals,omitempty"`
-	Nodes                   []wipeClusterNodeResult         `json:"nodes,omitempty"`
+	APIVersion          string                          `json:"apiVersion"`
+	Kind                string                          `json:"kind"`
+	Command             string                          `json:"command"`
+	Plan                bool                            `json:"plan"`
+	PartialCluster      bool                            `json:"partialCluster"`
+	Targets             []wipeClusterTarget             `json:"targets"`
+	KubernetesCleanup   string                          `json:"kubernetesCleanup"`
+	NodeLocalOperations []wipeClusterNodeLocalOperation `json:"nodeLocalOperations"`
+	WipedState          []string                        `json:"wipedState"`
+	PreservedState      []string                        `json:"preservedState"`
+	Refusals            []string                        `json:"refusals,omitempty"`
+	Nodes               []wipeClusterNodeResult         `json:"nodes,omitempty"`
 }
 
 type wipeNodeReport struct {
@@ -775,13 +809,12 @@ type wipeClusterNodeResult struct {
 
 func newWipeClusterReport(planOnly bool, partial bool, nodes []inventory.PlannedNode) wipeClusterReport {
 	report := wipeClusterReport{
-		APIVersion:              operation.APIVersion,
-		Kind:                    "WipeClusterReport",
-		Command:                 "katlctl cluster wipe",
-		Plan:                    planOnly,
-		PartialCluster:          partial,
-		AcknowledgementAccepted: true,
-		KubernetesCleanup:       "not-attempted",
+		APIVersion:        operation.APIVersion,
+		Kind:              "WipeClusterReport",
+		Command:           "katlctl cluster wipe",
+		Plan:              planOnly,
+		PartialCluster:    partial,
+		KubernetesCleanup: "not-attempted",
 		WipedState: []string{
 			"katlos-boot-artifacts",
 			"disk-boot-path",
@@ -810,7 +843,7 @@ func newWipeClusterReport(planOnly bool, partial bool, nodes []inventory.Planned
 func newWipeNodeReport(planOnly bool, partial bool, node inventory.PlannedNode) wipeNodeReport {
 	report := wipeNodeReport{wipeClusterReport: newWipeClusterReport(planOnly, partial, []inventory.PlannedNode{node})}
 	report.Kind = "WipeNodeReport"
-	report.Command = "katlctl wipe node"
+	report.Command = "katlctl node wipe"
 	if planOnly && strings.TrimSpace(report.KubernetesCleanup) == "not-attempted" {
 		report.KubernetesCleanup = "planned"
 	}
@@ -955,7 +988,7 @@ func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, re
 		}
 		result.Endpoint = conn.Endpoint
 		operationSpec := wipeClusterOperation(node)
-		if strings.HasSuffix(report.Command, "wipe node") {
+		if report.Kind == "WipeNodeReport" {
 			operationSpec = wipeNodeOperation(node)
 		}
 		actor := strings.TrimSpace(report.Command)
@@ -1140,7 +1173,7 @@ func containsString(values []string, want string) bool {
 func newConfigPathCommand(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "path",
-		Short: "Print the resolved katlctl config path",
+		Short: "Print the workstation context file path",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runConfigPath(stdout, stderr)
@@ -1163,6 +1196,7 @@ func workstationConfigPath() (string, error) {
 }
 
 type configTopologyOptions struct {
+	configPath  string
 	contextName string
 	output      string
 }
@@ -1177,7 +1211,8 @@ func newConfigTopologyCommand(stdout, stderr io.Writer) *cobra.Command {
 			return runConfigTopology(opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl config context name")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "context name")
 	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
 	return cmd
 }
@@ -1188,6 +1223,7 @@ func runConfigTopology(opts configTopologyOptions, stdout, stderr io.Writer) err
 		return fmt.Errorf("--output = %q, want json", opts.output)
 	}
 	resolved, err := workstation.ResolveTopology(workstation.ResolveRequest{
+		ConfigPath:  opts.configPath,
 		ContextName: opts.contextName,
 	})
 	if err != nil {
@@ -1498,7 +1534,7 @@ type configApplyOptions struct {
 var configApplyNow = func() time.Time { return time.Now().UTC() }
 
 func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl config apply", output: "json"}
+	opts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl node apply", output: "json"}
 	cmd := &cobra.Command{
 		Use:   "apply [SOURCE]",
 		Short: "Validate or apply node configuration",
@@ -1515,7 +1551,7 @@ func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	}
 	addConfigApplyFlags(cmd, &opts)
 
-	validateOpts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl config apply validate", plan: true, output: "json"}
+	validateOpts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl node apply validate", plan: true, output: "json"}
 	validateCmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate node configuration without accepting an operation",
@@ -1541,7 +1577,7 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
-	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.configPath, "file", "", "pre-rendered NodeConfigurationChange YAML")
 	addNodeConfigInputFlags(cmd, &opts.nodeConfig)
@@ -1738,7 +1774,7 @@ func newConfigApplyStatusCommand(ctx context.Context, stdout, stderr io.Writer) 
 	cmd.Flags().StringVar(&opts.root, "root", "/", "runtime root to inspect")
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
-	cmd.Flags().StringVar(&opts.workstationConfig, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.generationID, "generation", "", "generation id to query from katlc agent")

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -68,10 +68,11 @@ func TestRootHelpShowsCommandGroups(t *testing.T) {
 	}
 	out := stdout.String()
 	for _, want := range []string{
-		"KatlOS operator client",
+		"katlctl installs and manages KatlOS nodes",
 		"cluster     Cluster lifecycle operations",
-		"config      Katl configuration operations",
-		"wipe        Compatibility aliases for destructive wipe commands",
+		"config      Create and compile ClusterConfig",
+		"context     Inspect enrolled workstation context",
+		"node        Manage individual KatlOS nodes",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("stdout = %q, missing %q", out, want)
@@ -80,25 +81,68 @@ func TestRootHelpShowsCommandGroups(t *testing.T) {
 	if strings.Contains(out, "completion") {
 		t.Fatalf("stdout = %q, want no implicit completion command", out)
 	}
+	for _, obsolete := range []string{"\n  host ", "\n  wipe "} {
+		if strings.Contains(out, obsolete) {
+			t.Fatalf("stdout = %q, contains obsolete top-level command %q", out, obsolete)
+		}
+	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 
-func TestRootRequiresCommand(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), nil, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "command is required") {
-		t.Fatalf("run() error = %v, want command required", err)
+func TestCommandGroupsExposeOneSupportedPath(t *testing.T) {
+	tests := []struct {
+		group     string
+		required  []string
+		forbidden []string
+	}{
+		{group: "node", required: []string{"apply", "reboot", "status", "upgrade", "wipe"}},
+		{group: "cluster", required: []string{"bootstrap", "enroll", "wipe"}, forbidden: []string{"kubeadm-control-plane-config"}},
+		{group: "kubernetes", required: []string{"apply-config", "upgrade"}},
+		{group: "config", required: []string{"bundle", "init", "schema", "validate"}, forbidden: []string{"apply", "path", "topology"}},
+		{group: "context", required: []string{"path", "show"}},
 	}
-	if stdout.Len() != 0 || stderr.Len() != 0 {
-		t.Fatalf("stdout = %q stderr = %q, want empty", stdout.String(), stderr.String())
+	for _, test := range tests {
+		t.Run(test.group, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(context.Background(), []string{test.group, "--help"}, &stdout, &stderr); err != nil {
+				t.Fatalf("run() error = %v", err)
+			}
+			out := stdout.String()
+			for _, command := range test.required {
+				if !strings.Contains(out, command) {
+					t.Fatalf("stdout = %q, missing command %q", out, command)
+				}
+			}
+			for _, command := range test.forbidden {
+				if strings.Contains(out, command) {
+					t.Fatalf("stdout = %q, contains obsolete command %q", out, command)
+				}
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRootWithoutArgumentsPrintsHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), nil, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Usage:") || !strings.Contains(stdout.String(), "katlctl install discover") {
+		t.Fatalf("stdout = %q, want useful root help", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 
 func TestOutputFormatValidation(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{"config", "topology", "--output", "yaml"}, &stdout, &stderr)
+	err := run(context.Background(), []string{"context", "show", "--output", "yaml"}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), `--output = "yaml", want json`) {
 		t.Fatalf("run() error = %v, want output validation", err)
 	}
@@ -155,7 +199,7 @@ func TestConfigPathCommandPrintsResolvedPath(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"config", "path"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"context", "path"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 	if got, want := strings.TrimSpace(stdout.String()), filepath.Join(configHome, "katl", "katlctl.yaml"); got != want {
@@ -437,7 +481,7 @@ clusters:
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "topology",
+		"context", "show",
 		"--context", "stage",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -881,22 +925,17 @@ nodes:
 	}
 }
 
-func TestWipeClusterRequiresExactAcknowledgement(t *testing.T) {
-	inventoryPath := writeInventory(t)
+func TestWipeCommandsExplainConsequenceWithoutConfirmationCeremony(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{
-		"cluster", "wipe",
-		"--inventory", inventoryPath,
-		"--all",
-		"--confirm-destructive-wipe",
-		"--acknowledge", "I know this is destructive",
-		"--client-request-id", "wipe-req",
-	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "--acknowledge must exactly match") {
-		t.Fatalf("run() error = %v, want acknowledgement validation", err)
+	if err := run(context.Background(), []string{"node", "wipe", "--help"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
 	}
-	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %s, want empty", stdout.String())
+	out := stdout.String()
+	if !strings.Contains(out, "must boot installer media or PXE") {
+		t.Fatalf("stdout = %q, want reinstall consequence", out)
+	}
+	if strings.Contains(out, "acknowledge") || strings.Contains(out, "confirm-destructive") {
+		t.Fatalf("stdout = %q, want no confirmation ceremony", out)
 	}
 }
 
@@ -907,8 +946,6 @@ func TestWipeClusterRefusesPartialTargetWithoutOverride(t *testing.T) {
 		"cluster", "wipe",
 		"--inventory", inventoryPath,
 		"--node", "cp-1",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-req",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "partial cluster wipe requires --allow-partial-cluster") {
@@ -947,8 +984,6 @@ func TestWipeClusterPlanPrintsNodeLocalOperations(t *testing.T) {
 		"--inventory", inventoryPath,
 		"--all",
 		"--plan",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-req",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -958,7 +993,7 @@ func TestWipeClusterPlanPrintsNodeLocalOperations(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode report: %v\n%s", err, stdout.String())
 	}
-	if !report.Plan || !report.AcknowledgementAccepted || report.PartialCluster {
+	if !report.Plan || report.PartialCluster {
 		t.Fatalf("report flags = %#v", report)
 	}
 	if len(report.Targets) != 2 || len(report.NodeLocalOperations) != 2 {
@@ -974,7 +1009,7 @@ func TestWipeClusterPlanPrintsNodeLocalOperations(t *testing.T) {
 	}
 }
 
-func TestWipeClusterPlanAcceptsClusterConfigWithoutDestructiveAcknowledgement(t *testing.T) {
+func TestWipeClusterPlanAcceptsClusterConfig(t *testing.T) {
 	sourcePath := writeClusterConfig(t)
 	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
 		"cp-1": readyWipeClusterClient("cp-machine"),
@@ -996,7 +1031,52 @@ func TestWipeClusterPlanAcceptsClusterConfigWithoutDestructiveAcknowledgement(t 
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode report: %v\n%s", err, stdout.String())
 	}
-	if !report.Plan || report.AcknowledgementAccepted || len(report.Targets) != 1 || report.Targets[0].Name != "cp-1" {
+	if !report.Plan || len(report.Targets) != 1 || report.Targets[0].Name != "cp-1" {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestWipeClusterUsesEnrolledContextWithoutSource(t *testing.T) {
+	configPath := writeKatlctlConfig(t, `currentContext: lab
+contexts:
+- name: lab
+  cluster: katl-lab
+clusters:
+- name: katl-lab
+  controlPlaneEndpoint: api.lab.test:6443
+  nodes:
+  - name: cp-1
+    managementEndpoint: 192.0.2.11:9443
+    systemRole: control-plane
+    credentialRef: file:/secure/katl/cp-1.token
+  - name: worker-1
+    managementEndpoint: 192.0.2.21:9443
+    systemRole: worker
+    credentialRef: file:/secure/katl/worker-1.token
+`)
+	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
+		"cp-1":     readyWipeClusterClient("cp-machine"),
+		"worker-1": readyWipeClusterClient("worker-machine"),
+	})
+	oldConnector := newWipeClusterConnector
+	newWipeClusterConnector = func(string) cluster.AgentConnector { return connector }
+	t.Cleanup(func() { newWipeClusterConnector = oldConnector })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"cluster", "wipe",
+		"--context-file", configPath,
+		"--all",
+		"--plan",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	var report wipeClusterReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if len(report.Targets) != 2 || report.PartialCluster {
 		t.Fatalf("report = %#v", report)
 	}
 }
@@ -1018,8 +1098,6 @@ func TestWipeClusterSubmitsDestructiveResetToAllNodes(t *testing.T) {
 		"cluster", "wipe",
 		"--inventory", inventoryPath,
 		"--all",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-req",
 		"--timeout", "10m",
 	}, &stdout, &stderr)
@@ -1056,61 +1134,16 @@ func TestWipeClusterSubmitsDestructiveResetToAllNodes(t *testing.T) {
 	}
 }
 
-func TestWipeClusterCompatibilityAliasUsesPrimaryCommand(t *testing.T) {
-	inventoryPath := writeInventory(t)
-	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
-		"cp-1":     readyWipeClusterClient("cp-machine"),
-		"worker-1": readyWipeClusterClient("worker-machine"),
-	})
-	old := newWipeClusterConnector
-	newWipeClusterConnector = func(token string) cluster.AgentConnector {
-		return connector
-	}
-	t.Cleanup(func() { newWipeClusterConnector = old })
-
-	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{
-		"wipe", "cluster",
-		"--inventory", inventoryPath,
-		"--all",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
-		"--client-request-id", "cluster-wipe-req",
-	}, &stdout, &stderr)
-	if err != nil {
-		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
-	}
-	for name, client := range connector.clients {
-		req := client.submitRequest
-		if req == nil {
-			t.Fatalf("%s submit request = nil", name)
-		}
-		reset := req.GetDestructiveReset()
-		if req.Actor != "katlctl cluster wipe" || reset == nil || reset.ResetScope != "cluster" {
-			t.Fatalf("%s submit request = %+v reset=%+v", name, req, reset)
-		}
-	}
-	var report wipeClusterReport
-	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
-		t.Fatalf("decode report: %v\n%s", err, stdout.String())
-	}
-	if report.Command != "katlctl cluster wipe" {
-		t.Fatalf("report command = %q", report.Command)
-	}
-}
-
 func TestWipeNodeRequiresExactlyOneTarget(t *testing.T) {
 	inventoryPath := writeInventory(t)
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"wipe", "node",
+		"node", "wipe",
 		"--inventory", inventoryPath,
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-node-req",
 		"--kubeconfig", "admin.conf",
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "exactly one --node is required") {
+	if err == nil || !strings.Contains(err.Error(), "accepts between 1 and 2 arg") {
 		t.Fatalf("run() error = %v, want exact node target validation", err)
 	}
 	if stdout.Len() != 0 {
@@ -1118,7 +1151,7 @@ func TestWipeNodeRequiresExactlyOneTarget(t *testing.T) {
 	}
 }
 
-func TestClusterWipeNodeSubmitsWithNodeActor(t *testing.T) {
+func TestNodeWipeSubmitsWithNodeActor(t *testing.T) {
 	inventoryPath := writeInventory(t)
 	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
 		"worker-1": readyWipeClusterClient("worker-machine"),
@@ -1137,12 +1170,9 @@ func TestClusterWipeNodeSubmitsWithNodeActor(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"cluster", "wipe", "node",
+		"node", "wipe", "worker-1",
 		"--inventory", inventoryPath,
-		"--node", "worker-1",
 		"--kubeconfig", "admin.conf",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "cluster-wipe-node-req",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -1153,14 +1183,14 @@ func TestClusterWipeNodeSubmitsWithNodeActor(t *testing.T) {
 		t.Fatal("submit request = nil")
 	}
 	reset := req.GetDestructiveReset()
-	if req.Actor != "katlctl cluster wipe node" || reset == nil || reset.ResetScope != "node" {
+	if req.Actor != "katlctl node wipe" || reset == nil || reset.ResetScope != "node" {
 		t.Fatalf("submit request = %+v reset=%+v", req, reset)
 	}
 	var report wipeNodeReport
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode report: %v\n%s", err, stdout.String())
 	}
-	if report.Command != "katlctl cluster wipe node" {
+	if report.Command != "katlctl node wipe" {
 		t.Fatalf("report command = %q", report.Command)
 	}
 }
@@ -1184,12 +1214,9 @@ func TestWipeNodePlanPrintsUnknownKubernetesCleanupWithoutKubeconfig(t *testing.
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"wipe", "node",
+		"node", "wipe", "worker-1",
 		"--inventory", inventoryPath,
-		"--node", "worker-1",
 		"--plan",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-node-req",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -1199,7 +1226,7 @@ func TestWipeNodePlanPrintsUnknownKubernetesCleanupWithoutKubeconfig(t *testing.
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode report: %v\n%s", err, stdout.String())
 	}
-	if !report.Plan || report.Kind != "WipeNodeReport" || report.Command != "katlctl wipe node" {
+	if !report.Plan || report.Kind != "WipeNodeReport" || report.Command != "katlctl node wipe" {
 		t.Fatalf("report identity = %#v", report)
 	}
 	if report.KubernetesCleanup != "unknown" {
@@ -1210,6 +1237,49 @@ func TestWipeNodePlanPrintsUnknownKubernetesCleanupWithoutKubeconfig(t *testing.
 	}
 	if len(kubectl.calls) != 0 {
 		t.Fatalf("kubectl calls = %#v, want none for plan without kubeconfig", kubectl.calls)
+	}
+}
+
+func TestWipeNodeUsesEnrolledContextWithoutClusterSource(t *testing.T) {
+	configPath := writeKatlctlConfig(t, `currentContext: lab
+contexts:
+- name: lab
+  cluster: katl-lab
+clusters:
+- name: katl-lab
+  controlPlaneEndpoint: api.lab.test:6443
+  nodes:
+  - name: cp-1
+    managementEndpoint: 192.0.2.11:9443
+    systemRole: control-plane
+    credentialRef: file:/secure/katl/cp-1.token
+  - name: worker-1
+    managementEndpoint: 192.0.2.21:9443
+    systemRole: worker
+    credentialRef: file:/secure/katl/worker-1.token
+`)
+	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
+		"worker-1": readyWipeClusterClient("worker-machine"),
+	})
+	oldConnector := newWipeClusterConnector
+	newWipeClusterConnector = func(string) cluster.AgentConnector { return connector }
+	t.Cleanup(func() { newWipeClusterConnector = oldConnector })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"node", "wipe", "worker-1",
+		"--context-file", configPath,
+		"--plan",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	var report wipeNodeReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if len(report.Targets) != 1 || report.Targets[0].Name != "worker-1" || report.Targets[0].Address != "192.0.2.21" {
+		t.Fatalf("targets = %#v", report.Targets)
 	}
 }
 
@@ -1232,12 +1302,9 @@ func TestWipeNodeSubmitsAfterKubernetesCleanup(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"wipe", "node",
+		"node", "wipe", "worker-1",
 		"--inventory", inventoryPath,
-		"--node", "worker-1",
 		"--kubeconfig", "admin.conf",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-node-req",
 		"--timeout", "7m",
 	}, &stdout, &stderr)
@@ -1295,12 +1362,9 @@ func TestWipeNodeReportsRecoveryRequiredBeforeLocalReset(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"wipe", "node",
+		"node", "wipe", "worker-1",
 		"--inventory", inventoryPath,
-		"--node", "worker-1",
 		"--kubeconfig", "admin.conf",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-node-req",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "Kubernetes cleanup failed") {
@@ -1341,12 +1405,9 @@ func TestWipeNodeRefusesControlPlaneBeforeMutation(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"wipe", "node",
+		"node", "wipe", "cp-1",
 		"--inventory", inventoryPath,
-		"--node", "cp-1",
 		"--kubeconfig", "admin.conf",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeAcknowledgementText,
 		"--client-request-id", "wipe-node-req",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "etcd membership coordination") {
@@ -1386,7 +1447,7 @@ func TestConfigApplyStatusReportsActiveAndNextBootJSON(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply", "status",
+		"node", "apply", "status",
 		"--root", root,
 		"--active-generation", "2026.06.05-002",
 		"--next-boot-generation", "2026.06.05-003",
@@ -1433,7 +1494,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply",
+		"node", "apply",
 		"--endpoint", "node-a.example.test:9443",
 		"--file", configPath,
 		"--mode", generation.ApplyModeNextBoot,
@@ -1443,7 +1504,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
-	if fake.stageRequest == nil || fake.stageRequest.CandidateGenerationId != "generation-1" || fake.stageRequest.ClientRequestId != "req-stage" || fake.stageRequest.Actor != "katlctl config apply" {
+	if fake.stageRequest == nil || fake.stageRequest.CandidateGenerationId != "generation-1" || fake.stageRequest.ClientRequestId != "req-stage" || fake.stageRequest.Actor != "katlctl node apply" {
 		t.Fatalf("stage request = %+v", fake.stageRequest)
 	}
 	assertSuccessfulMutationOutput(t, stdout.Bytes())
@@ -1469,7 +1530,7 @@ func TestHostUpgradeSubmitsSingleImageOperation(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"host", "upgrade",
+		"node", "upgrade",
 		"--endpoint", "node-a.example.test:9443",
 		"--image-url", "https://updates.example.test/katlos-upgrade.squashfs",
 		"--candidate-generation", "generation-upgrade-1",
@@ -1509,7 +1570,7 @@ func TestHostUpgradeVersionStagesRebootsAndVerifiesHealth(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"host", "upgrade", "v2026.7.0-alpha.9", "--endpoint", "node-a.example.test:9443", "--timeout", "1m"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "upgrade", "v2026.7.0-alpha.9", "--endpoint", "node-a.example.test:9443", "--timeout", "1m"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	request := fake.submitRequest.GetHostUpgrade()
@@ -1556,7 +1617,7 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply",
+		"node", "apply",
 		"--endpoint", "node-a.example.test:9443",
 		"--file", configPath,
 		"--candidate-generation", "generation-auto",
@@ -1565,10 +1626,10 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
-	if fake.validateRequest == nil || fake.validateRequest.ApplyMode != generation.ApplyModeAuto || fake.validateRequest.CandidateGenerationId != "generation-auto" || fake.validateRequest.Actor != "katlctl config apply" {
+	if fake.validateRequest == nil || fake.validateRequest.ApplyMode != generation.ApplyModeAuto || fake.validateRequest.CandidateGenerationId != "generation-auto" || fake.validateRequest.Actor != "katlctl node apply" {
 		t.Fatalf("validate request = %+v", fake.validateRequest)
 	}
-	if fake.submitRequest == nil || fake.submitRequest.OperationKind != "generation-apply" || fake.submitRequest.Actor != "katlctl config apply" || fake.submitRequest.GetConfigApply().GetApplyMode() != generation.ApplyModeAuto {
+	if fake.submitRequest == nil || fake.submitRequest.OperationKind != "generation-apply" || fake.submitRequest.Actor != "katlctl node apply" || fake.submitRequest.GetConfigApply().GetApplyMode() != generation.ApplyModeAuto {
 		t.Fatalf("submit request = %+v", fake.submitRequest)
 	}
 	if fake.stageRequest != nil || fake.applyRequest != nil {
@@ -1601,7 +1662,7 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply", "validate",
+		"node", "apply", "validate",
 		"--endpoint", "node-a.example.test:9443",
 		"--file", configPath,
 		"--mode", generation.ApplyModeNextBoot,
@@ -1611,7 +1672,7 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
-	if fake.validateRequest == nil || fake.validateRequest.CandidateGenerationId != "generation-plan" || fake.validateRequest.ClientRequestId != "req-plan" || fake.validateRequest.Actor != "katlctl config apply validate" || fake.validateRequest.ApplyMode != generation.ApplyModeNextBoot {
+	if fake.validateRequest == nil || fake.validateRequest.CandidateGenerationId != "generation-plan" || fake.validateRequest.ClientRequestId != "req-plan" || fake.validateRequest.Actor != "katlctl node apply validate" || fake.validateRequest.ApplyMode != generation.ApplyModeNextBoot {
 		t.Fatalf("validate request = %+v", fake.validateRequest)
 	}
 	if fake.stageRequest != nil || fake.applyRequest != nil {
@@ -1653,7 +1714,7 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply",
+		"node", "apply",
 		"--endpoint", "node-a.example.test:9443",
 		"--config-bundle", bundlePath,
 		"--node", "cp-1",
@@ -1714,7 +1775,7 @@ func TestConfigApplyStatusQueriesGenerationFromAgent(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply", "status",
+		"node", "apply", "status",
 		"--endpoint", "node-a.example.test:9443",
 		"--generation", "generation-1",
 	}, &stdout, &stderr)
@@ -1755,7 +1816,7 @@ func TestConfigApplyStatusReportsFailureRollbackAndKubeadmRedacted(t *testing.T)
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"config", "apply", "status",
+		"node", "apply", "status",
 		"--root", root,
 		"--active-generation", "2026.06.05-004",
 		"--next-boot-generation", "2026.06.05-005",
@@ -1814,11 +1875,11 @@ func TestOperatorCommandsHideIntegrityDigestFlags(t *testing.T) {
 	for _, args := range [][]string{
 		{"install", "apply", "--help"},
 		{"config", "render-node", "--help"},
-		{"config", "apply", "--help"},
+		{"node", "apply", "--help"},
 		{"cluster", "bootstrap", "--help"},
-		{"cluster", "kubeadm-control-plane-config", "--help"},
-		{"host", "upgrade", "--help"},
-		{"operation", "status", "--help"},
+		{"kubernetes", "apply-config", "--help"},
+		{"node", "upgrade", "--help"},
+		{"operations", "status", "--help"},
 	} {
 		var stdout, stderr bytes.Buffer
 		if err := run(context.Background(), args, &stdout, &stderr); err != nil {

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -64,7 +64,7 @@ type operationListOptions struct {
 }
 
 func newOperationCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{Use: "operations", Aliases: []string{"operation"}, Short: "Inspect KatlOS operations"}
+	cmd := &cobra.Command{Use: "operations", Short: "Inspect KatlOS operations"}
 	cmd.AddCommand(newOperationStatusCommand(ctx, stdout, stderr))
 	cmd.AddCommand(newOperationListCommand(ctx, stdout, stderr))
 	return cmd
@@ -82,7 +82,7 @@ func newOperationStatusCommand(ctx context.Context, stdout, stderr io.Writer) *c
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
-	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.operationID, "operation-id", "", "accepted operation id")
@@ -105,7 +105,7 @@ func newOperationListCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
-	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().BoolVar(&opts.activeOnly, "active", false, "show only non-terminal operations")

--- a/cmd/katlctl/operation_test.go
+++ b/cmd/katlctl/operation_test.go
@@ -44,7 +44,7 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 
 			var stdout, stderr bytes.Buffer
 			err := run(context.Background(), []string{
-				"operation", "status",
+				"operations", "status",
 				"--endpoint", "node.test:9443",
 				"--agent-token-file", tokenPath,
 				"--operation-id", "operation-1",
@@ -163,10 +163,10 @@ func TestFollowOperationTimeoutReturnsLastStatus(t *testing.T) {
 
 func TestOperationStatusValidatesFlags(t *testing.T) {
 	for _, args := range [][]string{
-		{"operation", "status"},
-		{"operation", "status", "--endpoint", "node:9443"},
-		{"operation", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--diagnostics", "everything"},
-		{"operation", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--timeout", "0s"},
+		{"operations", "status"},
+		{"operations", "status", "--endpoint", "node:9443"},
+		{"operations", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--diagnostics", "everything"},
+		{"operations", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--timeout", "0s"},
 	} {
 		var stdout, stderr bytes.Buffer
 		if err := run(context.Background(), args, &stdout, &stderr); err == nil {
@@ -186,7 +186,7 @@ func TestOperationWatchReturnsFailureAfterStatus(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{"operation", "status", "--endpoint", "node:9443", "--operation-id", "operation-1", "--watch"}, &stdout, &stderr)
+	err := run(context.Background(), []string{"operations", "status", "--endpoint", "node:9443", "--operation-id", "operation-1", "--watch"}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "disk mutation requires recovery") {
 		t.Fatalf("run() error = %v", err)
 	}

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -193,7 +193,7 @@ func TestClusterEnrollCreatesContextAndPrivateTokens(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"cluster", "enroll", sourcePath, "--config", configPath}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"cluster", "enroll", sourcePath, "--context-file", configPath}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
 	}
 	cfg, err := workstation.Load(configPath)
@@ -254,7 +254,7 @@ func TestConfigApplyUsesContextAndDerivesBookkeeping(t *testing.T) {
 	t.Cleanup(func() { configApplyNow = oldNow })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"config", "apply", writeClusterConfig(t), "--config", configPath, "--node", "cp-1"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "apply", writeClusterConfig(t), "--context-file", configPath, "--node", "cp-1"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
 	}
 	if fake.validateRequest == nil || fake.validateRequest.CandidateGenerationId != "config-42" {

--- a/cmd/katlctl/target.go
+++ b/cmd/katlctl/target.go
@@ -23,7 +23,7 @@ type managementTarget struct {
 }
 
 func addManagementTargetFlags(cmd *cobra.Command, opts *managementTargetOptions) {
-	cmd.Flags().StringVar(&opts.configPath, "config", "", "katlctl workstation config path")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "explicit katlc agent endpoint host:port")
@@ -33,7 +33,7 @@ func addManagementTargetFlags(cmd *cobra.Command, opts *managementTargetOptions)
 func resolveManagementTarget(opts managementTargetOptions) (managementTarget, error) {
 	if endpoint := strings.TrimSpace(opts.endpoint); endpoint != "" {
 		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
-			return managementTarget{}, fmt.Errorf("--endpoint cannot be combined with --config or --context")
+			return managementTarget{}, fmt.Errorf("--endpoint cannot be combined with --context-file or --context")
 		}
 		token, err := readAgentToken(opts.agentTokenFile)
 		if err != nil {

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -454,7 +454,7 @@ request internally; operators do not maintain a second configuration schema.
 Optionally plan the exact per-node runtime request through the node agent:
 
 ```text
-katlctl config apply ./cluster.yaml --node cp-1 --plan
+katlctl node apply ./cluster.yaml --node cp-1 --plan
 ```
 
 `katlctl` derives the source version, candidate generation, authenticated
@@ -465,7 +465,7 @@ If the source has already been compiled, use the bundle instead of
 recompiling it:
 
 ```text
-katlctl config apply \
+katlctl node apply \
   --config-bundle ./katl-lab.katlcfg \
   --node cp-1 \
   --plan
@@ -496,7 +496,7 @@ interface, and digests. An upgrade operation creates a candidate generation from
 that image and validates component compatibility before selection.
 
 Kubernetes version upgrades remain separate from day-one install. Use
-`katlctl cluster upgrade kubernetes` to plan and execute the kubeadm-aware,
+`katlctl kubernetes upgrade` to plan and execute the kubeadm-aware,
 control-plane-first rollout from a published bundle. Katl resolves the bundle
 identity, captures control-plane etcd snapshot evidence, stages the target
 `kubeadm` privately before releasing the target kubelet, and reports recovery

--- a/docs/internal/cluster-recovery-and-rebuild.md
+++ b/docs/internal/cluster-recovery-and-rebuild.md
@@ -23,7 +23,7 @@ init/join after a post-mutation interruption.
 For day one, and likely beyond, Katl's general rebuild story is:
 
 ```text
-wipe selected nodes or disks with explicit data-loss acknowledgement
+invoke an explicit node or cluster wipe
 install clean KatlOS generation 0
 run a new explicit cluster bootstrap
 create a new Kubernetes cluster identity
@@ -44,7 +44,7 @@ kubelet state under /var/lib/kubelet
 etcd state or snapshots
 Kubernetes API reachability and observed cluster state
 control-plane endpoint intent
-operator acknowledgement of data loss, when destructive action is requested
+the explicitly selected destructive operation and target set
 ```
 
 Katl operation records contain redacted evidence. They do not replace backups of
@@ -77,7 +77,7 @@ Rules:
 ```text
 destructive reinstall
   may create a clean generation 0 and discard local Kubernetes state when the
-  operator explicitly acknowledges data loss
+  operator explicitly invokes the wipe or install workflow
 
 non-destructive reinstall or repair
   must preserve /var/lib/katl, projected /etc/kubernetes, /var/lib/kubelet, and
@@ -107,7 +107,7 @@ Rules:
 ```text
 wipe/reinstall selected nodes
   allowed only through the installer's destructive install guard or a future
-  destructive reset contract with explicit data-loss acknowledgement
+  explicit destructive reset contract
 
 new bootstrap after wipe/reinstall
   creates a new Kubernetes cluster identity and new kubeadm-owned cluster state
@@ -135,21 +135,12 @@ identity, CNI state, or Katl operation history from the selected nodes.
 The user-facing command contract is defined in
 `docs/internal/katlctl-wipe-contract.md`.
 
-The user-facing acknowledgement must be explicit and specific. A request is not
-accepted unless the operator supplies an affirmative destructive flag and a
-human-readable acknowledgement equivalent to:
-
-```text
-I understand this will erase KatlOS, Kubernetes, kubelet, etcd, CNI, operation,
-and generation state on the selected nodes and bootstrap a new cluster identity.
-```
-
-Short flags such as `--force`, `--yes`, or a repeated failed bootstrap attempt
-are not enough. The installer manifest requires `install.wipeTarget: true`, and
-install status records `wipeTargetAccepted` after validation. User-facing wipe
-commands may require stronger cluster lifecycle acknowledgements before they
-produce installer manifests. Diagnostics must not record secrets from the
-discarded cluster.
+The explicit `katlctl node wipe` or `katlctl cluster wipe` invocation is the
+operator's destructive intent. Katl does not require an additional confirmation
+flag, prompt, or acknowledgement phrase. The command must identify its targets
+and explain that installer media or PXE is required afterward. The installer
+still owns target-disk selection and its accepted install plan. Diagnostics must
+not record secrets from the discarded cluster.
 
 For v0.1, wipe/reinstall owns only selected KatlOS target disks and Katl-owned
 state on those disks:
@@ -322,7 +313,7 @@ operation record missing mutation boundary for a mutating workflow
 request digest mismatch between failed operation and retry
 node identity mismatch
 Kubernetes version incompatibility for the requested restore
-data-loss acknowledgement missing for destructive reset or rebuild
+destructive reset target set is empty or ambiguous
 ```
 
 The refusal output should name the state that blocked progress and the explicit

--- a/docs/internal/generations-and-operations.md
+++ b/docs/internal/generations-and-operations.md
@@ -1028,7 +1028,7 @@ common evidence
 common refusal states
   unsupported-recovery-kind, missing-target-record, record-digest-mismatch,
   node-identity-mismatch, stale-ambiguous, scope-not-authorized,
-  live-state-conflict, insufficient-evidence, data-loss-not-acknowledged,
+  live-state-conflict, insufficient-evidence, destructive-target-not-selected,
   quorum-risk, version-incompatible, and concurrent-operation
 ```
 
@@ -1053,7 +1053,7 @@ supported behavior. Each row must be completed with tests before implementation:
 | `repair-generation-status` | Scope `host-generation`; preflight generation spec/status/journal/boot-entry consistency; allow commit/rollback bookkeeping repair only; forbid partial root, sysext, or confext switching |
 | `retry-operation` | Scope matches the original operation; preflight parent record, stale class, request digest, live probes, and material validity; allow rerun only of idempotent or kind-declared retryable phases as a child operation; forbid automatic retry, stale-ambiguous replay, request changes, and implicit cleanup |
 | `renew-certificates` | Scope `kubeadm-state`; preflight kubeadm version, certificate expiry, API/static pod state, and redacted kubeconfig access; allow explicit kubeadm certificate renewal and declared restarts; forbid upgrades, etcd membership changes, and config drift repair |
-| `kubeadm-reset` | Scope `destructive-reset`; preflight explicit data-loss acknowledgement, node identity, system role, cluster membership, and etcd handling decision; allow only the declared reset surface; forbid etcd member replacement, snapshot restore, install input replacement, and undeclared disk wipe |
+| `kubeadm-reset` | Scope `destructive-reset`; preflight explicit operation kind and target set, node identity, system role, cluster membership, and etcd handling decision; allow only the declared reset surface; forbid etcd member replacement, snapshot restore, install input replacement, and undeclared disk wipe |
 | `replace-etcd-member` | Scope `etcd-state`; preflight quorum, member identity, peer URLs, certificate compatibility, version skew, and local member mapping; allow only a named member remove/add flow; forbid snapshot restore, stale data reuse without proof, and automatic failed-join cleanup |
 | `restore-etcd-snapshot` | Scope `etcd-state`; preflight explicit disaster intent, snapshot path/digest/revision, Kubernetes/etcd version compatibility, topology, participant set, and current-state backup decision; allow only the declared snapshot restore procedure; forbid in-place merge, unknown snapshots, partial topology restore, and treating host rollback as etcd rollback |
 

--- a/docs/internal/initial-design.md
+++ b/docs/internal/initial-design.md
@@ -164,7 +164,7 @@ Users supply:
 
 ```text
 target root disk selector
-destructive install authorization and exact data-loss acknowledgement
+explicit target-disk selection and destructive install intent
 node identity inputs such as hostname and SSH public keys
 KatlOS image reference and digest
 exact Kubernetes payload bundle source/ref, such as a source URL plus

--- a/docs/internal/katlc-agent-architecture.md
+++ b/docs/internal/katlc-agent-architecture.md
@@ -110,8 +110,8 @@ a separate local CLI contract.
 Target `katlctl` commands own workstation orchestration:
 
 ```text
-katlctl config apply
-katlctl config apply status
+katlctl node apply
+katlctl node apply status
 katlctl bootstrap init
 katlctl bootstrap join-control-plane
 katlctl bootstrap join-worker

--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -1,7 +1,7 @@
 # katlctl Wipe Command Contract
 
 This document defines the v0.1 user-facing contract for destructive wipe flows.
-It is implementation guidance for `katlctl wipe node` and
+It is implementation guidance for `katlctl node wipe` and
 `katlctl cluster wipe`; it does not make either command supported until the
 implementation and VM gates named here exist.
 
@@ -10,46 +10,39 @@ implementation and VM gates named here exist.
 Both commands are explicit operator actions. They are not automatic repair,
 retry, rollback, or reconciliation flows.
 
-Required destructive acknowledgement text:
-
-```text
-I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.
-```
-
 Normal input:
 
 ```text
+workstation context
+  The enrolled current context supplies node names, management endpoints,
+  roles, and credential references.
+
 SOURCE
-  The retained ClusterConfig used for installation and enrollment. katlctl
-  compiles its internal inventory automatically. --config-bundle and
-  --inventory remain expert alternatives.
+  Optional retained ClusterConfig when no enrolled context is available.
+  --config-bundle and --inventory remain expert alternatives.
 
 --context NAME
   Optional workstation context override for management addresses and
   credential references.
 ```
 
-Required execution flags:
+Execution behavior:
 
 ```text
-
---confirm-destructive-wipe
-  Required boolean flag. Short flags such as --yes or --force are not aliases.
-
---acknowledge TEXT
-  Must exactly match the acknowledgement text above after shell parsing.
-
 --output json
   v0.1 status and plan output format. Other formats are unsupported.
 ```
+
+The explicit `wipe` command is the operator's destructive intent. Katl does not
+add a confirmation flag, prompt, or acknowledgement phrase. Help and planning
+must state that the selected nodes will require installer media or PXE.
 
 Optional common flags:
 
 ```text
 --plan
   Validate targets, credentials, and visible cluster state, then print the
-  planned per-node actions without accepting node-local operations. Planning
-  does not require destructive acknowledgement.
+  planned per-node actions without accepting node-local operations.
 
 --timeout DURATION
   Upper bound for client-side waits. Timeout stops waiting but does not cancel an
@@ -75,9 +68,8 @@ Authentication and authorization:
 
 Plan and status output:
 
-- `--plan` prints JSON with `command`, `targets`, `acknowledgementAccepted`,
-  `kubernetesCleanup`, `nodeLocalOperations`, `wipedState`, `preservedState`,
-  and `refusals`.
+- `--plan` prints JSON with `command`, `targets`, `kubernetesCleanup`,
+  `nodeLocalOperations`, `wipedState`, `preservedState`, and `refusals`.
 - Executing commands wait by default and print JSON with one entry per selected
   node, including the final phase, terminal status, and redacted diagnostics.
   Opaque operation IDs appear only for detached execution or exact diagnostics.
@@ -102,11 +94,10 @@ State preserved:
 - Off-node artifact repositories, operator workstations, external backups,
   external load balancer configuration, and non-target disks.
 - Kubernetes resources for workloads may remain in an external backup or GitOps
-  source, but `katlctl wipe` does not preserve them from the discarded cluster.
+  source, but the wipe commands do not preserve them from the discarded cluster.
 
 Requests are refused before node-local mutation when:
 
-- An executing request is missing the acknowledgement flag or exact text.
 - Target selection is empty, duplicated, or ambiguous.
 - The inventory lacks a node address, role, or usable node-local credential for a
   selected node.
@@ -125,20 +116,21 @@ Failure behavior:
 - Diagnostics must redact bearer tokens, kubeconfigs, bootstrap tokens,
   certificate private keys, and etcd secrets.
 
-## `katlctl wipe node`
+## `katlctl node wipe`
 
 Command:
 
 ```text
-katlctl cluster wipe node SOURCE --node NAME --kubeconfig PATH \
-  --confirm-destructive-wipe --acknowledge TEXT
+katlctl node wipe NAME [SOURCE] --kubeconfig PATH
 ```
 
 Target selection:
 
-- Exactly one `--node NAME` is required.
+- Exactly one positional node name is required.
 - The node name must exist in the inventory and resolve to one node-local katlc
   endpoint.
+- `SOURCE` may be omitted when an enrolled workstation context supplies the
+  topology and node credential reference.
 
 Graceful Kubernetes cleanup:
 
@@ -179,13 +171,8 @@ Result:
 Command:
 
 ```text
-katlctl cluster wipe SOURCE --all \
-  --confirm-destructive-wipe --acknowledge TEXT
+katlctl cluster wipe [SOURCE] --all
 ```
-
-The old `katlctl wipe cluster` spelling is a temporary compatibility alias. It
-must emit the same report `command` and node-local operation `actor` strings as
-`katlctl cluster wipe`.
 
 Target selection:
 
@@ -208,7 +195,7 @@ Cluster identity:
 Node-local wipe trigger:
 
 - `katlctl` submits destructive-reset operations to all selected nodes after
-  validating inventory and acknowledgements.
+  validating inventory and target selection.
 - Ordering is best-effort parallel for worker nodes and conservative for control
   planes: requests may be submitted to all selected control planes without etcd
   quorum checks because the cluster identity is being discarded.
@@ -224,14 +211,14 @@ Result:
 
 ## VM Gates
 
-Implementation of `katlctl wipe node` must add and pass:
+Implementation of `katlctl node wipe` must add and pass:
 
 ```text
 scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios -run TestInstalledRuntimeTwoNodeWipeNodeBootstrapSmoke -count=1
 ```
 
 The gate must start from a bootstrapped Kubernetes cluster with real Kubernetes
-and etcd state, run `katlctl wipe node` against one node, prove Kubernetes Node
+and etcd state, run `katlctl node wipe` against one node, prove Kubernetes Node
 cleanup and etcd member cleanup when applicable, prove the node reaches
 installer-media handoff, then reinstall/bootstrap the node and prove remote
 kubectl/workload health.

--- a/docs/internal/katlctl-workstation-config.md
+++ b/docs/internal/katlctl-workstation-config.md
@@ -35,7 +35,7 @@ XDG_CONFIG_HOME
   base config directory; katlctl appends katl/katlctl.yaml
 ```
 
-`katlctl config path` prints the resolved path.
+`katlctl context path` prints the resolved path.
 
 ## Schema
 
@@ -72,7 +72,7 @@ cluster PKI. Enrollment stores per-node bearer tokens beneath the adjacent
 `credentials/<cluster>/` directory with mode `0600` and records only `file:`
 references here.
 
-`katlctl config topology` prints the resolved context topology as JSON.
+`katlctl context show` prints the resolved context topology as JSON.
 The topology output includes `credentialRef` values because they are operator
 references needed by orchestration, not credential material.
 

--- a/docs/internal/v0.1-release-gate-matrix.md
+++ b/docs/internal/v0.1-release-gate-matrix.md
@@ -260,7 +260,7 @@ Required before: `katlc` agent, generation metadata, config apply, remote host
 reboot, or installed-runtime fixture changes can be considered releasable.
 
 Expected artifacts: installed runtime serial logs, operation records, generated
-confext/generation files, live and next-boot apply evidence, katlctl host reboot
+confext/generation files, live and next-boot apply evidence, katlctl node reboot
 evidence, post-reboot health, and config-apply diagnostic artifacts.
 
 Failure mapping: generation/config apply/kubeadm projection Beads. Missing

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -63,7 +63,7 @@ katlctl operations list \
   --node cp-1
 ```
 
-`katlctl operation status --operation-id ID` remains an advanced diagnostic
+`katlctl operations status --operation-id ID` remains an advanced diagnostic
 path for one exact record. Use `--diagnostics verbose` when normal redacted
 status is insufficient.
 

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -1,7 +1,7 @@
 # Access Installed KatlOS Nodes
 
-Complete this runbook after generation 0 boots and before bootstrap, config
-apply, host upgrade, or wipe operations.
+Complete this runbook after generation 0 boots and before bootstrap, node
+configuration, node upgrade, or wipe operations.
 
 ## Security Boundary
 
@@ -74,8 +74,8 @@ different local token unless `--force` is explicit.
 Inspect the resolved context after enrollment:
 
 ```sh
-katlctl config topology
-katlctl host status cp-1
+katlctl context show
+katlctl node status cp-1
 ```
 
 Enrollment has already performed the authenticated agent health check. Normal
@@ -88,13 +88,13 @@ Show the current KatlOS version, generation, any staged next boot, health, and
 whether the node is busy without exposing machine identity or operation IDs:
 
 ```sh
-katlctl host status cp-1
+katlctl node status cp-1
 ```
 
 Reboot a node and wait for it to return healthy:
 
 ```sh
-katlctl host reboot cp-1
+katlctl node reboot cp-1
 ```
 
 The reboot command does not require a confirmation flag. It honors the node's

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -1,6 +1,6 @@
 # Apply KatlOS Node Configuration
 
-Use config apply for supported host configuration after installation. It is not
+Use `katlctl node apply` for supported node configuration after installation. It is not
 a general Kubernetes, disk, kubeadm, or operating-system upgrade mechanism.
 
 ## Supported Input
@@ -13,12 +13,12 @@ renderer carries:
 - operation-only system role and role-dependent Kubernetes bootstrap state.
 
 Runtime-safe fields can apply normally. Operation-only differences are planned
-and reported as requiring an explicit lifecycle action; config apply does not
+and reported as requiring an explicit lifecycle action; node apply does not
 run kubeadm. Disk/install selection and Kubernetes version changes use the
 dedicated install and Kubernetes upgrade workflows.
 
 If `spec.kubernetes.kubeadm` changes, planning reports a kubeadm-aware action.
-Normal config apply does not rewrite live kubeadm or Kubernetes state; use the
+Normal node apply does not rewrite live kubeadm or Kubernetes state; use the
 dedicated operation for a supported change, or follow the reported manual
 boundary when Katl does not support that transition.
 
@@ -28,7 +28,7 @@ An optional plan compiles the selected node configuration and asks the node to
 validate it without accepting an operation:
 
 ```sh
-katlctl config apply ./cluster.yaml \
+katlctl node apply ./cluster.yaml \
   --node cp-1 \
   --plan
 ```
@@ -42,7 +42,7 @@ If the source has already been compiled, use the expert bundle input instead of
 the positional source:
 
 ```sh
-katlctl config apply --config-bundle ./katl-lab.katlcfg --node cp-1 --plan
+katlctl node apply --config-bundle ./katl-lab.katlcfg --node cp-1 --plan
 ```
 
 Katl derives and verifies the bundle's integrity metadata from the file.
@@ -52,7 +52,7 @@ Katl derives and verifies the bundle's integrity metadata from the file.
 Run the same arguments without `--plan`:
 
 ```sh
-katlctl config apply ./cluster.yaml --node cp-1
+katlctl node apply ./cluster.yaml --node cp-1
 ```
 
 `katlctl` resolves the selected workstation context, reads the node credential,
@@ -66,7 +66,7 @@ is true, stop and follow `failureReason` and `nextAction`.
 Query the candidate through the agent:
 
 ```sh
-katlctl config apply status \
+katlctl node apply status \
   --node cp-1
 ```
 

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -18,7 +18,7 @@ at `/run/katl/console/rendered.txt` for collection over SSH.
 | Installed node does not complete boot | boot console; boot-health and handoff services |
 | Agent cannot be reached | network path to TCP 9443; `katlc-agent.service`; token file mapping |
 | Bootstrap or join fails | `katlctl` phase output; node operation record; kubelet/containerd/kubeadm journals |
-| Config apply stalls or rolls back | `katlctl config apply status`; generation and operation records |
+| Config apply stalls or rolls back | `katlctl node apply status`; generation and operation records |
 | Host upgrade does not stage or boot | host-upgrade operation; boot selection; boot-health journal |
 | Wipe is refused | wipe JSON refusals; selected topology; Kubernetes cleanup diagnostics |
 
@@ -45,7 +45,7 @@ katlctl operations list \
   --agent-token-file ./tokens/affected-node.token
 ```
 
-Use `katlctl operation status --operation-id ID --diagnostics verbose` when an
+Use `katlctl operations status --operation-id ID --diagnostics verbose` when an
 exact record needs deeper inspection.
 
 If the agent is unavailable, use SSH as a break-glass evidence path and read

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -20,7 +20,7 @@ orchestrate availability across several hosts.
 ## Plan
 
 ```sh
-katlctl host upgrade v2026.7.0-alpha.9 --node cp-1 --plan
+katlctl node upgrade v2026.7.0-alpha.9 --node cp-1 --plan
 ```
 
 A plan response has no durable mutation and does not reboot the node.
@@ -34,7 +34,7 @@ component metadata before changing the inactive slot.
 Run the command without `--plan`:
 
 ```sh
-katlctl host upgrade v2026.7.0-alpha.9 --node cp-1
+katlctl node upgrade v2026.7.0-alpha.9 --node cp-1
 ```
 
 `katlctl` follows staging progress, asks the authenticated node agent to reboot,

--- a/docs/operations/upgrade-kubernetes.md
+++ b/docs/operations/upgrade-kubernetes.md
@@ -23,18 +23,12 @@ release; operators do not supply the bundle identity.
 ## Plan
 
 ```sh
-katlctl cluster upgrade kubernetes \
+katlctl kubernetes upgrade \
   v1.36.1 --plan
 ```
 
-The shorter top-level form is equivalent:
-
-```sh
-katlctl kubernetes upgrade v1.36.1 --plan
-```
-
 By default, `katlctl` uses the current context in its workstation configuration.
-Use `--context NAME`, `--config PATH`, or `--inventory PATH` when needed.
+Use `--context NAME`, `--context-file PATH`, or `--inventory PATH` when needed.
 
 The plan connects to every node, reads its current healthy generation and
 Kubernetes payload, derives the control-plane/worker order, and asks every

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -18,38 +18,26 @@ before accepting the operation.
 - stop if a control-plane or etcd member is expected to remain part of the same
   cluster.
 
-Use the retained `ClusterConfig` as the normal input. `katlctl` compiles the
-internal inventory itself. `--config-bundle` remains available for PXE/offline
-material and `--inventory` for expert recovery tooling. Add `--context NAME`
-when the enrolled workstation context should supply management addresses and
-credentials independently of the source.
-
-The required acknowledgement is intentionally exact:
-
-```text
-I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.
-```
+After enrollment, the current workstation context is the normal topology and
+credential source. Pass a retained `ClusterConfig` when operating without an
+enrolled context. `--config-bundle` remains available for PXE/offline material
+and `--inventory` for expert recovery tooling.
 
 ## Plan a Whole-Cluster Wipe
 
 ```sh
 katlctl cluster wipe \
-  ./cluster.yaml \
   --plan \
   --all
 ```
 
-Planning is non-mutating and does not require destructive acknowledgement.
-Review every target, address, role, wiped surface, preserved surface, and
-refusal.
+Planning is non-mutating. Review every target, address, role, wiped surface,
+preserved surface, and refusal.
 
 Execute only when the cluster is intentionally being discarded:
 
 ```sh
-katlctl cluster wipe ./cluster.yaml \
-  --all \
-  --confirm-destructive-wipe \
-  --acknowledge 'I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity.'
+katlctl cluster wipe --all
 ```
 
 The command follows every node-local destructive reset and reports each
@@ -63,16 +51,20 @@ and `result: succeeded`. Treat `recoveryRequired: true` as a stop condition.
 Single-node wipe coordinates Kubernetes Node cleanup before the node-local reset:
 
 ```sh
-katlctl cluster wipe node \
-  ./cluster.yaml \
-  --plan \
-  --node worker-1
+katlctl node wipe worker-1 ./cluster.yaml --plan
 ```
 
-Execution additionally requires `--kubeconfig ./kubeconfig`. If Kubernetes
-cleanup fails, Katl reports recovery required and refuses the node-local wipe.
-Single control-plane wipe is refused because etcd membership coordination is
-not implemented as a supported operation.
+After enrollment, the workstation context supplies topology and credentials, so
+the source can be omitted:
+
+```sh
+katlctl node wipe worker-1 --kubeconfig ./kubeconfig
+```
+
+Execution requires `--kubeconfig` so Katl can remove the Kubernetes Node first.
+If Kubernetes cleanup fails, Katl reports recovery required and refuses the
+node-local wipe. Single control-plane wipe is refused because etcd membership
+coordination is not implemented as a supported operation.
 
 ## Reinstall
 

--- a/internal/katlctl/workstation/config.go
+++ b/internal/katlctl/workstation/config.go
@@ -122,7 +122,7 @@ func Load(path string) (Config, error) {
 func Save(path string, cfg Config) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return fmt.Errorf("katlctl config path is required")
+		return fmt.Errorf("workstation context file path is required")
 	}
 	if err := cfg.Validate(); err != nil {
 		return err

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -283,7 +283,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	stagedGeneration := "2026.06.06-vmtest-networkd"
 
 	rejectedOutput := runKatlctl(t, ctx, result, katlctl, "config-apply-validate-rejected",
-		"config", "apply", "validate",
+		"node", "apply", "validate",
 		"--endpoint", endpoint,
 		"--agent-token-file", tokenFile,
 		"--file", configApplyFixture(t, "rejected-live-without-preflight.yaml"),
@@ -360,7 +360,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 
 	previousBootID := guestBootID(t, ctx, client)
 	runKatlctl(t, ctx, result, katlctl, "host-reboot-staged-generation",
-		"host", "reboot", "cp-1",
+		"node", "reboot", "cp-1",
 		"--endpoint", endpoint,
 		"--agent-token-file", tokenFile,
 		"--timeout", "3m",
@@ -404,7 +404,7 @@ func assertInstalledSSHReady(t *testing.T, ctx context.Context, guest *GuestCont
 func submitKatlctlConfigApply(t *testing.T, ctx context.Context, result Result, katlctl, endpoint, tokenFile, name, mode, generationID, fixture string, wantFailure bool) agentapi.OperationAccepted {
 	t.Helper()
 	args := []string{
-		"config", "apply",
+		"node", "apply",
 		"--endpoint", endpoint,
 		"--agent-token-file", tokenFile,
 		"--file", fixture,
@@ -446,7 +446,7 @@ func submitKatlctlConfigApply(t *testing.T, ctx context.Context, result Result, 
 func katlctlGenerationStatus(t *testing.T, ctx context.Context, result Result, katlctl, endpoint, tokenFile, name, generationID string) agentapi.Generation {
 	t.Helper()
 	output := runKatlctl(t, ctx, result, katlctl, name,
-		"config", "apply", "status",
+		"node", "apply", "status",
 		"--endpoint", endpoint,
 		"--agent-token-file", tokenFile,
 		"--generation", generationID,

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -480,7 +480,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	katlctl := buildKatlctlCommand(t, ctx, katlRepoRoot(t))
 	for _, node := range nodes {
 		stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "stage-"+node.Name,
-			"config", "apply", "--endpoint", net.JoinHostPort(addresses[node.Name], "9443"), "--agent-token-file", tokenFiles[node.Name], "--file", requestPath, "--mode", "next-boot", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof")
+			"node", "apply", "--endpoint", net.JoinHostPort(addresses[node.Name], "9443"), "--agent-token-file", tokenFiles[node.Name], "--file", requestPath, "--mode", "next-boot", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof")
 		if err != nil {
 			return fmt.Errorf("stage desired generation on %s: %w: %s", node.Name, err, stderr)
 		}
@@ -509,7 +509,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-before-operation.txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
 		return err
 	}
-	args := []string{"cluster", "kubeadm-control-plane-config", "--inventory", inventoryPath, "--coordinator", "cp-3", "--generation", generationID, "--config-name", configName, "--rollout-id", "2026.07.11-vmtest-control-plane-config"}
+	args := []string{"kubernetes", "apply-config", "--inventory", inventoryPath, "--coordinator", "cp-3", "--generation", generationID, "--config-name", configName, "--rollout-id", "2026.07.11-vmtest-control-plane-config"}
 	stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "rollout", args...)
 	if err != nil {
 		return fmt.Errorf("run serial control-plane config rollout: %w: %s", err, stderr)
@@ -643,7 +643,7 @@ func waitForConfigGeneration(ctx context.Context, katlctl, dir string, node vmte
 				}
 			}
 		}
-		stdout, stderr, err := runProofKatlctl(ctx, katlctl, dir, "status-"+node.Name, "config", "apply", "status", "--endpoint", net.JoinHostPort(address, "9443"), "--agent-token-file", tokenFile, "--generation", generationID)
+		stdout, stderr, err := runProofKatlctl(ctx, katlctl, dir, "status-"+node.Name, "node", "apply", "status", "--endpoint", net.JoinHostPort(address, "9443"), "--agent-token-file", tokenFile, "--generation", generationID)
 		last = stderr
 		if err == nil {
 			var generation agentapi.Generation

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -739,7 +739,7 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 	if err != nil {
 		return err
 	}
-	command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "kubernetes", "upgrade", image.ArtifactVersion, "--config", configPath, "--timeout", "25m")
+	command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "kubernetes", "upgrade", image.ArtifactVersion, "--context-file", configPath, "--timeout", "25m")
 	command.Dir = repoRoot
 	stdout, err := command.Output()
 	if err != nil {

--- a/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
+++ b/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
@@ -156,8 +156,6 @@ type wipeClusterEvidence struct {
 	Diagnostics            map[string]string `json:"diagnostics,omitempty"`
 }
 
-const wipeClusterAcknowledgement = "I understand this will remove KatlOS disk boot artifacts on the selected nodes so the next reboot must use installer media or PXE to reinstall with a new cluster identity."
-
 func runWipeReinstallBootstrapSmoke(t *testing.T, run operationBackedSmokeRun) {
 	t.Helper()
 	runner := run.Runner
@@ -394,11 +392,11 @@ func runWipeNodeHandoff(t *testing.T, ctx context.Context, result vmtest.Result,
 		return err
 	}
 	var stdout, stderr bytes.Buffer
-	err := runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"cluster", "wipe", "node", "--inventory", initial.Inventory, "--node", "worker-1", "--kubeconfig", initial.Kubeconfig, "--confirm-destructive-wipe", "--acknowledge", wipeClusterAcknowledgement, "--timeout", "10m"}, &stdout, &stderr)
+	err := runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"node", "wipe", "worker-1", "--inventory", initial.Inventory, "--kubeconfig", initial.Kubeconfig, "--timeout", "10m"}, &stdout, &stderr)
 	_ = os.WriteFile(filepath.Join(dir, "katlctl-wipe-node.stdout"), stdout.Bytes(), 0o644)
 	_ = os.WriteFile(filepath.Join(dir, "katlctl-wipe-node.stderr"), stderr.Bytes(), 0o644)
 	if err != nil {
-		return fmt.Errorf("katlctl wipe node failed: %w: %s", err, stderr.String())
+		return fmt.Errorf("katlctl node wipe failed: %w: %s", err, stderr.String())
 	}
 	var report struct {
 		Kind              string `json:"kind"`
@@ -439,8 +437,6 @@ func runWipeClusterHandoff(t *testing.T, ctx context.Context, run operationBacke
 		"cluster", "wipe",
 		"--inventory", inventoryPath,
 		"--all",
-		"--confirm-destructive-wipe",
-		"--acknowledge", wipeClusterAcknowledgement,
 		"--timeout", "10m",
 	}, &stdout, &stderr)
 	_ = os.WriteFile(stdoutPath, stdout.Bytes(), 0o644)

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -122,7 +122,7 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 	tokenFile, token := writeKatlcAgentTokenFile(t, ctx, guest, result.RunDir)
 	candidateGeneration := "host-upgrade-" + strings.ReplaceAll(upgrade.Version, ".", "-")
 	acceptedData := runKatlctl(t, ctx, result, katlctl, "host-upgrade-submit",
-		"host", "upgrade",
+		"node", "upgrade",
 		"--endpoint", endpoint,
 		"--agent-token-file", tokenFile,
 		"--image-local-ref", localRef,


### PR DESCRIPTION
Makes no-argument invocation print useful help and gives each operator workflow one resource-oriented command path. Promotes node wipe, separates ClusterConfig from workstation context, removes duplicate aliases, and removes destructive acknowledgement ceremony because the explicit wipe command is already operator intent.