### PR TITLE
config: use control-plane boolean

### DIFF
--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -159,9 +159,10 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 		seen[node.name] = struct{}{}
 		targetDisk := node.disk
 		source.Spec.Nodes = append(source.Spec.Nodes, configbundle.SourceNode{
-			Name: node.name, SystemRole: node.role,
-			Install:   configbundle.SourceInstallLayer{TargetDisk: &targetDisk},
-			Bootstrap: configbundle.SourceBootstrapLayer{Address: node.address},
+			Name:         node.name,
+			ControlPlane: node.role == inventory.RoleControlPlane,
+			Install:      configbundle.SourceInstallLayer{TargetDisk: &targetDisk},
+			Bootstrap:    configbundle.SourceBootstrapLayer{Address: node.address},
 		})
 	}
 	data, err := yaml.Marshal(source)
@@ -201,6 +202,8 @@ func annotateStarterConfig(data []byte, missingSSHKeys bool) []byte {
 	comments := "spec:\n" +
 		"    # Stable Kubernetes API endpoint for multi-control-plane clusters.\n" +
 		"    # controlPlaneEndpoint: api.home.arpa:6443\n" +
+		"    # Set controlPlane: true on nodes that join the Kubernetes control plane.\n" +
+		"    # Omission means worker.\n" +
 		"    # Nodes use DHCP by default; native systemd-networkd files can be set under defaults or a node.\n"
 	if missingSSHKeys {
 		comments += "    # Add an SSH public key here if console-only access is not sufficient.\n" +

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -107,10 +107,10 @@ func TestInstallDiscoverWritesClusterConfig(t *testing.T) {
 		t.Fatalf("authorized keys = %#v", keys)
 	}
 	cp, worker := source.Spec.Nodes[0], source.Spec.Nodes[1]
-	if cp.Name != "cp-1" || cp.SystemRole != inventory.RoleControlPlane || cp.Bootstrap.Address != "192.0.2.11" || cp.Install.TargetDisk == nil || cp.Install.TargetDisk.ByID != "/dev/disk/by-id/ata-cp-root" {
+	if cp.Name != "cp-1" || !cp.ControlPlane || cp.Bootstrap.Address != "192.0.2.11" || cp.Install.TargetDisk == nil || cp.Install.TargetDisk.ByID != "/dev/disk/by-id/ata-cp-root" {
 		t.Fatalf("control-plane node = %#v", cp)
 	}
-	if worker.Name != "worker-1" || worker.SystemRole != inventory.RoleWorker || worker.Bootstrap.Address != "192.0.2.21" || worker.Install.TargetDisk == nil || worker.Install.TargetDisk.WWN != "worker-root-wwn" {
+	if worker.Name != "worker-1" || worker.ControlPlane || worker.Bootstrap.Address != "192.0.2.21" || worker.Install.TargetDisk == nil || worker.Install.TargetDisk.WWN != "worker-root-wwn" {
 		t.Fatalf("worker node = %#v", worker)
 	}
 	if !strings.Contains(stdout.String(), "created "+outputPath) {

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1290,8 +1290,8 @@ type nodeConfigInputOptions struct {
 }
 
 type configValidationNode struct {
-	Name       string `json:"name"`
-	SystemRole string `json:"systemRole"`
+	Name         string `json:"name"`
+	ControlPlane bool   `json:"controlPlane,omitempty"`
 }
 
 type configValidationReport struct {
@@ -1326,7 +1326,7 @@ func runConfigValidate(sourcePath string, stdout, stderr io.Writer) error {
 	}
 	nodes := make([]configValidationNode, 0, len(result.Manifest.Nodes))
 	for _, node := range result.Manifest.Nodes {
-		nodes = append(nodes, configValidationNode{Name: node.Name, SystemRole: node.SystemRole})
+		nodes = append(nodes, configValidationNode{Name: node.Name, ControlPlane: node.SystemRole == string(inventory.RoleControlPlane)})
 	}
 	report := configValidationReport{
 		APIVersion:  configbundle.APIVersion,

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -466,7 +466,7 @@ func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	if strings.Contains(stdout.String(), "Digest") || strings.Contains(stdout.String(), "artifactVersion") {
 		t.Fatalf("report exposes integrity plumbing = %s", stdout.String())
 	}
-	if len(report.Nodes) != 1 || report.Nodes[0] != (configValidationNode{Name: "cp-1", SystemRole: "control-plane"}) {
+	if len(report.Nodes) != 1 || report.Nodes[0] != (configValidationNode{Name: "cp-1", ControlPlane: true}) {
 		t.Fatalf("resolved nodes = %#v", report.Nodes)
 	}
 
@@ -2481,7 +2481,7 @@ spec:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
   nodes:
     - name: cp-1
-      systemRole: control-plane
+      controlPlane: true
       bootstrap:
         address: 10.0.0.11
       install:

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -49,13 +49,16 @@ func TestConfigInitEmitsStarterClusterConfig(t *testing.T) {
 	if got := source.Spec.Nodes[0].Bootstrap.Address; got != "192.0.2.11" {
 		t.Fatalf("generated bootstrap address = %q", got)
 	}
+	if !source.Spec.Nodes[0].ControlPlane || source.Spec.Nodes[1].ControlPlane {
+		t.Fatalf("generated control-plane choices = %#v", source.Spec.Nodes)
+	}
 	rendered := stdout.String()
 	for _, internalDefault := range []string{"katlosImage:", "wipeTarget:", "systemRoleDefaults:", "kubeadmConfigs:", "nodeClasses:", "overrides:", "bundle:", "catalogRef:", "hostname:", "access:"} {
 		if strings.Contains(rendered, internalDefault) {
 			t.Fatalf("generated config contains internal default %q:\n%s", internalDefault, rendered)
 		}
 	}
-	for _, guidance := range []string{"# controlPlaneEndpoint:", "# Nodes use DHCP by default"} {
+	for _, guidance := range []string{"# controlPlaneEndpoint:", "# Set controlPlane: true", "# Nodes use DHCP by default"} {
 		if !strings.Contains(rendered, guidance) {
 			t.Fatalf("generated config is missing guidance %q:\n%s", guidance, rendered)
 		}

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -150,6 +150,8 @@ metadata:
 spec:
   # Stable Kubernetes API endpoint for multi-control-plane clusters.
   # controlPlaneEndpoint: api.home.arpa:6443
+  # Set controlPlane: true on nodes that join the Kubernetes control plane.
+  # Omission means worker.
   # Nodes use DHCP by default; native systemd-networkd files can be set under defaults or a node.
   kubernetes:
     version: v1.36.1
@@ -160,14 +162,13 @@ spec:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
   nodes:
     - name: cp-1
-      systemRole: control-plane
+      controlPlane: true
       install:
         targetDisk:
           byID: /dev/disk/by-id/ata-KATL_CP_1_ROOT
       bootstrap:
         address: 192.0.2.11
     - name: worker-1
-      systemRole: worker
       install:
         targetDisk:
           byID: /dev/disk/by-id/ata-KATL_WORKER_1_ROOT

--- a/docs/internal/adrs/adr-002-live-and-next-boot-config-apply-modes.md
+++ b/docs/internal/adrs/adr-002-live-and-next-boot-config-apply-modes.md
@@ -262,8 +262,8 @@ networkd
 
 Bootstrap node metadata
   Live-applicable only for non-secret descriptive fields that do not change
-  systemRole, stable node identity, selected bootstrap profile, or selected
-  Kubernetes payload.
+  control-plane participation, stable node identity, selected bootstrap
+  profile, or selected Kubernetes payload.
 ```
 
 Outside the v0.1 release cut, next-boot-only domains can be rendered into a
@@ -313,7 +313,7 @@ bootstrap, join, reset, repair, certificate renewal, etcd membership changes
 Rejected changes fail before render or activation:
 
 ```text
-systemRole changes
+controlPlane changes
 selected bootstrap profile or rendered kubeadm input changes
 selected Kubernetes sysext payload changes requested for live apply
 kubelet node identity changes
@@ -451,7 +451,7 @@ GitOps controllers
 Changing kubeadm desired input is normal Katl configuration, but applying that
 input to a live cluster is a separate kubeadm-aware operation with its own
 planner, explicit user request, status, rollback story, and tests. A `live`
-configuration request that would change systemRole, selected bootstrap profile,
+configuration request that would change controlPlane, selected bootstrap profile,
 rendered kubeadm input, or node identity is rejected instead of silently
 changing cluster state.
 

--- a/docs/internal/adrs/adr-003-runtime-config-input-and-trust.md
+++ b/docs/internal/adrs/adr-003-runtime-config-input-and-trust.md
@@ -14,9 +14,9 @@ configuration for generated confext updates. It builds on
 
 Katl can render Katl-native node configuration into generated confext for first
 install. After the node is installed, the same rendering model must support
-changed cluster defaults, systemRole-level configuration, and per-node
-overrides without turning Katl into a general-purpose configuration manager or
-a Kubernetes lifecycle controller.
+changed cluster defaults and flat per-node configuration without turning Katl
+into a general-purpose configuration manager or a Kubernetes lifecycle
+controller.
 
 Runtime configuration input is security-sensitive because it can change
 effective `/etc` content, restart host services, and affect kubeadm-ready

--- a/docs/internal/adrs/adr-006-cluster-manifest-layering-and-node-classes.md
+++ b/docs/internal/adrs/adr-006-cluster-manifest-layering-and-node-classes.md
@@ -12,7 +12,7 @@ compiler concepts and forced operators to understand merge precedence.
 ## Superseding Decision
 
 ClusterConfig now has only shared `spec.defaults` and flat `spec.nodes[]`
-entries. Katl selects role profiles internally from `systemRole`. Node classes,
+entries. Katl selects role profiles internally from `controlPlane`. Node classes,
 system-role default layers, the `overrides` wrapper, and platform API endpoint
 helpers are outside the supported v1alpha1 contract.
 

--- a/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
+++ b/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
@@ -84,9 +84,10 @@ selected KubeadmConfig name
 canonical desired config SHA-256
 ```
 
-The name is compiled from `systemRole`; it is not an operator-authored
-ClusterConfig reference. When `spec.kubernetes.kubeadm` is present, the desired
-digest includes its validated and role-selected native documents and patches.
+The name is compiled from the node role derived from `controlPlane`; it is not
+an operator-authored ClusterConfig reference. When `spec.kubernetes.kubeadm` is
+present, the desired digest includes its validated and role-selected native
+documents and patches.
 
 The operation accepts only a config selected by the active generation. It does
 not accept an arbitrary path or inline replacement YAML. Every participating

--- a/docs/internal/cluster-bootstrap-cli.md
+++ b/docs/internal/cluster-bootstrap-cli.md
@@ -245,7 +245,8 @@ they must be included in the submitted operation request and recorded in the
 relevant node-local operation records, with any invocation summary linking the same
 values, so diagnostics show what was actually used.
 
-`systemRole` is the only source of desired cluster node role:
+The compiled `systemRole` derives solely from the ClusterConfig
+`controlPlane` choice:
 
 ```text
 control-plane

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -37,7 +37,7 @@ There are two authoring levels:
 
 There are no node classes, system-role default layers, or `overrides` wrapper.
 Katl selects its control-plane and worker kubeadm profiles internally from
-`systemRole`. Operators who need a native kubeadm setting that Katl does not
+`controlPlane`. Operators who need a native kubeadm setting that Katl does not
 model may supply one bounded cluster-wide kubeadm file and optional patch
 directory. They never name or select the generated profiles.
 
@@ -83,7 +83,9 @@ spec:
 
   nodes:
     - name: cp-1
-      systemRole: control-plane
+      # Set to true for nodes that join the Kubernetes control plane.
+      # Omission means worker.
+      controlPlane: true
       bootstrap:
         address: 192.0.2.11
       install:
@@ -103,6 +105,10 @@ enrollment, initial Kubernetes bootstrap, and the initial workstation context.
 It need not be a permanent node identity, but it must remain reachable through
 those steps. For DHCP nodes, use a reservation or update the workstation
 context after enrollment when the address changes.
+
+`controlPlane: true` is the only public role choice. Omission or `false` means
+worker, and at least one node must set it to true. Katl derives its internal
+system role, kubeadm material, and lifecycle ordering from this value.
 
 Nodes use a generated DHCP systemd-networkd profile when neither defaults nor
 the node supplies native networkd files. Default and node files merge by file
@@ -153,9 +159,9 @@ host paths, symlinks, traversal, and a kubeadm version that conflicts with
 When a ClusterConfig is rendered for an installed node, Katl includes every
 supported desired field in the node change request. Runtime-live fields such as
 SSH keys and networkd files can be applied directly. Operation-only fields such
-as system role and role-dependent Kubernetes bootstrap state remain visible to
-the planner and produce an explicit lifecycle action or refusal; the renderer
-must not silently omit them.
+as control-plane participation and role-dependent Kubernetes bootstrap state
+remain visible to the planner and produce an explicit lifecycle action or
+refusal; the renderer must not silently omit them.
 
 Changing bounded native kubeadm input updates desired role-dependent bootstrap
 state. Normal config apply may stage and report that state, but making a running
@@ -173,6 +179,7 @@ Katl v1alpha1 rejects aliases and speculative mechanisms including:
 
 ```text
 nodes[].overrides
+nodes[].systemRole
 spec.systemRoleDefaults
 spec.nodeClasses and nodes[].nodeClass
 spec.platformAPIEndpoint

--- a/docs/internal/installer-boot-artifact-variants.md
+++ b/docs/internal/installer-boot-artifact-variants.md
@@ -14,7 +14,7 @@ The single KatlOS payload contract is defined in
 
 Installer boot artifacts are generic per Katl build, architecture, and installer
 version. They must not be rebuilt for each node, cluster, address, target disk,
-systemRole, bootstrap profile, bootstrap token, or KatlOS image URL.
+control-plane choice, bootstrap profile, bootstrap token, or KatlOS image URL.
 
 They may contain:
 

--- a/docs/internal/kubeadm-config-input-design.md
+++ b/docs/internal/kubeadm-config-input-design.md
@@ -15,8 +15,9 @@ generations and then coordinate kubeadm init/join.
 ## Decision
 
 The ordinary path is Katl-owned complete kubeadm configuration selected from a
-node's `systemRole`. The bounded advanced path adds one native input to
-`ClusterConfig` without exposing Katl's internal names or references:
+node's compiled role, derived from `controlPlane`. The bounded advanced path
+adds one native input to `ClusterConfig` without exposing Katl's internal names
+or references:
 
 ```yaml
 spec:

--- a/docs/internal/platform-api-endpoint-user-story.md
+++ b/docs/internal/platform-api-endpoint-user-story.md
@@ -275,7 +275,7 @@ always-on endpoint controller by default.
 
 Optional endpoint helpers can be supported later through app sysexts and bounded
 native inputs. They must still be explicit user choices with tests, status, and
-rollback behavior. They do not become hidden behavior behind `systemRole`.
+rollback behavior. They do not become hidden behavior behind `controlPlane`.
 
 ## Readiness Gates
 

--- a/docs/internal/single-katlos-image-artifact.md
+++ b/docs/internal/single-katlos-image-artifact.md
@@ -158,8 +158,8 @@ component digests and compatibility metadata
 
 Node-specific configuration remains outside the image. The install manifest,
 PXE/preseed input, USB/local handoff, or VM harness supplies identity, disk
-selection, network configuration, bootstrap profile references, systemRole, the
-exact Kubernetes payload version, and other supported day-one node
+selection, network configuration, bootstrap profile references, the
+control-plane choice, the exact Kubernetes payload version, and other supported day-one node
 configuration. Capability overlays are a day-2 design item. Reusing the same
 install image for multiple nodes must not require rebuilding the image.
 
@@ -336,8 +336,8 @@ Secret rules:
 node identity, SSH host keys, kubeadm tokens, certificate keys, and cluster
   bootstrap secrets are not stored in KatlOS images
 
-node-specific network addresses and systemRole choices are not stored in KatlOS
-  images
+node-specific network addresses and control-plane choices are not stored in
+KatlOS images
 
 credentials for fetching a private image are supplied by installer input or a
   protected local channel, not embedded in the reusable image

--- a/docs/internal/system-roles-and-capabilities.md
+++ b/docs/internal/system-roles-and-capabilities.md
@@ -1,245 +1,107 @@
-# System Roles And Deferred Capabilities
+# Control-plane Participation And Deferred Capabilities
 
-Status: current decision, revised to defer capability overlays.
+Status: current decision, revised for the contracted ClusterConfig API.
 
-This document defines the day-one Katl node classification model without
-embedding a general-purpose templating language in Katl.
+This document defines Katl's day-one Kubernetes node classification without
+embedding compiler profiles or a general-purpose templating language in the
+operator API.
 
-Day one uses:
+## Public Decision
 
-```text
-cluster defaults
-flat per-node settings
-an internally selected profile for each systemRole
-explicit supported node configuration domains
+`nodes[].controlPlane` is the only ClusterConfig choice that determines a
+node's Kubernetes bootstrap role:
+
+```yaml
+nodes:
+  - name: cp-1
+    controlPlane: true
+  - name: worker-1
 ```
 
-Capability overlays remain a day-2 design topic. They need a clearer input
-model, merge model, and test contract before they become user-facing.
-The opt-in platform API endpoint routing capability is one concrete deferred
-capability. A proposal is documented in
-`docs/internal/platform-api-endpoint-routing-capability.md`. It must use the
-generic node app sysext contract in
-`docs/internal/node-app-sysext-contract.md`, and its proposed bounded input
-schema is documented in
-`docs/internal/platform-api-endpoint-helper-input-schema.md`.
+`true` means that the node joins the Kubernetes control plane. Omission or
+`false` means worker. A cluster must contain at least one node with
+`controlPlane: true`; Katl does not silently promote the first node.
 
-This document builds on `docs/internal/supported-node-config-domains.md`: every
-rendered output must still land in a supported systemd-native domain or bounded
-Katl-owned file. Day-2 application behavior remains in sysexts or user-managed
-GitOps.
+Katl compiles that choice into its internal `control-plane` or `worker` system
+role. Internal install manifests, inventories, node metadata, operation state,
+and kubeadm planning may retain that enum because those documents are generated
+Katl state rather than operator-authored ClusterConfig.
 
-## Decision
+The choice affects kubeadm input and lifecycle ordering only. It does not imply
+CNI, ingress, routing, storage, GPU, workload scheduling, or other application
+behavior. Control-plane scheduling remains governed by Kubernetes taints and
+operator policy.
 
-Each node has exactly one `systemRole`.
+## Authoring And Merge Model
 
-`systemRole` answers the Katl bootstrap role question only:
+Day-one configuration has two layers:
 
 ```text
-control-plane
-  node is intended to receive kubeadm control-plane input
-  may need control-plane storage defaults such as /var/lib/etcd policy
-  does not imply CNI, ingress, routing daemon, storage add-on, or GPU behavior
-
-worker
-  node is intended to receive kubeadm join/worker input
-  does not imply workload labels, taints, storage, GPU, or ingress behavior
+1. shared spec.defaults
+2. flat per-node settings
 ```
 
-Concrete values such as IP addresses, disk selectors, route metrics, SSH keys,
-networkd units, sysctl keys, mount requests, or bootstrap profile references
-remain direct supported domain configuration. They are not hidden behind roles.
+Concrete addresses, disk selectors, networkd units, SSH keys, labels, taints,
+and supported storage choices remain direct configuration. Katl selects
+role-dependent kubeadm state internally; operators do not name profiles or
+provide role-default maps.
 
-## First Implementation
-
-The first implementation supports built-in system roles only:
-
-```text
-control-plane
-worker
-```
-
-The first implementation does not support capability overlays.
-
-This keeps Katl from pretending to support complex domain behavior like GPUs,
-storage placement, routing daemons, ingress nodes, or alternate runtimes before
-the corresponding input schema, systemd-native rendering, sysext contract,
-runtime integration, and smoke tests exist.
-
-## Merge Order
-
-Per-node materials are rendered from these layers, in order:
-
-```text
-1. cluster defaults
-2. node class
-3. systemRole defaults
-4. node overrides
-```
-
-Later layers override earlier scalar settings only when the domain explicitly
-allows override semantics. List and map behavior is domain-specific and must be
-documented in the domain implementation.
-
-Recommended defaults:
-
-```text
-cluster defaults
-  shared DNS, time, SSH/operator keys, common sysctl/modules/tmpfiles policy,
-  artifact selections, and common Kubernetes sysext selection
-
-node class
-  user-declared hardware or model defaults, such as NIC names, safe
-  non-identifying target disk constraints, and hardware labels
-
-systemRole defaults
-  bootstrap profile defaults, control-plane storage policy, bootstrap labels or
-  taints that are needed by kubeadm input
-
-node overrides
-  concrete hostname, node name, addresses, disk selectors, and any explicit
-  per-node corrections
-```
-
-No layer may render outside the supported node configuration domains.
-
-## Conflict Handling
-
-Katl must detect conflicts before rendering per-node materials.
-
-Conflict rules:
-
-```text
-same output path produced by two layers
-  reject unless it is the same normalized content and the domain allows
-  idempotent duplicates
-
-same scalar set to different values by systemRole defaults and node override
-  reject unless the domain explicitly allows override semantics
-
-same scalar set to different values by node class and systemRole defaults
-  reject unless the domain explicitly allows override semantics
-
-same list item repeated
-  normalize and de-duplicate only when the domain defines item identity
-
-node override conflicts with systemRole bootstrap invariants
-  reject
-```
-
-Examples:
-
-```text
-node override changes a control-plane node to a worker bootstrap profile
-  reject unless systemRole is also changed to worker
-
-node override attempts to render into an unsupported domain
-  reject
-```
+Conflicting output paths or settings are rejected according to the owning
+configuration domain. No layer may render outside the supported node
+configuration domains.
 
 ## Validation
 
-Cluster plan validation must require:
+ClusterConfig validation requires:
 
 ```text
-every node has exactly one systemRole
-systemRole is control-plane or worker for the first implementation
-nodeClass references, when present, resolve to exactly one declared class
+at least one node
+at least one node with controlPlane: true
+the removed systemRole field is rejected rather than treated as an alias
 all layer merges are deterministic
 all rendered domains pass their domain-specific validation
-node identity is present or can be derived deterministically
-selected bootstrap profile matches systemRole intent
-target disk identity is explicit per node before destructive install
+selected internal kubeadm state matches the derived node role
+target disk identity is explicit before destructive installation
 ```
 
-`control-plane` nodes should select a bootstrap profile that can produce
-control-plane bootstrap input. `worker` nodes should select a worker profile.
-Katl may validate this by resolving the profile to native kubeadm YAML and
-parsing it, not by relying on the profile name alone.
-
-Applying Kubernetes labels and taints to a live cluster is not hidden in confext
-activation. It remains an explicit kubeadm/kubectl-aware action or user-managed
-GitOps.
+Changing `controlPlane` changes operation-only Kubernetes bootstrap intent. It
+must remain visible to runtime planning and cannot be silently applied as an
+ordinary live configuration change.
 
 ## Deferred Capability Overlays
 
-Capability overlays are deferred to day two.
+Composable traits such as GPU, storage, routing, or ingress behavior remain a
+day-two design topic. Each needs a real operator workflow, bounded input schema,
+systemd-native rendering or sysext contract, lifecycle behavior, status, and
+tests before becoming user-facing.
 
-Future capabilities may model composable node traits or workload affordances,
-for example:
-
-```text
-nvidia-gpu
-ceph-osd
-local-storage
-bird-router
-ingress
-```
-
-They must not replace `systemRole`. A future GPU control-plane node and a GPU
-worker node must both be expressible.
-
-Before capabilities become user-facing, Katl needs a separate design for:
-
-```text
-whether capabilities are built-in, user-defined, or both
-input schema and naming rules
-merge order relative to cluster defaults and flat node settings
-conflict handling when multiple capabilities touch the same domain
-interaction with sysexts and user-managed GitOps
-validation and golden-test expectations
-examples that do not require arbitrary templates or shell hooks
-```
-
-Future capability overlays must compile to supported domains, select an explicit
-day-2 sysext/app contract, or remain user GitOps. They must not smuggle
-application lifecycle into config rendering.
-
-The platform API endpoint routing capability follows that rule: it is opt-in,
-dynamic-routing-oriented, and expected to use an explicit app sysext plus
-bounded native inputs rather than becoming a hidden `systemRole`. It remains
-deferred until its helper-specific app contract, status schema, and node-local
-operation behavior are accepted and tested.
+Future capabilities must remain independent of `controlPlane`. A GPU
+control-plane node and a GPU worker must both be expressible. Application
+lifecycle remains in explicit Katl app contracts or user-managed GitOps.
 
 ## Rejected Options
 
-Katl does not embed a general-purpose templating language. There is no Jinja,
-Helm, Jsonnet, Starlark, Lua, shell, or arbitrary expression engine in the Katl
-cluster-plan format.
+Katl does not expose additional role strings for hypothetical future behavior.
+It does not embed Jinja, Helm, Jsonnet, Starlark, Lua, shell, or arbitrary
+expressions, and it does not implement Talos patch compatibility.
 
-Katl does not implement Talos patch compatibility.
-
-Katl does not model GPU, storage, router, ingress, or update-controller behavior
-as `systemRole` values. Those are future capabilities, day-2 sysexts, or user
-GitOps.
-
-User-side templating remains allowed outside Katl. Users may generate Katl input
-with their own tooling, but ClusterConfig remains explicit defaults, flat nodes,
-system roles, and supported domains for the first implementation.
+Node classes, role-default layers, an `overrides` wrapper, and capability
+overlays are not part of the current ClusterConfig contract. User-side
+templating may generate concrete ClusterConfig YAML, but Katl validates only the
+resulting document.
 
 ## Testing Contract
 
-The compiler and planner need deterministic tests:
+Tests cover:
 
 ```text
-golden tests for rendered per-node install materials
-golden tests for cluster defaults plus flat node settings
-negative tests for unknown systemRole
-negative tests for missing systemRole
-negative tests for systemRole and selected bootstrap profile mismatch
-negative tests for output outside supported domains
+controlPlane: true lowering to the internal control-plane role
+omitted controlPlane lowering to worker
+rejection when no control-plane node exists
+rejection of the removed systemRole alias
+role-dependent kubeadm material selection
+normalized rendered paths and content for both node kinds
 ```
 
-Golden fixtures should include at least:
-
-```text
-single control-plane node
-single worker node
-cluster defaults plus per-node network settings
-control-plane node with explicit per-node storage settings
-worker node with explicit per-node extra disk mount request
-```
-
-Tests must compare normalized rendered paths and content. They must not depend
-on host-specific absolute paths, current user home directories, Nix store paths,
-or mutable package versions.
+Fixtures must not depend on host-specific paths, current home directories, Nix
+store paths, or mutable package versions.

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -77,13 +77,13 @@ type SourceSpec struct {
 }
 
 type SourceNode struct {
-	Name       string                  `yaml:"name" json:"name"`
-	SystemRole inventory.SystemRole    `yaml:"systemRole" json:"systemRole"`
-	Identity   SourceIdentity          `yaml:"identity,omitempty" json:"identity,omitempty"`
-	Networkd   manifest.NetworkdConfig `yaml:"networkd,omitempty" json:"networkd,omitempty"`
-	Install    SourceInstallLayer      `yaml:"install,omitempty" json:"install,omitempty"`
-	Kubernetes SourceKubernetesLayer   `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty"`
-	Bootstrap  SourceBootstrapLayer    `yaml:"bootstrap,omitempty" json:"bootstrap,omitempty"`
+	Name         string                  `yaml:"name" json:"name"`
+	ControlPlane bool                    `yaml:"controlPlane,omitempty" json:"controlPlane,omitempty"`
+	Identity     SourceIdentity          `yaml:"identity,omitempty" json:"identity,omitempty"`
+	Networkd     manifest.NetworkdConfig `yaml:"networkd,omitempty" json:"networkd,omitempty"`
+	Install      SourceInstallLayer      `yaml:"install,omitempty" json:"install,omitempty"`
+	Kubernetes   SourceKubernetesLayer   `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty"`
+	Bootstrap    SourceBootstrapLayer    `yaml:"bootstrap,omitempty" json:"bootstrap,omitempty"`
 }
 
 type SourceNodeLayer struct {
@@ -342,23 +342,34 @@ func DecodeSource(reader io.Reader) (SourceConfig, error) {
 
 func LowerSource(source SourceConfig, planning PlanningInputs) (clusterplan.Config, error) {
 	source = defaultSource(source)
+	if len(source.Spec.Nodes) == 0 {
+		return clusterplan.Config{}, fmt.Errorf("spec.nodes must not be empty")
+	}
 	selection, err := lowerKubernetesSelection(source, planning.KubernetesBundle)
 	if err != nil {
 		return clusterplan.Config{}, err
 	}
 	nodes := make([]clusterplan.Node, 0, len(source.Spec.Nodes))
+	hasControlPlane := false
 	for _, node := range source.Spec.Nodes {
+		role := sourceNodeRole(node)
+		if role == inventory.RoleControlPlane {
+			hasControlPlane = true
+		}
 		layer := lowerNodeLayer(sourceNodeLayer(node))
 		layer.Bootstrap.Address = strings.TrimSpace(node.Bootstrap.Address)
 		if access, ok := planning.BootstrapAccess[node.Name]; ok {
 			layer.Bootstrap.Access = access
 		}
-		layer.Kubernetes.KubeadmConfigRef = defaultKubeadmConfigRef(node.SystemRole)
+		layer.Kubernetes.KubeadmConfigRef = defaultKubeadmConfigRef(role)
 		nodes = append(nodes, clusterplan.Node{
 			Name:       node.Name,
-			SystemRole: node.SystemRole,
+			SystemRole: role,
 			Overrides:  layer,
 		})
+	}
+	if !hasControlPlane {
+		return clusterplan.Config{}, fmt.Errorf("spec.nodes must include at least one node with controlPlane: true")
 	}
 	return clusterplan.Config{
 		APIVersion: clusterplan.APIVersion,
@@ -418,6 +429,13 @@ func sourceNodeLayer(node SourceNode) SourceNodeLayer {
 	}
 }
 
+func sourceNodeRole(node SourceNode) inventory.SystemRole {
+	if node.ControlPlane {
+		return inventory.RoleControlPlane
+	}
+	return inventory.RoleWorker
+}
+
 func defaultKubeadmConfigRef(role inventory.SystemRole) string {
 	switch role {
 	case inventory.RoleControlPlane:
@@ -438,7 +456,7 @@ func defaultSource(source SourceConfig) SourceConfig {
 	spec.Nodes = append([]SourceNode(nil), spec.Nodes...)
 	if strings.TrimSpace(spec.ControlPlaneEndpoint) == "" {
 		for _, node := range spec.Nodes {
-			if node.SystemRole == inventory.RoleControlPlane {
+			if node.ControlPlane {
 				if address := strings.TrimSpace(node.Bootstrap.Address); address != "" {
 					spec.ControlPlaneEndpoint = net.JoinHostPort(address, "6443")
 					break

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -50,6 +50,9 @@ func TestBuildArchiveWritesDeterministicBundle(t *testing.T) {
 	if bundle.Kind != "KatlConfigBundle" || bundle.ClusterName != "lab" || len(bundle.Nodes) != 2 {
 		t.Fatalf("bundle manifest = %#v", bundle)
 	}
+	if bundle.Nodes[0].SystemRole != string(inventory.RoleControlPlane) || bundle.Nodes[1].SystemRole != string(inventory.RoleWorker) {
+		t.Fatalf("compiled node roles = %#v", bundle.Nodes)
+	}
 	if bundle.Nodes[0].InstallMaterial.Digest == "" {
 		t.Fatalf("control-plane node record = %#v", bundle.Nodes[0])
 	}
@@ -188,7 +191,7 @@ spec:
           - `+testSSHKey+`
   nodes:
     - name: cp-1
-      systemRole: control-plane
+      controlPlane: true
       install:
         targetDisk:
           byID: /dev/disk/by-id/ata-cp-root
@@ -217,6 +220,14 @@ spec:
 	}
 	if selected.NodeMaterial.KubeadmConfig.Ref != "control-plane" || selected.KubeadmConfigs["control-plane"].Config.RenderPath == "" {
 		t.Fatalf("defaulted kubeadm = material %#v configs %#v", selected.NodeMaterial.KubeadmConfig, selected.KubeadmConfigs)
+	}
+}
+
+func TestBuildArchiveRequiresControlPlaneNode(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), "      controlPlane: true\n", "", 1)
+	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+	if err == nil || !strings.Contains(err.Error(), "at least one node with controlPlane: true") {
+		t.Fatalf("BuildArchive() error = %v, want missing control-plane guidance", err)
 	}
 }
 
@@ -361,6 +372,11 @@ func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 			want: "spec.systemRoleDefaults: field is not supported",
 		},
 		{
+			name: "system role alias",
+			raw:  strings.Replace(validSourceConfig(), "      controlPlane: true\n", "      systemRole: control-plane\n", 1),
+			want: "spec.nodes[0].systemRole: field is not supported",
+		},
+		{
 			name: "platform endpoint",
 			raw:  strings.Replace(validSourceConfig(), "  defaults:\n", "  platformAPIEndpoint: {}\n  defaults:\n", 1),
 			want: "spec.platformAPIEndpoint: field is not supported",
@@ -446,8 +462,15 @@ func TestSourceSchemaGolden(t *testing.T) {
 			t.Fatalf("root schema is missing %q", field)
 		}
 	}
+	node := document.Defs["configbundle.SourceNode"]
+	if _, ok := node.Properties["controlPlane"]; !ok {
+		t.Fatal("source node schema is missing controlPlane")
+	}
+	if _, ok := node.Properties["systemRole"]; ok {
+		t.Fatal("source node schema exposes removed systemRole")
+	}
 	got := fmt.Sprintf("%x", sha256.Sum256(data))
-	const want = "a131b02e81d1b2cf68cd7d55b032fb714a597e01d03b99892611c0370d1679c7"
+	const want = "54a2a0e591f398e4e927b84282004563a973631ecc07ea129d00ce4a125a2eec"
 	if got != want {
 		t.Fatalf("schema SHA-256 = %s, want %s; review the authoring contract before accepting a new golden", got, want)
 	}
@@ -693,7 +716,7 @@ spec:
             DHCP=yes
   nodes:
     - name: cp-1
-      systemRole: control-plane
+      controlPlane: true
       bootstrap:
         address: 10.0.0.11
       install:
@@ -706,7 +729,6 @@ spec:
           - key: node-role.kubernetes.io/control-plane
             effect: NoSchedule
     - name: worker-1
-      systemRole: worker
       bootstrap:
         address: 10.0.0.21
       install:

--- a/internal/installer/configbundle/schema.go
+++ b/internal/installer/configbundle/schema.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"gopkg.in/yaml.v3"
 )
 
@@ -61,9 +60,6 @@ type schemaBuilder struct {
 func (builder *schemaBuilder) schemaFor(t reflect.Type) schemaObject {
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
-	}
-	if t == reflect.TypeOf(inventory.SystemRole("")) {
-		return schemaObject{Type: "string", Enum: []string{string(inventory.RoleControlPlane), string(inventory.RoleWorker)}}
 	}
 	switch t.Kind() {
 	case reflect.Struct:

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -335,7 +335,7 @@ spec:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
   nodes:
     - name: cp-1
-      systemRole: control-plane
+      controlPlane: true
       install:
         targetDisk:
           byID: /dev/disk/by-id/ata-root

--- a/internal/vmtest/first_install_world.go
+++ b/internal/vmtest/first_install_world.go
@@ -1132,9 +1132,8 @@ func firstControlPlaneName(spec NodeSpec) string {
 }
 
 func firstInstallWorldSourceNode(name string, role NodeRole, diskID string) map[string]any {
-	return map[string]any{
-		"name":       name,
-		"systemRole": string(role),
+	node := map[string]any{
+		"name": name,
 		"install": map[string]any{
 			"targetDisk": map[string]any{
 				"byID":       diskID,
@@ -1142,6 +1141,10 @@ func firstInstallWorldSourceNode(name string, role NodeRole, diskID string) map[
 			},
 		},
 	}
+	if role == ControlPlane {
+		node["controlPlane"] = true
+	}
+	return node
 }
 
 func writeFirstInstallWorldManifestSource(scenario *WorldScenario, repo string, spec NodeSpec, index mkosiArtifactIndex) (string, error) {


### PR DESCRIPTION
Replace the operator-authored `systemRole` enum with `controlPlane: true`, with omission meaning worker. Katl continues to derive explicit internal roles for install and kubeadm state, while generated configs explain the simpler public choice and validation rejects the removed alias.