### PR TITLE
vmtest: make lifecycle gate deterministic

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -145,7 +145,7 @@ fixture environment files or invoking `scripts/vmtest-exec` directly:
 scripts/vmtest-run ./internal/vmtest \
   -run 'FirstInstallTargetDisk|InstalledRuntime|ConfigApply' -count=1
 scripts/vmtest-run ./internal/vmtest/scenarios \
-  -run 'TwoNodeKubeadmJoin|ThreeControlPlaneStackedEtcd' \
+  -run 'TwoNodeOperationBackedBootstrap|ThreeControlPlaneStackedEtcd' \
   -timeout 60m -count=1
 ```
 
@@ -166,7 +166,9 @@ host capabilities, records `world.json`, `host-capabilities.json`, `run.json`,
 and `go-test.log`, exports the world environment, and then executes `go test`
 with the caller's package patterns and flags. Argument meaning belongs to
 `go test`; `scripts/vmtest-run` only adds the harness execution needed to route
-compiled package test binaries through `scripts/vmtest-exec`.
+compiled package test binaries through `scripts/vmtest-exec`. VM test package
+binaries are serialized by default because they share world fixtures and host
+resource pools; pass an explicit `-p` value to override that policy.
 
 The runner keeps terminal output minimal: it prints the world paths, writes the
 full `go test` stream to `go-test.log`, and reports a concise final outcome.

--- a/internal/katlc/agent/kubeadm_upgrade_executor.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor.go
@@ -198,6 +198,16 @@ func (e *Executor) resolveKubernetesUpgradePayload(ctx context.Context, record o
 	if strings.TrimSpace(request.KubernetesBundleSource) == "" || strings.TrimSpace(request.KubernetesBundleRef) == "" {
 		return record, fmt.Errorf("Kubernetes bundle reference is missing")
 	}
+	record, err := e.Store.Update(record.OperationID, "kubernetes-upgrade-target-resolving", "target-resolving", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "target-resolving"
+		current.UpdatedAt = e.clock()
+		current.NextAction = "download and verify the target Kubernetes bundle"
+		return current, nil
+	})
+	if err != nil {
+		return record, err
+	}
+	request = record.KubernetesSysextUpdate
 	cacheDir := rootedRuntimePath(e.Root, filepath.ToSlash(filepath.Join("/var/lib/katl/artifacts/kubernetes-upgrades", record.OperationID)))
 	staged, err := kubernetesbundle.FetchAndStage(ctx, kubernetesbundle.Request{
 		Source:           request.KubernetesBundleSource,

--- a/internal/katlc/agent/kubeadm_upgrade_executor_test.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor_test.go
@@ -257,6 +257,13 @@ func TestExecutorResolvesUpgradeBundleInsideNode(t *testing.T) {
 	if err := verifyFileDigest(rootedRuntimePath(root, request.TargetSysextPath), request.TargetSysextSHA256, request.TargetSysextSize); err != nil {
 		t.Fatalf("resolved payload: %v", err)
 	}
+	events, err := store.EventsAfter(record.OperationID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 || events[1].EventType != "target-resolving" || events[1].Record.Phase != "target-resolving" || events[2].EventType != "target-resolved" {
+		t.Fatalf("resolution events = %#v", events)
+	}
 }
 
 func TestExecutorCapturesUpgradeSnapshotInsideNode(t *testing.T) {

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -468,6 +468,7 @@ func seedRuntimeCacheOutputs(t *testing.T, buildDir string) {
 		filepath.Join(buildDir, "artifacts.json"),
 		filepath.Join(buildDir, "katl-runtime-root"),
 		filepath.Join(buildDir, "katl-runtime.packages.tsv"),
+		filepath.Join(buildDir, "katl-runtime-root.initrd"),
 		filepath.Join(buildDir, "katl-runtime-root.vmlinuz"),
 	}
 	for _, path := range paths {

--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -112,6 +112,16 @@ func TestOperatorConsoleOwnsTTY1AndPreservesRecoveryAccess(t *testing.T) {
 	}
 }
 
+func TestRuntimeJournalRemainsVisibleOnSerialConsole(t *testing.T) {
+	repo := repoRoot(t)
+	journal := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles", "runtime", "mkosi.extra", "etc", "systemd", "journald.conf.d", "10-katl-runtime-console.conf")))
+	assertTextContains(t, journal,
+		"ForwardToConsole=yes",
+		"TTYPath=/dev/ttyS0",
+		"MaxLevelConsole=info",
+	)
+}
+
 func TestRuntimeOwnsPersistentSSHIdentity(t *testing.T) {
 	repo := repoRoot(t)
 	extra := filepath.Join(repo, "mkosi.profiles", "runtime", "mkosi.extra")

--- a/internal/vmtest/direct_runtime.go
+++ b/internal/vmtest/direct_runtime.go
@@ -96,6 +96,13 @@ func prepareDirectRuntime(result Result, config DirectRuntimeConfig) (DirectRunt
 }
 
 func discoverDirectRuntimeBootFiles(runtimeRoot string) (string, string, error) {
+	base := strings.TrimSuffix(runtimeRoot, ".squashfs")
+	kernel := base + ".vmlinuz"
+	initrd := base + ".initrd"
+	if requireRegularFile("direct runtime kernel", kernel) == nil && requireRegularFile("direct runtime initrd", initrd) == nil {
+		return kernel, initrd, nil
+	}
+
 	dir := filepath.Dir(runtimeRoot)
 	rootDir := strings.TrimSuffix(filepath.Base(runtimeRoot), ".squashfs")
 	candidates := []string{

--- a/internal/vmtest/direct_runtime_test.go
+++ b/internal/vmtest/direct_runtime_test.go
@@ -106,6 +106,26 @@ func TestDirectRuntimeRequiresRuntimeRoot(t *testing.T) {
 	}
 }
 
+func TestDirectRuntimeUsesPublishedSplitBootArtifacts(t *testing.T) {
+	root := t.TempDir()
+	runtimeRoot := filepath.Join(root, "katl-runtime-root.squashfs")
+	kernel := filepath.Join(root, "katl-runtime-root.vmlinuz")
+	initrd := filepath.Join(root, "katl-runtime-root.initrd")
+	for path, content := range map[string]string{runtimeRoot: "runtime", kernel: "kernel", initrd: "initrd"} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gotKernel, gotInitrd, err := discoverDirectRuntimeBootFiles(runtimeRoot)
+	if err != nil {
+		t.Fatalf("discoverDirectRuntimeBootFiles() error = %v", err)
+	}
+	if gotKernel != kernel || gotInitrd != initrd {
+		t.Fatalf("boot files = %q, %q; want %q, %q", gotKernel, gotInitrd, kernel, initrd)
+	}
+}
+
 func TestDirectRuntimeAddsDebugShellOptionWhenEnabled(t *testing.T) {
 	t.Setenv("KATL_VMTEST_DEBUG_ON_FAILURE", "1")
 	root := t.TempDir()

--- a/internal/vmtest/installed_smoke_test.go
+++ b/internal/vmtest/installed_smoke_test.go
@@ -378,50 +378,6 @@ func TestDirectRuntimeVMTestAgentSmoke(t *testing.T) {
 	_ = RequireWorld(t)
 }
 
-func TestInstalledRuntimeKubeadmReadySmoke(t *testing.T) {
-	if worldRun, ok := installedRuntimeWorldRunFor(t, "installed-runtime-kubeadm-ready", NodeSpec{Name: "cp-1", Role: ControlPlane}); ok {
-		scenario := Scenario{Name: "installed-runtime-kubeadm-ready"}
-		result, err := worldRun.Runner.Plan(scenario)
-		if err != nil {
-			t.Fatalf("Plan() error = %v", err)
-		}
-		result = requirePlannedVMHost(t, worldRun.Runner, scenario, result, HostRequirements{
-			Libvirt: true,
-			OVMF:    true,
-			KVM:     worldRun.Runner.options().KVM,
-		})
-		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
-		defer cancel()
-		config := worldRun.Config
-		config.VM = VMConfig{
-			KVM:     worldRun.Runner.options().KVM,
-			RAMMiB:  2048,
-			CPUs:    2,
-			Timeout: 5 * time.Minute,
-			VSock: VSockConfig{
-				Enabled: true,
-			},
-		}
-		result = RunInstalledKubeadmReadySmoke(ctx, result, KubeadmReadySmokeConfig{
-			Runtime: config,
-			Smoke: KubeadmReadySmokePlan{
-				ReadyTimeout:      20 * time.Second,
-				ReadyPollInterval: time.Second,
-			},
-		}, VMRunner{})
-		if err := worldRun.Runner.Write(scenario, result); err != nil {
-			t.Fatalf("Write() error = %v", err)
-		}
-		requireInstalledRuntimeKubeadmReadyTranscript(t, result)
-		return
-	}
-	options := DefaultOptions()
-	if !options.Enabled {
-		t.Skip("set -katl.vmtest.run or KATL_VMTEST_RUN=1 to run installed runtime kubeadm-ready smoke")
-	}
-	_ = RequireWorld(t)
-}
-
 func TestInstalledRuntimeKubeadmAPISmoke(t *testing.T) {
 	t.Skip("first-install installed-runtime fixtures stop at kubeadm-ready handoff; kubeadm API smoke needs a config-applied fixture")
 	if worldRun, ok := installedRuntimeWorldRunFor(t, "installed-runtime-kubeadm-api-smoke", NodeSpec{Name: "cp-1", Role: ControlPlane}); ok {

--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -117,6 +117,8 @@ func TestVMTestRunInjectsWorld(t *testing.T) {
 		"test",
 		"-exec",
 		filepath.Join(repo, "scripts", "vmtest-exec"),
+		"-p",
+		"1",
 		"./internal/vmtest/scenarios",
 		"-run",
 		"^TestTwoNode$",
@@ -191,6 +193,36 @@ func TestVMTestRunInjectsWorld(t *testing.T) {
 		t.Fatalf("go-test.log missing go test output:\n%s", goLog)
 	}
 	assertJSONEmptyObject(t, filepath.Join(runDir, "network", "leases.json"))
+}
+
+func TestVMTestRunHonorsPackageParallelismOverride(t *testing.T) {
+	repo := scriptTestRepoRoot(t)
+	tmp := t.TempDir()
+	fakeGo, fakeChild := writeFakeGoTools(t, tmp)
+	host := writeFakeHostTools(t, tmp, true)
+	runDir := filepath.Join(tmp, "run")
+	goArgsPath := filepath.Join(tmp, "go-args.txt")
+
+	cmd := exec.Command(filepath.Join(repo, "scripts", "vmtest-run"), "./internal/vmtest", "-run", "^TestWorldScenario$", "-p=3")
+	cmd.Dir = repo
+	cmd.Env = appendHostEnv(os.Environ(), host,
+		"KATL_VMTEST_GO="+fakeGo,
+		"KATL_FAKE_GO_ARGS="+goArgsPath,
+		"KATL_FAKE_CHILD="+fakeChild,
+		"KATL_FAKE_CHILD_ARGS="+filepath.Join(tmp, "child-args.txt"),
+		"KATL_FAKE_CHILD_ENV="+filepath.Join(tmp, "child-env.txt"),
+		"KATL_VMTEST_RUN_ID=run-package-parallelism",
+		"KATL_VMTEST_RUN_DIR="+runDir,
+		"TMPDIR="+tmp,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("vmtest-run failed: %v\n%s", err, output)
+	}
+	goArgs := readLines(t, goArgsPath)
+	joined := "\n" + strings.Join(goArgs, "\n") + "\n"
+	if strings.Count(joined, "-p") != 1 || !strings.Contains(joined, "\n-p=3\n") {
+		t.Fatalf("go args do not preserve the sole caller parallelism override: %#v", goArgs)
+	}
 }
 
 func TestVMTestRunDebugOnFailurePolicy(t *testing.T) {
@@ -351,6 +383,9 @@ func TestVMTestRunRejectsExplicitInstallerArtifacts(t *testing.T) {
 }
 
 func TestVMTestRunBuildsDefaultArtifacts(t *testing.T) {
+	t.Setenv("KATL_VMTEST_KUBERNETES_BUNDLE", "ghcr.io/katl-dev/kubernetes:v1.36.0-katl.3@sha256:"+strings.Repeat("a", 64))
+	t.Setenv("KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE", "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:"+strings.Repeat("b", 64))
+
 	realRepo := scriptTestRepoRoot(t)
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, "scripts"), 0o755); err != nil {
@@ -414,6 +449,8 @@ exec "$@"
 		"test",
 		"-exec",
 		filepath.Join(repo, "scripts", "vmtest-exec"),
+		"-p",
+		"1",
 		"-timeout",
 		"90m",
 		"./internal/vmtest",
@@ -674,6 +711,8 @@ exec "$@"
 		"test",
 		"-exec",
 		filepath.Join(repo, "scripts", "vmtest-exec"),
+		"-p",
+		"1",
 		"-timeout",
 		"90m",
 		"./internal/vmtest",
@@ -772,6 +811,8 @@ func TestVMTestRunPreservesArbitraryGoTestArgs(t *testing.T) {
 		"test",
 		"-exec",
 		filepath.Join(repo, "scripts", "vmtest-exec"),
+		"-p",
+		"1",
 		"-timeout",
 		"90m",
 		"-json",
@@ -901,6 +942,8 @@ func TestVMTestRunRecordsLibvirtHostGapsAndExecsGo(t *testing.T) {
 				"test",
 				"-exec",
 				filepath.Join(repo, "scripts", "vmtest-exec"),
+				"-p",
+				"1",
 				"-timeout",
 				"90m",
 				"./internal/vmtest",
@@ -970,6 +1013,8 @@ func TestVMTestRunDoesNotDefaultFlagOnlyArgs(t *testing.T) {
 		"test",
 		"-exec",
 		filepath.Join(repo, "scripts", "vmtest-exec"),
+		"-p",
+		"1",
 		"-run",
 		"^TestDoesNotNeedLibvirt$",
 		"-timeout",
@@ -1768,6 +1813,15 @@ printf 'manifest: %s\nmode: strict\nartifacts: 1\npackageSets: 1\nlockSHA256: %s
 }
 
 func appendHostEnv(env []string, tools fakeHostTools, extra ...string) []string {
+	// Runner tests must not silently inherit artifact selection from a parent
+	// vmtest-run invocation. Tests that need published bundles can add them back
+	// explicitly through extra.
+	for _, name := range []string{
+		"KATL_VMTEST_KUBERNETES_BUNDLE",
+		"KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE",
+	} {
+		env = removeEnv(env, name)
+	}
 	env = append(env,
 		"KATL_VMTEST_IMAGE_TOOL="+tools.imageTool,
 		"KATL_VMTEST_VIRSH="+tools.virsh,

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/katl-dev/katl/internal/installer/artifact"
 	"github.com/katl-dev/katl/internal/installer/kubeadmplan"
 	"github.com/katl-dev/katl/internal/installer/operation"
-	"github.com/katl-dev/katl/internal/installer/persistedrecord"
 	"github.com/katl-dev/katl/internal/installer/sysextcatalog"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"github.com/katl-dev/katl/internal/vmtest"
@@ -202,30 +201,12 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 	evidenceDir := filepath.Join(result.RunDir, "operation-evidence")
 	versionEvidenceDir := filepath.Join(result.RunDir, "kubernetes-version-evidence")
 	bootstrapFixture := bootstrapFixtureInputsFromEnv()
-	kubernetesBundle, err := stageThreeControlPlaneKubernetesPayloadBundles(katlRepoRoot(t), result, inputs.KubernetesVersion)
+	kubernetesBundle, bundleServer, err := stageOperationBackedKubernetesPayloadBundle(katlRepoRoot(t), result, smoke.WorldScenario.World.Network.Gateway, inputs.KubernetesVersion)
 	if err != nil {
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("stage Kubernetes payload bundles: %v", err)
 	}
-	bundleServer, err := startGuestReachableKubernetesBundleServer(smoke.WorldScenario.World.Network.Gateway, kubernetesBundle)
-	if err != nil {
-		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
-		t.Fatalf("start Kubernetes payload bundle server: %v", err)
-	}
 	defer bundleServer.Close()
-	kubernetesBundle.Source = bundleServer.Source
-	kubernetesBundle.Ref = bundleServer.Ref
-	kubernetesBundle.BundleManifestDigest = bundleServer.BundleManifestDigest
-	kubernetesBundle.CACertPEM = bundleServer.CACertPEM
-	kubernetesBundle.CACertPath = filepath.Join(result.ManifestDir, "kubernetes-bundle-ca.pem")
-	kubernetesBundle.CACertGuestPath = "/var/lib/katl/test-artifacts/kubernetes-bundle-ca.pem"
-	kubernetesBundle.LogPath = filepath.Join(result.RunDir, "kubernetes-payload-bundle.log")
-	if err := os.WriteFile(kubernetesBundle.CACertPath, kubernetesBundle.CACertPEM, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := writeKubernetesBundleSourceLog(kubernetesBundle.LogPath, kubernetesBundle); err != nil {
-		t.Fatal(err)
-	}
 	plannedNodes := make([]vmtest.RunningInstalledRuntimeNode, 0, 3)
 	for _, name := range []string{"cp-1", "cp-2", "cp-3"} {
 		nodeResult, err := vmtest.PlannedInstalledRuntimeNodeResult(result, name)
@@ -240,14 +221,14 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Minute)
 	defer cancel()
 
-	cp1Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, threeControlPlaneNodeConfigForRun(smoke, "cp-1", inputs.CP1Disk, inputs.CP1ESP, inputs.CP1Fixture, inputs.CP1Metadata, vmtest.DiskFormat(inputs.CP1DiskFormat), inputs.CP1MAC, 43201), vmtest.VMRunner{})
+	cp1Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, threeControlPlaneNodeConfigForRun(smoke, "cp-1", inputs.CP1Disk, inputs.CP1ESP, inputs.CP1Fixture, inputs.CP1Metadata, vmtest.DiskFormat(inputs.CP1DiskFormat), inputs.CP1MAC, 0), vmtest.VMRunner{})
 	if err != nil {
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("start cp-1 VM: %v", err)
 	}
 	defer stopNode(t, cp1Node)
 
-	cp2Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, threeControlPlaneNodeConfigForRun(smoke, "cp-2", inputs.CP2Disk, inputs.CP2ESP, inputs.CP2Fixture, inputs.CP2Metadata, vmtest.DiskFormat(inputs.CP2DiskFormat), inputs.CP2MAC, 43202), vmtest.VMRunner{})
+	cp2Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, threeControlPlaneNodeConfigForRun(smoke, "cp-2", inputs.CP2Disk, inputs.CP2ESP, inputs.CP2Fixture, inputs.CP2Metadata, vmtest.DiskFormat(inputs.CP2DiskFormat), inputs.CP2MAC, 0), vmtest.VMRunner{})
 	if err != nil {
 		collectTwoNodeDiagnostics("", cp1Node)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
@@ -255,7 +236,7 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 	}
 	defer stopNode(t, cp2Node)
 
-	cp3Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, threeControlPlaneNodeConfigForRun(smoke, "cp-3", inputs.CP3Disk, inputs.CP3ESP, inputs.CP3Fixture, inputs.CP3Metadata, vmtest.DiskFormat(inputs.CP3DiskFormat), inputs.CP3MAC, 43203), vmtest.VMRunner{})
+	cp3Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, threeControlPlaneNodeConfigForRun(smoke, "cp-3", inputs.CP3Disk, inputs.CP3ESP, inputs.CP3Fixture, inputs.CP3Metadata, vmtest.DiskFormat(inputs.CP3DiskFormat), inputs.CP3MAC, 0), vmtest.VMRunner{})
 	if err != nil {
 		collectTwoNodeDiagnostics("", cp1Node, cp2Node)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
@@ -281,14 +262,16 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("stage test CNI fixtures: %v", err)
 	}
-	var imageFixtures map[string][]nodeImageFixture
-	if smoke.WorkloadProof {
-		imageFixtures, err = stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), result.RunDir, nodes...)
-		if err != nil {
-			collectTwoNodeDiagnostics("", nodes...)
-			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
-			t.Fatalf("stage release workload images: %v", err)
-		}
+	imageFixtures, err := stageKubernetesImageFixtures(ctx, katlRepoRoot(t), inputs.KubernetesVersion, nodes...)
+	if err == nil && smoke.WorkloadProof {
+		var workloadFixtures map[string][]nodeImageFixture
+		workloadFixtures, err = stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), result.RunDir, nodes...)
+		mergeNodeImageFixtures(imageFixtures, workloadFixtures)
+	}
+	if err != nil {
+		collectTwoNodeDiagnostics("", nodes...)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("stage bootstrap images: %v", err)
 	}
 	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -484,11 +467,10 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 		if err != nil {
 			return fmt.Errorf("stage desired generation on %s: %w: %s", node.Name, err, stderr)
 		}
-		var accepted agentapi.OperationAccepted
-		if err := protojson.Unmarshal(stdout, &accepted); err != nil || accepted.RecordPath == "" {
-			return fmt.Errorf("decode %s staged generation acceptance: %w", node.Name, err)
+		if err := decodeGenerationStageResult(stdout, generationID); err != nil {
+			return fmt.Errorf("decode %s staged generation result: %w", node.Name, err)
 		}
-		if err := waitForConfigGeneration(ctx, katlctl, proofDir, node, addresses[node.Name], tokenFiles[node.Name], generationID, configName, accepted.RecordPath, false); err != nil {
+		if err := waitForConfigGeneration(ctx, katlctl, proofDir, node, addresses[node.Name], tokenFiles[node.Name], generationID, configName, false); err != nil {
 			return err
 		}
 	}
@@ -499,7 +481,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 		if err := activateNodeCNIFixture(ctx, node, cniFixtures[node.Name]); err != nil {
 			return fmt.Errorf("reactivate %s CNI fixture: %w", node.Name, err)
 		}
-		if err := waitForConfigGeneration(ctx, katlctl, proofDir, node, addresses[node.Name], tokenFiles[node.Name], generationID, configName, "", true); err != nil {
+		if err := waitForConfigGeneration(ctx, katlctl, proofDir, node, addresses[node.Name], tokenFiles[node.Name], generationID, configName, true); err != nil {
 			return err
 		}
 		if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-after-reboot-"+node.Name+".txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
@@ -630,19 +612,21 @@ func runProofKatlctl(ctx context.Context, binary, dir, name string, args ...stri
 	return stdout.Bytes(), stderr.String(), err
 }
 
-func waitForConfigGeneration(ctx context.Context, katlctl, dir string, node vmtest.RunningInstalledRuntimeNode, address, tokenFile, generationID, configName, operationRecordPath string, healthy bool) error {
+func decodeGenerationStageResult(data []byte, generationID string) error {
+	var status agentapi.OperationStatus
+	if err := protojson.Unmarshal(data, &status); err != nil {
+		return err
+	}
+	if status.OperationKind != "generation-stage" || !status.Terminal || status.Result != operation.ResultSucceeded || status.CandidateGenerationId != generationID {
+		return fmt.Errorf("unexpected generation stage status: %s", status.String())
+	}
+	return nil
+}
+
+func waitForConfigGeneration(ctx context.Context, katlctl, dir string, node vmtest.RunningInstalledRuntimeNode, address, tokenFile, generationID, configName string, healthy bool) error {
 	deadline := time.Now().Add(5 * time.Minute)
 	var last string
 	for time.Now().Before(deadline) {
-		if operationRecordPath != "" {
-			if data, readErr := readNodeFile(ctx, node, operationRecordPath, 1<<20); readErr == nil {
-				if envelope, decodeErr := persistedrecord.DecodeEnvelope(data); decodeErr == nil {
-					if snapshot, payloadErr := persistedrecord.DecodePayload[operation.Snapshot](envelope); payloadErr == nil && snapshot.Record.Terminal && snapshot.Record.Result != operation.ResultSucceeded {
-						return fmt.Errorf("generation stage on %s failed in %s: %s", node.Name, snapshot.Record.Phase, snapshot.Record.FailureReason)
-					}
-				}
-			}
-		}
 		stdout, stderr, err := runProofKatlctl(ctx, katlctl, dir, "status-"+node.Name, "node", "apply", "status", "--endpoint", net.JoinHostPort(address, "9443"), "--agent-token-file", tokenFile, "--generation", generationID)
 		last = stderr
 		if err == nil {
@@ -1573,8 +1557,8 @@ func assertOperationKubernetesBundle(t *testing.T, record operation.OperationRec
 	if req.KubernetesPayloadVersion != bundle.PayloadVersion ||
 		req.KubernetesBundleSource != bundle.Source ||
 		req.KubernetesBundleRef != bundle.Ref ||
-		req.KubernetesBundleManifestDigest != bundle.BundleManifestDigest ||
-		req.KubernetesSysextPayloadDigest != bundle.SysextPayloadDigest {
+		!resolvedBundleDigestMatches(req.KubernetesBundleManifestDigest, bundle.BundleManifestDigest) ||
+		!resolvedBundleDigestMatches(req.KubernetesSysextPayloadDigest, bundle.SysextPayloadDigest) {
 		t.Fatalf("operation %s Kubernetes bundle request = %#v, want %#v", record.OperationID, req, bundle)
 	}
 	if record.CandidateGenerationID == "" {
@@ -1594,13 +1578,20 @@ func assertGenerationKubernetesBundle(t *testing.T, ctx context.Context, node vm
 			continue
 		}
 		found = true
-		if ref.PayloadVersion != bundle.PayloadVersion || ref.SHA256 != strings.TrimPrefix(bundle.SysextPayloadDigest, "sha256:") || ref.ArtifactVersion == "" {
+		if ref.PayloadVersion != bundle.PayloadVersion || ref.ArtifactVersion == "" ||
+			!resolvedBundleDigestMatches(ref.SHA256, bundle.SysextPayloadDigest) {
 			t.Fatalf("%s Kubernetes sysext ref = %#v, want bundle %#v", node.Name, ref, bundle)
 		}
 	}
 	if !found {
 		t.Fatalf("%s generation %s missing Kubernetes sysext ref: %#v", node.Name, record.CandidateGenerationID, generationRecord.Spec.Sysexts)
 	}
+}
+
+func resolvedBundleDigestMatches(actual, expected string) bool {
+	actual = strings.TrimPrefix(strings.TrimSpace(actual), "sha256:")
+	expected = strings.TrimPrefix(strings.TrimSpace(expected), "sha256:")
+	return actual != "" && (expected == "" || actual == expected)
 }
 
 func threeControlPlaneFixtureInputs(cp1Disk, cp1Format, cp2Disk, cp2Format, cp3Disk, cp3Format, cp1ESP, cp2ESP, cp3ESP, cp1Fixture, cp2Fixture, cp3Fixture, cp1Metadata, cp2Metadata, cp3Metadata string) map[string]nodeFixtureInput {
@@ -2265,6 +2256,44 @@ func TestThreeControlPlaneOperationBackedInventoryCarriesKubernetesBundle(t *tes
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("inventory missing %q:\n%s", want, data)
 		}
+	}
+}
+
+func TestResolvedBundleDigestMatching(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	for _, test := range []struct {
+		name     string
+		actual   string
+		expected string
+		want     bool
+	}{
+		{name: "published bundle resolves digest", actual: "sha256:" + digest, want: true},
+		{name: "locally staged bundle matches digest", actual: digest, expected: "sha256:" + digest, want: true},
+		{name: "missing resolved digest", expected: "sha256:" + digest, want: false},
+		{name: "different resolved digest", actual: strings.Repeat("b", 64), expected: digest, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolvedBundleDigestMatches(test.actual, test.expected); got != test.want {
+				t.Fatalf("resolvedBundleDigestMatches(%q, %q) = %t, want %t", test.actual, test.expected, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeGenerationStageResultUsesTerminalStatus(t *testing.T) {
+	status := &agentapi.OperationStatus{
+		OperationKind:         "generation-stage",
+		Phase:                 operation.HostBookkeepingCompletionPhase,
+		Terminal:              true,
+		Result:                operation.ResultSucceeded,
+		CandidateGenerationId: "generation-1",
+	}
+	data, err := protojson.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := decodeGenerationStageResult(data, "generation-1"); err != nil {
+		t.Fatalf("decodeGenerationStageResult() error = %v", err)
 	}
 }
 

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -9,12 +9,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -371,11 +373,21 @@ func runOperationBackedBootstrapSmoke(t *testing.T, smoke operationBackedSmokeRu
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("stage test CNI fixtures: %v", err)
 	}
-	imageFixtures, err := stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), result.RunDir, nodes...)
+	imageFixtures, err := stageKubernetesImageFixtures(ctx, katlRepoRoot(t), inputs.KubernetesVersion, nodes...)
+	if err == nil && proveUpgrade {
+		var upgradeFixtures map[string][]nodeImageFixture
+		upgradeFixtures, err = stageKubernetesImageFixtures(ctx, katlRepoRoot(t), "v1.36.1", nodes...)
+		mergeNodeImageFixtures(imageFixtures, upgradeFixtures)
+	}
+	if err == nil {
+		var workloadFixtures map[string][]nodeImageFixture
+		workloadFixtures, err = stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), result.RunDir, nodes...)
+		mergeNodeImageFixtures(imageFixtures, workloadFixtures)
+	}
 	if err != nil {
 		collectTwoNodeDiagnostics("", nodes...)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
-		t.Fatalf("stage test workload images: %v", err)
+		t.Fatalf("stage bootstrap images: %v", err)
 	}
 	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -739,7 +751,11 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 	if err != nil {
 		return err
 	}
-	command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "kubernetes", "upgrade", image.ArtifactVersion, "--context-file", configPath, "--timeout", "25m")
+	targetVersion, err := publishedKubernetesUpgradeVersion(bundle)
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(ctx, "go", "run", "./cmd/katlctl", "kubernetes", "upgrade", targetVersion, "--context-file", configPath, "--timeout", "25m")
 	command.Dir = repoRoot
 	stdout, err := command.Output()
 	if err != nil {
@@ -787,8 +803,7 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 		if err != nil {
 			return err
 		}
-		versionRef := image.Repository + ":" + image.Tag
-		if record.KubernetesSysextUpdate == nil || record.KubernetesSysextUpdate.KubernetesBundleRef != versionRef || record.KubernetesSysextUpdate.BundleManifestDigest == "" || record.KubernetesSysextUpdate.TargetSysextSHA256 == "" {
+		if record.KubernetesSysextUpdate == nil || record.KubernetesSysextUpdate.KubernetesBundleRef != image.Value || record.KubernetesSysextUpdate.BundleManifestDigest == "" || record.KubernetesSysextUpdate.TargetSysextSHA256 == "" {
 			return fmt.Errorf("%s upgrade did not resolve the published bundle internally: %+v", item.Name, record.KubernetesSysextUpdate)
 		}
 		if item.Name == cpNode.Name && (record.KubernetesSysextUpdate.SnapshotDigest == "" || record.KubernetesSysextUpdate.SnapshotStorageLocation == "") {
@@ -796,6 +811,24 @@ func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle
 		}
 	}
 	return nil
+}
+
+func publishedKubernetesUpgradeVersion(bundle string) (string, error) {
+	image, err := kubernetesbundle.ParseImageReference(bundle)
+	if err != nil {
+		return "", err
+	}
+	return image.PayloadVersion, nil
+}
+
+func TestPublishedKubernetesUpgradeUsesPayloadVersion(t *testing.T) {
+	version, err := publishedKubernetesUpgradeVersion("ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1@sha256:" + strings.Repeat("a", 64))
+	if err != nil {
+		t.Fatalf("publishedKubernetesUpgradeVersion() error = %v", err)
+	}
+	if version != "v1.36.1" {
+		t.Fatalf("published Kubernetes upgrade version = %q, want payload version v1.36.1", version)
+	}
 }
 
 type upgradeSnapshotEvidence struct{ Ref, Digest, Revision, CreatedAt, MemberListDigest, EtcdVersion, Location string }
@@ -1007,19 +1040,6 @@ func stageOperationBackedKubernetesPayloadBundle(repo string, result vmtest.Resu
 	return bundle, server, nil
 }
 
-func TestInstalledRuntimeTwoNodeKubeadmJoinSmoke(t *testing.T) {
-	if run, ok := twoNodeWorldSmokeRun(t); ok {
-		runTwoNodeKubeadmJoinSmoke(t, run)
-		return
-	}
-
-	options := vmtest.DefaultOptions()
-	if !options.Enabled {
-		t.Skip("set -katl.vmtest.run or KATL_VMTEST_RUN=1 to run two-node kubeadm join smoke")
-	}
-	_ = vmtest.RequireWorld(t)
-}
-
 type twoNodeSmokeRun struct {
 	WorldScenario *vmtest.WorldScenario
 	Options       vmtest.Options
@@ -1215,11 +1235,16 @@ func runTwoNodeKubeadmJoinSmoke(t *testing.T, smoke twoNodeSmokeRun) {
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("stage test CNI fixtures: %v", err)
 	}
-	imageFixtures, err := stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), result.RunDir, nodes...)
+	imageFixtures, err := stageKubernetesImageFixtures(ctx, katlRepoRoot(t), inputs.KubernetesVersion, nodes...)
+	if err == nil {
+		var workloadFixtures map[string][]nodeImageFixture
+		workloadFixtures, err = stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), result.RunDir, nodes...)
+		mergeNodeImageFixtures(imageFixtures, workloadFixtures)
+	}
 	if err != nil {
 		collectTwoNodeDiagnostics(transcriptDir, cpNode, workerNode)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
-		t.Fatalf("stage test workload images: %v", err)
+		t.Fatalf("stage bootstrap images: %v", err)
 	}
 	if err := writeTwoNodeInventory(inventoryPath, inputs.KubernetesVersion, cpNode, workerNode); err != nil {
 		t.Fatal(err)
@@ -1332,7 +1357,7 @@ type multiNodeWorldProvenancePaths struct {
 func multiNodeWorldProvenanceForSpecs(world vmtest.World, repo string, specs []vmtest.NodeSpec) multiNodeWorldProvenancePaths {
 	provenance := multiNodeWorldProvenancePaths{
 		VMTestRun:              firstString(world.RunIndex, filepath.Join(world.RunDir, "run.json")),
-		WorldManifest:          firstString(os.Getenv(vmtest.WorldManifestEnv), filepath.Join(world.RunDir, "world.json")),
+		WorldManifest:          filepath.Join(world.RunDir, "world.json"),
 		HostCapabilities:       filepath.Join(world.RunDir, "host-capabilities.json"),
 		ResourceManifest:       world.ResourceManifest,
 		ResourceManifestSHA256: world.ResourceDigest,
@@ -1379,6 +1404,12 @@ func twoNodeHostToolPrereqs(lookPath func(string) (string, error)) []vmtest.Miss
 		missing = append(missing, vmtest.MissingPrerequisite{
 			Name:   "kubectl",
 			Detail: "required for host-side kubeconfig verification: " + err.Error(),
+		})
+	}
+	if _, err := lookPath("podman"); err != nil {
+		missing = append(missing, vmtest.MissingPrerequisite{
+			Name:   "podman",
+			Detail: "required to cache Kubernetes VM image fixtures: " + err.Error(),
 		})
 	}
 	return missing
@@ -1970,6 +2001,194 @@ StandardError=append:%s
 	return nil
 }
 
+type kubernetesImageCacheManifest struct {
+	KubernetesVersion string   `json:"kubernetesVersion"`
+	Images            []string `json:"images"`
+	ArchiveSHA256     string   `json:"archiveSHA256"`
+	ArchiveSize       int64    `json:"archiveSize"`
+}
+
+func stageKubernetesImageFixtures(ctx context.Context, repo, kubernetesVersion string, nodes ...vmtest.RunningInstalledRuntimeNode) (map[string][]nodeImageFixture, error) {
+	fixture, err := ensureKubernetesImageFixture(ctx, repo, kubernetesVersion)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(fixture.Source)
+	if err != nil {
+		return nil, fmt.Errorf("read Kubernetes image fixture %s: %w", fixture.Source, err)
+	}
+	staged := map[string][]nodeImageFixture{}
+	for _, node := range nodes {
+		nodeFixture := fixture
+		nodeFixture.GuestPath = filepath.Join("/var/lib/katl/test-artifacts/bootstrap-images", filepath.Base(fixture.Source))
+		if err := writeNodeFileChunked(ctx, node, nodeFixture.GuestPath, data, 0o644); err != nil {
+			return nil, fmt.Errorf("stage Kubernetes %s image fixture on %s: %w", kubernetesVersion, node.Name, err)
+		}
+		result, err := runNodeCommandWithRetry(ctx, node, []string{"ctr", "-n", "k8s.io", "images", "import", nodeFixture.GuestPath}, 128<<10)
+		if err != nil {
+			return nil, fmt.Errorf("import Kubernetes %s image fixture on %s: %w", kubernetesVersion, node.Name, err)
+		}
+		if result.ExitStatus != 0 {
+			return nil, fmt.Errorf("import Kubernetes %s image fixture on %s: %w", kubernetesVersion, node.Name, commandErrorDetail(result))
+		}
+		if err := writeNodeFile(ctx, node, nodeFixture.GuestPath, nil, 0o644, true); err != nil {
+			return nil, fmt.Errorf("truncate imported Kubernetes image fixture on %s: %w", node.Name, err)
+		}
+		staged[node.Name] = append(staged[node.Name], nodeFixture)
+	}
+	return staged, nil
+}
+
+func ensureKubernetesImageFixture(ctx context.Context, repo, kubernetesVersion string) (nodeImageFixture, error) {
+	images, err := kubernetesImageReferences(kubernetesVersion)
+	if err != nil {
+		return nodeImageFixture{}, err
+	}
+	cacheDir := filepath.Join(repo, "_build", "vmtest", "kubernetes-images", strings.TrimPrefix(kubernetesVersion, "v"))
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nodeImageFixture{}, err
+	}
+	lock, err := os.OpenFile(filepath.Join(cacheDir, ".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nodeImageFixture{}, err
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return nodeImageFixture{}, fmt.Errorf("lock Kubernetes image fixture cache: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+
+	archivePath := filepath.Join(cacheDir, "kubernetes-images.tar")
+	manifestPath := filepath.Join(cacheDir, "manifest.json")
+	if valid, err := validKubernetesImageFixture(archivePath, manifestPath, kubernetesVersion, images); err != nil {
+		return nodeImageFixture{}, err
+	} else if !valid {
+		if err := buildKubernetesImageFixture(ctx, archivePath, manifestPath, kubernetesVersion, images); err != nil {
+			return nodeImageFixture{}, err
+		}
+	}
+	return nodeImageFixture{Image: "kubeadm-required-images:" + kubernetesVersion, Source: archivePath}, nil
+}
+
+func kubernetesImageReferences(kubernetesVersion string) ([]string, error) {
+	switch kubernetesVersion {
+	case "v1.36.0", "v1.36.1":
+	default:
+		return nil, fmt.Errorf("Kubernetes VM image fixtures do not define kubeadm images for %s", kubernetesVersion)
+	}
+	return []string{
+		"registry.k8s.io/kube-apiserver:" + kubernetesVersion,
+		"registry.k8s.io/kube-controller-manager:" + kubernetesVersion,
+		"registry.k8s.io/kube-scheduler:" + kubernetesVersion,
+		"registry.k8s.io/kube-proxy:" + kubernetesVersion,
+		"registry.k8s.io/coredns/coredns:v1.14.2",
+		"registry.k8s.io/pause:3.10.2",
+		"registry.k8s.io/etcd:3.6.8-0",
+	}, nil
+}
+
+func validKubernetesImageFixture(archivePath, manifestPath, kubernetesVersion string, images []string) (bool, error) {
+	data, err := os.ReadFile(manifestPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var manifest kubernetesImageCacheManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return false, nil
+	}
+	if manifest.KubernetesVersion != kubernetesVersion || strings.Join(manifest.Images, "\n") != strings.Join(images, "\n") {
+		return false, nil
+	}
+	info, err := os.Stat(archivePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.Size() == 0 || info.Size() != manifest.ArchiveSize {
+		return false, nil
+	}
+	digest, err := fileSHA256Hex(archivePath)
+	if err != nil {
+		return false, err
+	}
+	return digest == manifest.ArchiveSHA256, nil
+}
+
+func buildKubernetesImageFixture(ctx context.Context, archivePath, manifestPath, kubernetesVersion string, images []string) error {
+	podman, err := exec.LookPath("podman")
+	if err != nil {
+		return fmt.Errorf("find podman for Kubernetes image fixtures: %w", err)
+	}
+	for _, image := range images {
+		cmd := exec.CommandContext(ctx, podman, "pull", "--quiet", image)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("cache Kubernetes image %s: %w\n%s", image, err, output)
+		}
+	}
+	temporaryArchive := archivePath + ".tmp-" + strconv.Itoa(os.Getpid())
+	defer os.Remove(temporaryArchive)
+	args := append([]string{"save", "--quiet", "--multi-image-archive", "--output", temporaryArchive}, images...)
+	cmd := exec.CommandContext(ctx, podman, args...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("save Kubernetes %s image fixture: %w\n%s", kubernetesVersion, err, output)
+	}
+	if err := os.Chmod(temporaryArchive, 0o644); err != nil {
+		return err
+	}
+	info, err := os.Stat(temporaryArchive)
+	if err != nil {
+		return err
+	}
+	digest, err := fileSHA256Hex(temporaryArchive)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryArchive, archivePath); err != nil {
+		return err
+	}
+	manifest := kubernetesImageCacheManifest{
+		KubernetesVersion: kubernetesVersion,
+		Images:            images,
+		ArchiveSHA256:     digest,
+		ArchiveSize:       info.Size(),
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	temporaryManifest := manifestPath + ".tmp-" + strconv.Itoa(os.Getpid())
+	defer os.Remove(temporaryManifest)
+	if err := os.WriteFile(temporaryManifest, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(temporaryManifest, manifestPath)
+}
+
+func fileSHA256Hex(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func mergeNodeImageFixtures(target, source map[string][]nodeImageFixture) {
+	for node, fixtures := range source {
+		target[node] = append(target[node], fixtures...)
+	}
+}
+
 func stageTwoNodeImageFixtures(ctx context.Context, repo, workDir string, nodes ...vmtest.RunningInstalledRuntimeNode) (map[string][]nodeImageFixture, error) {
 	fixtures, err := buildBootstrapImageFixtures(ctx, repo, filepath.Join(workDir, "bootstrap-images"))
 	if err != nil {
@@ -2380,36 +2599,27 @@ func retryDirectAgentOp[T any](ctx context.Context, node vmtest.RunningInstalled
 
 func writeNodeFileChunked(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, path string, content []byte, mode uint32) error {
 	const chunkSize = 512 << 10
-	if result, err := runNodeCommandWithRetry(ctx, node, []string{"install", "-d", "-m", "0755", filepath.Dir(path)}, 16<<10); err != nil {
-		return fmt.Errorf("create parent: %w", err)
-	} else if result.ExitStatus != 0 {
-		return fmt.Errorf("create parent: %w", commandErrorDetail(result))
-	}
-	if result, err := runNodeCommandWithRetry(ctx, node, []string{"dd", "if=/dev/null", "of=" + path, "bs=1", "count=0"}, 16<<10); err != nil {
-		return fmt.Errorf("create target: %w", err)
-	} else if result.ExitStatus != 0 {
-		return fmt.Errorf("create target: %w", commandErrorDetail(result))
-	}
 	for offset := 0; offset < len(content); offset += chunkSize {
 		end := offset + chunkSize
 		if end > len(content) {
 			end = len(content)
 		}
-		part := fmt.Sprintf("%s.part-%06d", path, offset/chunkSize)
-		if err := writeNodeFile(ctx, node, part, content[offset:end], 0o644, true); err != nil {
-			return fmt.Errorf("write part %d: %w", offset/chunkSize, err)
-		}
-		argv := []string{"dd", "if=" + part, "of=" + path, fmt.Sprintf("bs=%d", chunkSize), "seek=" + strconv.Itoa(offset/chunkSize), "conv=notrunc"}
-		if result, err := runNodeCommandWithRetry(ctx, node, argv, 16<<10); err != nil {
-			return fmt.Errorf("append part %d: %w", offset/chunkSize, err)
-		} else if result.ExitStatus != 0 {
-			return fmt.Errorf("append part %d: %w", offset/chunkSize, commandErrorDetail(result))
+		_, err := retryDirectAgentOp(ctx, node, 10*time.Second, func(opCtx context.Context, client *vmtest.AgentClient) (*vmtestpb.WriteFileResult, error) {
+			return client.WriteFile(opCtx, &vmtestpb.WriteFileRequest{
+				Path:      path,
+				Content:   content[offset:end],
+				Mode:      mode,
+				Sensitive: true,
+				Offset:    uint64(offset),
+				Truncate:  offset == 0,
+			})
+		})
+		if err != nil {
+			return fmt.Errorf("write chunk %d: %w", offset/chunkSize, err)
 		}
 	}
-	if result, err := runNodeCommandWithRetry(ctx, node, []string{"chmod", fmt.Sprintf("%04o", mode), path}, 16<<10); err != nil {
-		return fmt.Errorf("chmod target: %w", err)
-	} else if result.ExitStatus != 0 {
-		return fmt.Errorf("chmod target: %w", commandErrorDetail(result))
+	if len(content) == 0 {
+		return writeNodeFile(ctx, node, path, nil, mode, true)
 	}
 	return nil
 }
@@ -3965,16 +4175,70 @@ func twoNodeTestWorld(t *testing.T) vmtest.World {
 
 func TestTwoNodeHostToolPrereqsUseSelectedKubectl(t *testing.T) {
 	t.Setenv("KATL_VMTEST_KUBECTL", "/tmp/selected-kubectl")
-	var checked string
+	var checked []string
 	missing := twoNodeHostToolPrereqs(func(name string) (string, error) {
-		checked = name
+		checked = append(checked, name)
 		return name, nil
 	})
 	if len(missing) != 0 {
 		t.Fatalf("missing prereqs = %#v", missing)
 	}
-	if checked != "/tmp/selected-kubectl" {
-		t.Fatalf("checked kubectl = %q, want selected binary", checked)
+	if strings.Join(checked, ",") != "/tmp/selected-kubectl,podman" {
+		t.Fatalf("checked tools = %q", checked)
+	}
+}
+
+func TestKubernetesImageReferencesMatchSupportedKubeadmVersions(t *testing.T) {
+	for _, version := range []string{"v1.36.0", "v1.36.1"} {
+		images, err := kubernetesImageReferences(version)
+		if err != nil {
+			t.Fatalf("kubernetesImageReferences(%q) error = %v", version, err)
+		}
+		if len(images) != 7 || images[0] != "registry.k8s.io/kube-apiserver:"+version || images[3] != "registry.k8s.io/kube-proxy:"+version {
+			t.Fatalf("kubernetesImageReferences(%q) = %#v", version, images)
+		}
+	}
+	if _, err := kubernetesImageReferences("v1.37.0"); err == nil {
+		t.Fatal("kubernetesImageReferences(v1.37.0) error = nil")
+	}
+}
+
+func TestValidKubernetesImageFixtureRejectsChangedArchive(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "images.tar")
+	manifestPath := filepath.Join(dir, "manifest.json")
+	images, err := kubernetesImageReferences("v1.36.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := []byte("complete image archive")
+	if err := os.WriteFile(archivePath, archive, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(archive)
+	manifest := kubernetesImageCacheManifest{
+		KubernetesVersion: "v1.36.0",
+		Images:            images,
+		ArchiveSHA256:     hex.EncodeToString(digest[:]),
+		ArchiveSize:       int64(len(archive)),
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	valid, err := validKubernetesImageFixture(archivePath, manifestPath, "v1.36.0", images)
+	if err != nil || !valid {
+		t.Fatalf("valid fixture = %t, error = %v", valid, err)
+	}
+	if err := os.WriteFile(archivePath, []byte("truncated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	valid, err = validKubernetesImageFixture(archivePath, manifestPath, "v1.36.0", images)
+	if err != nil || valid {
+		t.Fatalf("changed fixture = %t, error = %v", valid, err)
 	}
 }
 

--- a/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
+++ b/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
@@ -721,9 +721,14 @@ func runWipeReinstallBootstrapRound(t *testing.T, ctx context.Context, run opera
 	if err != nil {
 		return wipeReinstallBootstrapEvidence{}, fmt.Errorf("stage test CNI fixtures: %w", err)
 	}
-	imageFixtures, err := stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), roundDir, nodes...)
+	imageFixtures, err := stageKubernetesImageFixtures(ctx, katlRepoRoot(t), run.Inputs.KubernetesVersion, nodes...)
+	if err == nil {
+		var workloadFixtures map[string][]nodeImageFixture
+		workloadFixtures, err = stageTwoNodeImageFixtures(ctx, katlRepoRoot(t), roundDir, nodes...)
+		mergeNodeImageFixtures(imageFixtures, workloadFixtures)
+	}
 	if err != nil {
-		return wipeReinstallBootstrapEvidence{}, fmt.Errorf("stage test workload images: %w", err)
+		return wipeReinstallBootstrapEvidence{}, fmt.Errorf("stage bootstrap images: %w", err)
 	}
 	bootSelectionsBefore := map[string]string{}
 	for _, node := range nodes {

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -103,7 +103,7 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 	previousGeneration := currentGenerationFromGuest(t, ctx, guest)
 	previousSpec, previousStatus := generationRecordsFromGuest(t, ctx, guest, previousGeneration)
 	previousSpec.KernelCommandLine = append(previousSpec.KernelCommandLine,
-		"console=ttyS0,115200n8", "systemd.log_target=console", "loglevel=6", "katl.vmtest_agent=1", "katl.vmtest_debug_shell=1")
+		"console=ttyS0,115200n8", "systemd.log_target=console", "loglevel=6", "katl.vmtest_agent=1")
 	digest, err := generation.CanonicalSpecDigest(previousSpec)
 	if err != nil {
 		t.Fatalf("digest vmtest-visible previous generation: %v", err)

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -18,7 +18,7 @@
     {
       "name": "runtime",
       "path": "mkosi.profiles/runtime",
-      "configSHA256": "eced30ab9e9e5daef2112c5012d787276f1f48c37cc6008f93c991103ddff281",
+      "configSHA256": "f2251e80c0b028cd9c9a14df113dca55883a1c0e9cd4a5cf0c9cb984ecf64229",
       "packageSetRef": "runtime",
       "mkosiVersion": "26"
     },

--- a/mkosi.profiles/runtime/mkosi.extra/etc/systemd/journald.conf.d/10-katl-runtime-console.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/etc/systemd/journald.conf.d/10-katl-runtime-console.conf
@@ -1,0 +1,4 @@
+[Journal]
+ForwardToConsole=yes
+TTYPath=/dev/ttyS0
+MaxLevelConsole=info

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -291,6 +291,8 @@ root_locked
 file_has /usr/lib/systemd/system/katl-runtime-boot-signal.service "Katl runtime reached systemd userspace"
 file_has /usr/lib/systemd/system/katl-runtime-boot-signal.service "StandardOutput=journal+console"
 file_has /usr/lib/systemd/system/katl-runtime-boot-signal.service "SyslogIdentifier=katl-runtime-boot"
+file_has /etc/systemd/journald.conf.d/10-katl-runtime-console.conf "ForwardToConsole=yes"
+file_has /etc/systemd/journald.conf.d/10-katl-runtime-console.conf "TTYPath=/dev/ttyS0"
 file_has /usr/lib/systemd/system/katl-console.service "ExecStart=/usr/bin/katl-console --mode=runtime --tty=/dev/tty1"
 file_has /usr/lib/systemd/system/katl-console.service "TTYPath=/dev/tty1"
 file_has /usr/lib/systemd/system/getty@tty1.service.d/10-katl-console.conf "ConditionPathExists=!/usr/bin/katl-console"

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -386,6 +386,7 @@ target_outputs() {
                 "$build_dir/katl-runtime-root.squashfs.json" \
                 "$build_dir/katl-runtime-root.squashfs.sha256" \
                 "$build_dir/katl-runtime.packages.tsv" \
+                "$build_dir/katl-runtime-root.initrd" \
                 "$build_dir/katl-runtime-root.vmlinuz" \
                 "$build_dir/katl-runtime.efi" \
                 "$build_dir/katl-runtime.efi.json" \
@@ -855,7 +856,9 @@ set +e
             echo "error: ukify is required to package the runtime UKI" >&2
             status=1
         else
-            rm -f "$artifact" "$artifact.sha256" "$artifact.json" "$boot_artifact" "$boot_artifact.sha256" "$boot_artifact.json"
+            runtime_kernel=_build/mkosi/katl-runtime-root.vmlinuz
+            runtime_initrd=_build/mkosi/katl-runtime-root.initrd
+            rm -f "$artifact" "$artifact.sha256" "$artifact.json" "$boot_artifact" "$boot_artifact.sha256" "$boot_artifact.json" "$runtime_kernel" "$runtime_initrd"
             kernel_dir=$(find "$root/boot" -type f -name linux -printf "%h\n" | sort | head -n 1)
             if [[ -z "$kernel_dir" ]]; then
                 echo "error: runtime kernel not found under $root/boot" >&2
@@ -872,6 +875,10 @@ set +e
                     echo "error: runtime os-release not found: $os_release" >&2
                     status=1
                 else
+                    if ! cp --reflink=auto "$kernel" "$runtime_kernel" || ! cp --reflink=auto "$initrd" "$runtime_initrd"; then
+                        echo "error: publish runtime direct-boot kernel and initrd" >&2
+                        status=1
+                    fi
                     ukify_args=(
                         build
                         --linux "$kernel"
@@ -884,7 +891,7 @@ set +e
                     if [[ -f /usr/lib/systemd/boot/efi/linuxx64.efi.stub ]]; then
                         ukify_args+=(--stub /usr/lib/systemd/boot/efi/linuxx64.efi.stub)
                     fi
-                    if ! ukify "${ukify_args[@]}"; then
+                    if [[ "$status" -eq 0 ]] && ! ukify "${ukify_args[@]}"; then
                         status=1
                     fi
                 fi

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -81,13 +81,40 @@ help_requested=0
 declare -A artifact_build_actions=()
 
 vmtest_requests_kubernetes_upgrade() {
-    local arg
-    for arg in "${go_test_input_args[@]}"; do
-        if [[ "$arg" == *TestKubeadmUpgradeOperationSmoke* ]]; then
-            return 0
-        fi
-    done
-    return 1
+	if [[ -n "${KATL_VMTEST_KUBERNETES_BUNDLE:-}" || -n "${KATL_VMTEST_KUBERNETES_UPGRADE_BUNDLE:-}" ]]; then
+		return 0
+	fi
+
+	local arg next_is_run=0 has_run=0 includes_scenarios=0
+	for arg in "${go_test_input_args[@]}"; do
+		if [[ "$arg" == "-args" ]]; then
+			break
+		fi
+		if [[ "$next_is_run" == 1 ]]; then
+			has_run=1
+			next_is_run=0
+			if [[ "TestKubeadmUpgradeOperationSmoke" =~ $arg ]]; then
+				return 0
+			fi
+			continue
+		fi
+		case "$arg" in
+			-run | --run | -test.run | --test.run)
+				next_is_run=1
+				;;
+			-run=* | --run=* | -test.run=* | --test.run=*)
+				has_run=1
+				local pattern="${arg#*=}"
+				if [[ "TestKubeadmUpgradeOperationSmoke" =~ $pattern ]]; then
+					return 0
+				fi
+				;;
+			./... | ./internal/vmtest/scenarios | ./internal/vmtest/scenarios/...)
+				includes_scenarios=1
+				;;
+		esac
+	done
+	[[ "$has_run" == 0 && "$includes_scenarios" == 1 ]]
 }
 
 vmtest_uses_published_kubernetes_upgrade_bundles() {
@@ -220,6 +247,26 @@ has_go_test_timeout() {
         shift
     done
     return 1
+}
+
+has_go_test_package_parallelism() {
+	local arg
+	while (($# > 0)); do
+		arg="$1"
+		case "$arg" in
+			-args)
+				return 1
+				;;
+			-p | --p)
+				return 0
+				;;
+			-p=* | --p=*)
+				return 0
+				;;
+		esac
+		shift
+	done
+	return 1
 }
 
 parse_runner_args() {
@@ -1296,6 +1343,12 @@ printf 'vmtest scenarios: %s\n' "$scenario_dir" >&2
 printf 'vmtest go test log: %s\n' "$go_test_log" >&2
 printf 'vmtest debug helper: scripts/vmtest-debug %q\n' "$run_dir" >&2
 go_test_args=()
+if ! has_go_test_package_parallelism "$@"; then
+	# VM packages share the world fixture cache and host resource pools. Keep
+	# package binaries serialized while retaining normal concurrency inside
+	# each package and honoring an explicit caller override.
+	go_test_args+=("-p" "1")
+fi
 if [[ -n "$go_test_timeout" ]] && ! has_go_test_timeout "$@"; then
     go_test_args+=("-timeout" "$go_test_timeout")
 fi


### PR DESCRIPTION
Makes the complete lifecycle VM gate deterministic across install, bootstrap, upgrade, wipe, and reinstall.\n\nThe failures shared several root causes: concurrent packages competed for host VM resources, direct-runtime artifacts and test contracts had drifted, and kubeadm bootstrap depended on unbounded registry pulls inside guests. The runner now serializes VM packages, lifecycle proofs use public contracts and complete artifacts, and Kubernetes images are cached and verified on the host before guest import.