### PR TITLE
console: split runtime status into panes

### DIFF
--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -83,6 +83,7 @@ func (c Collector) Collect(snapshot *Snapshot) {
 			}
 		}
 	} else {
+		snapshot.KubernetesBootstrapped = fileExists(rooted(c.Root, "/etc/kubernetes/kubelet.conf"))
 		c.collectGeneration(snapshot)
 	}
 }

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -12,22 +12,23 @@ const (
 )
 
 type Snapshot struct {
-	Mode                Mode
-	Version             string
-	KubernetesVersion   string
-	Hostname            string
-	State               string
-	CurrentStep         string
-	Generation          string
-	GenerationHealth    string
-	DestructiveMutation bool
-	LastError           string
-	RetryHint           string
-	Handoff             Handoff
-	Network             []NetworkInterface
-	SSHEnabled          bool
-	UpdatedAt           time.Time
-	StatusError         string
+	Mode                   Mode
+	Version                string
+	KubernetesVersion      string
+	KubernetesBootstrapped bool
+	Hostname               string
+	State                  string
+	CurrentStep            string
+	Generation             string
+	GenerationHealth       string
+	DestructiveMutation    bool
+	LastError              string
+	RetryHint              string
+	Handoff                Handoff
+	Network                []NetworkInterface
+	SSHEnabled             bool
+	UpdatedAt              time.Time
+	StatusError            string
 }
 
 type NetworkInterface struct {

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -90,6 +90,12 @@ func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 
 func TestCollectorReadsInstalledVersionsFromBootedGeneration(t *testing.T) {
 	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc", "kubernetes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc", "kubernetes", "kubelet.conf"), []byte("configured\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	record, err := generation.NewFirstInstallRecord(generation.FirstInstallRequest{
 		GenerationID:          "4",
 		RuntimeVersion:        "2026.7.0-alpha.12",
@@ -154,8 +160,8 @@ func TestCollectorReadsInstalledVersionsFromBootedGeneration(t *testing.T) {
 	}
 	var snapshot Snapshot
 	collector.Collect(&snapshot)
-	if snapshot.Version != "2026.7.0-alpha.12" || snapshot.KubernetesVersion != "v1.36.1" {
-		t.Fatalf("installed versions = KatlOS %q, Kubernetes %q", snapshot.Version, snapshot.KubernetesVersion)
+	if snapshot.Version != "2026.7.0-alpha.12" || snapshot.KubernetesVersion != "v1.36.1" || !snapshot.KubernetesBootstrapped {
+		t.Fatalf("installed state = KatlOS %q, Kubernetes %q, bootstrapped=%t", snapshot.Version, snapshot.KubernetesVersion, snapshot.KubernetesBootstrapped)
 	}
 }
 
@@ -234,7 +240,7 @@ func TestRenderRuntimeFailure(t *testing.T) {
 	}
 	var renderer Renderer
 	got := string(renderer.Append(make([]byte, 0, RenderCapacity(80, 20)), &snapshot, nil, 80, 20))
-	for _, want := range []string{"KatlOS needs repair", "KatlOS:       2026.7.0-alpha.9", "Kubernetes:   v1.36.1", "Generation:   4  health=FAILED", "Error:", "boot health check failed", "SSH: root@192.0.2.20"} {
+	for _, want := range []string{"Status", "Host", "Kubernetes", "Needs repair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation: 4", "Error:", "boot health check failed", "SSH: root@192.0.2.20"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
@@ -251,7 +257,7 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 	}
 	var renderer Renderer
 	plain := string(renderer.Append(nil, &snapshot, nil, 80, 15))
-	for _, want := range []string{"KatlOS\n", "Generation:   0  health=OK", "Journal"} {
+	for _, want := range []string{"KatlOS\n", "Status\n", "State:      OK", "Generation: 0", "Journal"} {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("plain render missing %q:\n%s", want, plain)
 		}
@@ -265,6 +271,111 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 	if !strings.Contains(colored, styleTitle) || !strings.Contains(colored, styleGood) {
 		t.Fatalf("coloured render lacks semantic styles: %q", colored)
 	}
+}
+
+func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:                   ModeRuntime,
+		Version:                "2026.7.0-alpha.12",
+		KubernetesVersion:      "v1.36.1",
+		KubernetesBootstrapped: true,
+		Hostname:               "cp-1",
+		State:                  installstatus.StateWaitingForClusterBootstrap,
+		Generation:             "4",
+		GenerationHealth:       "healthy",
+	}
+	var renderer Renderer
+	got := string(renderer.Append(nil, &snapshot, testJournal{[]byte("latest journal event")}, 80, 18))
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+	statusRow := lineIndex(lines, "Status")
+	splitRow := lineIndexContaining(lines, "Host")
+	journalRow := lineIndex(lines, "Journal")
+	if statusRow < 0 || splitRow <= statusRow || journalRow <= splitRow {
+		t.Fatalf("pane order = status %d, split %d, journal %d:\n%s", statusRow, splitRow, journalRow, got)
+	}
+	if !strings.Contains(lines[splitRow], "│Kubernetes") {
+		t.Fatalf("split title row = %q", lines[splitRow])
+	}
+	stateRow := lines[splitRow+1]
+	if !strings.Contains(stateRow, "State:      OK") || !strings.Contains(stateRow, "│State:      Bootstrapped") {
+		t.Fatalf("split state row = %q", stateRow)
+	}
+	versionRow := lines[splitRow+2]
+	if !strings.Contains(versionRow, "Node:       cp-1") || !strings.Contains(versionRow, "│Version:    v1.36.1") {
+		t.Fatalf("split version row = %q", versionRow)
+	}
+	if !strings.Contains(got, "latest journal event") {
+		t.Fatalf("journal pane missing content:\n%s", got)
+	}
+}
+
+func TestRenderRuntimeSubPanesWrapOverflowIndependently(t *testing.T) {
+	hostname := "cp-with-a-deliberately-long-hostname.example.test"
+	version := "v1.36.1-with-a-deliberately-long-build-identifier"
+	generationID := "generation-with-a-deliberately-long-identifier"
+	snapshot := Snapshot{
+		Mode:                   ModeRuntime,
+		Version:                "2026.7.0-alpha.12-with-a-long-build-identifier",
+		KubernetesVersion:      version,
+		KubernetesBootstrapped: true,
+		Hostname:               hostname,
+		State:                  installstatus.StateWaitingForClusterBootstrap,
+		Generation:             generationID,
+		GenerationHealth:       "healthy",
+	}
+	var renderer Renderer
+	plain := string(renderer.Append(nil, &snapshot, nil, 40, 40))
+	colored := string(renderer.AppendColor(nil, &snapshot, nil, 40, 40))
+	for name, output := range map[string]string{"plain": plain, "colored": colored} {
+		if strings.Contains(output, "~") {
+			t.Fatalf("%s render truncated overflow:\n%s", name, output)
+		}
+		for number, line := range strings.Split(strings.TrimSuffix(output, "\n"), "\n") {
+			if width := visibleWidth(line); width > 40 {
+				t.Fatalf("%s line %d width = %d: %q", name, number+1, width, line)
+			}
+		}
+	}
+
+	lines := strings.Split(strings.TrimSuffix(plain, "\n"), "\n")
+	splitRow := lineIndexContaining(lines, "Host")
+	networkRow := lineIndexContaining(lines, "Network:")
+	journalRow := lineIndex(lines, "Journal")
+	if splitRow < 0 || networkRow <= splitRow || journalRow <= networkRow {
+		t.Fatalf("missing nested panes:\n%s", plain)
+	}
+	var left, right strings.Builder
+	for _, line := range lines[splitRow:networkRow] {
+		divider := strings.IndexRune(line, '│')
+		if divider < 0 || len([]rune(line[:divider])) != 19 {
+			t.Fatalf("unstable divider in %q", line)
+		}
+		left.WriteString(strings.ReplaceAll(line[:divider], " ", ""))
+		right.WriteString(strings.ReplaceAll(line[divider+len("│"):], " ", ""))
+	}
+	for value, side := range map[string]string{hostname: left.String(), generationID: left.String(), version: right.String()} {
+		if !strings.Contains(side, value) {
+			t.Fatalf("wrapped panes lost %q:\n%s", value, plain)
+		}
+	}
+}
+
+func lineIndex(lines []string, value string) int {
+	for index, line := range lines {
+		if line == value {
+			return index
+		}
+	}
+	return -1
+}
+
+func lineIndexContaining(lines []string, value string) int {
+	for index, line := range lines {
+		if strings.Contains(line, value) {
+			return index
+		}
+	}
+	return -1
 }
 
 func TestRenderRebootHidesRedundantProgress(t *testing.T) {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	minimumWidth  = 40
-	minimumHeight = 12
-	fieldWidth    = 14
+	minimumWidth    = 40
+	minimumHeight   = 12
+	fieldWidth      = 14
+	panelFieldWidth = 12
 
 	styleReset = "\x1b[0m"
 	styleTitle = "\x1b[1;36m"
@@ -80,41 +81,15 @@ func (render *Renderer) append(dst []byte, snapshot *Snapshot, journal Journal, 
 	line.resetStyle()
 	line.finish()
 
-	field := render.wrappedField("State")
-	field.style(stateStyle(snapshot.State))
-	field.appendString(stateLabel(snapshot.State))
-	field.resetStyle()
-	field.finish()
-	if snapshot.Hostname != "" {
-		render.wrappedField("Node").appendString(snapshot.Hostname).finish()
-	}
-	appendNetwork(render, snapshot.Network)
-	if snapshot.Version != "" {
-		label := "KatlOS"
-		if snapshot.Mode == ModeInstaller {
-			label = "Media"
-		}
-		render.wrappedField(label).appendString(snapshot.Version).finish()
-	}
-	if snapshot.Mode == ModeRuntime && snapshot.KubernetesVersion != "" {
-		render.wrappedField("Kubernetes").appendString(snapshot.KubernetesVersion).finish()
-	}
-	if snapshot.State == "running" && snapshot.CurrentStep != "" {
-		render.wrappedField("Progress").appendString(snapshot.CurrentStep).finish()
-	}
-	if snapshot.Generation != "" {
-		field = render.wrappedField("Generation")
-		field.appendString(snapshot.Generation)
-		if health := healthLabel(snapshot.GenerationHealth); health != "" {
-			field.appendString("  health=")
-			field.style(healthStyle(health))
-			field.appendString(health)
-			field.resetStyle()
-		}
-		field.finish()
+	if snapshot.Mode == ModeRuntime {
+		appendPaneHeading(render, "Status")
+		appendRuntimeStatusPane(render, snapshot)
+		appendNetwork(render, snapshot.Network)
+	} else {
+		appendInstallerStatus(render, snapshot)
 	}
 	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
-		field = render.wrappedField("Disk changes")
+		field := render.wrappedField("Disk changes")
 		if snapshot.DestructiveMutation {
 			field.style(styleWarn)
 			field.appendString("started - do not power off")
@@ -126,7 +101,7 @@ func (render *Renderer) append(dst []byte, snapshot *Snapshot, journal Journal, 
 	}
 	if snapshot.Handoff.URL != "" {
 		render.wrappedField("Configure").appendString(snapshot.Handoff.URL).finish()
-		field = render.wrappedField("Run")
+		field := render.wrappedField("Run")
 		field.appendString("katlctl config init cluster.yaml --installer ")
 		if address := firstIPv4(snapshot.Network); address != "" {
 			field.appendString(address)
@@ -174,6 +149,246 @@ func (render *Renderer) append(dst []byte, snapshot *Snapshot, journal Journal, 
 	}
 	footer.resetStyle()
 	return footer.end()
+}
+
+type pane struct {
+	title  string
+	fields []paneField
+}
+
+type paneField struct {
+	label string
+	value string
+	style string
+}
+
+type paneFieldState struct {
+	field    paneField
+	position int
+	first    bool
+	done     bool
+}
+
+func appendPaneHeading(render *Renderer, title string) {
+	line := render.line()
+	line.style(styleTitle).appendString(title).resetStyle()
+	line.finish()
+}
+
+func appendRuntimeStatusPane(render *Renderer, snapshot *Snapshot) {
+	hostState, hostStyle := runtimeHostState(snapshot)
+	kubernetesState, kubernetesStyle := runtimeKubernetesState(snapshot)
+	leftFields := [...]paneField{
+		{label: "State", value: hostState, style: hostStyle},
+		{label: "Node", value: fallback(snapshot.Hostname, "Unknown")},
+		{label: "KatlOS", value: fallback(snapshot.Version, "Unknown")},
+		{label: "Generation", value: fallback(snapshot.Generation, "Unknown")},
+	}
+	rightFields := [...]paneField{
+		{label: "State", value: kubernetesState, style: kubernetesStyle},
+		{label: "Version", value: fallback(snapshot.KubernetesVersion, "Not installed")},
+	}
+	appendSplitPanes(render,
+		pane{title: "Host", fields: leftFields[:]},
+		pane{title: "Kubernetes", fields: rightFields[:]},
+	)
+}
+
+func appendInstallerStatus(render *Renderer, snapshot *Snapshot) {
+	field := render.wrappedField("State")
+	field.style(stateStyle(snapshot.State))
+	field.appendString(stateLabel(snapshot.State))
+	field.resetStyle()
+	field.finish()
+	if snapshot.Hostname != "" {
+		render.wrappedField("Node").appendString(snapshot.Hostname).finish()
+	}
+	appendNetwork(render, snapshot.Network)
+	if snapshot.Version != "" {
+		render.wrappedField("Media").appendString(snapshot.Version).finish()
+	}
+	if snapshot.State == "running" && snapshot.CurrentStep != "" {
+		render.wrappedField("Progress").appendString(snapshot.CurrentStep).finish()
+	}
+	if snapshot.Generation == "" {
+		return
+	}
+	field = render.wrappedField("Generation")
+	field.appendString(snapshot.Generation)
+	if health := healthLabel(snapshot.GenerationHealth); health != "" {
+		field.appendString("  health=")
+		field.style(healthStyle(health))
+		field.appendString(health)
+		field.resetStyle()
+	}
+	field.finish()
+}
+
+func appendSplitPanes(render *Renderer, left, right pane) {
+	if render.rows >= render.contentRows {
+		return
+	}
+	divider := (render.width - 1) / 2
+	line := render.line()
+	line.style(styleTitle)
+	appendStringUntil(line, left.title, divider)
+	line.resetStyle()
+	padLineTo(line, divider)
+	line.style(styleDim).appendRune('│').resetStyle()
+	line.style(styleTitle)
+	appendStringUntil(line, right.title, render.width)
+	line.resetStyle()
+	line.finish()
+
+	count := max(len(left.fields), len(right.fields))
+	for index := 0; index < count && render.rows < render.contentRows; index++ {
+		leftState := paneFieldState{first: true, done: index >= len(left.fields)}
+		if !leftState.done {
+			leftState.field = left.fields[index]
+		}
+		rightState := paneFieldState{first: true, done: index >= len(right.fields)}
+		if !rightState.done {
+			rightState.field = right.fields[index]
+		}
+		for (!leftState.done || !rightState.done) && render.rows < render.contentRows {
+			line = render.line()
+			appendPaneFieldSegment(line, &leftState, 0, divider)
+			padLineTo(line, divider)
+			line.style(styleDim).appendRune('│').resetStyle()
+			appendPaneFieldSegment(line, &rightState, divider+1, render.width)
+			line.finish()
+		}
+	}
+}
+
+func appendPaneFieldSegment(line *lineWriter, state *paneFieldState, start, end int) {
+	if state.done || end <= start {
+		return
+	}
+	padLineTo(line, start)
+	labelWidth := min(panelFieldWidth, end-start-1)
+	if labelWidth < 1 {
+		state.done = true
+		return
+	}
+	if state.first {
+		appendStringUntil(line, state.field.label, start+labelWidth-1)
+		if line.columns < start+labelWidth {
+			line.appendByte(':')
+		}
+		state.first = false
+	}
+	padLineTo(line, start+labelWidth)
+	if line.columns >= end {
+		return
+	}
+
+	state.position = skipVisibleSpace(state.field.value, state.position)
+	if state.position >= len(state.field.value) {
+		state.done = true
+		return
+	}
+	segmentEnd, next := paneSegment(state.field.value, state.position, end-line.columns)
+	if state.field.style != "" {
+		line.style(state.field.style)
+	}
+	line.appendString(state.field.value[state.position:segmentEnd])
+	if state.field.style != "" {
+		line.resetStyle()
+	}
+	state.position = next
+	state.done = skipVisibleSpace(state.field.value, state.position) >= len(state.field.value)
+}
+
+func paneSegment(value string, position, available int) (int, int) {
+	scan := position
+	end := position
+	lastSpace := -1
+	visible := 0
+	for scan < len(value) && visible < available {
+		r, next, ok := nextVisibleString(value, scan)
+		if !ok {
+			return len(value), len(value)
+		}
+		if r == '\n' {
+			return scan, next
+		}
+		if unicode.IsSpace(r) {
+			lastSpace = scan
+		}
+		end = next
+		scan = next
+		visible++
+	}
+	if scan >= len(value) {
+		return end, end
+	}
+	if lastSpace > position {
+		return lastSpace, skipVisibleSpace(value, lastSpace)
+	}
+	return end, end
+}
+
+func skipVisibleSpace(value string, position int) int {
+	for position < len(value) {
+		r, next, ok := nextVisibleString(value, position)
+		if !ok || (!unicode.IsSpace(r) && r != '\n') {
+			return position
+		}
+		position = next
+	}
+	return position
+}
+
+func padLineTo(line *lineWriter, column int) {
+	for line.columns < column {
+		line.appendByte(' ')
+	}
+}
+
+func appendStringUntil(line *lineWriter, value string, end int) {
+	for position := 0; position < len(value) && line.columns < end; {
+		r, next, ok := nextVisibleString(value, position)
+		position = next
+		if !ok || r == '\n' {
+			return
+		}
+		line.appendRune(r)
+	}
+}
+
+func runtimeHostState(snapshot *Snapshot) (string, string) {
+	if snapshot.State == "runtime-failed-needs-repair" {
+		return "Needs repair", styleBad
+	}
+	if health := healthLabel(snapshot.GenerationHealth); health != "" {
+		return health, healthStyle(health)
+	}
+	if snapshot.State == "starting-runtime" {
+		return "Starting", styleWarn
+	}
+	if snapshot.State == "runtime-booted-not-ready" {
+		return "Not ready", styleWarn
+	}
+	return "Running", styleGood
+}
+
+func runtimeKubernetesState(snapshot *Snapshot) (string, string) {
+	if snapshot.KubernetesVersion == "" {
+		return "Not installed", styleWarn
+	}
+	if snapshot.State == "runtime-failed-needs-repair" {
+		return "Unavailable", styleBad
+	}
+	if snapshot.KubernetesBootstrapped {
+		return "Bootstrapped", styleGood
+	}
+	switch snapshot.State {
+	case "kubeadm-ready", "waiting-for-cluster-bootstrap":
+		return "Ready for bootstrap", styleGood
+	default:
+		return "Waiting for KatlOS", styleWarn
+	}
 }
 
 // AppendJournalLine sanitizes and wraps one logical journal line into at most


### PR DESCRIPTION
Splits the installed console into a Status pane above Journal, with Host and Kubernetes sub-panes in the status area.\n\nThe pane renderer bounds each column independently and wraps overflow without truncating operator-visible values or crossing the divider. Installer presentation remains unchanged, and the Kubernetes pane reports version plus honest local bootstrap state.