### PR TITLE
katlctl: separate install target selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,24 @@ installer reports exactly one safe selectable disk; ambiguous disks produce an
 error instead of a guess. Review the generated node names, roles, addresses,
 disk identities, and Kubernetes selection before applying it.
 
-When exactly one installer is waiting, no URL needs to be copied from the
-console:
+Select the node to install by its configured name or bootstrap address. A
+single-node config infers the node, so `--node` can be omitted:
 
 ```sh
 katlctl install apply --config ./cluster.yaml --node cp-1
 ```
 
-With multiple waiting installers, select the intended URL from discovery with
-`--endpoint`.
+Katl contacts the selected node's configured bootstrap address. If the
+installer is temporarily reachable somewhere else—for example, it booted with
+DHCP before applying a static address—override only the connection target:
+
+```sh
+katlctl install apply --config ./cluster.yaml --node cp-1 --endpoint 192.0.2.42
+```
+
+`--endpoint` accepts an IP, hostname, host and port, or complete HTTP(S) base
+URL. When the selected node has no bootstrap address and no override is given,
+Katl discovers a unique waiting installer.
 
 The command validates and compiles the source locally, confirms the installer
 is waiting, submits the selected configuration once, and waits for reboot-ready

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -67,8 +67,8 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 		},
 	}
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL; discovers a unique waiting installer when omitted")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name or configured address; inferred when the config contains one node")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer address or HTTP(S) base URL; overrides the selected node's bootstrap address")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "configured node name or bootstrap address; required unless the config contains one node")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
@@ -85,7 +85,7 @@ func newInstallStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 			return runInstallStatus(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer base URL; discovers a unique waiting installer when omitted")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer IP, host, host:port, or HTTP(S) base URL; discovers a unique waiting installer when omitted")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "status request timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
 	return cmd
@@ -118,7 +118,11 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if err != nil {
 		return fmt.Errorf("select node from compiled cluster config: %w", err)
 	}
-	endpointHint, err := installEndpointHint(opts.endpoint, opts.nodeName, nodeName)
+	bootstrapAddress := ""
+	if selected.InstallManifest.Node.Bootstrap != nil {
+		bootstrapAddress = selected.InstallManifest.Node.Bootstrap.NodeAddress
+	}
+	endpointHint, err := installEndpointHint(opts.endpoint, bootstrapAddress)
 	if err != nil {
 		return err
 	}
@@ -160,13 +164,12 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	return nil
 }
 
-func installEndpointHint(endpoint, selector, nodeName string) (string, error) {
+func installEndpointHint(endpoint, bootstrapAddress string) (string, error) {
 	if endpoint = strings.TrimSpace(endpoint); endpoint != "" {
-		return normalizeInstallerEndpoint(endpoint)
+		return normalizeInstallerAddress(endpoint)
 	}
-	selector = strings.TrimSpace(selector)
-	if selector != "" && selector != nodeName {
-		return normalizeInstallerAddress(selector)
+	if bootstrapAddress = strings.TrimSpace(bootstrapAddress); bootstrapAddress != "" {
+		return normalizeInstallerAddress(bootstrapAddress)
 	}
 	return "", nil
 }
@@ -205,7 +208,7 @@ func selectInstallNode(manifest configbundle.BundleManifest, selector string) (s
 		sort.Strings(matches)
 		return "", fmt.Errorf("--node address %q matches multiple nodes (%s); use a node name", selector, strings.Join(matches, ", "))
 	}
-	return "", fmt.Errorf("--node %q does not match a configured node name or address; choose %s", selector, installNodeChoices(manifest))
+	return "", fmt.Errorf("--node %q does not match a configured node name or bootstrap address; choose %s; use --endpoint to override the selected installer's current address", selector, installNodeChoices(manifest))
 }
 
 func installNodeChoices(manifest configbundle.BundleManifest) string {

--- a/cmd/katlctl/install_discover.go
+++ b/cmd/katlctl/install_discover.go
@@ -156,7 +156,7 @@ func discoveredTargetDisk(installer discoveredInstaller) (manifest.DiskSelector,
 
 func resolveInstallerEndpoint(ctx context.Context, value string, timeout time.Duration) (string, error) {
 	if strings.TrimSpace(value) != "" {
-		return normalizeInstallerEndpoint(value)
+		return normalizeInstallerAddress(value)
 	}
 	if timeout <= 0 || timeout > 3*time.Second {
 		timeout = 3 * time.Second

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -238,7 +238,7 @@ func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
 	defer ts.Close()
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{"install", "status", "--endpoint", ts.URL}, &stdout, &stderr)
+	err := run(context.Background(), []string{"install", "status", "--endpoint", strings.TrimPrefix(ts.URL, "http://")}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
 	}
@@ -252,7 +252,6 @@ func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
 }
 
 func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
-	sourcePath := writeClusterConfig(t)
 	server := handoff.NewHandoffServerWithDefaultImage(nil, manifest.KatlosImage{
 		LocalRef:         "images/katlos-install-test-x86_64.squashfs",
 		SHA256:           strings.Repeat("a", 64),
@@ -264,11 +263,19 @@ func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
 	})
 	ts := httptest.NewServer(server.Handler())
 	defer ts.Close()
+	sourcePath := writeClusterConfig(t)
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source = bytes.ReplaceAll(source, []byte("10.0.0.11"), []byte(strings.TrimPrefix(ts.URL, "http://")))
+	if err := os.WriteFile(sourcePath, source, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{
+	err = run(context.Background(), []string{
 		"install", "apply", "--config", sourcePath,
-		"--endpoint", ts.URL,
 		"--no-wait",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -318,7 +325,7 @@ func TestInstallApplyAcceptsGeneratedConfigByAddress(t *testing.T) {
 	stderr.Reset()
 	if err := run(context.Background(), []string{
 		"install", "apply", "--config", outputPath,
-		"--endpoint", ts.URL,
+		"--endpoint", strings.TrimPrefix(ts.URL, "http://"),
 		"--node", "192.0.2.11",
 		"--no-wait",
 	}, &stdout, &stderr); err != nil {
@@ -375,30 +382,27 @@ func TestSelectInstallNode(t *testing.T) {
 
 func TestInstallEndpointHint(t *testing.T) {
 	for _, test := range []struct {
-		name     string
-		endpoint string
-		selector string
-		nodeName string
-		want     string
+		name             string
+		endpoint         string
+		bootstrapAddress string
+		want             string
 	}{
-		{name: "explicit endpoint", endpoint: "http://installer.test:8080", selector: "192.0.2.11", nodeName: "cp-1", want: "http://installer.test:8080"},
-		{name: "IPv4 address selector", selector: "192.0.2.11", nodeName: "cp-1", want: "http://192.0.2.11:8080"},
-		{name: "IPv6 address selector", selector: "2001:db8::11", nodeName: "cp-1", want: "http://[2001:db8::11]:8080"},
-		{name: "hostname selector", selector: "installer.home.arpa", nodeName: "cp-1", want: "http://installer.home.arpa:8080"},
-		{name: "address with port selector", selector: "192.0.2.11:9080", nodeName: "cp-1", want: "http://192.0.2.11:9080"},
-		{name: "node name discovers", selector: "cp-1", nodeName: "cp-1"},
-		{name: "inferred node discovers", nodeName: "cp-1"},
+		{name: "configured IPv4", bootstrapAddress: "192.0.2.11", want: "http://192.0.2.11:8080"},
+		{name: "configured IPv6", bootstrapAddress: "2001:db8::11", want: "http://[2001:db8::11]:8080"},
+		{name: "configured hostname", bootstrapAddress: "installer.home.arpa", want: "http://installer.home.arpa:8080"},
+		{name: "configured address with port", bootstrapAddress: "192.0.2.11:9080", want: "http://192.0.2.11:9080"},
+		{name: "explicit bare IP overrides configured address", endpoint: "192.0.2.42", bootstrapAddress: "192.0.2.11", want: "http://192.0.2.42:8080"},
+		{name: "explicit host and port overrides configured address", endpoint: "installer.test:9080", bootstrapAddress: "192.0.2.11", want: "http://installer.test:9080"},
+		{name: "explicit complete HTTP URL overrides configured address", endpoint: "http://installer.test:8080", bootstrapAddress: "192.0.2.11", want: "http://installer.test:8080"},
+		{name: "explicit complete HTTPS URL overrides configured address", endpoint: "https://installer.test:8443", bootstrapAddress: "192.0.2.11", want: "https://installer.test:8443"},
+		{name: "missing address discovers"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := installEndpointHint(test.endpoint, test.selector, test.nodeName)
+			got, err := installEndpointHint(test.endpoint, test.bootstrapAddress)
 			if err != nil || got != test.want {
 				t.Fatalf("installEndpointHint() = %q, %v, want %q", got, err, test.want)
 			}
 		})
-	}
-
-	if _, err := installEndpointHint("installer.test:8080", "192.0.2.11", "cp-1"); err == nil || !strings.Contains(err.Error(), "scheme must be http or https") {
-		t.Fatalf("bare explicit endpoint error = %v", err)
 	}
 }
 
@@ -411,6 +415,11 @@ func TestInstallApplyHelpKeepsBundleInternal(t *testing.T) {
 	help := stdout.String()
 	if !strings.Contains(help, "katlctl install apply --config cluster.yaml") || !strings.Contains(help, "--config string") {
 		t.Fatalf("help does not advertise unified config input:\n%s", help)
+	}
+	for _, guidance := range []string{"configured node name or bootstrap address", "overrides the selected node's bootstrap address"} {
+		if !strings.Contains(help, guidance) {
+			t.Fatalf("help does not explain %q:\n%s", guidance, help)
+		}
 	}
 	for _, hiddenDetail := range []string{"--config-bundle", "--source", "--token", "--token-file"} {
 		if strings.Contains(help, hiddenDetail) {

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -323,9 +323,19 @@ Apply the cluster source directly:
 katlctl install apply --config ./cluster.yaml --node cp-1
 ```
 
-`katlctl` selects the endpoint automatically when exactly one installer is
-waiting. If multiple installers are present, choose the intended discovery
-result with `--endpoint URL`.
+`--node` selects the logical config entry by its configured name or bootstrap
+address and is optional only for a single-node config. `katlctl` contacts that
+node's bootstrap address by default. If the installer is currently using a
+different address, such as a DHCP lease before the configured static network
+is installed, override only the connection target:
+
+```sh
+katlctl install apply --config ./cluster.yaml --node cp-1 --endpoint 192.0.2.42
+```
+
+The endpoint override accepts a bare IP or hostname, `host:port`, or a complete
+HTTP(S) base URL. If the selected node has no bootstrap address and no override
+is supplied, `katlctl` falls back to discovering one waiting installer.
 
 For the worker, boot the same ISO and apply the same source with
 `--node worker-1`. `katlctl install apply` compiles and validates the source and


### PR DESCRIPTION
Select install nodes only by their configured name or bootstrap address, with single-node inference. The selected bootstrap address is now the default handoff target, while --endpoint cleanly overrides connectivity using IP, host, host:port, or complete HTTP(S) URL syntax.

This lets an installer boot on DHCP while the cluster config describes its eventual static address.