### PR TITLE
katlctl: target nodes from ClusterConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,27 +231,28 @@ Supported changes compile into generation-scoped confext/sysext state and are
 applied live or on next boot according to the domain policy. See
 [Apply runtime configuration](docs/installing.md#apply-runtime-configuration).
 
-Routine host management can use an optional workstation context created with
-`katlctl context save --config ./cluster.yaml`. The command records and checks
-topology only; it does not retrieve credentials. The current context selects a
-single-node lab automatically; pass a node name in a larger cluster:
+Routine host management uses the same `ClusterConfig` as installation and
+bootstrap. Pass a node name in a larger cluster:
 
 ```sh
-katlctl node status cp-1
-katlctl node reboot cp-1
+katlctl node status cp-1 --config ./cluster.yaml
+katlctl node reboot cp-1 --config ./cluster.yaml
 ```
+
+An optional workstation context created with `katlctl context save --config
+./cluster.yaml` shortens repeated commands; it is not a prerequisite.
 
 Status and reboot results are concise text by default. Add `--output json` for
 automation. Reboot honors any generation already staged for the next boot and
 waits for a new agent instance to report healthy; `--no-wait` deliberately
 detaches after the reboot is scheduled.
 
-Host upgrades take a release version and a node from the current workstation
-context. `katlctl` resolves the published image, stages it, reboots the node,
-and waits for the new generation to pass boot health:
+Host upgrades take a release version and select the node from `ClusterConfig`.
+`katlctl` resolves the published image, stages it, reboots the node, and waits
+for the new generation to pass boot health:
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 --node cp-1
+katlctl node upgrade v2026.7.0-alpha.9 --config ./cluster.yaml --node cp-1
 ```
 
 Add `--plan` to check the upgrade without changing or rebooting the node. The

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -206,10 +206,10 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 		"katlctl operations":              "katlctl operations list --node cp-1",
 		"katlctl operations status":       "katlctl operations status --node cp-1 --operation-id OPERATION_ID",
 		"katlctl operations list":         "katlctl operations list --node cp-1",
-		"katlctl node":                    "katlctl node status cp-1",
-		"katlctl node status":             "katlctl node status cp-1",
-		"katlctl node reboot":             "katlctl node reboot cp-1",
-		"katlctl node upgrade":            "katlctl node upgrade 2026.7.0 --node cp-1",
+		"katlctl node":                    "katlctl node status cp-1 --config cluster.yaml",
+		"katlctl node status":             "katlctl node status cp-1 --config cluster.yaml",
+		"katlctl node reboot":             "katlctl node reboot cp-1 --config cluster.yaml",
+		"katlctl node upgrade":            "katlctl node upgrade 2026.7.0 --config cluster.yaml --node cp-1",
 		"katlctl node apply":              "katlctl node apply --config cluster.yaml --node cp-1",
 		"katlctl node apply validate":     "katlctl node apply validate --config cluster.yaml --node cp-1",
 		"katlctl node apply status":       "katlctl node apply status --node cp-1",
@@ -226,16 +226,13 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 }
 
 type hostUpgradeOptions struct {
-	version           string
-	endpoint          string
-	workstationConfig string
-	contextName       string
-	nodeName          string
-	clientRequestID   string
-	actor             string
-	plan              bool
-	waitTimeout       time.Duration
-	output            string
+	version         string
+	target          managementTargetOptions
+	clientRequestID string
+	actor           string
+	plan            bool
+	waitTimeout     time.Duration
+	output          string
 }
 
 type hostUpgradeReport struct {
@@ -254,7 +251,10 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	cmd := &cobra.Command{
 		Use:   "upgrade VERSION",
 		Short: "Upgrade one KatlOS node and verify its next boot",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Upgrade one KatlOS node to a published KatlOS release, reboot it, and verify that it returns healthy.
+
+Use the same ClusterConfig used to install the node. --endpoint can override its recorded address when DHCP or local routing changed. A saved katlctl context is optional shorthand for repeated commands.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return command.Help()
@@ -263,16 +263,15 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 			return runHostUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
-	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
+	addManagementTargetFlags(cmd, &opts.target)
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
+	cmd.Flags().Lookup("actor").Hidden = true
 	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate without accepting an operation")
 	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
 	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	cmd.Flags().Lookup("output").Hidden = true
 	return cmd
 }
 
@@ -295,10 +294,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	request := operation.HostUpgrade{
 		CandidateGenerationID: "katlos-" + version,
 	}
-	target, err := resolveManagementTarget(managementTargetOptions{
-		configPath: opts.workstationConfig, contextName: opts.contextName, nodeName: opts.nodeName,
-		endpoint: opts.endpoint,
-	})
+	target, err := resolveManagementTarget(opts.target)
 	if err != nil {
 		return err
 	}

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -160,6 +160,9 @@ func TestConfigInputFlagsUseOneName(t *testing.T) {
 		"katlctl install apply":       true,
 		"katlctl node apply":          true,
 		"katlctl node apply validate": true,
+		"katlctl node reboot":         true,
+		"katlctl node status":         true,
+		"katlctl node upgrade":        true,
 		"katlctl node wipe":           true,
 	}
 	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
@@ -292,13 +295,101 @@ func TestHostUpgradeWithoutVersionPrintsHelp(t *testing.T) {
 	if err := run(context.Background(), []string{"node", "upgrade"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
-	for _, want := range []string{"Usage:", "katlctl node upgrade VERSION", "katlctl node upgrade 2026.7.0 --node cp-1"} {
+	for _, want := range []string{"Usage:", "katlctl node upgrade VERSION", "katlctl node upgrade 2026.7.0 --config cluster.yaml --node cp-1"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
 		}
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestHostUpgradeHelpLeadsWithClusterConfig(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"node", "upgrade", "--help"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	for _, want := range []string{
+		"Use the same ClusterConfig used to install the node",
+		"--config string",
+		"--node string",
+		"--endpoint string",
+		"optional saved context created by 'katlctl context save'",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+	for _, hidden := range []string{"--actor", "--context-file", "--no-wait", "--output"} {
+		if strings.Contains(stdout.String(), hidden) {
+			t.Fatalf("stdout = %q, exposes internal flag %q", stdout.String(), hidden)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestManagementTargetUsesClusterConfigAndEndpointOverride(t *testing.T) {
+	configPath := writeClusterConfig(t)
+	target, err := resolveManagementTarget(managementTargetOptions{clusterConfigPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.nodeName != "cp-1" || target.endpoint != "10.0.0.11:9443" {
+		t.Fatalf("target = %#v", target)
+	}
+
+	target, err = resolveManagementTarget(managementTargetOptions{clusterConfigPath: configPath, nodeName: "cp-1", endpoint: "192.0.2.44"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.nodeName != "cp-1" || target.endpoint != "192.0.2.44:9443" {
+		t.Fatalf("override target = %#v", target)
+	}
+
+	bundlePath, _ := writeConfigBundle(t)
+	target, err = resolveManagementTarget(managementTargetOptions{clusterConfigPath: bundlePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.nodeName != "cp-1" || target.endpoint != "10.0.0.11:9443" {
+		t.Fatalf("bundle target = %#v", target)
+	}
+}
+
+func TestManagementTargetMissingSourceExplainsRecovery(t *testing.T) {
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(t.TempDir(), "missing-katlctl.yaml"))
+	_, err := resolveManagementTarget(managementTargetOptions{nodeName: "cp-1"})
+	if err == nil {
+		t.Fatal("resolveManagementTarget() error = nil")
+	}
+	for _, want := range []string{"--config cluster.yaml", "--endpoint ADDRESS", "katlctl context save --config cluster.yaml"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, missing %q", err, want)
+		}
+	}
+}
+
+func TestManagementEndpointAcceptsOperatorAddressForms(t *testing.T) {
+	tests := map[string]string{
+		"192.0.2.44":            "192.0.2.44:9443",
+		"node.home.arpa":        "node.home.arpa:9443",
+		"node.home.arpa:10443":  "node.home.arpa:10443",
+		"tcp://node.home.arpa":  "node.home.arpa:9443",
+		"tcp://[2001:db8::44]/": "[2001:db8::44]:9443",
+	}
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			got, err := normalizeManagementAddress(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Fatalf("normalizeManagementAddress(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 
@@ -1645,13 +1736,16 @@ func TestHostUpgradeVersionStagesRebootsAndVerifiesHealth(t *testing.T) {
 		fake.generation = &agentapi.Generation{GenerationId: req.TargetGenerationId, CommitState: generation.CommitStateCommitted, BootState: generation.BootStateGood, HealthState: generation.HealthStateHealthy}
 	}
 	oldDial := dialKatlcAgent
-	dialKatlcAgent = func(context.Context, string) (katlcAgentConnection, error) {
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("dial endpoint = %q", endpoint)
+		}
 		return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
 	}
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "upgrade", "v2026.7.0-alpha.9", "--endpoint", "node-a.example.test:9443", "--timeout", "1m"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "upgrade", "v2026.7.0-alpha.9", "--config", writeClusterConfig(t), "--node", "cp-1", "--timeout", "1m"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	request := fake.submitRequest.GetHostUpgrade()

--- a/cmd/katlctl/target.go
+++ b/cmd/katlctl/target.go
@@ -1,18 +1,28 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
 	"strings"
 
+	"github.com/katl-dev/katl/internal/bootstrap/cluster"
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/katlctl/workstation"
 	"github.com/spf13/cobra"
 )
 
 type managementTargetOptions struct {
-	configPath  string
-	contextName string
-	nodeName    string
-	endpoint    string
+	clusterConfigPath string
+	configPath        string
+	contextName       string
+	nodeName          string
+	endpoint          string
 }
 
 type managementTarget struct {
@@ -21,28 +31,127 @@ type managementTarget struct {
 }
 
 func addManagementTargetFlags(cmd *cobra.Command, opts *managementTargetOptions) {
-	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "explicit katlc agent endpoint host:port")
+	cmd.Flags().StringVar(&opts.clusterConfigPath, "config", "", "ClusterConfig YAML or compiled Katl config bundle")
+	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "saved katlctl context file path")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "optional saved context created by 'katlctl context save'")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name from --config or a saved context; optional for one node")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "node address override: IP, hostname, host:port, or tcp:// URL")
 }
 
 func resolveManagementTarget(opts managementTargetOptions) (managementTarget, error) {
-	if endpoint := strings.TrimSpace(opts.endpoint); endpoint != "" {
-		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
-			return managementTarget{}, fmt.Errorf("--endpoint cannot be combined with --context-file or --context")
-		}
-		return managementTarget{nodeName: strings.TrimSpace(opts.nodeName), endpoint: endpoint}, nil
-	}
-
-	topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
-		ConfigPath:  strings.TrimSpace(opts.configPath),
-		ContextName: strings.TrimSpace(opts.contextName),
-	})
+	endpoint, err := normalizeManagementAddress(opts.endpoint)
 	if err != nil {
 		return managementTarget{}, err
 	}
-	nodeName := strings.TrimSpace(opts.nodeName)
+	if configPath := strings.TrimSpace(opts.clusterConfigPath); configPath != "" {
+		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
+			return managementTarget{}, fmt.Errorf("--config cannot be combined with --context-file or --context")
+		}
+		inv, err := readManagementInventory(configPath)
+		if err != nil {
+			return managementTarget{}, err
+		}
+		target, err := targetFromInventory(inv, opts.nodeName)
+		if err != nil {
+			return managementTarget{}, err
+		}
+		if endpoint != "" {
+			target.endpoint = endpoint
+		}
+		if target.endpoint == "" {
+			return managementTarget{}, fmt.Errorf("node %q has no bootstrap.address in --config; set it or pass --endpoint ADDRESS", target.nodeName)
+		}
+		return target, nil
+	}
+
+	useContext := strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" || endpoint == ""
+	if !useContext {
+		return managementTarget{nodeName: strings.TrimSpace(opts.nodeName), endpoint: endpoint}, nil
+	}
+	topology, err := workstation.ResolveTopology(workstation.ResolveRequest{ConfigPath: strings.TrimSpace(opts.configPath), ContextName: strings.TrimSpace(opts.contextName)})
+	if err != nil {
+		if endpoint == "" && errors.Is(err, os.ErrNotExist) {
+			return managementTarget{}, fmt.Errorf("no node address source: use --config cluster.yaml or --endpoint ADDRESS; for shorter repeated commands, first run 'katlctl context save --config cluster.yaml'")
+		}
+		return managementTarget{}, err
+	}
+	target, err := targetFromTopology(topology.Topology, opts.nodeName)
+	if err != nil {
+		return managementTarget{}, err
+	}
+	if endpoint != "" {
+		target.endpoint = endpoint
+	}
+	return target, nil
+}
+
+func readManagementInventory(path string) (inventory.Inventory, error) {
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("read --config %s: %w", path, err)
+	}
+	source, sourceErr := configbundle.DecodeSource(bytes.NewReader(data))
+	if sourceErr == nil {
+		if len(source.Spec.Nodes) == 0 {
+			return inventory.Inventory{}, fmt.Errorf("read --config %s: spec.nodes must not be empty", path)
+		}
+		inv := inventory.Inventory{ControlPlaneEndpoint: strings.TrimSpace(source.Spec.ControlPlaneEndpoint)}
+		seen := make(map[string]struct{}, len(source.Spec.Nodes))
+		for _, sourceNode := range source.Spec.Nodes {
+			name := strings.TrimSpace(sourceNode.Name)
+			if name == "" {
+				return inventory.Inventory{}, fmt.Errorf("read --config %s: spec.nodes[].name is required", path)
+			}
+			if _, exists := seen[name]; exists {
+				return inventory.Inventory{}, fmt.Errorf("read --config %s: duplicate node name %q", path, name)
+			}
+			seen[name] = struct{}{}
+			role := inventory.RoleWorker
+			if sourceNode.ControlPlane {
+				role = inventory.RoleControlPlane
+			}
+			inv.Nodes = append(inv.Nodes, inventory.Node{Name: name, Address: strings.TrimSpace(sourceNode.Bootstrap.Address), SystemRole: role})
+		}
+		return inv, nil
+	}
+	bundle, bundleErr := configbundle.ReadBundle(bytes.NewReader(data), "")
+	if bundleErr != nil {
+		return inventory.Inventory{}, fmt.Errorf("read --config %s as ClusterConfig YAML or Katl config bundle: YAML: %v; bundle: %w", path, sourceErr, bundleErr)
+	}
+	return bundle.Manifest.Cluster.BootstrapInventory, nil
+}
+
+func targetFromInventory(inv inventory.Inventory, selected string) (managementTarget, error) {
+	selected = strings.TrimSpace(selected)
+	if selected == "" {
+		if len(inv.Nodes) != 1 {
+			return managementTarget{}, fmt.Errorf("--node is required because --config contains %d nodes", len(inv.Nodes))
+		}
+		selected = inv.Nodes[0].Name
+	}
+	for _, node := range inv.Nodes {
+		if node.Name == selected {
+			endpoint := ""
+			if strings.TrimSpace(node.Address) != "" {
+				endpoint = cluster.AgentEndpoint(node.Address, "9443")
+			}
+			return managementTarget{nodeName: node.Name, endpoint: endpoint}, nil
+		}
+	}
+	return managementTarget{}, fmt.Errorf("node %q was not found in --config; choose one of: %s", selected, inventoryNodeNames(inv.Nodes))
+}
+
+func inventoryNodeNames(nodes []inventory.Node) string {
+	names := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		names = append(names, node.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func targetFromTopology(topology workstation.Topology, selected string) (managementTarget, error) {
+	nodeName := strings.TrimSpace(selected)
 	if nodeName == "" {
 		if len(topology.Nodes) != 1 {
 			return managementTarget{}, fmt.Errorf("--node is required because context %q contains %d nodes", topology.ContextName, len(topology.Nodes))
@@ -56,4 +165,44 @@ func resolveManagementTarget(opts managementTargetOptions) (managementTarget, er
 		return managementTarget{nodeName: nodeName, endpoint: node.ManagementEndpoint}, nil
 	}
 	return managementTarget{}, fmt.Errorf("node %q was not found in context %q", nodeName, topology.ContextName)
+}
+
+func normalizeManagementAddress(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if strings.Contains(value, "://") {
+		parsed, err := url.Parse(value)
+		if err != nil {
+			return "", fmt.Errorf("--endpoint is invalid: %w", err)
+		}
+		if parsed.Scheme != "tcp" {
+			return "", fmt.Errorf("--endpoint URL scheme must be tcp")
+		}
+		if parsed.Host == "" || parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return "", fmt.Errorf("--endpoint must be a tcp:// host or host:port without credentials, path, query, or fragment")
+		}
+		value = parsed.Hostname()
+		if port := parsed.Port(); port != "" {
+			value = net.JoinHostPort(value, port)
+		}
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		return net.JoinHostPort(ip.String(), "9443"), nil
+	}
+	if host, port, err := net.SplitHostPort(value); err == nil {
+		if strings.TrimSpace(host) == "" || strings.TrimSpace(port) == "" {
+			return "", fmt.Errorf("--endpoint must include a host and port")
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return "", fmt.Errorf("--endpoint port must be a number from 1 to 65535")
+		}
+		return value, nil
+	}
+	if strings.Contains(value, ":") {
+		return "", fmt.Errorf("--endpoint %q must be an IP, hostname, host:port, or tcp:// URL", value)
+	}
+	return net.JoinHostPort(value, "9443"), nil
 }

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -12,14 +12,15 @@ orchestrate availability across several hosts.
 - the selected upgrade SquashFS is from the intended KatlOS release;
 - the upgrade declares a compatible architecture and runtime interface;
 - the node can fetch release artifacts from GitHub;
-- the current workstation context contains the node management endpoint;
+- the installation `ClusterConfig` contains the node and its current management
+  address, or `--endpoint` supplies an override;
 - the command is run during the intended reboot window; and
 - Kubernetes and workload availability have been handled outside Katl.
 
 ## Plan
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 --node cp-1 --plan
+katlctl node upgrade v2026.7.0-alpha.9 --config ./cluster.yaml --node cp-1 --plan
 ```
 
 A plan response has no durable mutation and does not reboot the node.
@@ -33,8 +34,12 @@ component metadata before changing the inactive slot.
 Run the command without `--plan`:
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 --node cp-1
+katlctl node upgrade v2026.7.0-alpha.9 --config ./cluster.yaml --node cp-1
 ```
+
+For repeated day-two commands, `katlctl context save --config ./cluster.yaml`
+can save this topology locally. That context is optional; it is not a second
+cluster configuration operators must maintain.
 
 `katlctl` follows staging progress, asks the node agent to reboot,
 waits for the agent to restart, and requires the selected generation to be


### PR DESCRIPTION
Makes the installation `ClusterConfig` the normal address source for node status, reboot, and upgrade commands. Single-node configs select their node automatically, while `--endpoint` remains an explicit address override.

Upgrade help now leads with this workflow, keeps saved contexts optional, hides operation bookkeeping, and explains how to recover when no address source is available.
