### PR TITLE
boot: suppress phantom serial gettys

### DIFF
--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -445,6 +445,7 @@ func runtimeKernelCommandLine() []string {
 		"ro",
 		"console=ttyS0,115200n8",
 		"console=tty0",
+		"systemd.getty_auto=no",
 	}
 }
 
@@ -1193,7 +1194,7 @@ func writeBootMetadata(role, format, artifactPath, created string, cfg config) e
 		Compression:              installerBootCompression(role),
 		CreatedAt:                created,
 		InstallerInterface:       cfg.InstallerInterface,
-		DefaultKernelCommandLine: []string{"console=ttyS0,115200n8", "console=tty0", "systemd.log_target=console", "loglevel=6"},
+		DefaultKernelCommandLine: []string{"console=ttyS0,115200n8", "console=tty0", "systemd.getty_auto=no", "systemd.log_target=console", "loglevel=6"},
 		SupportedInputModes:      []string{"pxe-preseed", "local-handoff", "offline-media"},
 	}
 	data, err := json.MarshalIndent(metadata, "", "  ")

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -329,7 +329,7 @@ func TestMetadataWriters(t *testing.T) {
 	if rootMetadata.CompatibleBoot == nil || rootMetadata.CompatibleBoot.Kind != "uki" {
 		t.Fatalf("runtime root boot compatibility = %#v", rootMetadata.CompatibleBoot)
 	}
-	if got := strings.Join(rootMetadata.CompatibleBoot.KernelCommandLine, " "); !strings.Contains(got, "console=ttyS0,115200n8 console=tty0") {
+	if got := strings.Join(rootMetadata.CompatibleBoot.KernelCommandLine, " "); !strings.Contains(got, "console=ttyS0,115200n8 console=tty0 systemd.getty_auto=no") {
 		t.Fatalf("runtime root kernel command line = %q", got)
 	}
 
@@ -354,7 +354,7 @@ func TestMetadataWriters(t *testing.T) {
 	if ukiMetadata.KernelVersion != "6.12.0" {
 		t.Fatalf("kernelVersion = %q", ukiMetadata.KernelVersion)
 	}
-	if got := strings.Join(ukiMetadata.KernelCommandLine, " "); !strings.Contains(got, "console=ttyS0,115200n8 console=tty0") {
+	if got := strings.Join(ukiMetadata.KernelCommandLine, " "); !strings.Contains(got, "console=ttyS0,115200n8 console=tty0 systemd.getty_auto=no") {
 		t.Fatalf("runtime UKI kernel command line = %q", got)
 	}
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -251,7 +251,7 @@ Illustrative iPXE entry for `cp-1`:
 #!ipxe
 set base https://boot.example.invalid/katl/2026.7.0
 set node cp-1
-kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.install.mode=auto
+kernel ${base}/katl-installer.vmlinuz initrd=katl-installer.initrd console=ttyS0,115200n8 systemd.getty_auto=no katl.node=${node} katl.bundle.url=${base}/katl-lab.katlcfg katl.install.mode=auto
 initrd ${base}/katl-installer.initrd
 boot
 ```

--- a/docs/internal/v0.1-supported-image-surface.md
+++ b/docs/internal/v0.1-supported-image-surface.md
@@ -51,7 +51,7 @@ Supported installer services and units:
 | --- | --- | --- |
 | `katl-installer.target` | supported | dedicated installer boot target; keeps the initrd environment active without misreporting the installer as starting. |
 | `katlos-install.service` | supported | boot-time installer operation. |
-| `katl-console.service` | supported | owns VGA `tty1`; `tty2`, SSH, and serial remain separate recovery surfaces. |
+| `katl-console.service` | supported | owns VGA `tty1`; `tty2` and SSH remain separate recovery surfaces, while serial carries logs when available. |
 | `katl-input-apply.service` | supported | applies installer handoff input. |
 | `katl-installer-smoke.service` | VM/test-only | smoke signal, not a production install contract. |
 | `systemd-networkd.service` and `systemd-resolved.service` | supported | installer networking and DNS. |

--- a/internal/installer/generation/kernel_command_line.go
+++ b/internal/installer/generation/kernel_command_line.go
@@ -37,6 +37,8 @@ func controlledKernelCommandLineOption(option string) bool {
 		return true
 	case strings.HasPrefix(option, "systemd.machine_id="):
 		return true
+	case strings.HasPrefix(option, "systemd.getty_auto="):
+		return true
 	case strings.HasPrefix(option, "katl.generation="):
 		return true
 	case strings.HasPrefix(option, "katl.root-slot="):

--- a/internal/installer/generation/kernel_command_line_test.go
+++ b/internal/installer/generation/kernel_command_line_test.go
@@ -1,0 +1,29 @@
+package generation
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestMergeKernelCommandLineOwnsGettyPolicy(t *testing.T) {
+	base := []string{
+		"root=PARTUUID=new",
+		"systemd.getty_auto=no",
+	}
+	current := []string{
+		"root=PARTUUID=old",
+		"systemd.getty_auto=yes",
+		"console=ttyS0,115200n8",
+		"quiet",
+	}
+	want := []string{
+		"root=PARTUUID=new",
+		"systemd.getty_auto=no",
+		"console=ttyS0,115200n8",
+		"quiet",
+	}
+
+	if got := MergeKernelCommandLine(base, current); !slices.Equal(got, want) {
+		t.Fatalf("MergeKernelCommandLine() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/scriptstest/check_katlos_install_image_test.go
+++ b/internal/scriptstest/check_katlos_install_image_test.go
@@ -20,6 +20,7 @@ func TestCheckKatlOSInstallImageKernelCommandLine(t *testing.T) {
 		"ro",
 		"console=ttyS0,115200n8",
 		"console=tty0",
+		"systemd.getty_auto=no",
 	}
 	cases := []testCase{
 		{
@@ -29,6 +30,7 @@ func TestCheckKatlOSInstallImageKernelCommandLine(t *testing.T) {
 				"quiet",
 				"ro",
 				"console=ttyS0,115200n8",
+				"systemd.getty_auto=no",
 				"rootfstype=squashfs",
 			},
 		},

--- a/internal/scriptstest/installer_iso_scripts_test.go
+++ b/internal/scriptstest/installer_iso_scripts_test.go
@@ -150,7 +150,7 @@ func TestInstallerConsoleAndArtifactContract(t *testing.T) {
 	profile := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles/installer-image/mkosi.conf")))
 	journal := string(mustReadFile(t, filepath.Join(repo, "mkosi.profiles/installer-image/mkosi.extra/etc/systemd/journald.conf.d/10-katl-installer-console.conf")))
 
-	for _, value := range []string{"console=tty0", "console=ttyS0,115200n8"} {
+	for _, value := range []string{"console=tty0", "console=ttyS0,115200n8", "systemd.getty_auto=no"} {
 		if !strings.Contains(profile, value) {
 			t.Fatalf("installer profile missing console %q", value)
 		}

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -87,7 +87,7 @@ RemoveFiles=
         /usr/share/dnf5
         /usr/share/licenses/pkgconf
         /var/lib/rpm-state
-KernelCommandLine=console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6 rd.systemd.unit=katl-installer.target
+KernelCommandLine=console=ttyS0,115200n8 console=tty0 systemd.getty_auto=no systemd.log_target=console loglevel=6 rd.systemd.unit=katl-installer.target
 Hostname=katl-installer
 Autologin=yes
 MakeInitrd=yes

--- a/mkosi.profiles/resource-package-lock.json
+++ b/mkosi.profiles/resource-package-lock.json
@@ -11,7 +11,7 @@
     {
       "name": "installer-image",
       "path": "mkosi.profiles/installer-image",
-      "configSHA256": "829e7117cf23570c0dc7ba6b737be20a390a5f2b447fefebd0dd4a70b3581921",
+      "configSHA256": "df4cc9b1b955810aae0774324453c09c4662f2472291061f1df9ac8f586d3125",
       "packageSetRef": "installer-image",
       "mkosiVersion": "26"
     },

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -31,7 +31,7 @@ inspect="$(ukify inspect "$artifact")" || fail "inspect installer UKI failed"
 grep -Fq '.linux:' <<<"$inspect" || fail "installer UKI missing .linux section"
 grep -Fq '.initrd:' <<<"$inspect" || fail "installer UKI missing .initrd section"
 grep -Fq '.cmdline:' <<<"$inspect" || fail "installer UKI missing .cmdline section"
-grep -Fq 'console=ttyS0,115200n8 console=tty0 systemd.log_target=console loglevel=6' <<<"$inspect" ||
+grep -Fq 'console=ttyS0,115200n8 console=tty0 systemd.getty_auto=no systemd.log_target=console loglevel=6' <<<"$inspect" ||
     fail "installer UKI command line mismatch"
 
 initrd_list="$(cpio -it <"$initrd_cpio" 2>/dev/null)" || fail "list installer initrd failed"

--- a/scripts/check-katlos-install-image
+++ b/scripts/check-katlos-install-image
@@ -159,7 +159,8 @@ jq -e '
       "rootfstype=squashfs",
       "ro",
       "console=ttyS0,115200n8",
-      "console=tty0"
+      "console=tty0",
+      "systemd.getty_auto=no"
     ][]; . as $required | $cmdline | index($required) != null)) and
   .installTarget.kind == "esp-or-xbootldr"' "$index" >/dev/null ||
     fail "runtime UKI component metadata is incomplete"


### PR DESCRIPTION
Disable automatic getty generation in installer and runtime boot policy while retaining Katl's explicit VGA, tty2, SSH, and serial-log surfaces. This stops Fedora agetty from repeatedly failing with EINVAL when ttyS0 is listed as a console on machines that expose no serial device.