### PR TITLE
build: separate kubernetes sysext production

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -166,7 +166,7 @@ jobs:
         shell: bash
         run: |
           scripts/mkosi build-runtime
-          scripts/mkosi build-kubernetes-sysext
+          scripts/build-kubernetes-sysext
 
       - name: Verify built runtime and Kubernetes sysext
         shell: bash

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -55,8 +55,11 @@ updates, GUI tools, and end-user asset publishing.
 
 ## Required For The Current Loop
 
-- `scripts/mkosi`: builds installer, runtime, Kubernetes sysext, and KatlOS
+- `scripts/mkosi`: builds installer, runtime, and KatlOS
   image artifacts through the containerized mkosi builder.
+- `scripts/build-kubernetes-sysext`: explicitly builds one Kubernetes sysext
+  from the selected release manifest and package versions. VM upgrade fixtures
+  call the same builder with explicit version and output inputs.
 - `scripts/vmtest-run`: runs enabled VM, first-install, installed-runtime, and
   multinode kubeadm smokes through a runner-created world.
 - `libvirt`/`virsh`: defines, starts, observes, and tears down local VM test
@@ -66,10 +69,11 @@ updates, GUI tools, and end-user asset publishing.
 - `git commit-wrapped`: required for agent-authored commits.
 
 The supported top-level script surface is intentionally small. Use
-`scripts/mkosi` for local build artifacts and `scripts/vmtest-run` for enabled
-test worlds. Other scripts are compatibility wrappers, debug aids, or temporary
-validators for scaffolding work; do not treat the whole `scripts/` directory as
-the public developer interface.
+`scripts/mkosi` for KatlOS image artifacts,
+`scripts/build-kubernetes-sysext` for Kubernetes payload artifacts, and
+`scripts/vmtest-run` for enabled test worlds. Other scripts are compatibility
+wrappers, debug aids, or temporary validators for scaffolding work; do not
+treat the whole `scripts/` directory as the public developer interface.
 
 ## Nix Dev Shell
 

--- a/docs/internal/adrs/adr-004-tooling-layout-policy.md
+++ b/docs/internal/adrs/adr-004-tooling-layout-policy.md
@@ -315,7 +315,8 @@ world path.
 
 | Script | Current role | Policy action |
 | --- | --- | --- |
-| `scripts/mkosi` | Supported build entrypoint and containerized mkosi adapter | Keep as the top-level mkosi adapter while scaffolding. Artifact metadata and package provenance are delegated to `cmd/katl-mkosi-artifacts`; move Kubernetes repository mutation and remaining build policy into Go or mkosi config as they stabilize. |
+| `scripts/mkosi` | Supported KatlOS image build entrypoint and containerized mkosi adapter | Keep as the generic top-level mkosi adapter while scaffolding. It must not select Kubernetes payload versions, outputs, or VM fixture variants. Artifact metadata and package provenance are delegated to `cmd/katl-mkosi-artifacts`. |
+| `scripts/build-kubernetes-sysext` | Explicit Kubernetes sysext producer over the generic mkosi adapter | Keep as a narrow artifact entrypoint. It owns the Kubernetes repository/profile preparation and one requested output; callers, including VM tests, supply non-release versions and output names explicitly. Move its remaining structured validation and cache policy into Go as they stabilize. |
 | `scripts/vmtest-run` | Supported enabled VM world entrypoint over `go test -exec` | Keep as the canonical developer entrypoint. Keep it thin; move fixture policy, leases, aggregation, and host policy into Go helpers or a future Go runner command. |
 | `scripts/vmtest-exec` | `go test -exec` package-binary wrapper | Keep as an implementation detail of `scripts/vmtest-run`; do not document it as a developer entrypoint. |
 | `scripts/vmtest-debug` | Compatibility wrapper for retained-domain debug target rendering | Keep as a thin wrapper around `cmd/katl-vmtest-debug`; debug target discovery and rendering policy live in Go. |

--- a/internal/scriptstest/kubernetes_sysext_builder_test.go
+++ b/internal/scriptstest/kubernetes_sysext_builder_test.go
@@ -1,0 +1,136 @@
+package scriptstest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestKubernetesSysextBuilderOwnsProfileAndOutputSelection(t *testing.T) {
+	realRepo := repoRoot(t)
+	repo := t.TempDir()
+	buildDir := filepath.Join(repo, "_build", "mkosi")
+	profileDir := filepath.Join(repo, "mkosi.profiles", "kubernetes-sysext")
+	repoFile := filepath.Join(profileDir, "mkosi.sandbox", "etc", "yum.repos.d", "kubernetes.repo")
+	profile := filepath.Join(profileDir, "mkosi.conf")
+	manifest := filepath.Join(profileDir, "kubernetes.env")
+	for _, dir := range []string{filepath.Join(repo, "scripts"), filepath.Dir(repoFile), buildDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	builder, err := os.ReadFile(filepath.Join(realRepo, "scripts", "build-kubernetes-sysext"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "scripts", "build-kubernetes-sysext"), builder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalProfile := `[Output]
+Output=katl-kubernetes
+
+[Content]
+Packages=
+        kubeadm-old.x86_64
+        kubelet-old.x86_64
+        kubectl-old.x86_64
+        cri-tools-old.x86_64
+        ethtool
+        socat
+`
+	originalRepo := "[old]\nbaseurl=https://old.invalid/\n"
+	writeTemporaryFile(t, profile, originalProfile)
+	writeTemporaryFile(t, repoFile, originalRepo)
+	writeTemporaryFile(t, manifest, `KATL_KUBERNETES_MINOR=v1.36
+KATL_KUBERNETES_REPO_ID=kubernetes
+KATL_KUBERNETES_REPO_BASEURL=https://packages.example/v1.36/rpm/
+KATL_KUBERNETES_REPO_GPGKEY=https://packages.example/v1.36/rpm/key
+KATL_KUBERNETES_PAYLOAD_VERSION=v1.36.1
+KATL_KUBERNETES_KUBEADM_VERSION=0:1.36.1-1
+KATL_KUBERNETES_KUBELET_VERSION=0:1.36.1-1
+KATL_KUBERNETES_KUBECTL_VERSION=0:1.36.1-1
+KATL_KUBERNETES_CRITOOLS_VERSION=0:1.36.0-1
+KATL_KUBERNETES_ETHTOOL_VERSION=
+KATL_KUBERNETES_SOCAT_VERSION=
+`)
+	writeTemporaryFile(t, filepath.Join(buildDir, "katl-runtime-root.squashfs"), "runtime")
+	writeTemporaryFile(t, filepath.Join(buildDir, "katl-runtime-root.squashfs.json"), `{"sha256":"runtime"}`)
+
+	bin := filepath.Join(repo, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mkosiArgs := filepath.Join(repo, "mkosi-args.txt")
+	goArgs := filepath.Join(repo, "go-args.txt")
+	writeFakeExecutable(t, filepath.Join(repo, "scripts"), "mkosi", `printf '%s\n' "$@" > "$KATL_FAKE_MKOSI_ARGS"
+printf 'sysext payload\n' > "$KATL_MKOSI_BUILD_DIR/katl-kubernetes.raw"
+printf 'kubeadm x 0:1.36.1-1 kubernetes\n'
+printf 'kubelet x 0:1.36.1-1 kubernetes\n'
+printf 'kubectl x 0:1.36.1-1 kubernetes\n'
+printf 'cri-tools x 0:1.36.0-1 kubernetes\n'
+printf 'ethtool x 1:1.0 fedora\n'
+printf 'socat x 1:1.0 fedora\n'
+`)
+	writeFakeExecutable(t, bin, "go", `printf '%s\n' "$@" > "$KATL_FAKE_GO_ARGS"
+artifact=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--artifact" ]]; then
+    artifact="$2"
+    break
+  fi
+  shift
+done
+[[ -n "$artifact" ]]
+digest="$(sha256sum "$artifact")"
+digest="${digest%% *}"
+size="$(stat -c %s "$artifact")"
+printf '{"sha256":"%s","sizeBytes":%s}\n' "$digest" "$size" > "$artifact.json"
+(
+  cd "$(dirname "$artifact")"
+  sha256sum "$(basename "$artifact")" > "$(basename "$artifact").sha256"
+)
+`)
+
+	cmd := exec.Command(filepath.Join(repo, "scripts", "build-kubernetes-sysext"), "--output", "katl-kubernetes-upgrade", "--no-cache")
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"KATL_REPO_ROOT="+repo,
+		"KATL_MKOSI_BUILD_DIR="+buildDir,
+		"KATL_FAKE_MKOSI_ARGS="+mkosiArgs,
+		"KATL_FAKE_GO_ARGS="+goArgs,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build-kubernetes-sysext failed: %v\n%s", err, output)
+	}
+
+	args := readLinesForScripts(t, mkosiArgs)
+	for _, want := range []string{
+		"--profile",
+		"kubernetes-sysext",
+		"-f",
+		"build",
+		"KATL_KUBERNETES_PAYLOAD_VERSION=v1.36.1",
+		"KATL_KUBERNETES_KUBEADM_VERSION=0:1.36.1-1",
+	} {
+		if !containsString(args, want) {
+			t.Fatalf("mkosi args missing %q: %#v", want, args)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(buildDir, "katl-kubernetes-upgrade.raw.json")); err != nil {
+		t.Fatalf("custom sysext output metadata: %v", err)
+	}
+	if got := string(mustReadFile(t, profile)); got != originalProfile {
+		t.Fatalf("profile was not restored:\n%s", got)
+	}
+	if got := string(mustReadFile(t, repoFile)); got != originalRepo {
+		t.Fatalf("repository file was not restored:\n%s", got)
+	}
+	if got := strings.Join(readLinesForScripts(t, goArgs), " "); !strings.Contains(got, "--artifact "+filepath.Join(buildDir, "katl-kubernetes-upgrade.raw")) {
+		t.Fatalf("metadata command did not receive the explicit output: %s", got)
+	}
+}

--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -396,6 +396,10 @@ func TestVMTestRunBuildsDefaultArtifacts(t *testing.T) {
 set -euo pipefail
 printf '%s\n' "$*" >> "$KATL_FAKE_MKOSI_ARGS"
 `)
+	writeExecutable(t, filepath.Join(repo, "scripts", "build-kubernetes-sysext"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${*:-default}" >> "$KATL_FAKE_SYSEXT_ARGS"
+`)
 	writeExecutable(t, filepath.Join(repo, "scripts", "vmtest-exec"), `#!/usr/bin/env bash
 set -euo pipefail
 export KATL_VMTEST_RUN=1
@@ -409,6 +413,7 @@ exec "$@"
 	runDir := filepath.Join(tmp, "run")
 	goArgsPath := filepath.Join(tmp, "go-args.txt")
 	mkosiArgsPath := filepath.Join(tmp, "mkosi-args.txt")
+	sysextArgsPath := filepath.Join(tmp, "sysext-args.txt")
 	env := appendHostEnv(os.Environ(), host,
 		"KATL_VMTEST_GO="+fakeGo,
 		"KATL_FAKE_GO_ARGS="+goArgsPath,
@@ -416,6 +421,7 @@ exec "$@"
 		"KATL_FAKE_CHILD_ARGS="+filepath.Join(tmp, "child-args.txt"),
 		"KATL_FAKE_CHILD_ENV="+filepath.Join(tmp, "child-env.txt"),
 		"KATL_FAKE_MKOSI_ARGS="+mkosiArgsPath,
+		"KATL_FAKE_SYSEXT_ARGS="+sysextArgsPath,
 		"KATL_VMTEST_RUN_ID=run-build-default",
 		"KATL_VMTEST_RUN_DIR="+runDir,
 		"TMPDIR="+tmp,
@@ -441,8 +447,11 @@ exec "$@"
 	}
 
 	mkosiArgs := readLines(t, mkosiArgsPath)
-	if !reflect.DeepEqual(mkosiArgs, []string{"build-katlos-install-image", "build-katlos-upgrade-image", "build-kubernetes-sysext", "build-installer-iso"}) {
+	if !reflect.DeepEqual(mkosiArgs, []string{"build-katlos-install-image", "build-katlos-upgrade-image", "build-installer-iso"}) {
 		t.Fatalf("mkosi args = %#v", mkosiArgs)
+	}
+	if sysextArgs := readLines(t, sysextArgsPath); !reflect.DeepEqual(sysextArgs, []string{"default"}) {
+		t.Fatalf("sysext args = %#v", sysextArgs)
 	}
 	goArgs := readLines(t, goArgsPath)
 	if !reflect.DeepEqual(goArgs, []string{
@@ -486,6 +495,10 @@ case "$*" in
     printf 'mkosi cache hit: katlos-install-image artifacts match the current repo\n'
     ;;
 esac
+`)
+	writeExecutable(t, filepath.Join(repo, "scripts", "build-kubernetes-sysext"), `#!/usr/bin/env bash
+set -euo pipefail
+printf 'sysext cache hit: katl-kubernetes artifacts match the current inputs\n'
 `)
 	writeExecutable(t, filepath.Join(repo, "scripts", "vmtest-exec"), `#!/usr/bin/env bash
 set -euo pipefail

--- a/scripts/build-kubernetes-sysext
+++ b/scripts/build-kubernetes-sysext
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${KATL_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+build_dir="${KATL_MKOSI_BUILD_DIR:-$repo_root/_build/mkosi}"
+manifest="${KATL_KUBERNETES_MANIFEST:-$repo_root/mkosi.profiles/kubernetes-sysext/kubernetes.env}"
+output_name="katl-kubernetes"
+use_cache=1
+
+usage() {
+    echo "usage: scripts/build-kubernetes-sysext [--output NAME] [--no-cache]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output)
+            [[ $# -ge 2 ]] || {
+                usage
+                exit 2
+            }
+            output_name="$2"
+            shift 2
+            ;;
+        --no-cache)
+            use_cache=0
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown Kubernetes sysext build argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! "$output_name" =~ ^[a-z0-9][a-z0-9.-]*$ ]]; then
+    echo "error: --output must be a file basename containing lowercase letters, digits, dots, or dashes" >&2
+    exit 2
+fi
+if [[ ! -f "$manifest" ]]; then
+    echo "error: Kubernetes sysext manifest not found: $manifest" >&2
+    exit 1
+fi
+
+# shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
+# shellcheck disable=SC1090,SC1091
+source "$manifest"
+cd "$repo_root"
+
+profile="$repo_root/mkosi.profiles/kubernetes-sysext/mkosi.conf"
+repo_file="$repo_root/mkosi.profiles/kubernetes-sysext/mkosi.sandbox/etc/yum.repos.d/kubernetes.repo"
+runtime_artifact="$build_dir/katl-runtime-root.squashfs"
+runtime_metadata="$runtime_artifact.json"
+base_artifact="$build_dir/katl-kubernetes.raw"
+artifact="$build_dir/$output_name.raw"
+stamp="$build_dir/.katl-stamps/kubernetes-sysext-$output_name.sha256"
+build_commit="${KATL_BUILD_COMMIT:-${KATL_VERSION:-0.0.0-dev}}"
+architecture="${KATL_ARCHITECTURE:-$(uname -m)}"
+
+builder_image_identity() {
+    local runtime="${KATL_CONTAINER_RUNTIME:-}"
+    local image="${KATL_MKOSI_IMAGE:-localhost/katl-mkosi-builder:fedora-44-go-squashfs}"
+    if [[ -z "$runtime" ]]; then
+        if command -v podman >/dev/null 2>&1; then
+            runtime=podman
+        elif command -v docker >/dev/null 2>&1; then
+            runtime=docker
+        else
+            runtime=unavailable
+        fi
+    fi
+    case "$runtime" in
+        docker | podman)
+            "$runtime" image inspect --format '{{.Id}}' "$image" 2>/dev/null || printf '%s\n' "$image"
+            ;;
+        *)
+            printf '%s\n' "$runtime"
+            ;;
+    esac
+}
+
+list_cache_inputs() {
+    {
+        printf '%s\0' \
+            Containerfile.mkosi \
+            containers-policy.json \
+            go.mod \
+            go.sum \
+            scripts/build-kubernetes-sysext \
+            scripts/mkosi
+        git -C "$repo_root" ls-files -z \
+            cmd/katl-mkosi-artifacts \
+            internal/installer/manifest \
+            mkosi.profiles/kubernetes-sysext
+        git -C "$repo_root" ls-files --others --exclude-standard -z -- \
+            cmd/katl-mkosi-artifacts \
+            internal/installer/manifest \
+            mkosi.profiles/kubernetes-sysext
+    } | sort -zu
+}
+
+cache_fingerprint() {
+    local path digest
+    digest="$({
+        printf 'output=%s\n' "$output_name"
+        printf 'builder-image=%s\n' "${KATL_MKOSI_IMAGE:-localhost/katl-mkosi-builder:fedora-44-go-squashfs}"
+        printf 'builder-image-identity=%s\n' "$(builder_image_identity)"
+        printf 'KATL_BUILD_COMMIT=%s\n' "$build_commit"
+        printf 'KATL_VERSION=%s\n' "${KATL_VERSION:-}"
+        printf 'KATL_ARCHITECTURE=%s\n' "$architecture"
+        printf 'KATL_KUBERNETES_MINOR=%s\n' "$KATL_KUBERNETES_MINOR"
+        printf 'KATL_KUBERNETES_REPO_ID=%s\n' "$KATL_KUBERNETES_REPO_ID"
+        printf 'KATL_KUBERNETES_REPO_BASEURL=%s\n' "$KATL_KUBERNETES_REPO_BASEURL"
+        printf 'KATL_KUBERNETES_REPO_GPGKEY=%s\n' "$KATL_KUBERNETES_REPO_GPGKEY"
+        printf 'KATL_KUBERNETES_PAYLOAD_VERSION=%s\n' "$KATL_KUBERNETES_PAYLOAD_VERSION"
+        printf 'KATL_KUBERNETES_ARTIFACT_REVISION=%s\n' "$KATL_KUBERNETES_ARTIFACT_REVISION"
+        printf 'KATL_KUBERNETES_KUBEADM_VERSION=%s\n' "$KATL_KUBERNETES_KUBEADM_VERSION"
+        printf 'KATL_KUBERNETES_KUBELET_VERSION=%s\n' "$KATL_KUBERNETES_KUBELET_VERSION"
+        printf 'KATL_KUBERNETES_KUBECTL_VERSION=%s\n' "$KATL_KUBERNETES_KUBECTL_VERSION"
+        printf 'KATL_KUBERNETES_CRITOOLS_VERSION=%s\n' "$KATL_KUBERNETES_CRITOOLS_VERSION"
+        while IFS= read -r -d "" path; do
+            if [[ -f "$repo_root/$path" ]]; then
+                sha256sum "$repo_root/$path"
+            else
+                printf 'missing %s\n' "$path"
+            fi
+        done < <(list_cache_inputs)
+        if [[ -f "$runtime_metadata" ]]; then
+            sha256sum "$runtime_metadata"
+        else
+            printf 'missing %s\n' "$runtime_metadata"
+        fi
+    } | sha256sum)"
+    printf '%s\n' "${digest%% *}"
+}
+
+artifact_is_valid() {
+    local digest size
+    [[ -f "$artifact" && -f "$artifact.json" && -f "$artifact.sha256" ]] || return 1
+    (cd "$build_dir" && sha256sum --status -c "$(basename "$artifact.sha256")") || return 1
+    digest="$(sha256sum "$artifact")"
+    digest="${digest%% *}"
+    size="$(stat -c %s "$artifact")"
+    jq -e --arg digest "$digest" --argjson size "$size" \
+        '.sha256 == $digest and .sizeBytes == $size' "$artifact.json" >/dev/null
+}
+
+if [[ "$use_cache" == 1 && -f "$stamp" ]] && artifact_is_valid; then
+    current="$(cache_fingerprint)"
+    recorded="$(<"$stamp")"
+    if [[ "$current" == "$recorded" ]]; then
+        printf 'sysext cache hit: %s artifacts match the current inputs\n' "$output_name" >&2
+        exit 0
+    fi
+fi
+
+repo_backup="$(mktemp)"
+profile_backup="$(mktemp)"
+log="$(mktemp)"
+cp "$repo_file" "$repo_backup"
+cp "$profile" "$profile_backup"
+
+restore_build_files() {
+    if [[ -f "$repo_backup" ]]; then
+        cp "$repo_backup" "$repo_file"
+        rm -f "$repo_backup"
+    fi
+    if [[ -f "$profile_backup" ]]; then
+        cp "$profile_backup" "$profile"
+        rm -f "$profile_backup"
+    fi
+}
+trap 'restore_build_files; rm -f "$log"' EXIT
+
+mkdir -p "$(dirname "$repo_file")" "$build_dir"
+cat >"$repo_file" <<EOF
+[${KATL_KUBERNETES_REPO_ID}]
+name=Kubernetes ${KATL_KUBERNETES_MINOR}
+baseurl=${KATL_KUBERNETES_REPO_BASEURL}
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=${KATL_KUBERNETES_REPO_GPGKEY}
+EOF
+
+for package in kubeadm kubelet kubectl cri-tools; do
+    case "$package" in
+        kubeadm) version="$KATL_KUBERNETES_KUBEADM_VERSION" ;;
+        kubelet) version="$KATL_KUBERNETES_KUBELET_VERSION" ;;
+        kubectl) version="$KATL_KUBERNETES_KUBECTL_VERSION" ;;
+        cri-tools) version="$KATL_KUBERNETES_CRITOOLS_VERSION" ;;
+    esac
+    version="${version%.x86_64}.x86_64"
+    sed -i -E "s#^([[:space:]]*)${package}-[^[:space:]]+#\\1${package}-${version}#" "$profile"
+done
+
+rm -f "$artifact" "$artifact.json" "$artifact.sha256"
+set +e
+"$repo_root/scripts/mkosi" \
+    --environment "KATL_KUBERNETES_MINOR=$KATL_KUBERNETES_MINOR" \
+    --environment "KATL_KUBERNETES_REPO_ID=$KATL_KUBERNETES_REPO_ID" \
+    --environment "KATL_KUBERNETES_REPO_BASEURL=$KATL_KUBERNETES_REPO_BASEURL" \
+    --environment "KATL_KUBERNETES_PAYLOAD_VERSION=$KATL_KUBERNETES_PAYLOAD_VERSION" \
+    --environment "KATL_KUBERNETES_KUBEADM_VERSION=$KATL_KUBERNETES_KUBEADM_VERSION" \
+    --environment "KATL_KUBERNETES_KUBELET_VERSION=$KATL_KUBERNETES_KUBELET_VERSION" \
+    --environment "KATL_KUBERNETES_KUBECTL_VERSION=$KATL_KUBERNETES_KUBECTL_VERSION" \
+    --environment "KATL_KUBERNETES_CRITOOLS_VERSION=$KATL_KUBERNETES_CRITOOLS_VERSION" \
+    --profile kubernetes-sysext \
+    -f build 2>&1 | tee "$log"
+build_status=("${PIPESTATUS[@]}")
+set -e
+restore_build_files
+if [[ "${build_status[0]}" -ne 0 || "${build_status[1]}" -ne 0 ]]; then
+    exit 1
+fi
+if [[ ! -f "$base_artifact" ]]; then
+    echo "error: Kubernetes sysext artifact not found: $base_artifact" >&2
+    exit 1
+fi
+if [[ "$artifact" != "$base_artifact" ]]; then
+    cp --reflink=auto "$base_artifact" "$artifact"
+fi
+
+KATL_BUILD_COMMIT="$build_commit" \
+KATL_ARCHITECTURE="$architecture" \
+    go run ./cmd/katl-mkosi-artifacts write-kubernetes-sysext-from-log \
+    --artifact "$artifact" \
+    --log "$log" \
+    --runtime-artifact "$runtime_artifact" \
+    --runtime-metadata "$runtime_metadata" \
+    --repo-id "$KATL_KUBERNETES_REPO_ID" \
+    --repo-base-url "$KATL_KUBERNETES_REPO_BASEURL" \
+    --repo-minor "$KATL_KUBERNETES_MINOR" \
+    --expected-payload-version "$KATL_KUBERNETES_PAYLOAD_VERSION" \
+    --expected-kubeadm-version "$KATL_KUBERNETES_KUBEADM_VERSION" \
+    --expected-kubelet-version "$KATL_KUBERNETES_KUBELET_VERSION" \
+    --expected-kubectl-version "$KATL_KUBERNETES_KUBECTL_VERSION" \
+    --expected-cri-tools-version "$KATL_KUBERNETES_CRITOOLS_VERSION" \
+    --expected-ethtool-version "$KATL_KUBERNETES_ETHTOOL_VERSION" \
+    --expected-socat-version "$KATL_KUBERNETES_SOCAT_VERSION" >/dev/null
+
+if [[ "$use_cache" == 1 ]]; then
+    mkdir -p "$(dirname "$stamp")"
+    cache_fingerprint >"$stamp"
+fi

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -9,10 +9,6 @@ build_dir="${KATL_MKOSI_BUILD_DIR:-$repo_root/_build/mkosi}"
 stamp_dir="$build_dir/.katl-stamps"
 go_mod_cache="${KATL_GO_MOD_CACHE:-$repo_root/_build/go-mod}"
 go_build_cache="${KATL_GO_BUILD_CACHE:-$repo_root/_build/go-cache}"
-kube_manifest="$repo_root/mkosi.profiles/kubernetes-sysext/kubernetes.env"
-# shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
-# shellcheck disable=SC1091
-source "$kube_manifest"
 mkosi_env=(--environment "KATL_BUILD_COMMIT=$build_commit")
 if [[ -n "${KATL_VERSION:-}" ]]; then
     mkosi_env+=(--environment "KATL_VERSION=$KATL_VERSION")
@@ -27,14 +23,9 @@ case "$vmtest_image_support" in
 esac
 mkosi_env+=(--environment "KATL_VMTEST_IMAGE_SUPPORT=$vmtest_image_support")
 emit_runtime_artifact=0
-emit_kubernetes_sysext=0
 emit_installer_iso=0
 installer_package_set=""
 cache_target=""
-kubernetes_repo_file=""
-kubernetes_repo_backup=""
-kubernetes_profile_file=""
-kubernetes_profile_backup=""
 mkosi_installer_package_set=""
 container_mkosi_storage_args=(
     --output-directory /mkosi-build
@@ -55,60 +46,6 @@ prepare_build_dirs() {
         "$go_mod_cache" \
         "$go_build_cache"
 }
-
-write_kubernetes_repo_file() {
-    local path="$1"
-    mkdir -p "$(dirname "$path")"
-    cat > "$path" <<EOF
-[${KATL_KUBERNETES_REPO_ID}]
-name=Kubernetes ${KATL_KUBERNETES_MINOR}
-baseurl=${KATL_KUBERNETES_REPO_BASEURL}
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=${KATL_KUBERNETES_REPO_GPGKEY}
-EOF
-}
-
-restore_kubernetes_repo_file() {
-    if [[ -n "$kubernetes_repo_file" && -n "$kubernetes_repo_backup" && -f "$kubernetes_repo_backup" ]]; then
-        cp "$kubernetes_repo_backup" "$kubernetes_repo_file"
-        rm -f "$kubernetes_repo_backup"
-    fi
-}
-
-prepare_kubernetes_package_profile() {
-	local path="$repo_root/mkosi.profiles/kubernetes-sysext/mkosi.conf"
-	local package variable version
-	kubernetes_profile_file="$path"
-	kubernetes_profile_backup="$(mktemp)"
-	cp "$path" "$kubernetes_profile_backup"
-	for package in kubeadm kubelet kubectl cri-tools; do
-		case "$package" in
-			kubeadm) variable="${KATL_KUBERNETES_KUBEADM_VERSION:-}" ;;
-			kubelet) variable="${KATL_KUBERNETES_KUBELET_VERSION:-}" ;;
-			kubectl) variable="${KATL_KUBERNETES_KUBECTL_VERSION:-}" ;;
-			cri-tools) variable="${KATL_KUBERNETES_CRITOOLS_VERSION:-}" ;;
-		esac
-		[[ -n "$variable" ]] || continue
-		version="${variable%.x86_64}.x86_64"
-		sed -i -E "s#^([[:space:]]*)${package}-[^[:space:]]+#\\1${package}-${version}#" "$path"
-	done
-}
-
-restore_kubernetes_profile_file() {
-	if [[ -n "$kubernetes_profile_file" && -n "$kubernetes_profile_backup" && -f "$kubernetes_profile_backup" ]]; then
-		cp "$kubernetes_profile_backup" "$kubernetes_profile_file"
-		rm -f "$kubernetes_profile_backup"
-	fi
-}
-
-restore_kubernetes_build_files() {
-	restore_kubernetes_repo_file
-	restore_kubernetes_profile_file
-}
-
-trap restore_kubernetes_build_files EXIT
 
 list_repo_inputs() {
     {
@@ -160,13 +97,6 @@ cache_input_matches_target() {
                     ;;
             esac
             ;;
-        kubernetes-sysext)
-            case "$path" in
-                mkosi.profiles/kubernetes-sysext/*)
-                    return 0
-                    ;;
-            esac
-            ;;
         katlos-install-image)
             case "$path" in
                 scripts/build-katlos-install-image | mkosi.profiles/installer-image/* | mkosi.profiles/runtime/*)
@@ -194,9 +124,6 @@ target_go_binaries() {
             printf '%s\t%s\t%s\n' "included-binary:/usr/lib/katl/runtime/katl-runtime-status" "./cmd/katl-runtime-status" "plain"
             printf '%s\t%s\t%s\n' "included-binary:/usr/lib/katl/runtime/katl-generation-activate" "./cmd/katl-generation-activate" "plain"
             printf '%s\t%s\t%s\n' "included-binary:/usr/lib/katl/runtime/katl-boot-health" "./cmd/katl-boot-health" "plain"
-            printf '%s\t%s\t%s\n' "metadata-tool:katl-mkosi-artifacts" "./cmd/katl-mkosi-artifacts" "plain"
-            ;;
-        kubernetes-sysext)
             printf '%s\t%s\t%s\n' "metadata-tool:katl-mkosi-artifacts" "./cmd/katl-mkosi-artifacts" "plain"
             ;;
         katlos-install-image)
@@ -287,14 +214,6 @@ cache_fingerprint() {
             printf 'KATL_KATLOS_IMAGE_ROLE=%s\n' "${KATL_KATLOS_IMAGE_ROLE:-install}"
             printf 'KATL_RUNTIME_INTERFACE=%s\n' "${KATL_RUNTIME_INTERFACE:-katl-runtime-1}"
             printf 'KATL_VMTEST_IMAGE_SUPPORT=%s\n' "$vmtest_image_support"
-            printf 'KATL_KUBERNETES_MINOR=%s\n' "$KATL_KUBERNETES_MINOR"
-            printf 'KATL_KUBERNETES_REPO_ID=%s\n' "$KATL_KUBERNETES_REPO_ID"
-            printf 'KATL_KUBERNETES_REPO_BASEURL=%s\n' "$KATL_KUBERNETES_REPO_BASEURL"
-            printf 'KATL_KUBERNETES_PAYLOAD_VERSION=%s\n' "$KATL_KUBERNETES_PAYLOAD_VERSION"
-            printf 'KATL_KUBERNETES_KUBEADM_VERSION=%s\n' "$KATL_KUBERNETES_KUBEADM_VERSION"
-            printf 'KATL_KUBERNETES_KUBELET_VERSION=%s\n' "$KATL_KUBERNETES_KUBELET_VERSION"
-            printf 'KATL_KUBERNETES_KUBECTL_VERSION=%s\n' "$KATL_KUBERNETES_KUBECTL_VERSION"
-            printf 'KATL_KUBERNETES_CRITOOLS_VERSION=%s\n' "$KATL_KUBERNETES_CRITOOLS_VERSION"
             while IFS= read -r -d "" path; do
                 if [[ -f "$repo_root/$path" ]]; then
                     read -r file_digest _ < <(sha256sum "$repo_root/$path")
@@ -315,15 +234,6 @@ cache_fingerprint() {
             case "$target" in
                 installer-iso)
                     path="$(katlos_image_output).json"
-                    if [[ -f "$path" ]]; then
-                        read -r file_digest _ < <(sha256sum "$path")
-                        printf 'generated %s %s\n' "${path#$repo_root/}" "$file_digest"
-                    else
-                        printf 'missing %s\n' "${path#$repo_root/}"
-                    fi
-                    ;;
-                kubernetes-sysext)
-                    path="$build_dir/katl-runtime-root.squashfs.json"
                     if [[ -f "$path" ]]; then
                         read -r file_digest _ < <(sha256sum "$path")
                         printf 'generated %s %s\n' "${path#$repo_root/}" "$file_digest"
@@ -383,13 +293,6 @@ target_outputs() {
                 "$build_dir/katl-runtime.efi" \
                 "$build_dir/katl-runtime.efi.json" \
                 "$build_dir/katl-runtime.efi.sha256"
-            ;;
-        kubernetes-sysext)
-            printf '%s\n' \
-                "$build_dir/artifacts.json" \
-                "$build_dir/katl-kubernetes.raw" \
-                "$build_dir/katl-kubernetes.raw.json" \
-                "$build_dir/katl-kubernetes.raw.sha256"
             ;;
         katlos-install-image)
             local image_output
@@ -596,56 +499,6 @@ else
                 set -- --profile runtime -f build "$@"
             fi
             ;;
-        build-kubernetes-sysext)
-            shift
-            emit_kubernetes_sysext=1
-            kubernetes_repo_file="$repo_root/mkosi.profiles/kubernetes-sysext/mkosi.sandbox/etc/yum.repos.d/kubernetes.repo"
-            kubernetes_repo_backup="$(mktemp)"
-            cp "$kubernetes_repo_file" "$kubernetes_repo_backup"
-            write_kubernetes_repo_file "$kubernetes_repo_file"
-            prepare_kubernetes_package_profile
-            if [[ $# -eq 0 ]]; then
-                cache_target=kubernetes-sysext
-                prepare_cached_target "$cache_target"
-                set -- --profile kubernetes-sysext -f build
-            else
-                set -- --profile kubernetes-sysext -f build "$@"
-            fi
-            ;;
-		build-kubernetes-upgrade-sysext)
-			shift
-			if [[ $# -ne 0 ]]; then
-				echo "error: build-kubernetes-upgrade-sysext does not accept mkosi arguments" >&2
-				exit 2
-			fi
-			KATL_KUBERNETES_PAYLOAD_VERSION="${KATL_KUBERNETES_UPGRADE_PAYLOAD_VERSION:-v1.36.1}" \
-				KATL_KUBERNETES_KUBEADM_VERSION="${KATL_KUBERNETES_UPGRADE_KUBEADM_VERSION:-0:1.36.1-150500.1.1}" \
-				KATL_KUBERNETES_KUBELET_VERSION="${KATL_KUBERNETES_UPGRADE_KUBELET_VERSION:-0:1.36.1-150500.1.1}" \
-				KATL_KUBERNETES_KUBECTL_VERSION="${KATL_KUBERNETES_UPGRADE_KUBECTL_VERSION:-0:1.36.1-150500.1.1}" \
-				"$repo_root/scripts/mkosi" build-kubernetes-sysext
-			for suffix in raw raw.json; do
-				cp "$build_dir/katl-kubernetes.$suffix" "$build_dir/katl-kubernetes-upgrade.$suffix"
-			done
-			(
-				cd "$build_dir"
-				sha256sum katl-kubernetes-upgrade.raw > katl-kubernetes-upgrade.raw.sha256
-			)
-			exit 0
-			;;
-		build-kubernetes-upgrade-source-sysext)
-			shift
-			if [[ $# -ne 0 ]]; then
-				echo "error: build-kubernetes-upgrade-source-sysext does not accept mkosi arguments" >&2
-				exit 2
-			fi
-			KATL_KUBERNETES_PAYLOAD_VERSION="${KATL_KUBERNETES_UPGRADE_SOURCE_PAYLOAD_VERSION:-v1.36.0}" \
-				KATL_KUBERNETES_ARTIFACT_REVISION="${KATL_KUBERNETES_UPGRADE_SOURCE_ARTIFACT_REVISION:-3}" \
-				KATL_KUBERNETES_KUBEADM_VERSION="${KATL_KUBERNETES_UPGRADE_SOURCE_KUBEADM_VERSION:-0:1.36.0-150500.1.1}" \
-				KATL_KUBERNETES_KUBELET_VERSION="${KATL_KUBERNETES_UPGRADE_SOURCE_KUBELET_VERSION:-0:1.36.0-150500.1.1}" \
-				KATL_KUBERNETES_KUBECTL_VERSION="${KATL_KUBERNETES_UPGRADE_SOURCE_KUBECTL_VERSION:-0:1.36.0-150500.1.1}" \
-				"$repo_root/scripts/mkosi" build-kubernetes-sysext
-			exit 0
-			;;
         build-katlos-install-image)
             shift
             if [[ $# -eq 0 ]] && target_cache_hit katlos-install-image; then
@@ -695,17 +548,8 @@ run_flags=(
     --env "KATL_BUILD_COMMIT=$build_commit"
     --env "KATL_VERSION=${KATL_VERSION:-0.0.0-dev}"
     --env "KATL_EMIT_RUNTIME_ARTIFACT=$emit_runtime_artifact"
-    --env "KATL_EMIT_KUBERNETES_SYSEXT=$emit_kubernetes_sysext"
     --env "KATL_EMIT_INSTALLER_ISO=$emit_installer_iso"
     --env "KATL_VMTEST_IMAGE_SUPPORT=$vmtest_image_support"
-    --env "KATL_KUBERNETES_MINOR=$KATL_KUBERNETES_MINOR"
-    --env "KATL_KUBERNETES_REPO_ID=$KATL_KUBERNETES_REPO_ID"
-    --env "KATL_KUBERNETES_REPO_BASEURL=$KATL_KUBERNETES_REPO_BASEURL"
-    --env "KATL_KUBERNETES_PAYLOAD_VERSION=$KATL_KUBERNETES_PAYLOAD_VERSION"
-    --env "KATL_KUBERNETES_KUBEADM_VERSION=$KATL_KUBERNETES_KUBEADM_VERSION"
-    --env "KATL_KUBERNETES_KUBELET_VERSION=$KATL_KUBERNETES_KUBELET_VERSION"
-    --env "KATL_KUBERNETES_KUBECTL_VERSION=$KATL_KUBERNETES_KUBECTL_VERSION"
-    --env "KATL_KUBERNETES_CRITOOLS_VERSION=$KATL_KUBERNETES_CRITOOLS_VERSION"
 )
 chown_build=1
 
@@ -736,12 +580,12 @@ if [[ "$runtime" == direct ]]; then
         mkosi_installer_package_set="$repo_root/$installer_package_set"
         mkosi_env+=(--environment "KATL_INSTALLER_PACKAGE_SET=$mkosi_installer_package_set")
     fi
-    if [[ "$emit_runtime_artifact" == 1 || "$emit_kubernetes_sysext" == 1 || "$emit_installer_iso" == 1 ]]; then
+    if [[ "$emit_runtime_artifact" == 1 || "$emit_installer_iso" == 1 ]]; then
         echo "error: KATL_CONTAINER_RUNTIME=direct currently supports installer-image builds only" >&2
         exit 1
     fi
     log="$(mktemp)"
-    trap 'restore_kubernetes_build_files; rm -f "$log"' EXIT
+    trap 'rm -f "$log"' EXIT
     prepare_build_dirs
     direct_workspace="${KATL_MKOSI_WORKSPACE_DIR:-${TMPDIR:-/tmp}/katl-mkosi-workspace}"
     mkdir -p "$direct_workspace"
@@ -949,32 +793,6 @@ set +e
     if [[ "$status" -eq 0 && "${KATL_EMIT_RUNTIME_ARTIFACT:-0}" == 1 ]]; then
         if ! mkosi_artifacts write-runtime-index >/dev/null; then
             status=1
-        fi
-    fi
-    if [[ "$status" -eq 0 && "${KATL_EMIT_KUBERNETES_SYSEXT:-0}" == 1 ]]; then
-        artifact=_build/mkosi/katl-kubernetes.raw
-        runtime_meta=_build/mkosi/katl-runtime-root.squashfs.json
-        if [[ ! -f "$artifact" ]]; then
-            echo "error: Kubernetes sysext artifact not found: $artifact" >&2
-            status=1
-        else
-            if ! mkosi_artifacts write-kubernetes-sysext-from-log \
-                --artifact "$artifact" \
-                --log "$log" \
-                --runtime-artifact _build/mkosi/katl-runtime-root.squashfs \
-                --runtime-metadata "$runtime_meta" \
-                --repo-id "${KATL_KUBERNETES_REPO_ID:?}" \
-                --repo-base-url "${KATL_KUBERNETES_REPO_BASEURL:?}" \
-                --repo-minor "${KATL_KUBERNETES_MINOR:?}" \
-                --expected-payload-version "${KATL_KUBERNETES_PAYLOAD_VERSION:-}" \
-                --expected-kubeadm-version "${KATL_KUBERNETES_KUBEADM_VERSION:-}" \
-                --expected-kubelet-version "${KATL_KUBERNETES_KUBELET_VERSION:-}" \
-                --expected-kubectl-version "${KATL_KUBERNETES_KUBECTL_VERSION:-}" \
-                --expected-cri-tools-version "${KATL_KUBERNETES_CRITOOLS_VERSION:-}" \
-                --expected-ethtool-version "${KATL_KUBERNETES_ETHTOOL_VERSION:-}" \
-                --expected-socat-version "${KATL_KUBERNETES_SOCAT_VERSION:-}" >/dev/null; then
-                status=1
-            fi
         fi
     fi
     if [[ "$status" -eq 0 && "${KATL_EMIT_INSTALLER_ISO:-0}" == 1 ]]; then

--- a/scripts/prepare-kubernetes-release
+++ b/scripts/prepare-kubernetes-release
@@ -12,7 +12,7 @@ fi
 cd "$repo_root"
 go run ./cmd/katl-kubernetes-release prepare --payload-version "$payload_version"
 scripts/mkosi build-runtime
-scripts/mkosi build-kubernetes-sysext
+scripts/build-kubernetes-sysext
 scripts/check-kubernetes-sysext
 go test \
     ./cmd/katl-kubernetes-release \

--- a/scripts/vmtest-run
+++ b/scripts/vmtest-run
@@ -434,19 +434,53 @@ build_default_artifacts() {
 	for target in "${targets[@]}"; do
         local log
         local cache_label
+        local -a build_command
         log="$(mktemp)"
+        case "$target" in
+            build-kubernetes-sysext)
+                build_command=("$repo_root/scripts/build-kubernetes-sysext")
+                ;;
+            build-kubernetes-upgrade-sysext)
+                build_command=(
+                    env
+                    "KATL_KUBERNETES_PAYLOAD_VERSION=${KATL_KUBERNETES_UPGRADE_PAYLOAD_VERSION:-v1.36.1}"
+                    "KATL_KUBERNETES_KUBEADM_VERSION=${KATL_KUBERNETES_UPGRADE_KUBEADM_VERSION:-0:1.36.1-150500.1.1}"
+                    "KATL_KUBERNETES_KUBELET_VERSION=${KATL_KUBERNETES_UPGRADE_KUBELET_VERSION:-0:1.36.1-150500.1.1}"
+                    "KATL_KUBERNETES_KUBECTL_VERSION=${KATL_KUBERNETES_UPGRADE_KUBECTL_VERSION:-0:1.36.1-150500.1.1}"
+                    "$repo_root/scripts/build-kubernetes-sysext"
+                    --output katl-kubernetes-upgrade
+                )
+                ;;
+            build-kubernetes-upgrade-source-sysext)
+                build_command=(
+                    env
+                    "KATL_KUBERNETES_PAYLOAD_VERSION=${KATL_KUBERNETES_UPGRADE_SOURCE_PAYLOAD_VERSION:-v1.36.0}"
+                    "KATL_KUBERNETES_ARTIFACT_REVISION=${KATL_KUBERNETES_UPGRADE_SOURCE_ARTIFACT_REVISION:-3}"
+                    "KATL_KUBERNETES_KUBEADM_VERSION=${KATL_KUBERNETES_UPGRADE_SOURCE_KUBEADM_VERSION:-0:1.36.0-150500.1.1}"
+                    "KATL_KUBERNETES_KUBELET_VERSION=${KATL_KUBERNETES_UPGRADE_SOURCE_KUBELET_VERSION:-0:1.36.0-150500.1.1}"
+                    "KATL_KUBERNETES_KUBECTL_VERSION=${KATL_KUBERNETES_UPGRADE_SOURCE_KUBECTL_VERSION:-0:1.36.0-150500.1.1}"
+                    "$repo_root/scripts/build-kubernetes-sysext"
+                )
+                ;;
+            *)
+                build_command=("$repo_root/scripts/mkosi" "$target")
+                ;;
+        esac
 		cache_label="$(mkosi_cache_label_for_target "$target")"
-		printf 'vmtest building current repo artifact: scripts/mkosi %s\n' "$target" >&2
+        printf 'vmtest building current repo artifact:' >&2
+        printf ' %q' "${build_command[@]}" >&2
+        printf '\n' >&2
 		set +e
-		KATL_VMTEST_IMAGE_SUPPORT=1 "$repo_root/scripts/mkosi" "$target" 2>&1 | tee "$log" >&2
+		KATL_VMTEST_IMAGE_SUPPORT=1 "${build_command[@]}" 2>&1 | tee "$log" >&2
 		local -a build_status=("${PIPESTATUS[@]}")
 		set -e
 		if [[ "${build_status[0]}" -ne 0 || "${build_status[1]}" -ne 0 ]]; then
-			setup_failures+=("build default vmtest artifact with scripts/mkosi $target failed")
+			setup_failures+=("build default vmtest artifact $target failed")
 			rm -f "$log"
 			return 1
 		fi
-        if grep -q "^mkosi cache hit: ${cache_label} artifacts match the current repo$" "$log"; then
+        if grep -q "^mkosi cache hit: ${cache_label} artifacts match the current repo$" "$log" ||
+            grep -q '^sysext cache hit: .* artifacts match the current inputs$' "$log"; then
             artifact_build_actions["$target"]="cache-resolved"
         else
             artifact_build_actions["$target"]="built"


### PR DESCRIPTION
Moves Kubernetes sysext production into an explicit dedicated builder and keeps scripts/mkosi as the generic containerized mkosi adapter. Release callers select the release artifact directly, while vmtest owns its source and target fixture versions and output names. This removes the leaked Kubernetes and test-fixture responsibilities that made the generic adapter responsible for product-specific variants. Tracks katl-dty.15.3.3.1.