### PR TITLE
cli: unify Katl config inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ When exactly one installer is waiting, no URL needs to be copied from the
 console:
 
 ```sh
-katlctl install apply ./cluster.yaml --node cp-1
+katlctl install apply --config ./cluster.yaml --node cp-1
 ```
 
 With multiple waiting installers, select the intended URL from discovery with
@@ -197,13 +197,13 @@ cluster source. This retrieves each distinct agent token, stores it privately,
 verifies the management API, and creates the current workstation context:
 
 ```sh
-katlctl cluster enroll ./cluster.yaml
+katlctl cluster enroll --config ./cluster.yaml
 ```
 
 Then bootstrap without repeating endpoints or credential files:
 
 ```sh
-katlctl cluster bootstrap ./cluster.yaml \
+katlctl cluster bootstrap --config ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig
@@ -220,7 +220,7 @@ kubeconfig to the operator.
 optional plan contacts the selected node but does not accept an operation:
 
 ```sh
-katlctl node apply ./cluster.yaml --node cp-1 --plan
+katlctl node apply --config ./cluster.yaml --node cp-1 --plan
 ```
 
 Run the command without `--plan` to apply it. `katlctl` derives config versions,

--- a/cmd/katlctl/config_input.go
+++ b/cmd/katlctl/config_input.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+)
+
+type katlConfigInput struct {
+	Archive []byte
+	Bundle  configbundle.Bundle
+	Source  bool
+}
+
+func loadKatlConfig(path, createdBy string, planning configbundle.PlanningInputs) (katlConfigInput, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return katlConfigInput{}, fmt.Errorf("--config is required")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return katlConfigInput{}, fmt.Errorf("read --config %s: %w", path, err)
+	}
+
+	_, sourceErr := configbundle.DecodeSource(bytes.NewReader(data))
+	if sourceErr == nil {
+		archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
+			SourcePath:     path,
+			KatlctlVersion: version,
+			KatlctlCommit:  commit,
+			CreatedBy:      createdBy,
+			Planning:       planning,
+		})
+		if err != nil {
+			return katlConfigInput{}, fmt.Errorf("compile --config %s: %w", path, err)
+		}
+		bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
+		if err != nil {
+			return katlConfigInput{}, fmt.Errorf("read compiled --config %s: %w", path, err)
+		}
+		return katlConfigInput{Archive: archive, Bundle: bundle, Source: true}, nil
+	}
+
+	bundle, bundleErr := configbundle.ReadBundle(bytes.NewReader(data), "")
+	if bundleErr != nil {
+		return katlConfigInput{}, fmt.Errorf("read --config %s as ClusterConfig YAML or Katl config bundle: YAML: %v; bundle: %w", path, sourceErr, bundleErr)
+	}
+	return katlConfigInput{Archive: data, Bundle: bundle}, nil
+}

--- a/cmd/katlctl/enroll.go
+++ b/cmd/katlctl/enroll.go
@@ -20,8 +20,8 @@ import (
 )
 
 type enrollOptions struct {
-	sourcePath   string
-	configPath   string
+	configInput  string
+	contextPath  string
 	contextName  string
 	sshUser      string
 	identityFile string
@@ -66,15 +66,15 @@ var runEnrollmentSSH = func(ctx context.Context, user, address, identityFile str
 func newClusterEnrollCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := enrollOptions{sshUser: "root"}
 	cmd := &cobra.Command{
-		Use:   "enroll SOURCE",
+		Use:   "enroll",
 		Short: "Set up workstation access to installed KatlOS nodes",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			opts.sourcePath = args[0]
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runClusterEnroll(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
+	cmd.Flags().StringVar(&opts.configInput, "config", "", "ClusterConfig YAML or Katl config bundle")
+	cmd.Flags().StringVar(&opts.contextPath, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "context name; defaults to the cluster name")
 	cmd.Flags().StringVar(&opts.sshUser, "ssh-user", opts.sshUser, "installed-node SSH user")
 	cmd.Flags().StringVar(&opts.identityFile, "identity-file", "", "SSH private key file")
@@ -84,18 +84,13 @@ func newClusterEnrollCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 
 func runClusterEnroll(ctx context.Context, opts enrollOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
-		SourcePath: opts.sourcePath, KatlctlVersion: version, KatlctlCommit: commit, CreatedBy: "katlctl cluster enroll",
-	})
+	config, err := loadKatlConfig(opts.configInput, "katlctl cluster enroll", configbundle.PlanningInputs{})
 	if err != nil {
-		return fmt.Errorf("compile cluster config: %w", err)
+		return err
 	}
-	bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
-	if err != nil {
-		return fmt.Errorf("read compiled cluster config: %w", err)
-	}
+	bundle := config.Bundle
 	inv := bundle.Manifest.Cluster.BootstrapInventory
-	configPath := strings.TrimSpace(opts.configPath)
+	configPath := strings.TrimSpace(opts.contextPath)
 	if configPath == "" {
 		configPath, err = workstation.ConfigPath()
 		if err != nil {

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -27,7 +27,7 @@ const (
 
 type installApplyOptions struct {
 	endpoint   string
-	sourcePath string
+	configPath string
 	nodeName   string
 	noWait     bool
 	timeout    time.Duration
@@ -59,14 +59,14 @@ func newInstallCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := installApplyOptions{timeout: 30 * time.Minute, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "apply SOURCE",
-		Short: "Compile a cluster config and apply it to a waiting KatlOS installer",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			opts.sourcePath = args[0]
+		Use:   "apply",
+		Short: "Apply a ClusterConfig YAML or config bundle to a waiting KatlOS installer",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runInstallApply(ctx, opts, stdout, stderr)
 		},
 	}
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL; discovers a unique waiting installer when omitted")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name or configured address; inferred when the config contains one node")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
@@ -98,27 +98,20 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
-	if strings.TrimSpace(opts.sourcePath) == "" {
-		return fmt.Errorf("source config path is required")
-	}
-	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
-		SourcePath:     opts.sourcePath,
-		KatlctlVersion: version,
-		KatlctlCommit:  commit,
-		CreatedBy:      installApplyCreator,
-	})
+	config, err := loadKatlConfig(opts.configPath, installApplyCreator, configbundle.PlanningInputs{})
 	if err != nil {
-		return fmt.Errorf("compile cluster config: %w", err)
+		return err
 	}
+	archive := config.Archive
 	if len(archive) > maxInstallBundleSize {
 		return fmt.Errorf("compiled config bundle size %d exceeds %d bytes", len(archive), maxInstallBundleSize)
 	}
-	nodeName, err := resolveInstallNode(archive, result.Digest, opts.nodeName)
+	nodeName, err := resolveInstallNode(archive, config.Bundle.Digest, opts.nodeName)
 	if err != nil {
 		return err
 	}
 	selected, err := configbundle.ReadSelectedNode(bytes.NewReader(archive), configbundle.ReadOptions{
-		ExpectedDigest:          result.Digest,
+		ExpectedDigest:          config.Bundle.Digest,
 		NodeName:                nodeName,
 		AllowMissingKatlosImage: true,
 	})

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -267,7 +267,7 @@ func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", sourcePath,
+		"install", "apply", "--config", sourcePath,
 		"--endpoint", ts.URL,
 		"--no-wait",
 	}, &stdout, &stderr)
@@ -317,7 +317,7 @@ func TestInstallApplyAcceptsGeneratedConfigByAddress(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	if err := run(context.Background(), []string{
-		"install", "apply", outputPath,
+		"install", "apply", "--config", outputPath,
 		"--endpoint", ts.URL,
 		"--node", "192.0.2.11",
 		"--no-wait",
@@ -409,10 +409,10 @@ func TestInstallApplyHelpKeepsBundleInternal(t *testing.T) {
 		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
 	}
 	help := stdout.String()
-	if !strings.Contains(help, "katlctl install apply SOURCE") {
-		t.Fatalf("help does not advertise source input:\n%s", help)
+	if !strings.Contains(help, "katlctl install apply --config cluster.yaml") || !strings.Contains(help, "--config string") {
+		t.Fatalf("help does not advertise unified config input:\n%s", help)
 	}
-	for _, hiddenDetail := range []string{"--config-bundle", "--token", "--token-file"} {
+	for _, hiddenDetail := range []string{"--config-bundle", "--source", "--token", "--token-file"} {
 		if strings.Contains(help, hiddenDetail) {
 			t.Fatalf("help exposes %q:\n%s", hiddenDetail, help)
 		}
@@ -449,7 +449,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", sourcePath,
+		"install", "apply", "--config", sourcePath,
 		"--endpoint", ts.URL,
 		"--node", "cp-1",
 		"--timeout", "5s",
@@ -486,7 +486,7 @@ func TestInstallApplyReportsClassifiedFailure(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", sourcePath, "--endpoint", ts.URL,
+		"install", "apply", "--config", sourcePath, "--endpoint", ts.URL,
 		"--node", "cp-1", "--timeout", "5s",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "failed-before-mutation") || !strings.Contains(err.Error(), "target disk was not found") {
@@ -508,7 +508,7 @@ func TestInstallApplyValidatesLocallyBeforeNetwork(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", sourcePath, "--endpoint", ts.URL,
+		"install", "apply", "--config", sourcePath, "--endpoint", ts.URL,
 		"--node", "missing-node", "--no-wait",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "missing-node") {
@@ -538,7 +538,7 @@ func TestInstallApplySendsNoAuthorization(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", sourcePath, "--endpoint", ts.URL,
+		"install", "apply", "--config", sourcePath, "--endpoint", ts.URL,
 		"--node", "cp-1", "--no-wait",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -592,7 +592,7 @@ func TestInstallApplyRejectsUnavailableStatusAfterSubmission(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"install", "apply", sourcePath, "--endpoint", ts.URL,
+		"install", "apply", "--config", sourcePath, "--endpoint", ts.URL,
 		"--node", "cp-1", "--timeout", "3s",
 	}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "became unavailable") || !strings.Contains(err.Error(), "Partition") {

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -144,7 +144,54 @@ Start with "katlctl install discover" for a waiting installer or
 	nodeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl node wipe"))
 	cmd.AddCommand(nodeCmd)
 
+	setMinimumInvocationExamples(cmd)
 	return cmd
+}
+
+func setMinimumInvocationExamples(root *cobra.Command) {
+	examples := map[string]string{
+		"katlctl":                         "katlctl install discover",
+		"katlctl version":                 "katlctl version",
+		"katlctl cluster":                 "katlctl cluster bootstrap --config cluster.yaml",
+		"katlctl cluster enroll":          "katlctl cluster enroll --config cluster.yaml",
+		"katlctl cluster bootstrap":       "katlctl cluster bootstrap --config cluster.yaml",
+		"katlctl cluster wipe":            "katlctl cluster wipe --all",
+		"katlctl kubernetes":              "katlctl kubernetes upgrade v1.36.1",
+		"katlctl kubernetes upgrade":      "katlctl kubernetes upgrade v1.36.1",
+		"katlctl kubernetes apply-config": "katlctl kubernetes apply-config --inventory cluster.json --coordinator cp-1 --generation 1 --config-name default --rollout-id rollout-1",
+		"katlctl config":                  "katlctl config validate cluster.yaml",
+		"katlctl config init":             "katlctl config init cluster.yaml --node cp-1=control-plane,192.0.2.10,/dev/disk/by-id/ata-root",
+		"katlctl config validate":         "katlctl config validate cluster.yaml",
+		"katlctl config schema":           "katlctl config schema",
+		"katlctl config bundle":           "katlctl config bundle cluster.yaml --output cluster.katlcfg",
+		"katlctl config render-node":      "katlctl config render-node --config cluster.yaml --node cp-1 --desired-version 1",
+		"katlctl context":                 "katlctl context show",
+		"katlctl context path":            "katlctl context path",
+		"katlctl context show":            "katlctl context show",
+		"katlctl install":                 "katlctl install discover",
+		"katlctl install discover":        "katlctl install discover",
+		"katlctl install apply":           "katlctl install apply --config cluster.yaml",
+		"katlctl install status":          "katlctl install status",
+		"katlctl operations":              "katlctl operations list --node cp-1",
+		"katlctl operations status":       "katlctl operations status --node cp-1 --operation-id OPERATION_ID",
+		"katlctl operations list":         "katlctl operations list --node cp-1",
+		"katlctl node":                    "katlctl node status cp-1",
+		"katlctl node status":             "katlctl node status cp-1",
+		"katlctl node reboot":             "katlctl node reboot cp-1",
+		"katlctl node upgrade":            "katlctl node upgrade 2026.7.0 --node cp-1",
+		"katlctl node apply":              "katlctl node apply --config cluster.yaml --node cp-1",
+		"katlctl node apply validate":     "katlctl node apply validate --config cluster.yaml --node cp-1",
+		"katlctl node apply status":       "katlctl node apply status --node cp-1",
+		"katlctl node wipe":               "katlctl node wipe worker-1 --kubeconfig kubeconfig",
+	}
+	var visit func(*cobra.Command)
+	visit = func(command *cobra.Command) {
+		command.Example = examples[command.CommandPath()]
+		for _, child := range command.Commands() {
+			visit(child)
+		}
+	}
+	visit(root)
 }
 
 type hostUpgradeOptions struct {
@@ -389,9 +436,8 @@ func writeJSON(stdout io.Writer, value any) error {
 type wipeClusterOptions struct {
 	command           string
 	selectedNodes     stringList
-	sourcePath        string
+	configPath        string
 	inventoryPath     string
-	configBundlePath  string
 	workstationConfig string
 	contextName       string
 	all               bool
@@ -407,19 +453,16 @@ type wipeClusterOptions struct {
 func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
 	opts := wipeClusterOptions{command: commandName, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "wipe [SOURCE]",
+		Use:   "wipe",
 		Short: "Destructively reset cluster nodes for installer-media reinstall",
 		Long:  "Erase KatlOS boot artifacts from the selected cluster nodes. Every wiped node must boot installer media or PXE before it can be used again.",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) == 1 {
-				opts.sourcePath = args[0]
-			}
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runWipeClusterOptions(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
-	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "select every node in the inventory")
@@ -492,7 +535,7 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 }
 
 func resolveWipeClusterTargets(opts wipeClusterOptions) ([]inventory.PlannedNode, bool, error) {
-	hasExplicitTopology := strings.TrimSpace(opts.sourcePath) != "" || strings.TrimSpace(opts.configBundlePath) != "" || strings.TrimSpace(opts.inventoryPath) != ""
+	hasExplicitTopology := strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.inventoryPath) != ""
 	if !hasExplicitTopology {
 		topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
 			ConfigPath:  strings.TrimSpace(opts.workstationConfig),
@@ -517,7 +560,7 @@ func resolveWipeClusterTargets(opts wipeClusterOptions) ([]inventory.PlannedNode
 		return wipeClusterTargets(plan, opts.all, opts.selectedNodes.values)
 	}
 
-	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	inv, err := loadWipeInventory(opts.configPath, opts.inventoryPath)
 	if err != nil {
 		return nil, false, err
 	}
@@ -535,9 +578,8 @@ func resolveWipeClusterTargets(opts wipeClusterOptions) ([]inventory.PlannedNode
 type wipeNodeOptions struct {
 	command           string
 	selectedNodes     stringList
-	sourcePath        string
+	configPath        string
 	inventoryPath     string
-	configBundlePath  string
 	workstationConfig string
 	contextName       string
 	kubeconfigPath    string
@@ -552,20 +594,17 @@ type wipeNodeOptions struct {
 func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
 	opts := wipeNodeOptions{command: commandName, output: "json"}
 	cmd := &cobra.Command{
-		Use:   "wipe NODE [SOURCE]",
+		Use:   "wipe NODE",
 		Short: "Remove one node and reset it for installer-media reinstall",
 		Long:  "Remove one worker from Kubernetes and erase its KatlOS boot artifacts. The node must boot installer media or PXE before it can be used again.",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			opts.selectedNodes.values = []string{args[0]}
-			if len(args) == 2 {
-				opts.sourcePath = args[1]
-			}
 			return runWipeNodeOptions(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
-	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.kubeconfigPath, "kubeconfig", "", "path to operator kubeconfig")
@@ -654,7 +693,7 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 }
 
 func resolveWipeNodeTarget(opts wipeNodeOptions) (inventory.PlannedNode, bool, error) {
-	hasExplicitTopology := strings.TrimSpace(opts.sourcePath) != "" || strings.TrimSpace(opts.configBundlePath) != "" || strings.TrimSpace(opts.inventoryPath) != ""
+	hasExplicitTopology := strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.inventoryPath) != ""
 	if !hasExplicitTopology {
 		topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
 			ConfigPath:  strings.TrimSpace(opts.workstationConfig),
@@ -681,7 +720,7 @@ func resolveWipeNodeTarget(opts wipeNodeOptions) (inventory.PlannedNode, bool, e
 		return inventory.PlannedNode{}, false, fmt.Errorf("node %q is not in context %q", opts.selectedNodes.values[0], topology.ContextName)
 	}
 
-	inv, err := loadWipeInventory(opts.sourcePath, opts.configBundlePath, opts.inventoryPath)
+	inv, err := loadWipeInventory(opts.configPath, opts.inventoryPath)
 	if err != nil {
 		return inventory.PlannedNode{}, false, err
 	}
@@ -700,37 +739,24 @@ func resolveWipeNodeTarget(opts wipeNodeOptions) (inventory.PlannedNode, bool, e
 	return targets[0], partial, nil
 }
 
-func loadWipeInventory(sourcePath, bundlePath, inventoryPath string) (inventory.Inventory, error) {
+func loadWipeInventory(configPath, inventoryPath string) (inventory.Inventory, error) {
 	inputs := 0
-	for _, value := range []string{sourcePath, bundlePath, inventoryPath} {
+	for _, value := range []string{configPath, inventoryPath} {
 		if strings.TrimSpace(value) != "" {
 			inputs++
 		}
 	}
 	if inputs != 1 {
-		return inventory.Inventory{}, fmt.Errorf("exactly one cluster config SOURCE, --config-bundle, or --inventory is required")
+		return inventory.Inventory{}, fmt.Errorf("exactly one of --config or --inventory is required")
 	}
 	if strings.TrimSpace(inventoryPath) != "" {
 		return loadInventory(inventoryPath)
 	}
-	if strings.TrimSpace(sourcePath) != "" {
-		archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
-			SourcePath: sourcePath, KatlctlVersion: version, KatlctlCommit: commit, CreatedBy: "katlctl cluster wipe",
-		})
-		if err != nil {
-			return inventory.Inventory{}, fmt.Errorf("compile cluster config: %w", err)
-		}
-		bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
-		if err != nil {
-			return inventory.Inventory{}, fmt.Errorf("read compiled cluster config: %w", err)
-		}
-		return bundle.Manifest.Cluster.BootstrapInventory, nil
-	}
-	bundle, err := configbundle.ReadBundleFile(bundlePath, "")
+	config, err := loadKatlConfig(configPath, "katlctl cluster wipe", configbundle.PlanningInputs{})
 	if err != nil {
 		return inventory.Inventory{}, err
 	}
-	return bundle.Manifest.Cluster.BootstrapInventory, nil
+	return config.Bundle.Manifest.Cluster.BootstrapInventory, nil
 }
 
 func overlayWipeContext(inv inventory.Inventory, configPath, contextName string) (inventory.Inventory, error) {
@@ -1257,8 +1283,7 @@ type katlosImageArtifactMetadata struct {
 }
 
 type nodeConfigInputOptions struct {
-	sourcePath     string
-	bundlePath     string
+	configPath     string
 	nodeName       string
 	sourceID       string
 	desiredVersion string
@@ -1458,19 +1483,13 @@ func newConfigRenderNodeCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func addNodeConfigInputFlags(cmd *cobra.Command, opts *nodeConfigInputOptions) {
-	cmd.Flags().StringVar(&opts.sourcePath, "source", "", "ClusterConfig source YAML")
-	cmd.Flags().StringVar(&opts.bundlePath, "config-bundle", "", "Katl config bundle")
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node to select from cluster intent")
 	cmd.Flags().StringVar(&opts.sourceID, "source-id", "", "runtime configuration source id; defaults to the cluster name")
 	cmd.Flags().StringVar(&opts.desiredVersion, "desired-version", "", "monotonic unsigned runtime configuration version")
 }
 
 func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) {
-	fromSource := strings.TrimSpace(opts.sourcePath) != ""
-	fromBundle := strings.TrimSpace(opts.bundlePath) != ""
-	if fromSource == fromBundle {
-		return nil, fmt.Errorf("exactly one of --source or --config-bundle is required")
-	}
 	if strings.TrimSpace(opts.nodeName) == "" {
 		return nil, fmt.Errorf("--node is required")
 	}
@@ -1481,22 +1500,11 @@ func renderNodeConfig(opts nodeConfigInputOptions, mode string) ([]byte, error) 
 		NodeName:                opts.nodeName,
 		AllowMissingKatlosImage: true,
 	}
-	var selected configbundle.SelectedNodeMaterial
-	var err error
-	if fromSource {
-		archive, _, buildErr := configbundle.BuildArchive(configbundle.BuildRequest{
-			SourcePath:     opts.sourcePath,
-			KatlctlVersion: version,
-			KatlctlCommit:  commit,
-			CreatedBy:      configBundleCreator,
-		})
-		if buildErr != nil {
-			return nil, buildErr
-		}
-		selected, err = configbundle.ReadSelectedNode(bytes.NewReader(archive), readOptions)
-	} else {
-		selected, err = configbundle.ReadSelectedNodeFile(opts.bundlePath, readOptions)
+	config, err := loadKatlConfig(opts.configPath, configBundleCreator, configbundle.PlanningInputs{})
+	if err != nil {
+		return nil, err
 	}
+	selected, err := configbundle.ReadSelectedNode(bytes.NewReader(config.Archive), readOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -1519,7 +1527,6 @@ type configApplyOptions struct {
 	agentTokenFile      string
 	workstationConfig   string
 	contextName         string
-	configPath          string
 	nodeConfig          nodeConfigInputOptions
 	mode                string
 	candidateGeneration string
@@ -1536,16 +1543,10 @@ var configApplyNow = func() time.Time { return time.Now().UTC() }
 func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl node apply", output: "json"}
 	cmd := &cobra.Command{
-		Use:   "apply [SOURCE]",
+		Use:   "apply",
 		Short: "Validate or apply node configuration",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) == 1 {
-				if strings.TrimSpace(opts.nodeConfig.sourcePath) != "" {
-					return fmt.Errorf("SOURCE cannot be combined with --source")
-				}
-				opts.nodeConfig.sourcePath = args[0]
-			}
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runConfigApply(ctx, opts, stdout, stderr)
 		},
 	}
@@ -1579,11 +1580,10 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	cmd.Flags().StringVar(&opts.agentTokenFile, "agent-token-file", "", "katlc agent bearer token file")
 	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
-	cmd.Flags().StringVar(&opts.configPath, "file", "", "pre-rendered NodeConfigurationChange YAML")
 	addNodeConfigInputFlags(cmd, &opts.nodeConfig)
 	cmd.Flags().StringVar(&opts.mode, "mode", opts.mode, "apply mode: auto, live, or next-boot")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
-	for _, name := range []string{"source", "desired-version", "candidate-generation"} {
+	for _, name := range []string{"desired-version", "candidate-generation"} {
 		if flag := cmd.Flags().Lookup(name); flag != nil {
 			flag.Hidden = true
 		}
@@ -1608,10 +1608,8 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
-	fileInput := strings.TrimSpace(opts.configPath) != ""
-	intentInput := strings.TrimSpace(opts.nodeConfig.sourcePath) != "" || strings.TrimSpace(opts.nodeConfig.bundlePath) != ""
-	if fileInput == intentInput {
-		return fmt.Errorf("exactly one of --file, --source, or --config-bundle is required")
+	if strings.TrimSpace(opts.nodeConfig.configPath) == "" {
+		return fmt.Errorf("--config is required")
 	}
 	target, err := resolveManagementTarget(managementTargetOptions{
 		configPath: opts.workstationConfig, contextName: opts.contextName,
@@ -1623,25 +1621,16 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if strings.TrimSpace(opts.nodeConfig.nodeName) == "" {
 		opts.nodeConfig.nodeName = target.nodeName
 	}
-	if strings.TrimSpace(opts.nodeConfig.desiredVersion) == "" && intentInput {
-		opts.nodeConfig.desiredVersion = strconv.FormatInt(configApplyNow().UnixNano(), 10)
-	}
 	if strings.TrimSpace(opts.candidateGeneration) == "" {
 		opts.candidateGeneration = "config-" + strconv.FormatInt(configApplyNow().UnixNano(), 10)
 	}
-	var configYAML []byte
-	if fileInput {
+	configYAML, rendered, err := nodeConfigYAML(opts.nodeConfig, opts.mode)
+	if err != nil {
+		return err
+	}
+	if !rendered {
 		if strings.TrimSpace(opts.nodeConfig.sourceID) != "" || strings.TrimSpace(opts.nodeConfig.desiredVersion) != "" {
-			return fmt.Errorf("--source-id and --desired-version require --source or --config-bundle")
-		}
-		configYAML, err = os.ReadFile(opts.configPath)
-		if err != nil {
-			return fmt.Errorf("read config file: %w", err)
-		}
-	} else {
-		configYAML, err = renderNodeConfig(opts.nodeConfig, opts.mode)
-		if err != nil {
-			return err
+			return fmt.Errorf("--source-id and --desired-version cannot be used with a pre-rendered NodeConfigurationChange")
 		}
 	}
 	conn, err := dialKatlcAgent(ctx, target.endpoint, target.token)
@@ -1735,6 +1724,24 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		return writeOperationAccepted(stdout, accepted)
 	}
 	return waitAcceptedOperation(ctx, conn.Client, accepted, opts.waitTimeout, stdout, stderr)
+}
+
+func nodeConfigYAML(opts nodeConfigInputOptions, mode string) ([]byte, bool, error) {
+	data, err := os.ReadFile(strings.TrimSpace(opts.configPath))
+	if err != nil {
+		return nil, false, fmt.Errorf("read --config %s: %w", opts.configPath, err)
+	}
+	var identity struct {
+		Kind string `yaml:"kind"`
+	}
+	if err := yaml.Unmarshal(data, &identity); err == nil && identity.Kind == configapply.NodeConfigurationChangeKind {
+		return data, false, nil
+	}
+	if strings.TrimSpace(opts.desiredVersion) == "" {
+		opts.desiredVersion = strconv.FormatInt(configApplyNow().UnixNano(), 10)
+	}
+	rendered, err := renderNodeConfig(opts, mode)
+	return rendered, true, err
 }
 
 func configApplyOperationKind(acceptedMode string) (string, error) {
@@ -1976,9 +1983,8 @@ func firstNonEmpty(values ...string) string {
 
 type clusterBootstrapOptions struct {
 	addresses                              addressOverrides
-	sourcePath                             string
+	configPath                             string
 	inventoryPath                          string
-	configBundlePath                       string
 	initNode                               string
 	joinWorker                             string
 	controlPlaneEndpoint                   string
@@ -1998,18 +2004,17 @@ type clusterBootstrapOptions struct {
 func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := clusterBootstrapOptions{}
 	cmd := &cobra.Command{
-		Use:   "bootstrap [SOURCE]",
-		Short: "Bootstrap Kubernetes from a cluster config or node inventory",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			if len(args) == 1 {
-				opts.sourcePath = args[0]
-			}
+		Use:   "bootstrap",
+		Short: "Bootstrap Kubernetes from a ClusterConfig or config bundle",
+		Long:  "Bootstrap Kubernetes from a ClusterConfig YAML manifest or compiled Katl config bundle. Katl detects the --config format internally.",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runClusterBootstrap(ctx, opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster bootstrap inventory")
-	cmd.Flags().StringVar(&opts.configBundlePath, "config-bundle", "", "path to a Katl config bundle")
+	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
+	cmd.Flags().Lookup("inventory").Hidden = true
 	cmd.Flags().StringVar(&opts.initNode, "init-node", "", "first control-plane node for kubeadm init")
 	cmd.Flags().StringVar(&opts.joinWorker, "join-worker", "", "join one fresh worker to an already initialized cluster without rerunning kubeadm init")
 	cmd.Flags().StringVar(&opts.controlPlaneEndpoint, "control-plane-endpoint", "", "control-plane endpoint host:port")
@@ -2085,17 +2090,16 @@ func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdo
 }
 
 func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, error) {
-	sourcePath := strings.TrimSpace(opts.sourcePath)
+	configPath := strings.TrimSpace(opts.configPath)
 	inventoryPath := strings.TrimSpace(opts.inventoryPath)
-	bundlePath := strings.TrimSpace(opts.configBundlePath)
 	inputs := 0
-	for _, value := range []string{sourcePath, inventoryPath, bundlePath} {
+	for _, value := range []string{configPath, inventoryPath} {
 		if value != "" {
 			inputs++
 		}
 	}
 	if inputs != 1 {
-		return inventory.Inventory{}, fmt.Errorf("exactly one cluster config SOURCE, --config-bundle, or --inventory is required")
+		return inventory.Inventory{}, fmt.Errorf("exactly one of --config or --inventory is required")
 	}
 	if inventoryPath != "" {
 		return loadInventory(inventoryPath)
@@ -2103,33 +2107,14 @@ func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, erro
 	if strings.TrimSpace(opts.controlPlaneEndpoint) != "" {
 		return inventory.Inventory{}, fmt.Errorf("--control-plane-endpoint conflicts with the endpoint embedded in the cluster config")
 	}
-	if sourcePath != "" {
-		archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
-			SourcePath:     sourcePath,
-			KatlctlVersion: version,
-			KatlctlCommit:  commit,
-			CreatedBy:      clusterBootstrapCreator,
-			Planning: configbundle.PlanningInputs{
-				KubernetesBundle: opts.kubernetesBundle,
-			},
-		})
-		if err != nil {
-			return inventory.Inventory{}, fmt.Errorf("compile cluster config: %w", err)
-		}
-		bundle, err := configbundle.ReadBundle(bytes.NewReader(archive), result.Digest)
-		if err != nil {
-			return inventory.Inventory{}, fmt.Errorf("read compiled cluster config: %w", err)
-		}
-		return bundle.Manifest.Cluster.BootstrapInventory, nil
-	}
-	if strings.TrimSpace(opts.kubernetesBundle) != "" {
-		return inventory.Inventory{}, fmt.Errorf("--kubernetes-bundle conflicts with the selection embedded in the compiled config bundle")
-	}
-	bundle, err := configbundle.ReadBundleFile(bundlePath, "")
+	config, err := loadKatlConfig(configPath, clusterBootstrapCreator, configbundle.PlanningInputs{KubernetesBundle: opts.kubernetesBundle})
 	if err != nil {
 		return inventory.Inventory{}, err
 	}
-	return bundle.Manifest.Cluster.BootstrapInventory, nil
+	if !config.Source && strings.TrimSpace(opts.kubernetesBundle) != "" {
+		return inventory.Inventory{}, fmt.Errorf("--kubernetes-bundle conflicts with the selection embedded in the compiled config bundle")
+	}
+	return config.Bundle.Manifest.Cluster.BootstrapInventory, nil
 }
 
 func bootstrapDependencies(vmtestTranscriptDir string) cluster.Dependencies {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/katl-dev/katl/internal/katlctl/workstation"
 	"github.com/katl-dev/katl/internal/vmtest"
 	vmtestpb "github.com/katl-dev/katl/internal/vmtest/proto"
+	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -88,6 +89,101 @@ func TestRootHelpShowsCommandGroups(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEveryCommandHelpShowsOneMinimumInvocation(t *testing.T) {
+	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
+	var commands []*cobra.Command
+	var collect func(*cobra.Command)
+	collect = func(command *cobra.Command) {
+		commands = append(commands, command)
+		for _, child := range command.Commands() {
+			collect(child)
+		}
+	}
+	collect(root)
+
+	for _, command := range commands {
+		path := command.CommandPath()
+		example := strings.TrimSpace(command.Example)
+		if example == "" {
+			t.Errorf("%s has no minimum invocation example", path)
+			continue
+		}
+		if strings.Contains(example, "\n") {
+			t.Errorf("%s example = %q, want one concise invocation", path, example)
+		}
+		if !strings.HasPrefix(example, path) {
+			t.Errorf("%s example = %q, want command path prefix", path, example)
+		}
+		var help bytes.Buffer
+		command.SetOut(&help)
+		if err := command.Help(); err != nil {
+			t.Errorf("%s help error = %v", path, err)
+			continue
+		}
+		if !strings.Contains(help.String(), "Examples:\n"+example+"\n") {
+			t.Errorf("%s help does not show its minimum invocation:\n%s", path, help.String())
+		}
+	}
+}
+
+func TestClusterBootstrapHelpLeadsWithUnifiedConfigInput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"cluster", "bootstrap", "--help"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	help := stdout.String()
+	for _, want := range []string{
+		"ClusterConfig YAML manifest or compiled Katl config bundle",
+		"katlctl cluster bootstrap --config cluster.yaml",
+		"--config string",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help is missing %q:\n%s", want, help)
+		}
+	}
+	for _, obsolete := range []string{"--source", "--config-bundle"} {
+		if strings.Contains(help, obsolete) {
+			t.Fatalf("help exposes obsolete config input %q:\n%s", obsolete, help)
+		}
+	}
+}
+
+func TestConfigInputFlagsUseOneName(t *testing.T) {
+	want := map[string]bool{
+		"katlctl cluster enroll":      true,
+		"katlctl cluster bootstrap":   true,
+		"katlctl cluster wipe":        true,
+		"katlctl config render-node":  true,
+		"katlctl install apply":       true,
+		"katlctl node apply":          true,
+		"katlctl node apply validate": true,
+		"katlctl node wipe":           true,
+	}
+	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
+	var visit func(*cobra.Command)
+	visit = func(command *cobra.Command) {
+		path := command.CommandPath()
+		if flag := command.Flags().Lookup("config"); flag != nil {
+			if !want[path] {
+				t.Errorf("unexpected --config input on %s", path)
+			}
+			delete(want, path)
+		}
+		for _, obsolete := range []string{"source", "config-bundle", "file"} {
+			if command.Flags().Lookup(obsolete) != nil {
+				t.Errorf("%s still exposes --%s instead of --config", path, obsolete)
+			}
+		}
+		for _, child := range command.Commands() {
+			visit(child)
+		}
+	}
+	visit(root)
+	for path := range want {
+		t.Errorf("%s does not expose --config", path)
 	}
 }
 
@@ -283,7 +379,7 @@ func TestConfigRenderNodeFromSource(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if err := run(context.Background(), []string{
 		"config", "render-node",
-		"--source", sourcePath,
+		"--config", sourcePath,
 		"--node", "cp-1",
 		"--desired-version", "2",
 	}, &stdout, &stderr); err != nil {
@@ -323,7 +419,7 @@ func TestConfigRenderNodeFromMediaBundle(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if err := run(context.Background(), []string{
 		"config", "render-node",
-		"--config-bundle", bundlePath,
+		"--config", bundlePath,
 		"--node", "cp-1",
 		"--desired-version", "2",
 	}, &stdout, &stderr); err != nil {
@@ -755,7 +851,7 @@ func TestClusterBootstrapReturnsAgentBootstrapError(t *testing.T) {
 func TestClusterBootstrapRequiresInput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{"cluster", "bootstrap"}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "exactly one cluster config SOURCE") {
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --config or --inventory") {
 		t.Fatalf("run() error = %v, want input error", err)
 	}
 }
@@ -772,7 +868,7 @@ func TestClusterBootstrapCompilesSourceInventory(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"cluster", "bootstrap", sourcePath,
+		"cluster", "bootstrap", "--config", sourcePath,
 		"--init-node", "cp-1",
 		"--dry-run",
 	}, &stdout, &stderr)
@@ -797,7 +893,7 @@ func TestClusterBootstrapUsesConfigBundleInventory(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"cluster", "bootstrap",
-		"--config-bundle", bundlePath,
+		"--config", bundlePath,
 		"--init-node", "cp-1",
 		"--dry-run",
 	}, &stdout, &stderr)
@@ -814,17 +910,15 @@ func TestClusterBootstrapUsesConfigBundleInventory(t *testing.T) {
 
 func TestClusterBootstrapRejectsConfigBundleConflicts(t *testing.T) {
 	bundlePath, _ := writeConfigBundle(t)
-	sourcePath := writeClusterConfig(t)
 	inventoryPath := writeInventory(t)
 	tests := []struct {
 		name string
 		args []string
 		want string
 	}{
-		{name: "inventory", args: []string{"--config-bundle", bundlePath, "--inventory", inventoryPath}, want: "exactly one"},
-		{name: "source and bundle", args: []string{sourcePath, "--config-bundle", bundlePath}, want: "exactly one"},
-		{name: "Kubernetes", args: []string{"--config-bundle", bundlePath, "--kubernetes-bundle", "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.2"}, want: "conflicts with the selection embedded"},
-		{name: "endpoint", args: []string{"--config-bundle", bundlePath, "--control-plane-endpoint", "other.test:6443"}, want: "conflicts with the endpoint embedded"},
+		{name: "inventory", args: []string{"--config", bundlePath, "--inventory", inventoryPath}, want: "exactly one"},
+		{name: "Kubernetes", args: []string{"--config", bundlePath, "--kubernetes-bundle", "ghcr.io/katl-dev/kubernetes:v1.36.1-katl.2"}, want: "conflicts with the selection embedded"},
+		{name: "endpoint", args: []string{"--config", bundlePath, "--control-plane-endpoint", "other.test:6443"}, want: "conflicts with the endpoint embedded"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1020,7 +1114,7 @@ func TestWipeClusterPlanAcceptsClusterConfig(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
-		"cluster", "wipe", sourcePath,
+		"cluster", "wipe", "--config", sourcePath,
 		"--all",
 		"--plan",
 	}, &stdout, &stderr)
@@ -1143,7 +1237,7 @@ func TestWipeNodeRequiresExactlyOneTarget(t *testing.T) {
 		"--client-request-id", "wipe-node-req",
 		"--kubeconfig", "admin.conf",
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "accepts between 1 and 2 arg") {
+	if err == nil || !strings.Contains(err.Error(), "accepts 1 arg") {
 		t.Fatalf("run() error = %v, want exact node target validation", err)
 	}
 	if stdout.Len() != 0 {
@@ -1496,7 +1590,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 	err := run(context.Background(), []string{
 		"node", "apply",
 		"--endpoint", "node-a.example.test:9443",
-		"--file", configPath,
+		"--config", configPath,
 		"--mode", generation.ApplyModeNextBoot,
 		"--candidate-generation", "generation-1",
 		"--client-request-id", "req-stage",
@@ -1619,7 +1713,7 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 	err := run(context.Background(), []string{
 		"node", "apply",
 		"--endpoint", "node-a.example.test:9443",
-		"--file", configPath,
+		"--config", configPath,
 		"--candidate-generation", "generation-auto",
 		"--client-request-id", "req-auto",
 	}, &stdout, &stderr)
@@ -1664,7 +1758,7 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 	err := run(context.Background(), []string{
 		"node", "apply", "validate",
 		"--endpoint", "node-a.example.test:9443",
-		"--file", configPath,
+		"--config", configPath,
 		"--mode", generation.ApplyModeNextBoot,
 		"--candidate-generation", "generation-plan",
 		"--client-request-id", "req-plan",
@@ -1716,7 +1810,7 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 	err := run(context.Background(), []string{
 		"node", "apply",
 		"--endpoint", "node-a.example.test:9443",
-		"--config-bundle", bundlePath,
+		"--config", bundlePath,
 		"--node", "cp-1",
 		"--desired-version", "2",
 		"--candidate-generation", "generation-bundle",

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -193,7 +193,7 @@ func TestClusterEnrollCreatesContextAndPrivateTokens(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"cluster", "enroll", sourcePath, "--context-file", configPath}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"cluster", "enroll", "--config", sourcePath, "--context-file", configPath}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
 	}
 	cfg, err := workstation.Load(configPath)
@@ -254,7 +254,7 @@ func TestConfigApplyUsesContextAndDerivesBookkeeping(t *testing.T) {
 	t.Cleanup(func() { configApplyNow = oldNow })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "apply", writeClusterConfig(t), "--context-file", configPath, "--node", "cp-1"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "apply", "--config", writeClusterConfig(t), "--context-file", configPath, "--node", "cp-1"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
 	}
 	if fake.validateRequest == nil || fake.validateRequest.CandidateGenerationId != "config-42" {

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -319,7 +319,7 @@ and Kubernetes selection before applying it. Never substitute a transient
 Apply the cluster source directly:
 
 ```sh
-katlctl install apply ./cluster.yaml --node cp-1
+katlctl install apply --config ./cluster.yaml --node cp-1
 ```
 
 `katlctl` selects the endpoint automatically when exactly one installer is
@@ -413,7 +413,7 @@ After all nodes are installed and reachable through their node-local `katlc`
 management endpoints, bootstrap directly from the same source:
 
 ```text
-katlctl cluster bootstrap ./cluster.yaml \
+katlctl cluster bootstrap --config ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out kubeconfig \
   --overwrite-kubeconfig
@@ -428,7 +428,7 @@ Each freshly installed node generates a distinct agent token. Enroll the
 installed nodes before bootstrap:
 
 ```text
-katlctl cluster enroll ./cluster.yaml
+katlctl cluster enroll --config ./cluster.yaml
 ```
 
 `katlctl` retrieves the tokens over SSH, stores them at the `file:` credential
@@ -455,7 +455,7 @@ request internally; operators do not maintain a second configuration schema.
 Optionally plan the exact per-node runtime request through the node agent:
 
 ```text
-katlctl node apply ./cluster.yaml --node cp-1 --plan
+katlctl node apply --config ./cluster.yaml --node cp-1 --plan
 ```
 
 `katlctl` derives the source version, candidate generation, authenticated
@@ -467,7 +467,7 @@ recompiling it:
 
 ```text
 katlctl node apply \
-  --config-bundle ./katl-lab.katlcfg \
+  --config ./katl-lab.katlcfg \
   --node cp-1 \
   --plan
 ```

--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -17,9 +17,9 @@ workstation context
   The enrolled current context supplies node names, management endpoints,
   roles, and credential references.
 
-SOURCE
-  Optional retained ClusterConfig when no enrolled context is available.
-  --config-bundle and --inventory remain expert alternatives.
+--config PATH
+  Optional retained ClusterConfig YAML or compiled Katl config bundle when no
+  enrolled context is available. --inventory remains an expert alternative.
 
 --context NAME
   Optional workstation context override for management addresses and
@@ -121,7 +121,7 @@ Failure behavior:
 Command:
 
 ```text
-katlctl node wipe NAME [SOURCE] --kubeconfig PATH
+katlctl node wipe NAME [--config PATH] --kubeconfig PATH
 ```
 
 Target selection:
@@ -129,7 +129,7 @@ Target selection:
 - Exactly one positional node name is required.
 - The node name must exist in the inventory and resolve to one node-local katlc
   endpoint.
-- `SOURCE` may be omitted when an enrolled workstation context supplies the
+- `--config` may be omitted when an enrolled workstation context supplies the
   topology and node credential reference.
 
 Graceful Kubernetes cleanup:
@@ -171,7 +171,7 @@ Result:
 Command:
 
 ```text
-katlctl cluster wipe [SOURCE] --all
+katlctl cluster wipe [--config PATH] --all
 ```
 
 Target selection:

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -45,7 +45,7 @@ Expected state before Kubernetes bootstrap:
 Use the same source used for installation:
 
 ```sh
-katlctl cluster enroll ./cluster.yaml
+katlctl cluster enroll --config ./cluster.yaml
 ```
 
 The command connects as `root` using the workstation's normal SSH agent. Use

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -7,7 +7,7 @@ an explicit mutation of node-local kubeadm state and the Kubernetes API.
 
 - every intended node completed [generation 0 handoff](access.md);
 - the same `ClusterConfig` source used for installation is available;
-- `katlctl cluster enroll ./cluster.yaml` completed successfully;
+- `katlctl cluster enroll --config ./cluster.yaml` completed successfully;
 - `spec.kubernetes.version` is available in this Katl release's compatibility
   catalog;
 - the control-plane endpoint resolves or routes as designed; and
@@ -31,7 +31,7 @@ Validate topology, node access, bundle selection, and bootstrap ordering without
 running kubeadm:
 
 ```sh
-katlctl cluster bootstrap ./cluster.yaml \
+katlctl cluster bootstrap --config ./cluster.yaml \
   --dry-run \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig
@@ -50,7 +50,7 @@ run must not create generation 1 or invoke kubeadm.
 Run the same command without `--dry-run`:
 
 ```sh
-katlctl cluster bootstrap ./cluster.yaml \
+katlctl cluster bootstrap --config ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --overwrite-kubeconfig
@@ -78,7 +78,7 @@ management workflow, or explicitly include reviewed manifests and readiness
 conditions:
 
 ```sh
-katlctl cluster bootstrap ./cluster.yaml \
+katlctl cluster bootstrap --config ./cluster.yaml \
   --init-node cp-1 \
   --kubeconfig-out ./kubeconfig \
   --bootstrap-manifest ./cni.yaml \

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -28,7 +28,7 @@ An optional plan compiles the selected node configuration and asks the node to
 validate it without accepting an operation:
 
 ```sh
-katlctl node apply ./cluster.yaml \
+katlctl node apply --config ./cluster.yaml \
   --node cp-1 \
   --plan
 ```
@@ -38,11 +38,10 @@ accepting an operation. The default `auto` lets the domain policy select live or
 next-boot application. Request `--mode live` or `--mode next-boot` only when you
 intend to constrain that policy; unsafe requests are refused.
 
-If the source has already been compiled, use the expert bundle input instead of
-the positional source:
+If the source has already been compiled, pass the bundle through the same flag:
 
 ```sh
-katlctl node apply --config-bundle ./katl-lab.katlcfg --node cp-1 --plan
+katlctl node apply --config ./katl-lab.katlcfg --node cp-1 --plan
 ```
 
 Katl derives and verifies the bundle's integrity metadata from the file.
@@ -52,7 +51,7 @@ Katl derives and verifies the bundle's integrity metadata from the file.
 Run the same arguments without `--plan`:
 
 ```sh
-katlctl node apply ./cluster.yaml --node cp-1
+katlctl node apply --config ./cluster.yaml --node cp-1
 ```
 
 `katlctl` resolves the selected workstation context, reads the node credential,

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -19,9 +19,9 @@ before accepting the operation.
   cluster.
 
 After enrollment, the current workstation context is the normal topology and
-credential source. Pass a retained `ClusterConfig` when operating without an
-enrolled context. `--config-bundle` remains available for PXE/offline material
-and `--inventory` for expert recovery tooling.
+credential source. Pass a retained `ClusterConfig` or PXE/offline config bundle
+through `--config` when operating without an enrolled context. `--inventory`
+remains available for expert recovery tooling.
 
 ## Plan a Whole-Cluster Wipe
 
@@ -51,7 +51,7 @@ and `result: succeeded`. Treat `recoveryRequired: true` as a stop condition.
 Single-node wipe coordinates Kubernetes Node cleanup before the node-local reset:
 
 ```sh
-katlctl node wipe worker-1 ./cluster.yaml --plan
+katlctl node wipe worker-1 --config ./cluster.yaml --plan
 ```
 
 After enrollment, the workstation context supplies topology and credentials, so


### PR DESCRIPTION
## Summary

Unify operational Katl configuration inputs on `--config`, with automatic handling for ClusterConfig YAML, compiled bundles, and pre-rendered node changes.

Add concise minimum invocations to every `katlctl` help surface and align operator documentation. This removes artifact-specific input ceremony that made cluster bootstrap appear to require a prebuilt config bundle.

## Validation note

The required two-node bootstrap VM gate was attempted but could not launch because this host lacks `mksquashfs`.
