### PR TITLE
dev: make VM tooling the default shell

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -89,11 +89,12 @@ Use `direnv` plus `nix-direnv` if you want the flake shell loaded
 automatically when entering the repository.
 
 That shell provides the Go and protobuf toolchain, Git, OpenSSH, `jq`, `curl`,
-and Podman. Image construction stays behind `scripts/mkosi`; mkosi, Fedora
-package tools, UKI tooling, filesystem tools, and compression tools run inside
-its builder container instead of being installed on the host.
+Podman, libvirt clients, QEMU image tooling, OVMF firmware, and the filesystem
+and artifact-inspection tools used by VM tests. Image construction stays behind
+`scripts/mkosi`; mkosi and Fedora package installation run inside its builder
+container.
 
-`katlctl` is also available in both development shells. It runs from the current
+`katlctl` is also available in the development shell. It runs from the current
 checkout so local source changes are used immediately:
 
 ```sh
@@ -106,16 +107,9 @@ Build current artifacts through the supported container wrapper:
 nix develop --command scripts/mkosi build-installer
 ```
 
-For manual VM work and VM tests, use the optional VM shell:
-
-```sh
-nix develop .#vm
-```
-
-The VM shell adds libvirt client tools, QEMU image tooling, and OVMF firmware
-packages. It does not configure host libvirt, `/dev/kvm`, `/dev/net/tun`,
-networks, storage pools, or polkit access; keep those in the NixOS host
-configuration.
+The development shell includes the complete supported VM test toolchain. It
+does not configure host libvirt, `/dev/kvm`, `/dev/net/tun`, networks, storage
+pools, or polkit access; keep those in the host configuration.
 
 The host must provide:
 
@@ -415,13 +409,13 @@ is done.
 
 ### Capable-Host Proof
 
-Run the full enabled world suite from the Nix VM shell on a host with readable
-OVMF firmware, `/dev/kvm`, `/dev/vhost-vsock`, `/dev/net/tun`,
+Run the full enabled world suite from the Nix development shell on a host with
+readable OVMF firmware, `/dev/kvm`, `/dev/vhost-vsock`, `/dev/net/tun`,
 libvirt system access, an active libvirt network, and an active libvirt storage
 pool:
 
 ```sh
-nix develop .#vm -c env \
+nix develop -c env \
   KATL_VMTEST_RUN_ID=capable-host-$(date -u +%Y%m%dT%H%M%SZ) \
   scripts/vmtest-run ./... -count=1
 ```

--- a/docs/internal/v0.1-release-gate-matrix.md
+++ b/docs/internal/v0.1-release-gate-matrix.md
@@ -24,8 +24,8 @@ Tier 1, single-node VM host:
   `cpio`, `mformat`, `mcopy`, `mkfs.vfat`, `mksquashfs`, `rpm`, `truncate`,
   `sfdisk`, `sha256sum`, `ukify`, `unsquashfs`, `xorriso`, `zstd`, `awk`, and
   `realpath`.
-- Readable OVMF code and vars images, either discovered by the VM shell or set
-  with `KATL_OVMF_CODE` and `KATL_OVMF_VARS`.
+- Readable OVMF code and vars images, either provided by the development shell
+  or set with `KATL_OVMF_CODE` and `KATL_OVMF_VARS`.
 - Access to `qemu:///system`, or an explicit `KATL_VMTEST_LIBVIRT_URI`.
 - Active libvirt network and storage pool, normally `default` or explicitly set
   with `KATL_VMTEST_LIBVIRT_NETWORK` and
@@ -118,7 +118,7 @@ No GitHub-hosted VM orchestration is currently available. Run the direct
 runtime, first-install, release-media install/reboot, runtime
 config/management, operation-backed two-node bootstrap, KatlOS
 upgrade/rollback, and Kubernetes upgrade gates on a capable host through
-`nix develop .#vm` and `scripts/vmtest-run`. Use `-count=1`, `-failfast`, and an
+`nix develop` and `scripts/vmtest-run`. Use `-count=1`, `-failfast`, and an
 explicit Go test `-timeout`. Hosted orchestration must not be restored until a
 runner environment and its ownership, isolation, cleanup, and capacity model
 have been designed and provisioned.
@@ -387,7 +387,7 @@ vsock, OVMF, KVM, or capacity gaps.
 Command:
 
 ```sh
-nix develop .#vm -c env \
+nix develop -c env \
   KATL_VMTEST_RUN_ID=v0.1-capable-host-$(date -u +%Y%m%dT%H%M%SZ) \
   scripts/vmtest-run ./... -count=1 -failfast -timeout 90m
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -24,46 +24,39 @@
           exec ${pkgs.go}/bin/go run "$repo_root/cmd/katlctl" "$@"
         '';
       shellFor =
-        pkgs: vmTools:
+        pkgs:
         pkgs.mkShell {
           packages =
             (with pkgs; [
               bashInteractive
               cacert
+              cpio
               curl
+              dosfstools
               git
               go
               jq
+              kubectl
+              libvirt
+              mtools
+              OVMFFull
               openssh
               podman
               protobuf
               protoc-gen-go
               protoc-gen-go-grpc
+              qemu_kvm
+              rpm
+              squashfsTools
+              systemdUkify
+              util-linux
+              xorriso
+              zstd
             ])
-            ++ [ (katlctlFor pkgs) ]
-            ++ pkgs.lib.optionals vmTools (
-              with pkgs;
-              [
-                kubectl
-                libvirt
-                mtools
-                OVMFFull
-                qemu_kvm
-                cpio
-                dosfstools
-                rpm
-                squashfsTools
-                systemdUkify
-                util-linux
-                xorriso
-                zstd
-              ]
-            );
+            ++ [ (katlctlFor pkgs) ];
 
           shellHook = ''
             export TMPDIR="''${TMPDIR:-/tmp}"
-          ''
-          + pkgs.lib.optionalString vmTools ''
             export KATL_OVMF_CODE="''${KATL_OVMF_CODE:-${pkgs.OVMFFull.fd}/FV/OVMF_CODE.fd}"
             export KATL_OVMF_VARS="''${KATL_OVMF_VARS:-${pkgs.OVMFFull.fd}/FV/OVMF_VARS.fd}"
             export KATL_VMTEST_IMAGE_TOOL="''${KATL_VMTEST_IMAGE_TOOL:-${pkgs.qemu_kvm}/bin/qemu-img}"
@@ -81,8 +74,7 @@
           pkgs = pkgsFor system;
         in
         {
-          default = shellFor pkgs false;
-          vm = shellFor pkgs true;
+          default = shellFor pkgs;
         }
       );
     };


### PR DESCRIPTION
Replace the split default and VM development shells with one supported environment. Plain `nix develop` now provides katlctl, libvirt/QEMU, OVMF, Kubernetes, and artifact tooling so VM testing is the normal development path rather than an optional shell.