### PR TITLE
console: own rendering storage

### DIFF
--- a/cmd/katl-console/main.go
+++ b/cmd/katl-console/main.go
@@ -77,14 +77,13 @@ func run(ctx context.Context, args []string) error {
 	}
 	snapshotPathValue := strings.TrimSpace(*snapshotPath)
 	var snapshot operatorconsole.Snapshot
-	var renderBuffer []byte
-	var snapshotBuffer []byte
 	var dashboard operatorconsole.Renderer
+	var plainDashboard operatorconsole.Renderer
 	ticker := time.NewTicker(*refresh)
 	defer ticker.Stop()
 	for {
 		collector.Collect(&snapshot)
-		if err := render(tty, snapshotPathValue, &snapshot, ring, &dashboard, &renderBuffer, &snapshotBuffer); err != nil {
+		if err := render(tty, snapshotPathValue, &snapshot, ring, &dashboard, &plainDashboard); err != nil {
 			return err
 		}
 		select {
@@ -95,27 +94,24 @@ func run(ctx context.Context, args []string) error {
 	}
 }
 
-func render(tty *os.File, snapshotPath string, snapshot *operatorconsole.Snapshot, journal operatorconsole.Journal, dashboard *operatorconsole.Renderer, buffer, snapshotBuffer *[]byte) error {
+func render(tty *os.File, snapshotPath string, snapshot *operatorconsole.Snapshot, journal operatorconsole.Journal, dashboard, plainDashboard *operatorconsole.Renderer) error {
 	width, height := terminalSize(tty)
-	required := len("\x1b[H\x1b[2J") + operatorconsole.RenderCapacity(width, height)
-	if cap(*buffer) < required {
-		*buffer = make([]byte, 0, required)
+	if !dashboard.MatchesDimensions(width, height) {
+		target := operatorconsole.NewRenderTarget(make([]byte, operatorconsole.RenderCapacity(width, height)), width, height)
+		*dashboard = operatorconsole.NewRenderer(target, true)
 	}
-	data := (*buffer)[:0]
-	data = append(data, "\x1b[H\x1b[2J"...)
-	data = dashboard.AppendColor(data, snapshot, journal, width, height)
-	*buffer = data
+	data := dashboard.Render(snapshot, journal)
 	if written, err := tty.Write(data); err != nil {
 		return fmt.Errorf("render dashboard: %w", err)
 	} else if written != len(data) {
 		return fmt.Errorf("render dashboard: %w", io.ErrShortWrite)
 	}
 	if snapshotPath != "" {
-		if cap(*snapshotBuffer) < required {
-			*snapshotBuffer = make([]byte, 0, required)
+		if !plainDashboard.MatchesDimensions(width, height) {
+			target := operatorconsole.NewRenderTarget(make([]byte, operatorconsole.RenderCapacity(width, height)), width, height)
+			*plainDashboard = operatorconsole.NewRenderer(target, false)
 		}
-		plain := dashboard.Append((*snapshotBuffer)[:0], snapshot, journal, width, height)
-		*snapshotBuffer = plain
+		plain := plainDashboard.Render(snapshot, journal)
 		if err := writeSnapshot(snapshotPath, plain); err != nil {
 			return err
 		}
@@ -289,29 +285,27 @@ func isDigit(value byte) bool {
 	return value >= '0' && value <= '9'
 }
 
-func (r *journalRing) AppendTail(dst []byte, rows, width int) ([]byte, int) {
+func (r *journalRing) WriteTail(writer *operatorconsole.JournalWriter) {
 	r.mu.Lock()
 	selected := 0
 	selectedRows := 0
-	for selected < r.count && selectedRows < rows {
+	for selected < r.count && selectedRows < writer.RowsRemaining() {
 		index := (r.start + r.count - selected - 1) % len(r.lines)
-		lineRows := operatorconsole.JournalLineRows(r.lines[index], width)
-		if selected > 0 && selectedRows+lineRows > rows {
+		lineRows := writer.LineRows(r.lines[index])
+		if selected > 0 && selectedRows+lineRows > writer.RowsRemaining() {
 			break
 		}
 		selected++
 		selectedRows += lineRows
 	}
 	first := r.count - selected
-	written := 0
 	for offset := range selected {
 		index := (r.start + first + offset) % len(r.lines)
-		var lineRows int
-		dst, lineRows = operatorconsole.AppendJournalLine(dst, r.lines[index], width, rows-written)
-		written += lineRows
+		if !writer.WriteLine(r.lines[index]) {
+			break
+		}
 	}
 	r.mu.Unlock()
-	return dst, written
 }
 
 func followJournal(ctx context.Context, ring *journalRing) {

--- a/cmd/katl-console/main_test.go
+++ b/cmd/katl-console/main_test.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/katl-dev/katl/internal/operatorconsole"
 )
 
 func TestJournalRingIsBounded(t *testing.T) {
@@ -13,9 +15,12 @@ func TestJournalRingIsBounded(t *testing.T) {
 	ring.Add([]byte("one"))
 	ring.Add([]byte("two"))
 	ring.Add([]byte("three"))
-	got, rows := ring.AppendTail(make([]byte, 0, 32), 2, 80)
+	target := operatorconsole.NewRenderTarget(make([]byte, 256), 80, 2)
+	writer := operatorconsole.NewJournalWriter(target)
+	ring.WriteTail(&writer)
+	got, rows := writer.Bytes(), writer.RowsWritten()
 	if rows != 2 || string(got) != "two\nthree\n" {
-		t.Fatalf("AppendTail() = %q, %d rows", got, rows)
+		t.Fatalf("WriteTail() = %q, %d rows", got, rows)
 	}
 }
 
@@ -56,7 +61,10 @@ func TestJournalRingCompactsDateTimeTimestamps(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ring := newJournalRing(1)
 			ring.Add([]byte(test.line))
-			got, _ := ring.AppendTail(make([]byte, 0, 128), 1, 128)
+			target := operatorconsole.NewRenderTarget(make([]byte, 256), 128, 1)
+			writer := operatorconsole.NewJournalWriter(target)
+			ring.WriteTail(&writer)
+			got := writer.Bytes()
 			if string(got) != test.want {
 				t.Fatalf("journal line = %q, want %q", got, test.want)
 			}
@@ -67,10 +75,12 @@ func TestJournalRingCompactsDateTimeTimestamps(t *testing.T) {
 func TestJournalRingReusesPreallocatedLines(t *testing.T) {
 	ring := newJournalRing(2)
 	line := []byte("2026-07-17T18:02:03.123456+01:00 " + strings.Repeat("x", journalLineCapacity-39))
-	buffer := make([]byte, 0, 4096)
+	storage := make([]byte, 4096)
 	allocations := testing.AllocsPerRun(1000, func() {
 		ring.Add(line)
-		buffer, _ = ring.AppendTail(buffer[:0], 2, 80)
+		writer := operatorconsole.NewJournalWriter(operatorconsole.NewRenderTarget(storage, 80, 2))
+		ring.WriteTail(&writer)
+		_ = writer.Bytes()
 	})
 	if allocations != 0 {
 		t.Fatalf("journal add/render allocations = %v, want 0", allocations)
@@ -88,12 +98,13 @@ func TestJournalRingSPSC(t *testing.T) {
 		close(done)
 	}()
 
-	buffer := make([]byte, 0, 4096)
+	storage := make([]byte, 4096)
 	for {
-		var rows int
-		buffer, rows = ring.AppendTail(buffer[:0], 8, 80)
+		writer := operatorconsole.NewJournalWriter(operatorconsole.NewRenderTarget(storage, 80, 8))
+		ring.WriteTail(&writer)
+		rows := writer.RowsWritten()
 		if rows > 8 {
-			t.Fatalf("AppendTail() rows = %d, want at most 8", rows)
+			t.Fatalf("WriteTail() rows = %d, want at most 8", rows)
 		}
 		select {
 		case <-done:

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -1,6 +1,7 @@
 package operatorconsole
 
 import (
+	"bytes"
 	"net"
 	"os"
 	"path/filepath"
@@ -177,8 +178,7 @@ func TestRenderInstallerDashboard(t *testing.T) {
 		Network:             []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
 	}
 	journal := testJournal{[]byte("old line"), []byte("installing root\x1b[31m"), []byte("latest line")}
-	var renderer Renderer
-	got := string(renderer.Append(make([]byte, 0, RenderCapacity(80, 25)), &snapshot, journal, 80, 25))
+	got := string(renderDashboard(&snapshot, journal, 80, 25, false))
 	for _, want := range []string{
 		"KatlOS Installer",
 		"State:        Installing",
@@ -216,8 +216,7 @@ func TestRenderInstallerCommandUsesHandoffURLWithoutIPv4(t *testing.T) {
 		Handoff: Handoff{URL: "http://[2001:db8::10]:8080/v1/config-bundle"},
 		Network: []NetworkInterface{{Name: "enp1s0", Addresses: []string{"2001:db8::10/64"}}},
 	}
-	var renderer Renderer
-	got := string(renderer.Append(make([]byte, 0, RenderCapacity(100, 18)), &snapshot, nil, 100, 18))
+	got := string(renderDashboard(&snapshot, nil, 100, 18, false))
 	want := "Run:          katlctl config init cluster.yaml --installer http://[2001:db8::10]:8080"
 	if !strings.Contains(got, want) {
 		t.Fatalf("render missing %q:\n%s", want, got)
@@ -238,8 +237,7 @@ func TestRenderRuntimeFailure(t *testing.T) {
 		SSHEnabled:        true,
 		Network:           []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
 	}
-	var renderer Renderer
-	got := string(renderer.Append(make([]byte, 0, RenderCapacity(80, 20)), &snapshot, nil, 80, 20))
+	got := string(renderDashboard(&snapshot, nil, 80, 20, false))
 	for _, want := range []string{"Status", "Host", "Kubernetes", "Needs repair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation: 4", "Error:", "boot health check failed", "SSH: root@192.0.2.20"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
@@ -255,8 +253,7 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 		GenerationHealth: "healthy",
 		CurrentStep:      "Reboot",
 	}
-	var renderer Renderer
-	plain := string(renderer.Append(nil, &snapshot, nil, 80, 15))
+	plain := string(renderDashboard(&snapshot, nil, 80, 15, false))
 	for _, want := range []string{"KatlOS\n", "Status\n", "State:      OK", "Generation: 0", "Journal"} {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("plain render missing %q:\n%s", want, plain)
@@ -267,7 +264,7 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 			t.Fatalf("plain render contains %q:\n%s", unwanted, plain)
 		}
 	}
-	colored := string(renderer.AppendColor(nil, &snapshot, nil, 80, 15))
+	colored := string(renderDashboard(&snapshot, nil, 80, 15, true))
 	if !strings.Contains(colored, styleTitle) || !strings.Contains(colored, styleGood) {
 		t.Fatalf("coloured render lacks semantic styles: %q", colored)
 	}
@@ -284,8 +281,7 @@ func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
 		Generation:             "4",
 		GenerationHealth:       "healthy",
 	}
-	var renderer Renderer
-	got := string(renderer.Append(nil, &snapshot, testJournal{[]byte("latest journal event")}, 80, 18))
+	got := string(renderDashboard(&snapshot, testJournal{[]byte("latest journal event")}, 80, 18, false))
 	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
 	statusRow := lineIndex(lines, "Status")
 	splitRow := lineIndexContaining(lines, "Host")
@@ -323,9 +319,8 @@ func TestRenderRuntimeSubPanesWrapOverflowIndependently(t *testing.T) {
 		Generation:             generationID,
 		GenerationHealth:       "healthy",
 	}
-	var renderer Renderer
-	plain := string(renderer.Append(nil, &snapshot, nil, 40, 40))
-	colored := string(renderer.AppendColor(nil, &snapshot, nil, 40, 40))
+	plain := string(renderDashboard(&snapshot, nil, 40, 40, false))
+	colored := string(renderDashboard(&snapshot, nil, 40, 40, true))
 	for name, output := range map[string]string{"plain": plain, "colored": colored} {
 		if strings.Contains(output, "~") {
 			t.Fatalf("%s render truncated overflow:\n%s", name, output)
@@ -384,8 +379,7 @@ func TestRenderRebootHidesRedundantProgress(t *testing.T) {
 		State:       installstatus.StateRebootRequested,
 		CurrentStep: "Reboot",
 	}
-	var renderer Renderer
-	got := string(renderer.Append(nil, &snapshot, nil, 80, 15))
+	got := string(renderDashboard(&snapshot, nil, 80, 15, false))
 	if !strings.Contains(got, "Installation complete; rebooting") || strings.Contains(got, "Progress:") {
 		t.Fatalf("reboot dashboard =\n%s", got)
 	}
@@ -402,8 +396,7 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 			Addresses: []string{"2001:db8:1234:5678::10/64", "192.0.2.10/24"},
 		}},
 	}
-	var renderer Renderer
-	got := string(renderer.Append(nil, &snapshot, nil, 40, 40))
+	got := string(renderDashboard(&snapshot, nil, 40, 40, false))
 	joined := strings.ReplaceAll(got, "\n"+strings.Repeat(" ", fieldWidth), "")
 	for _, want := range []string{"tail-marker", "config-bundle", "192.0.2.10/24"} {
 		if !strings.Contains(joined, want) {
@@ -422,9 +415,11 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 
 func TestJournalLineWrapsAndStripsANSI(t *testing.T) {
 	value := []byte("2026-07-14T00:01:02+01:00 host service[1]: " + strings.Repeat("payload", 8) + "\x1b[31m")
-	got, rows := AppendJournalLine(nil, value, 40, 10)
+	writer := NewJournalWriter(NewRenderTarget(make([]byte, RenderCapacity(40, 10)), 40, 10))
+	writer.WriteLine(value)
+	got, rows := writer.Bytes(), writer.RowsWritten()
 	if rows < 2 || strings.Contains(string(got), "\x1b") || strings.Contains(string(got), "[31m") || strings.Contains(string(got), "~") {
-		t.Fatalf("AppendJournalLine() = %q, rows=%d", got, rows)
+		t.Fatalf("JournalWriter.WriteLine() = %q, rows=%d", got, rows)
 	}
 	for number, line := range strings.Split(strings.TrimSuffix(string(got), "\n"), "\n") {
 		if len([]rune(line)) > 40 {
@@ -438,36 +433,78 @@ func TestJournalLineWrapsAndStripsANSI(t *testing.T) {
 
 func TestRendererReusesBuffer(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:       ModeRuntime,
-		State:      installstatus.StateKubeadmReady,
-		SSHEnabled: true,
+		Mode:                   ModeRuntime,
+		State:                  installstatus.StateKubeadmReady,
+		Hostname:               "cp-1",
+		Version:                "2026.7.0-alpha.15",
+		Generation:             "4",
+		GenerationHealth:       "healthy",
+		KubernetesVersion:      "v1.36.1",
+		KubernetesBootstrapped: true,
+		SSHEnabled:             true,
+		Network: []NetworkInterface{{
+			Name:      "enp1s0",
+			Addresses: []string{"10.1.2.254/24", "fd00::254/64"},
+		}},
 	}
 	journal := testJournal{[]byte("journal line")}
-	var renderer Renderer
-	buffer := make([]byte, 0, RenderCapacity(80, 25))
-	buffer = renderer.Append(buffer, &snapshot, &journal, 80, 25)
-	start := &buffer[0]
+	for _, color := range []bool{false, true} {
+		name := "plain"
+		if color {
+			name = "color"
+		}
+		t.Run(name, func(t *testing.T) {
+			storage := make([]byte, RenderCapacity(80, 25))
+			renderer := NewRenderer(NewRenderTarget(storage, 80, 25), color)
+			buffer := renderer.Render(&snapshot, &journal)
+			start := &buffer[0]
 
-	allocations := testing.AllocsPerRun(1000, func() {
-		buffer = renderer.Append(buffer[:0], &snapshot, &journal, 80, 25)
-	})
-	if allocations != 0 {
-		t.Fatalf("Renderer.Append() allocations = %v, want 0", allocations)
+			allocations := testing.AllocsPerRun(1000, func() {
+				buffer = renderer.Render(&snapshot, &journal)
+			})
+			if allocations != 0 {
+				t.Fatalf("Renderer.Render() allocations = %v, want 0", allocations)
+			}
+			if &buffer[0] != start {
+				t.Fatal("Renderer.Render() replaced owned storage")
+			}
+		})
 	}
-	if &buffer[0] != start {
-		t.Fatal("Renderer.Append() replaced caller-owned buffer")
+}
+
+func TestRendererStartsAtTopLeft(t *testing.T) {
+	snapshot := Snapshot{Mode: ModeRuntime}
+	for _, test := range []struct {
+		name   string
+		color  bool
+		prefix []byte
+	}{
+		{name: "plain", prefix: []byte("KatlOS")},
+		{name: "terminal", color: true, prefix: []byte(clearScreen + styleTitle + "KatlOS")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			storage := bytes.Repeat([]byte{'x'}, RenderCapacity(80, 25))
+			renderer := NewRenderer(NewRenderTarget(storage, 80, 25), test.color)
+			if got := renderer.Render(&snapshot, nil); !bytes.HasPrefix(got, test.prefix) {
+				t.Fatalf("render prefix = %q, want %q", got[:min(len(got), len(test.prefix))], test.prefix)
+			}
+		})
 	}
 }
 
 type testJournal [][]byte
 
-func (j testJournal) AppendTail(dst []byte, rows, width int) ([]byte, int) {
-	rows = min(rows, len(j))
-	written := 0
+func (j testJournal) WriteTail(writer *JournalWriter) {
+	rows := min(writer.RowsRemaining(), len(j))
 	for _, line := range j[len(j)-rows:] {
-		var lineRows int
-		dst, lineRows = AppendJournalLine(dst, line, width, rows-written)
-		written += lineRows
+		if !writer.WriteLine(line) {
+			break
+		}
 	}
-	return dst, written
+}
+
+func renderDashboard(snapshot *Snapshot, journal Journal, width, height int, color bool) []byte {
+	target := NewRenderTarget(make([]byte, RenderCapacity(width, height)), width, height)
+	renderer := NewRenderer(target, color)
+	return renderer.Render(snapshot, journal)
 }

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -20,10 +20,12 @@ const (
 	styleDim   = "\x1b[2m"
 )
 
-// Journal appends its newest lines to dst. Implementations may retain a lock
-// while appending because the caller has already reserved enough render memory.
+const clearScreen = "\x1b[H\x1b[2J"
+
+// Journal writes its newest lines into the bounded dashboard journal region.
+// Implementations may retain a lock while writing.
 type Journal interface {
-	AppendTail(dst []byte, rows, width int) ([]byte, int)
+	WriteTail(*JournalWriter)
 }
 
 // RenderCapacity returns enough capacity for a complete render without growth.
@@ -33,122 +35,197 @@ func RenderCapacity(width, height int) int {
 	return height * (width*utf8.UTFMax + 32)
 }
 
-// Renderer retains line state between calls so fluent line construction does
-// not allocate.
+// RenderTarget owns fixed storage and its terminal geometry. Writers start at
+// the top-left and may reset the cursor, but they never grow the storage.
+type RenderTarget struct {
+	storage  []byte
+	width    int
+	rows     int
+	position int
+}
+
+// NewRenderTarget binds fixed storage to a terminal-sized region.
+func NewRenderTarget(storage []byte, width, rows int) RenderTarget {
+	return RenderTarget{storage: storage, width: width, rows: rows}
+}
+
+func (target *RenderTarget) reset() {
+	target.position = 0
+}
+
+func (target *RenderTarget) bytes() []byte {
+	return target.storage[:target.position]
+}
+
+func (target *RenderTarget) writeByte(value byte) {
+	if target.position >= len(target.storage) {
+		panic("operatorconsole: render capacity exhausted")
+	}
+	target.storage[target.position] = value
+	target.position++
+}
+
+func (target *RenderTarget) writeString(value string) {
+	if len(value) > len(target.storage)-target.position {
+		panic("operatorconsole: render capacity exhausted")
+	}
+	target.position += copy(target.storage[target.position:], value)
+}
+
+func (target *RenderTarget) writeRune(value rune) {
+	if value < utf8.RuneSelf {
+		target.writeByte(byte(value))
+		return
+	}
+	if utf8.RuneLen(value) > len(target.storage)-target.position {
+		panic("operatorconsole: render capacity exhausted")
+	}
+	target.position += utf8.EncodeRune(target.storage[target.position:], value)
+}
+
+func (target *RenderTarget) truncate(position int) {
+	target.position = position
+}
+
+func (target *RenderTarget) tail(rows int) RenderTarget {
+	return RenderTarget{
+		storage: target.storage[target.position:],
+		width:   target.width,
+		rows:    rows,
+	}
+}
+
+// Renderer owns fixed output storage, terminal geometry, cursor state and line
+// writers. Render always starts at the top-left of that storage and never grows
+// it; callers replace the renderer when the terminal dimensions change.
 type Renderer struct {
-	dst         []byte
-	width       int
-	contentRows int
-	rows        int
-	color       bool
-	lineState   lineWriter
+	output       RenderTarget
+	contentRows  int
+	row          int
+	color        bool
+	lineState    lineWriter
+	wrappedState wrappedWriter
+	journalState JournalWriter
 }
 
-// Append appends a dashboard to caller-owned memory.
-func (render *Renderer) Append(dst []byte, snapshot *Snapshot, journal Journal, width, height int) []byte {
-	return render.append(dst, snapshot, journal, width, height, false)
-}
-
-// AppendColor appends a dashboard with ANSI colour suitable for an interactive
-// terminal. Width accounting excludes the styling sequences.
-func (render *Renderer) AppendColor(dst []byte, snapshot *Snapshot, journal Journal, width, height int) []byte {
-	return render.append(dst, snapshot, journal, width, height, true)
-}
-
-func (render *Renderer) append(dst []byte, snapshot *Snapshot, journal Journal, width, height int, color bool) []byte {
-	width, height = renderDimensions(width, height)
-	*render = Renderer{
-		dst:         dst,
-		width:       width,
-		contentRows: height - 1,
+// NewRenderer binds a renderer to a fixed render target.
+func NewRenderer(target RenderTarget, color bool) Renderer {
+	target.width, target.rows = renderDimensions(target.width, target.rows)
+	required := RenderCapacity(target.width, target.rows)
+	if len(target.storage) < required {
+		panic("operatorconsole: renderer storage is smaller than RenderCapacity")
+	}
+	target.storage = target.storage[:required]
+	return Renderer{
+		output:      target,
+		contentRows: target.rows - 1,
 		color:       color,
+	}
+}
+
+// MatchesDimensions reports whether the renderer owns storage for the given
+// terminal geometry.
+func (render *Renderer) MatchesDimensions(width, height int) bool {
+	width, height = renderDimensions(width, height)
+	return render.output.width == width && render.output.rows == height && len(render.output.storage) >= RenderCapacity(width, height)
+}
+
+// Render writes a complete dashboard from the top-left of the owned storage.
+// Colour renderers include the terminal cursor-home and clear sequence.
+func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
+	render.output.reset()
+	render.row = 0
+	if render.color {
+		render.output.writeString(clearScreen)
 	}
 
 	line := render.line()
 	line.style(styleTitle)
-	line.appendString("KatlOS")
+	line.writeString("KatlOS")
 	if snapshot.Mode == ModeInstaller {
-		line.appendString(" Installer")
+		line.writeString(" Installer")
 	}
 	line.resetStyle()
 	line.finish()
 
 	line = render.line()
 	line.style(styleDim)
-	for range min(width, 72) {
-		line.appendByte('=')
+	for range min(render.output.width, 72) {
+		line.writeByte('=')
 	}
 	line.resetStyle()
 	line.finish()
 
 	if snapshot.Mode == ModeRuntime {
-		appendPaneHeading(render, "Status")
-		appendRuntimeStatusPane(render, snapshot)
-		appendNetwork(render, snapshot.Network)
+		render.writePaneHeading("Status")
+		render.writeRuntimeStatusPane(snapshot)
+		render.writeNetwork(snapshot.Network)
 	} else {
-		appendInstallerStatus(render, snapshot)
+		render.writeInstallerStatus(snapshot)
 	}
 	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
 		field := render.wrappedField("Disk changes")
 		if snapshot.DestructiveMutation {
 			field.style(styleWarn)
-			field.appendString("started - do not power off")
+			field.writeString("started - do not power off")
 			field.resetStyle()
 		} else {
-			field.appendString("not started")
+			field.writeString("not started")
 		}
 		field.finish()
 	}
 	if snapshot.Handoff.URL != "" {
-		render.wrappedField("Configure").appendString(snapshot.Handoff.URL).finish()
+		render.wrappedField("Configure").writeString(snapshot.Handoff.URL).finish()
 		field := render.wrappedField("Run")
-		field.appendString("katlctl config init cluster.yaml --installer ")
+		field.writeString("katlctl config init cluster.yaml --installer ")
 		if address := firstIPv4(snapshot.Network); address != "" {
-			field.appendString(address)
+			field.writeString(address)
 		} else {
-			field.appendString(installerBaseURL(snapshot.Handoff.URL))
+			field.writeString(installerBaseURL(snapshot.Handoff.URL))
 		}
 		field.finish()
 	}
-	appendWrappedField(render, "Error", snapshot.LastError, styleBad)
-	appendWrappedField(render, "Next action", snapshot.RetryHint, styleWarn)
-	appendWrappedField(render, "Status read", snapshot.StatusError, styleWarn)
+	render.writeWrappedField("Error", snapshot.LastError, styleBad)
+	render.writeWrappedField("Next action", snapshot.RetryHint, styleWarn)
+	render.writeWrappedField("Status read", snapshot.StatusError, styleWarn)
 
 	render.finishBlank()
 	line = render.line()
 	line.style(styleTitle)
-	line.appendString("Journal")
+	line.writeString("Journal")
 	line.resetStyle()
 	line.finish()
-	if remaining := render.contentRows - render.rows; journal != nil && remaining > 0 {
-		var written int
-		render.dst, written = journal.AppendTail(render.dst, remaining, width)
-		render.rows += written
+	if remaining := render.contentRows - render.row; journal != nil && remaining > 0 {
+		render.journalState = NewJournalWriter(render.output.tail(remaining))
+		journal.WriteTail(&render.journalState)
+		render.output.position += render.journalState.output.position
+		render.row += render.journalState.rows
 	}
-	for render.rows < render.contentRows {
+	for render.row < render.contentRows {
 		render.finishBlank()
 	}
 
-	footer := newLine(render.dst, width)
-	footer.color = color
+	footer := newLine(&render.output)
+	footer.color = render.color
 	footer.style(styleDim)
-	footer.appendString("Ctrl+Alt+F2: console")
+	footer.writeString("Ctrl+Alt+F2: console")
 	if snapshot.SSHEnabled {
 		if address := firstIPv4(snapshot.Network); address != "" {
-			ssh := " | SSH: root@" + address
-			if visibleWidth("Ctrl+Alt+F2: console"+ssh) <= width {
-				footer.appendString(ssh)
+			if visibleWidth("Ctrl+Alt+F2: console | SSH: root@")+visibleWidth(address) <= render.output.width {
+				footer.writeString(" | SSH: root@")
+				footer.writeString(address)
 			} else {
-				footer.appendString(" | SSH enabled")
+				footer.writeString(" | SSH enabled")
 			}
 		} else {
-			footer.appendString(" | SSH enabled")
+			footer.writeString(" | SSH enabled")
 		}
 	} else if snapshot.Mode == ModeInstaller {
-		footer.appendString(" | SSH disabled")
+		footer.writeString(" | SSH disabled")
 	}
 	footer.resetStyle()
-	return footer.end()
+	footer.end()
+	return render.output.bytes()
 }
 
 type pane struct {
@@ -169,13 +246,13 @@ type paneFieldState struct {
 	done     bool
 }
 
-func appendPaneHeading(render *Renderer, title string) {
+func (render *Renderer) writePaneHeading(title string) {
 	line := render.line()
-	line.style(styleTitle).appendString(title).resetStyle()
+	line.style(styleTitle).writeString(title).resetStyle()
 	line.finish()
 }
 
-func appendRuntimeStatusPane(render *Renderer, snapshot *Snapshot) {
+func (render *Renderer) writeRuntimeStatusPane(snapshot *Snapshot) {
 	hostState, hostStyle := runtimeHostState(snapshot)
 	kubernetesState, kubernetesStyle := runtimeKubernetesState(snapshot)
 	leftFields := [...]paneField{
@@ -188,60 +265,60 @@ func appendRuntimeStatusPane(render *Renderer, snapshot *Snapshot) {
 		{label: "State", value: kubernetesState, style: kubernetesStyle},
 		{label: "Version", value: fallback(snapshot.KubernetesVersion, "Not installed")},
 	}
-	appendSplitPanes(render,
+	render.writeSplitPanes(
 		pane{title: "Host", fields: leftFields[:]},
 		pane{title: "Kubernetes", fields: rightFields[:]},
 	)
 }
 
-func appendInstallerStatus(render *Renderer, snapshot *Snapshot) {
+func (render *Renderer) writeInstallerStatus(snapshot *Snapshot) {
 	field := render.wrappedField("State")
 	field.style(stateStyle(snapshot.State))
-	field.appendString(stateLabel(snapshot.State))
+	field.writeString(stateLabel(snapshot.State))
 	field.resetStyle()
 	field.finish()
 	if snapshot.Hostname != "" {
-		render.wrappedField("Node").appendString(snapshot.Hostname).finish()
+		render.wrappedField("Node").writeString(snapshot.Hostname).finish()
 	}
-	appendNetwork(render, snapshot.Network)
+	render.writeNetwork(snapshot.Network)
 	if snapshot.Version != "" {
-		render.wrappedField("Media").appendString(snapshot.Version).finish()
+		render.wrappedField("Media").writeString(snapshot.Version).finish()
 	}
 	if snapshot.State == "running" && snapshot.CurrentStep != "" {
-		render.wrappedField("Progress").appendString(snapshot.CurrentStep).finish()
+		render.wrappedField("Progress").writeString(snapshot.CurrentStep).finish()
 	}
 	if snapshot.Generation == "" {
 		return
 	}
 	field = render.wrappedField("Generation")
-	field.appendString(snapshot.Generation)
+	field.writeString(snapshot.Generation)
 	if health := healthLabel(snapshot.GenerationHealth); health != "" {
-		field.appendString("  health=")
+		field.writeString("  health=")
 		field.style(healthStyle(health))
-		field.appendString(health)
+		field.writeString(health)
 		field.resetStyle()
 	}
 	field.finish()
 }
 
-func appendSplitPanes(render *Renderer, left, right pane) {
-	if render.rows >= render.contentRows {
+func (render *Renderer) writeSplitPanes(left, right pane) {
+	if render.row >= render.contentRows {
 		return
 	}
-	divider := (render.width - 1) / 2
+	divider := (render.output.width - 1) / 2
 	line := render.line()
 	line.style(styleTitle)
-	appendStringUntil(line, left.title, divider)
+	line.writeUntil(left.title, divider)
 	line.resetStyle()
-	padLineTo(line, divider)
-	line.style(styleDim).appendRune('│').resetStyle()
+	line.padTo(divider)
+	line.style(styleDim).writeRune('│').resetStyle()
 	line.style(styleTitle)
-	appendStringUntil(line, right.title, render.width)
+	line.writeUntil(right.title, render.output.width)
 	line.resetStyle()
 	line.finish()
 
 	count := max(len(left.fields), len(right.fields))
-	for index := 0; index < count && render.rows < render.contentRows; index++ {
+	for index := 0; index < count && render.row < render.contentRows; index++ {
 		leftState := paneFieldState{first: true, done: index >= len(left.fields)}
 		if !leftState.done {
 			leftState.field = left.fields[index]
@@ -250,35 +327,35 @@ func appendSplitPanes(render *Renderer, left, right pane) {
 		if !rightState.done {
 			rightState.field = right.fields[index]
 		}
-		for (!leftState.done || !rightState.done) && render.rows < render.contentRows {
+		for (!leftState.done || !rightState.done) && render.row < render.contentRows {
 			line = render.line()
-			appendPaneFieldSegment(line, &leftState, 0, divider)
-			padLineTo(line, divider)
-			line.style(styleDim).appendRune('│').resetStyle()
-			appendPaneFieldSegment(line, &rightState, divider+1, render.width)
+			render.writePaneFieldSegment(line, &leftState, 0, divider)
+			line.padTo(divider)
+			line.style(styleDim).writeRune('│').resetStyle()
+			render.writePaneFieldSegment(line, &rightState, divider+1, render.output.width)
 			line.finish()
 		}
 	}
 }
 
-func appendPaneFieldSegment(line *lineWriter, state *paneFieldState, start, end int) {
+func (render *Renderer) writePaneFieldSegment(line *lineWriter, state *paneFieldState, start, end int) {
 	if state.done || end <= start {
 		return
 	}
-	padLineTo(line, start)
+	line.padTo(start)
 	labelWidth := min(panelFieldWidth, end-start-1)
 	if labelWidth < 1 {
 		state.done = true
 		return
 	}
 	if state.first {
-		appendStringUntil(line, state.field.label, start+labelWidth-1)
+		line.writeUntil(state.field.label, start+labelWidth-1)
 		if line.columns < start+labelWidth {
-			line.appendByte(':')
+			line.writeByte(':')
 		}
 		state.first = false
 	}
-	padLineTo(line, start+labelWidth)
+	line.padTo(start + labelWidth)
 	if line.columns >= end {
 		return
 	}
@@ -292,7 +369,7 @@ func appendPaneFieldSegment(line *lineWriter, state *paneFieldState, start, end 
 	if state.field.style != "" {
 		line.style(state.field.style)
 	}
-	line.appendString(state.field.value[state.position:segmentEnd])
+	line.writeString(state.field.value[state.position:segmentEnd])
 	if state.field.style != "" {
 		line.resetStyle()
 	}
@@ -340,20 +417,20 @@ func skipVisibleSpace(value string, position int) int {
 	return position
 }
 
-func padLineTo(line *lineWriter, column int) {
+func (line *lineWriter) padTo(column int) {
 	for line.columns < column {
-		line.appendByte(' ')
+		line.writeByte(' ')
 	}
 }
 
-func appendStringUntil(line *lineWriter, value string, end int) {
+func (line *lineWriter) writeUntil(value string, end int) {
 	for position := 0; position < len(value) && line.columns < end; {
 		r, next, ok := nextVisibleString(value, position)
 		position = next
 		if !ok || r == '\n' {
 			return
 		}
-		line.appendRune(r)
+		line.writeRune(r)
 	}
 }
 
@@ -391,16 +468,59 @@ func runtimeKubernetesState(snapshot *Snapshot) (string, string) {
 	}
 }
 
-// AppendJournalLine sanitizes and wraps one logical journal line into at most
-// maxRows physical terminal rows.
-func AppendJournalLine(dst, value []byte, width, maxRows int) ([]byte, int) {
-	if width < minimumWidth {
-		width = minimumWidth
+// JournalWriter owns the bounded journal region within a dashboard render.
+// Journal implementations write logical lines without access to output storage.
+type JournalWriter struct {
+	output RenderTarget
+	rows   int
+}
+
+// NewJournalWriter binds a bounded journal writer to a fixed render target. It
+// is primarily useful for testing journal sources independently.
+func NewJournalWriter(target RenderTarget) JournalWriter {
+	if target.width < minimumWidth {
+		target.width = minimumWidth
 	}
-	if maxRows <= 0 {
-		return dst, 0
+	target.rows = max(target.rows, 0)
+	target.reset()
+	return JournalWriter{output: target}
+}
+
+// Bytes returns the journal output written into owned storage.
+func (writer *JournalWriter) Bytes() []byte {
+	return writer.output.bytes()
+}
+
+// RowsWritten reports the number of physical terminal rows written.
+func (writer *JournalWriter) RowsWritten() int {
+	return writer.rows
+}
+
+// RowsRemaining reports how many physical terminal rows remain available.
+func (writer *JournalWriter) RowsRemaining() int {
+	return writer.output.rows - writer.rows
+}
+
+// LineRows reports how many physical terminal rows a logical line needs in
+// this journal region.
+func (writer *JournalWriter) LineRows(value []byte) int {
+	return journalLineRows(value, writer.output.width)
+}
+
+// WriteLine sanitizes and wraps one logical journal line. It returns false
+// when the journal pane has no room for another line.
+func (writer *JournalWriter) WriteLine(value []byte) bool {
+	if writer.RowsRemaining() <= 0 {
+		return false
 	}
-	line := newLine(dst, width)
+	written := writer.writeLine(value)
+	writer.rows += written
+	return true
+}
+
+func (writer *JournalWriter) writeLine(value []byte) int {
+	remaining := writer.RowsRemaining()
+	line := newLine(&writer.output)
 	rows := 0
 	wrote := false
 	for position := 0; position < len(value); {
@@ -409,30 +529,28 @@ func AppendJournalLine(dst, value []byte, width, maxRows int) ([]byte, int) {
 		if !ok {
 			break
 		}
-		if r == '\n' || line.columns == width {
-			dst = line.end()
+		if r == '\n' || line.columns == writer.output.width {
+			line.end()
 			rows++
-			if rows == maxRows {
-				return dst, rows
+			if rows == remaining {
+				return rows
 			}
-			line = newLine(dst, width)
+			line = newLine(&writer.output)
 			if r == '\n' {
 				continue
 			}
 		}
-		line.appendRune(r)
+		line.writeRune(r)
 		wrote = true
 	}
-	if wrote && rows < maxRows {
-		dst = line.end()
+	if wrote && rows < remaining {
+		line.end()
 		rows++
 	}
-	return dst, rows
+	return rows
 }
 
-// JournalLineRows returns the number of terminal rows needed for one logical
-// journal line after sanitization and wrapping.
-func JournalLineRows(value []byte, width int) int {
+func journalLineRows(value []byte, width int) int {
 	if width < minimumWidth {
 		width = minimumWidth
 	}
@@ -462,11 +580,11 @@ func JournalLineRows(value []byte, width int) int {
 }
 
 func (r *Renderer) line() *lineWriter {
-	if r.rows >= r.contentRows {
+	if r.row >= r.contentRows {
 		r.lineState = lineWriter{owner: r}
 		return &r.lineState
 	}
-	r.lineState = newLine(r.dst, r.width)
+	r.lineState = newLine(&r.output)
 	r.lineState.owner = r
 	r.lineState.color = r.color
 	return &r.lineState
@@ -477,12 +595,12 @@ func (r *Renderer) fieldLine(label string) *lineWriter {
 	if !line.active {
 		return line
 	}
-	line.appendString(label)
+	line.writeString(label)
 	if label != "" {
-		line.appendByte(':')
+		line.writeByte(':')
 	}
 	for line.columns < fieldWidth {
-		line.appendByte(' ')
+		line.writeByte(' ')
 	}
 	return line
 }
@@ -493,16 +611,16 @@ func (r *Renderer) continuationLine() *lineWriter {
 		return line
 	}
 	for range fieldWidth {
-		line.appendByte(' ')
+		line.writeByte(' ')
 	}
 	return line
 }
 
 func (r *Renderer) finishLine(line *lineWriter) {
-	if r.rows < r.contentRows {
-		r.dst = line.end()
+	if r.row < r.contentRows {
+		line.end()
 	}
-	r.rows++
+	r.row++
 }
 
 func (r *Renderer) finishBlank() {
@@ -511,22 +629,21 @@ func (r *Renderer) finishBlank() {
 
 type lineWriter struct {
 	owner     *Renderer
-	dst       []byte
+	output    *RenderTarget
 	lastRune  int
-	width     int
 	columns   int
 	truncated bool
 	active    bool
 	color     bool
 }
 
-func newLine(dst []byte, width int) lineWriter {
-	return lineWriter{dst: dst, lastRune: len(dst), width: width, active: true}
+func newLine(output *RenderTarget) lineWriter {
+	return lineWriter{output: output, lastRune: output.position, active: true}
 }
 
 func (l *lineWriter) style(value string) *lineWriter {
 	if l.active && l.color {
-		l.dst = append(l.dst, value...)
+		l.output.writeString(value)
 	}
 	return l
 }
@@ -535,42 +652,42 @@ func (l *lineWriter) resetStyle() *lineWriter {
 	return l.style(styleReset)
 }
 
-func (l *lineWriter) appendByte(value byte) *lineWriter {
+func (l *lineWriter) writeByte(value byte) *lineWriter {
 	if !l.active || l.truncated {
 		return l
 	}
-	if l.columns == l.width {
+	if l.columns == l.output.width {
 		l.truncated = true
 		return l
 	}
-	l.lastRune = len(l.dst)
-	l.dst = append(l.dst, value)
+	l.lastRune = l.output.position
+	l.output.writeByte(value)
 	l.columns++
 	return l
 }
 
-func (l *lineWriter) appendString(value string) *lineWriter {
+func (l *lineWriter) writeString(value string) *lineWriter {
 	for position := 0; position < len(value) && !l.truncated && l.active; {
 		r, next, ok := nextVisibleString(value, position)
 		position = next
 		if !ok {
 			break
 		}
-		if l.columns == l.width {
+		if l.columns == l.output.width {
 			l.truncated = true
 			return l
 		}
-		l.appendRune(r)
+		l.writeRune(r)
 	}
 	return l
 }
 
-func (l *lineWriter) appendRune(r rune) *lineWriter {
-	if !l.active || l.truncated || l.columns == l.width {
+func (l *lineWriter) writeRune(r rune) *lineWriter {
+	if !l.active || l.truncated || l.columns == l.output.width {
 		return l
 	}
-	l.lastRune = len(l.dst)
-	l.dst = utf8.AppendRune(l.dst, r)
+	l.lastRune = l.output.position
+	l.output.writeRune(r)
 	l.columns++
 	return l
 }
@@ -579,18 +696,18 @@ func (l *lineWriter) finish() {
 	l.owner.finishLine(l)
 }
 
-func (l *lineWriter) end() []byte {
+func (l *lineWriter) end() {
 	if !l.active {
-		return l.dst
+		return
 	}
 	if l.truncated {
-		l.dst = l.dst[:l.lastRune]
-		l.dst = append(l.dst, '~')
+		l.output.truncate(l.lastRune)
+		l.output.writeByte('~')
 		if l.color {
-			l.dst = append(l.dst, styleReset...)
+			l.output.writeString(styleReset)
 		}
 	}
-	return append(l.dst, '\n')
+	l.output.writeByte('\n')
 }
 
 type wrappedWriter struct {
@@ -601,10 +718,11 @@ type wrappedWriter struct {
 }
 
 func (r *Renderer) wrappedField(label string) *wrappedWriter {
-	return &wrappedWriter{render: r, line: r.fieldLine(label)}
+	r.wrappedState = wrappedWriter{render: r, line: r.fieldLine(label)}
+	return &r.wrappedState
 }
 
-func (w *wrappedWriter) appendString(value string) *wrappedWriter {
+func (w *wrappedWriter) writeString(value string) *wrappedWriter {
 	for position := 0; position < len(value); {
 		r, next, ok := nextVisibleString(value, position)
 		if !ok {
@@ -638,24 +756,24 @@ func (w *wrappedWriter) appendString(value string) *wrappedWriter {
 			position = next
 			continue
 		}
-		w.appendWord(value[wordStart:wordEnd], wordWidth)
+		w.writeWord(value[wordStart:wordEnd], wordWidth)
 		position = wordEnd
 	}
 	return w
 }
 
-func (w *wrappedWriter) appendWord(word string, wordWidth int) {
+func (w *wrappedWriter) writeWord(word string, wordWidth int) {
 	contentStart := fieldWidth
-	if w.line.columns > contentStart && w.pendingSpace > 0 && wordWidth <= w.render.width-contentStart && w.line.columns+w.pendingSpace+wordWidth > w.render.width {
+	if w.line.columns > contentStart && w.pendingSpace > 0 && wordWidth <= w.render.output.width-contentStart && w.line.columns+w.pendingSpace+wordWidth > w.render.output.width {
 		w.continueLine()
 	}
 	if w.line.columns > contentStart {
 		for range w.pendingSpace {
-			if w.line.columns == w.render.width {
+			if w.line.columns == w.render.output.width {
 				w.continueLine()
 				break
 			}
-			w.line.appendRune(' ')
+			w.line.writeRune(' ')
 		}
 	}
 	w.pendingSpace = 0
@@ -665,10 +783,10 @@ func (w *wrappedWriter) appendWord(word string, wordWidth int) {
 		if !ok {
 			break
 		}
-		if w.line.columns == w.render.width {
+		if w.line.columns == w.render.output.width {
 			w.continueLine()
 		}
-		w.line.appendRune(r)
+		w.line.writeRune(r)
 	}
 }
 
@@ -696,9 +814,9 @@ func (w *wrappedWriter) finish() {
 	w.line.finish()
 }
 
-func appendNetwork(render *Renderer, network []NetworkInterface) {
+func (render *Renderer) writeNetwork(network []NetworkInterface) {
 	if len(network) == 0 {
-		render.wrappedField("Network").appendString("waiting for an active interface").finish()
+		render.wrappedField("Network").writeString("waiting for an active interface").finish()
 		return
 	}
 	for index, iface := range network {
@@ -707,23 +825,23 @@ func appendNetwork(render *Renderer, network []NetworkInterface) {
 			label = "Network"
 		}
 		field := render.wrappedField(label)
-		field.appendString(iface.Name)
+		field.writeString(iface.Name)
 		if len(iface.Addresses) == 0 {
-			field.appendString(": configuring")
+			field.writeString(": configuring")
 		} else {
-			field.appendString(": ")
+			field.writeString(": ")
 			for addressIndex, address := range iface.Addresses {
 				if addressIndex > 0 {
-					field.appendString(", ")
+					field.writeString(", ")
 				}
-				field.appendString(address)
+				field.writeString(address)
 			}
 		}
 		field.finish()
 	}
 }
 
-func appendWrappedField(render *Renderer, label, value, style string) {
+func (render *Renderer) writeWrappedField(label, value, style string) {
 	if value == "" {
 		return
 	}
@@ -731,7 +849,7 @@ func appendWrappedField(render *Renderer, label, value, style string) {
 	if style != "" {
 		field.style(style)
 	}
-	field.appendString(value)
+	field.writeString(value)
 	if style != "" {
 		field.resetStyle()
 	}


### PR DESCRIPTION
Introduces a fixed RenderTarget that owns storage, terminal geometry, and write position. Dashboard and journal rendering now start at the top-left, use bounded writer methods, and hide append mechanics while preserving zero-allocation steady-state rendering. This removes the split ownership that made pane composition and buffer reuse harder to reason about.