### PR TITLE
katlctl: unify operator inputs and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ kubeconfig to the operator.
 optional plan contacts the selected node but does not accept an operation:
 
 ```sh
-katlctl node apply --config ./cluster.yaml --node cp-1 --plan
+katlctl node apply cp-1 --config ./cluster.yaml --plan
 ```
 
 Run the command without `--plan` to apply it. `katlctl` derives config versions,
@@ -252,19 +252,19 @@ Host upgrades take a release version and select the node from `ClusterConfig`.
 for the new generation to pass boot health:
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 --config ./cluster.yaml --node cp-1
+katlctl node upgrade v2026.7.0-alpha.9 cp-1 --config ./cluster.yaml
 ```
 
 Add `--plan` to check the upgrade without changing or rebooting the node. The
 node calculates and records image identity internally before changing the
 inactive root slot.
 
-Kubernetes upgrades use the workstation cluster context and an exact Kubernetes
+Kubernetes upgrades use the retained `ClusterConfig` and an exact Kubernetes
 version. Plan the whole control-plane-first rollout without supplying bundle
 digests, artifact paths, snapshot metadata, generation IDs, or operation IDs:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1 --plan
+katlctl kubernetes upgrade v1.36.1 --config ./cluster.yaml --plan
 ```
 
 Remove `--plan` to run the complete control-plane-first, worker-second rollout.
@@ -284,7 +284,7 @@ discoverable afterward:
 
 ```sh
 katlctl operations list \
-  --node cp-1
+  --config ./cluster.yaml --node cp-1
 ```
 
 ## Release artifacts

--- a/cmd/katlctl/cluster_status.go
+++ b/cmd/katlctl/cluster_status.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+	"github.com/spf13/cobra"
+)
+
+type clusterStatusOptions struct {
+	clusterConfig string
+	contextFile   string
+	contextName   string
+	timeout       time.Duration
+	output        string
+}
+
+type clusterNodeStatus struct {
+	Node          string `json:"node"`
+	Role          string `json:"role"`
+	Endpoint      string `json:"endpoint"`
+	Reachable     bool   `json:"reachable"`
+	Health        string `json:"health,omitempty"`
+	KatlOSVersion string `json:"katlosVersion,omitempty"`
+	Generation    string `json:"generation,omitempty"`
+	Activity      string `json:"activity,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+type clusterStatusReport struct {
+	Cluster string              `json:"cluster"`
+	Nodes   []clusterNodeStatus `json:"nodes"`
+}
+
+func newClusterStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := clusterStatusOptions{timeout: 15 * time.Second, output: "text"}
+	cmd := &cobra.Command{Use: "status", Short: "Show the state of every KatlOS node", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error {
+		_ = stderr
+		return runClusterStatus(ctx, opts, stdout)
+	}}
+	cmd.Flags().StringVar(&opts.clusterConfig, "config", "", "ClusterConfig YAML or Katl config bundle")
+	cmd.Flags().StringVar(&opts.contextFile, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "optional saved context created by 'katlctl context save'")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "per-node management request timeout")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
+	return cmd
+}
+
+func resolveClusterTopology(opts clusterStatusOptions) (workstation.ResolvedTopology, error) {
+	if strings.TrimSpace(opts.clusterConfig) != "" {
+		if strings.TrimSpace(opts.contextFile) != "" || strings.TrimSpace(opts.contextName) != "" {
+			return workstation.ResolvedTopology{}, fmt.Errorf("--config cannot be combined with --context or --context-file")
+		}
+		return resolveClusterConfigTopology(opts.clusterConfig)
+	}
+	resolved, err := workstation.ResolveTopology(workstation.ResolveRequest{ConfigPath: opts.contextFile, ContextName: opts.contextName})
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return workstation.ResolvedTopology{}, fmt.Errorf("no cluster source: use --config cluster.yaml; for shorter repeated commands, first run 'katlctl context save --config cluster.yaml'")
+	}
+	return resolved, err
+}
+
+func runClusterStatus(ctx context.Context, opts clusterStatusOptions, stdout io.Writer) error {
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
+	}
+	topology, err := resolveClusterTopology(opts)
+	if err != nil {
+		return err
+	}
+	report := clusterStatusReport{Cluster: topology.ClusterName, Nodes: make([]clusterNodeStatus, len(topology.Nodes))}
+	var wg sync.WaitGroup
+	for i, node := range topology.Nodes {
+		wg.Add(1)
+		go func(i int, node workstation.TopologyNode) {
+			defer wg.Done()
+			result := clusterNodeStatus{Node: node.Name, Role: string(node.SystemRole), Endpoint: node.ManagementEndpoint}
+			requestCtx, cancel := context.WithTimeout(ctx, opts.timeout)
+			defer cancel()
+			conn, err := dialKatlcAgent(requestCtx, node.ManagementEndpoint)
+			if err != nil {
+				result.Error = err.Error()
+				report.Nodes[i] = result
+				return
+			}
+			defer conn.Close()
+			status, current, err := readHostState(requestCtx, conn.Client, node.Name)
+			if err != nil {
+				result.Error = err.Error()
+				report.Nodes[i] = result
+				return
+			}
+			host := newHostStatusReport(node.Name, node.ManagementEndpoint, status, current)
+			result.Reachable = true
+			result.Health = host.Health
+			result.KatlOSVersion = host.KatlOSVersion
+			result.Generation = host.Generation
+			result.Activity = host.Activity
+			report.Nodes[i] = result
+		}(i, node)
+	}
+	wg.Wait()
+	sort.Slice(report.Nodes, func(i, j int) bool { return report.Nodes[i].Node < report.Nodes[j].Node })
+	if opts.output == "json" {
+		return json.NewEncoder(stdout).Encode(report)
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NODE\tROLE\tREACHABLE\tHEALTH\tKATLOS\tGENERATION\tACTIVITY")
+	for _, node := range report.Nodes {
+		reachable := "no"
+		health, version, generation, activity := "-", "-", "-", "-"
+		if node.Reachable {
+			reachable = "yes"
+			health, version, generation, activity = node.Health, node.KatlOSVersion, node.Generation, node.Activity
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", node.Node, node.Role, reachable, health, version, generation, activity)
+		if node.Error != "" {
+			fmt.Fprintf(w, "\t\t\t%s\n", node.Error)
+		}
+	}
+	return w.Flush()
+}

--- a/cmd/katlctl/cluster_status_test.go
+++ b/cmd/katlctl/cluster_status_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+func TestClusterStatusKeepsHealthyAndUnreachableNodes(t *testing.T) {
+	contextPath := writeKatlctlConfig(t, `currentContext: lab
+contexts:
+- name: lab
+  cluster: lab
+clusters:
+- name: lab
+  nodes:
+  - name: cp-1
+    managementEndpoint: 192.0.2.11:9443
+    systemRole: control-plane
+  - name: worker-1
+    managementEndpoint: 192.0.2.21:9443
+    systemRole: worker
+`)
+	client := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{CurrentGenerationId: "generation-1"},
+		generation: &agentapi.Generation{GenerationId: "generation-1", RuntimeVersion: "2026.7.0-alpha.15", CommitState: generation.CommitStateCommitted, BootState: generation.BootStateGood, HealthState: generation.HealthStateHealthy},
+	}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint == "192.0.2.21:9443" {
+			return katlcAgentConnection{}, fmt.Errorf("connection refused")
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"cluster", "status", "--context-file", contextPath, "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	var report clusterStatusReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Nodes) != 2 || !report.Nodes[0].Reachable || report.Nodes[0].Health != "OK" || report.Nodes[1].Reachable || !strings.Contains(report.Nodes[1].Error, "connection refused") {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestClusterStatusResolvesClusterConfigWithoutContext(t *testing.T) {
+	topology, err := resolveClusterTopology(clusterStatusOptions{clusterConfig: writeClusterConfig(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(topology.Nodes) != 1 || topology.Nodes[0].Name != "cp-1" || topology.Nodes[0].ManagementEndpoint != "10.0.0.11:9443" {
+		t.Fatalf("topology = %#v", topology)
+	}
+}

--- a/cmd/katlctl/enroll.go
+++ b/cmd/katlctl/enroll.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net"
 	"os"
+	"sort"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -20,6 +22,7 @@ type contextSaveOptions struct {
 	configInput string
 	contextPath string
 	contextName string
+	output      string
 }
 
 type contextSaveNodeReport struct {
@@ -37,7 +40,7 @@ type contextSaveReport struct {
 }
 
 func newContextSaveCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := contextSaveOptions{}
+	opts := contextSaveOptions{output: "text"}
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "Save installed KatlOS nodes as the current workstation context",
@@ -48,12 +51,135 @@ func newContextSaveCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	}
 	cmd.Flags().StringVar(&opts.configInput, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.contextPath, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("context-file").Hidden = true
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "context name; defaults to the cluster name")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
+	return cmd
+}
+
+type contextFileOptions struct {
+	path   string
+	output string
+}
+
+func addContextFileFlags(cmd *cobra.Command, opts *contextFileOptions) {
+	cmd.Flags().StringVar(&opts.path, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
+}
+
+func contextFilePath(path string) (string, error) {
+	if path = strings.TrimSpace(path); path != "" {
+		return path, nil
+	}
+	return workstation.ConfigPath()
+}
+
+func loadContexts(path string) (workstation.Config, string, error) {
+	resolved, err := contextFilePath(path)
+	if err != nil {
+		return workstation.Config{}, "", err
+	}
+	cfg, err := workstation.Load(resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return workstation.Config{}, resolved, fmt.Errorf("no saved katlctl contexts; create one with 'katlctl context save --config cluster.yaml'")
+		}
+		return workstation.Config{}, resolved, err
+	}
+	return cfg, resolved, nil
+}
+
+func newContextListCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := contextFileOptions{output: "text"}
+	cmd := &cobra.Command{Use: "list", Short: "List saved workstation contexts", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error {
+		_ = stderr
+		cfg, _, err := loadContexts(opts.path)
+		if err != nil {
+			return err
+		}
+		if opts.output == "json" {
+			return json.NewEncoder(stdout).Encode(cfg.Contexts)
+		}
+		if opts.output != "text" {
+			return fmt.Errorf("--output = %q, want text or json", opts.output)
+		}
+		contexts := append([]workstation.Context(nil), cfg.Contexts...)
+		sort.Slice(contexts, func(i, j int) bool { return contexts[i].Name < contexts[j].Name })
+		w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "CURRENT\tCONTEXT\tCLUSTER")
+		for _, ctx := range contexts {
+			current := ""
+			if ctx.Name == cfg.CurrentContext {
+				current = "*"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", current, ctx.Name, ctx.Cluster)
+		}
+		return w.Flush()
+	}}
+	addContextFileFlags(cmd, &opts)
+	return cmd
+}
+
+func newContextCurrentCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := contextFileOptions{output: "text"}
+	cmd := &cobra.Command{Use: "current", Short: "Print the current workstation context", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error {
+		_ = stderr
+		cfg, _, err := loadContexts(opts.path)
+		if err != nil {
+			return err
+		}
+		if opts.output == "json" {
+			return json.NewEncoder(stdout).Encode(map[string]string{"currentContext": cfg.CurrentContext})
+		}
+		if opts.output != "text" {
+			return fmt.Errorf("--output = %q, want text or json", opts.output)
+		}
+		_, err = fmt.Fprintln(stdout, cfg.CurrentContext)
+		return err
+	}}
+	addContextFileFlags(cmd, &opts)
+	return cmd
+}
+
+func newContextUseCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := contextFileOptions{output: "text"}
+	cmd := &cobra.Command{Use: "use NAME", Short: "Select the current workstation context", Args: cobra.ExactArgs(1), RunE: func(_ *cobra.Command, args []string) error {
+		_ = stderr
+		if opts.output != "text" && opts.output != "json" {
+			return fmt.Errorf("--output = %q, want text or json", opts.output)
+		}
+		cfg, path, err := loadContexts(opts.path)
+		if err != nil {
+			return err
+		}
+		name := strings.TrimSpace(args[0])
+		found := false
+		for _, ctx := range cfg.Contexts {
+			found = found || ctx.Name == name
+		}
+		if !found {
+			return fmt.Errorf("context %q was not found; run 'katlctl context list'", name)
+		}
+		cfg.CurrentContext = name
+		if err := workstation.Save(path, cfg); err != nil {
+			return err
+		}
+		if opts.output == "json" {
+			return json.NewEncoder(stdout).Encode(map[string]string{"currentContext": name})
+		}
+		_, err = fmt.Fprintf(stdout, "Current context is now %s\n", name)
+		return err
+	}}
+	addContextFileFlags(cmd, &opts)
 	return cmd
 }
 
 func runContextSave(ctx context.Context, opts contextSaveOptions, stdout, stderr io.Writer) error {
 	_ = stderr
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
+	}
 	config, err := loadKatlConfig(opts.configInput, "katlctl context save", configbundle.PlanningInputs{})
 	if err != nil {
 		return err
@@ -105,6 +231,10 @@ func runContextSave(ctx context.Context, opts contextSaveOptions, stdout, stderr
 	}
 	cfg = cfg.UpsertCluster(contextName, clusterProfile)
 	if err := workstation.Save(configPath, cfg); err != nil {
+		return err
+	}
+	if opts.output == "text" {
+		_, err := fmt.Fprintf(stdout, "Saved context %s with %d node(s)\n", contextName, len(report.Nodes))
 		return err
 	}
 	data, err := json.MarshalIndent(report, "", "  ")

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer/configbundle"
@@ -57,7 +58,7 @@ func newInstallCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Com
 }
 
 func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := installApplyOptions{timeout: 30 * time.Minute, output: "json"}
+	opts := installApplyOptions{timeout: 30 * time.Minute, output: "text"}
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply a ClusterConfig YAML or config bundle to a waiting KatlOS installer",
@@ -71,12 +72,12 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "configured node name or bootstrap address; required unless the config contains one node")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	return cmd
 }
 
 func newInstallStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := installStatusOptions{timeout: 15 * time.Second, output: "json"}
+	opts := installStatusOptions{timeout: 15 * time.Second, output: "text"}
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Report a waiting or running KatlOS installer",
@@ -87,13 +88,13 @@ func newInstallStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 	}
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer IP, host, host:port, or HTTP(S) base URL; discovers a unique waiting installer when omitted")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "status request timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	return cmd
 }
 
 func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stderr io.Writer) error {
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
@@ -148,14 +149,14 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	}
 	report := newInstallHandoffReport(endpoint, selected.Node.Name, accepted)
 	if opts.noWait {
-		return writeInstallReport(stdout, report)
+		return writeInstallReport(stdout, opts.output, report)
 	}
 	status, err := waitForInstall(waitCtx, client, endpoint, accepted, stderr)
 	if err != nil {
 		return err
 	}
 	report.Handoff = status
-	if err := writeInstallReport(stdout, report); err != nil {
+	if err := writeInstallReport(stdout, opts.output, report); err != nil {
 		return err
 	}
 	if installFailed(status.InstallStatus.State) {
@@ -230,8 +231,8 @@ func installNodeChoices(manifest configbundle.BundleManifest) string {
 
 func runInstallStatus(ctx context.Context, opts installStatusOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	endpoint, err := resolveInstallerEndpoint(ctx, opts.endpoint, opts.timeout)
 	if err != nil {
@@ -246,7 +247,7 @@ func runInstallStatus(ctx context.Context, opts installStatusOptions, stdout, st
 	if err != nil {
 		return err
 	}
-	return writeInstallReport(stdout, newInstallHandoffReport(endpoint, status.SelectedNode, status))
+	return writeInstallReport(stdout, opts.output, newInstallHandoffReport(endpoint, status.SelectedNode, status))
 }
 
 func normalizeInstallerEndpoint(value string) (string, error) {
@@ -425,11 +426,25 @@ func newInstallHandoffReport(endpoint, node string, status handoff.HandoffStatus
 	}
 }
 
-func writeInstallReport(stdout io.Writer, report installHandoffReport) error {
+func writeInstallReport(stdout io.Writer, output string, report installHandoffReport) error {
 	report.Handoff.InstallStatus.BundleDigest = ""
 	report.Handoff.InstallStatus.SourceDigest = ""
 	report.Handoff.InstallStatus.NodeMaterialDigest = ""
 	report.Handoff.InstallStatus.InstallMaterialDigest = ""
+	if output == "text" {
+		step := strings.TrimSpace(report.Handoff.InstallStatus.CurrentStep)
+		if step == "" {
+			step = "-"
+		}
+		node := report.SelectedNode
+		if node == "" {
+			node = "-"
+		}
+		w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NODE\tENDPOINT\tSTATE\tSTEP")
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", node, report.Endpoint, report.Handoff.State, step)
+		return w.Flush()
+	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal installer handoff report: %w", err)

--- a/cmd/katlctl/install_discover.go
+++ b/cmd/katlctl/install_discover.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
@@ -21,6 +22,7 @@ import (
 
 type installDiscoverOptions struct {
 	timeout    time.Duration
+	output     string
 	configInit configInitOptions
 }
 
@@ -41,7 +43,7 @@ var installerDiscoveryProbe = func(ctx context.Context, endpoint string, timeout
 }
 
 func newInstallDiscoverCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := installDiscoverOptions{timeout: 3 * time.Second, configInit: defaultConfigInitOptions()}
+	opts := installDiscoverOptions{timeout: 3 * time.Second, output: "text", configInit: defaultConfigInitOptions()}
 	cmd := &cobra.Command{
 		Use:   "discover [CLUSTER_CONFIG]",
 		Short: "Find waiting KatlOS installers and optionally create a ClusterConfig",
@@ -54,6 +56,7 @@ func newInstallDiscoverCommand(ctx context.Context, stdout, stderr io.Writer) *c
 		},
 	}
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall local-network discovery timeout")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	addConfigInitFlags(cmd, &opts.configInit)
 	return cmd
 }
@@ -71,6 +74,17 @@ func runInstallDiscover(ctx context.Context, opts installDiscoverOptions, stdout
 		return runConfigInit(ctx, opts.configInit, stdout, stderr)
 	}
 	report := installDiscoveryReport{APIVersion: "katl.dev/v1alpha1", Kind: "InstallerDiscovery", Installers: installers}
+	if opts.output == "text" {
+		w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "ENDPOINT\tSTATE\tNODE")
+		for _, installer := range installers {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", installer.Endpoint, installer.Status.State, installer.Status.SelectedNode)
+		}
+		return w.Flush()
+	}
+	if opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
+	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode installer discovery: %w", err)

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -39,7 +39,7 @@ func TestInstallDiscoverFindsWaitingInstallerAndDisks(t *testing.T) {
 	t.Cleanup(func() { installerDiscoveryProbe = oldProbe })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"install", "discover"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"install", "discover", "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 	var report installDiscoveryReport
@@ -238,7 +238,7 @@ func TestInstallStatusReportsWaitingInstaller(t *testing.T) {
 	defer ts.Close()
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{"install", "status", "--endpoint", strings.TrimPrefix(ts.URL, "http://")}, &stdout, &stderr)
+	err := run(context.Background(), []string{"install", "status", "--endpoint", strings.TrimPrefix(ts.URL, "http://"), "--output", "json"}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
 	}
@@ -276,6 +276,7 @@ func TestInstallApplyCompilesAndSubmitsSource(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err = run(context.Background(), []string{
 		"install", "apply", "--config", sourcePath,
+		"--output", "json",
 		"--no-wait",
 	}, &stdout, &stderr)
 	if err != nil {
@@ -325,6 +326,7 @@ func TestInstallApplyAcceptsGeneratedConfigByAddress(t *testing.T) {
 	stderr.Reset()
 	if err := run(context.Background(), []string{
 		"install", "apply", "--config", outputPath,
+		"--output", "json",
 		"--endpoint", strings.TrimPrefix(ts.URL, "http://"),
 		"--node", "192.0.2.11",
 		"--no-wait",
@@ -459,6 +461,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"install", "apply", "--config", sourcePath,
+		"--output", "json",
 		"--endpoint", ts.URL,
 		"--node", "cp-1",
 		"--timeout", "5s",

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
@@ -23,6 +25,7 @@ import (
 
 type kubernetesUpgradeOptions struct {
 	version       string
+	clusterConfig string
 	configPath    string
 	contextName   string
 	inventoryPath string
@@ -76,35 +79,40 @@ var dialKubernetesEndpoint = func(ctx context.Context, endpoint string) error {
 }
 
 func newKubernetesUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := kubernetesUpgradeOptions{timeout: 25 * time.Minute, output: "json"}
+	opts := kubernetesUpgradeOptions{timeout: 25 * time.Minute, output: "text"}
 	cmd := &cobra.Command{
 		Use:   "upgrade VERSION",
 		Short: "Upgrade Kubernetes control planes and workers online",
 		Args:  cobra.MaximumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(command *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				opts.version = args[0]
+			} else {
+				return command.Help()
 			}
 			return runKubernetesUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
+	cmd.Flags().StringVar(&opts.clusterConfig, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl config context name")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "optional saved context created by 'katlctl context save'")
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "cluster inventory instead of a workstation context")
+	cmd.Flags().Lookup("inventory").Hidden = true
 	cmd.Flags().StringVar(&opts.bundle, "bundle", "", "Kubernetes bundle image, for example ghcr.io/katl-dev/kubernetes:v1.36.1-katl.1")
 	cmd.Flags().Lookup("bundle").Hidden = true
 	cmd.Flags().BoolVar(&opts.cordon, "cordon", false, "temporarily cordon each node during its online upgrade")
 	cmd.Flags().StringVar(&opts.kubeconfig, "kubeconfig", "", "operator kubeconfig used with --cordon")
 	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate the complete rollout without accepting operations")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "per-node operation timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	_ = stderr
 	return cmd
 }
 
 func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, stdout, stderr io.Writer) error {
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
@@ -148,7 +156,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 	} else {
 		report.SourceVersion = image.PayloadVersion
 		report.NextAction = "every node already runs the selected Kubernetes version"
-		return writeKubernetesUpgradeReport(stdout, report)
+		return writeKubernetesUpgradeReport(stdout, opts.output, report)
 	}
 	for _, target := range targets {
 		body := kubernetesUpgradeBody(target, image)
@@ -167,7 +175,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 		report.Nodes = append(report.Nodes, kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: "planned"})
 	}
 	if opts.plan {
-		return writeKubernetesUpgradeReport(stdout, report)
+		return writeKubernetesUpgradeReport(stdout, opts.output, report)
 	}
 
 	report.Nodes = nil
@@ -176,12 +184,12 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 		nodeReport, err := runKubernetesUpgradeTarget(ctx, topology, opts, *target, image, stderr)
 		report.Nodes = append(report.Nodes, nodeReport)
 		if err != nil {
-			_ = writeKubernetesUpgradeReport(stdout, report)
+			_ = writeKubernetesUpgradeReport(stdout, opts.output, report)
 			return err
 		}
 	}
 	report.NextAction = "rollout complete; every upgraded node is healthy on the target Kubernetes version without reboot"
-	return writeKubernetesUpgradeReport(stdout, report)
+	return writeKubernetesUpgradeReport(stdout, opts.output, report)
 }
 
 func runKubernetesUpgradeTarget(ctx context.Context, topology workstation.ResolvedTopology, opts kubernetesUpgradeOptions, target kubernetesUpgradeTarget, image kubernetesbundle.ImageReference, stderr io.Writer) (nodeReport kubernetesUpgradeNodeReport, resultErr error) {
@@ -329,6 +337,12 @@ func waitKubernetesUpgrade(ctx context.Context, client agentapi.KatlcAgentClient
 }
 
 func resolveKubernetesUpgradeTopology(opts kubernetesUpgradeOptions) (workstation.ResolvedTopology, error) {
+	if strings.TrimSpace(opts.clusterConfig) != "" {
+		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" || strings.TrimSpace(opts.inventoryPath) != "" {
+			return workstation.ResolvedTopology{}, fmt.Errorf("--config cannot be combined with --context, --context-file, or --inventory")
+		}
+		return resolveClusterConfigTopology(opts.clusterConfig)
+	}
 	request := workstation.ResolveRequest{ConfigPath: strings.TrimSpace(opts.configPath), ContextName: strings.TrimSpace(opts.contextName)}
 	if strings.TrimSpace(opts.inventoryPath) != "" {
 		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
@@ -340,7 +354,11 @@ func resolveKubernetesUpgradeTopology(opts kubernetesUpgradeOptions) (workstatio
 		}
 		request.ExplicitInventory = &inv
 	}
-	return workstation.ResolveTopology(request)
+	resolved, err := workstation.ResolveTopology(request)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return workstation.ResolvedTopology{}, fmt.Errorf("no cluster source: use --config cluster.yaml; for shorter repeated commands, first run 'katlctl context save --config cluster.yaml'")
+	}
+	return resolved, err
 }
 
 func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.ResolvedTopology, targetVersion string) ([]kubernetesUpgradeTarget, error) {
@@ -473,7 +491,31 @@ func kubernetesUpgradeCandidate(version, node, runID string) string {
 	return "kubernetes-" + version + "-" + node + "-" + runID
 }
 
-func writeKubernetesUpgradeReport(stdout io.Writer, report kubernetesUpgradeReport) error {
+func writeKubernetesUpgradeReport(stdout io.Writer, output string, report kubernetesUpgradeReport) error {
+	if output == "text" {
+		action := "Kubernetes upgrade"
+		if report.Plan {
+			action = "Kubernetes upgrade plan"
+		}
+		fmt.Fprintf(stdout, "%s: %s -> %s\n", action, report.SourceVersion, report.TargetVersion)
+		w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "NODE\tROLE\tRESULT\tPHASE")
+		for _, node := range report.Nodes {
+			phase := node.Phase
+			if phase == "" {
+				phase = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", node.Name, node.Role, node.Result, phase)
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		if report.NextAction != "" {
+			_, err := fmt.Fprintf(stdout, "Next action: %s\n", report.NextAction)
+			return err
+		}
+		return nil
+	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -124,11 +124,21 @@ func TestKubernetesUpgradePlanDoesNotExecute(t *testing.T) {
 		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
 	}
 	var stdout bytes.Buffer
-	if err := run(context.Background(), []string{"kubernetes", "upgrade", "v1.36.1", "--inventory", inv, "--plan", "--timeout", "1m"}, &stdout, &bytes.Buffer{}); err != nil {
+	if err := run(context.Background(), []string{"kubernetes", "upgrade", "v1.36.1", "--inventory", inv, "--plan", "--timeout", "1m", "--output", "json"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.submitRequests) != 1 || !client.submitRequests[0].DryRun || !strings.Contains(stdout.String(), `"result": "planned"`) {
 		t.Fatalf("requests=%#v output=%s", client.submitRequests, stdout.String())
+	}
+}
+
+func TestKubernetesUpgradeResolvesClusterConfigWithoutContext(t *testing.T) {
+	topology, err := resolveKubernetesUpgradeTopology(kubernetesUpgradeOptions{clusterConfig: writeClusterConfig(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(topology.Nodes) != 1 || topology.Nodes[0].Name != "cp-1" || topology.Nodes[0].ManagementEndpoint != "10.0.0.11:9443" {
+		t.Fatalf("topology = %#v", topology)
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
@@ -105,13 +106,16 @@ Start with "katlctl install discover" for a waiting installer or
 	})
 
 	clusterCmd := &cobra.Command{Use: "cluster", Short: "Cluster lifecycle operations"}
+	clusterCmd.AddCommand(newClusterStatusCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newClusterBootstrapCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe"))
 	cmd.AddCommand(clusterCmd)
 
 	kubernetesCmd := &cobra.Command{Use: "kubernetes", Short: "Kubernetes lifecycle operations"}
 	kubernetesCmd.AddCommand(newKubernetesUpgradeCommand(ctx, stdout, stderr))
-	kubernetesCmd.AddCommand(newKubeadmControlPlaneConfigCommand(ctx, stdout, stderr))
+	kubeadmConfigCmd := newKubeadmControlPlaneConfigCommand(ctx, stdout, stderr)
+	kubeadmConfigCmd.Hidden = true
+	kubernetesCmd.AddCommand(kubeadmConfigCmd)
 	cmd.AddCommand(kubernetesCmd)
 
 	configCmd := &cobra.Command{Use: "config", Short: "Create and compile ClusterConfig"}
@@ -127,6 +131,9 @@ Start with "katlctl install discover" for a waiting installer or
 	contextCmd := &cobra.Command{Use: "context", Short: "Save and inspect workstation contexts"}
 	contextCmd.AddCommand(newContextSaveCommand(ctx, stdout, stderr))
 	contextCmd.AddCommand(newConfigPathCommand(stdout, stderr))
+	contextCmd.AddCommand(newContextListCommand(stdout, stderr))
+	contextCmd.AddCommand(newContextCurrentCommand(stdout, stderr))
+	contextCmd.AddCommand(newContextUseCommand(stdout, stderr))
 	topologyCmd := newConfigTopologyCommand(stdout, stderr)
 	topologyCmd.Use = "show"
 	topologyCmd.Short = "Show the selected cluster and its nodes"
@@ -181,39 +188,42 @@ func rejectUnknownSubcommand(command *cobra.Command, args []string) error {
 
 func setMinimumInvocationExamples(root *cobra.Command) {
 	examples := map[string]string{
-		"katlctl":                         "katlctl install discover",
-		"katlctl version":                 "katlctl version",
-		"katlctl cluster":                 "katlctl cluster bootstrap --config cluster.yaml",
-		"katlctl context save":            "katlctl context save --config cluster.yaml",
-		"katlctl cluster bootstrap":       "katlctl cluster bootstrap --config cluster.yaml",
-		"katlctl cluster wipe":            "katlctl cluster wipe --all",
-		"katlctl kubernetes":              "katlctl kubernetes upgrade v1.36.1",
-		"katlctl kubernetes upgrade":      "katlctl kubernetes upgrade v1.36.1",
-		"katlctl kubernetes apply-config": "katlctl kubernetes apply-config --inventory cluster.json --coordinator cp-1 --generation 1 --config-name default --rollout-id rollout-1",
-		"katlctl config":                  "katlctl config validate cluster.yaml",
-		"katlctl config init":             "katlctl config init cluster.yaml --node cp-1=control-plane,192.0.2.10,/dev/disk/by-id/ata-root",
-		"katlctl config validate":         "katlctl config validate cluster.yaml",
-		"katlctl config schema":           "katlctl config schema",
-		"katlctl config bundle":           "katlctl config bundle cluster.yaml --output cluster.katlcfg",
-		"katlctl config render-node":      "katlctl config render-node --config cluster.yaml --node cp-1 --desired-version 1",
-		"katlctl context":                 "katlctl context show",
-		"katlctl context path":            "katlctl context path",
-		"katlctl context show":            "katlctl context show",
-		"katlctl install":                 "katlctl install discover",
-		"katlctl install discover":        "katlctl install discover",
-		"katlctl install apply":           "katlctl install apply --config cluster.yaml",
-		"katlctl install status":          "katlctl install status",
-		"katlctl operations":              "katlctl operations list --node cp-1",
-		"katlctl operations status":       "katlctl operations status --node cp-1 --operation-id OPERATION_ID",
-		"katlctl operations list":         "katlctl operations list --node cp-1",
-		"katlctl node":                    "katlctl node status cp-1 --config cluster.yaml",
-		"katlctl node status":             "katlctl node status cp-1 --config cluster.yaml",
-		"katlctl node reboot":             "katlctl node reboot cp-1 --config cluster.yaml",
-		"katlctl node upgrade":            "katlctl node upgrade 2026.7.0 --config cluster.yaml --node cp-1",
-		"katlctl node apply":              "katlctl node apply --config cluster.yaml --node cp-1",
-		"katlctl node apply validate":     "katlctl node apply validate --config cluster.yaml --node cp-1",
-		"katlctl node apply status":       "katlctl node apply status --node cp-1",
-		"katlctl node wipe":               "katlctl node wipe worker-1 --kubeconfig kubeconfig",
+		"katlctl":                     "katlctl install discover",
+		"katlctl version":             "katlctl version",
+		"katlctl cluster":             "katlctl cluster bootstrap --config cluster.yaml",
+		"katlctl cluster status":      "katlctl cluster status --config cluster.yaml",
+		"katlctl context save":        "katlctl context save --config cluster.yaml",
+		"katlctl cluster bootstrap":   "katlctl cluster bootstrap --config cluster.yaml",
+		"katlctl cluster wipe":        "katlctl cluster wipe --config cluster.yaml --all",
+		"katlctl kubernetes":          "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
+		"katlctl kubernetes upgrade":  "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
+		"katlctl config":              "katlctl config validate cluster.yaml",
+		"katlctl config init":         "katlctl config init cluster.yaml --node cp-1=control-plane,192.0.2.10,/dev/disk/by-id/ata-root",
+		"katlctl config validate":     "katlctl config validate cluster.yaml",
+		"katlctl config schema":       "katlctl config schema",
+		"katlctl config bundle":       "katlctl config bundle cluster.yaml --output cluster.katlcfg",
+		"katlctl config render-node":  "katlctl config render-node --config cluster.yaml --node cp-1 --desired-version 1",
+		"katlctl context":             "katlctl context show",
+		"katlctl context path":        "katlctl context path",
+		"katlctl context list":        "katlctl context list",
+		"katlctl context current":     "katlctl context current",
+		"katlctl context use":         "katlctl context use homelab",
+		"katlctl context show":        "katlctl context show",
+		"katlctl install":             "katlctl install discover",
+		"katlctl install discover":    "katlctl install discover",
+		"katlctl install apply":       "katlctl install apply --config cluster.yaml",
+		"katlctl install status":      "katlctl install status",
+		"katlctl operations":          "katlctl operations list --config cluster.yaml --node cp-1",
+		"katlctl operations status":   "katlctl operations status OPERATION_ID --config cluster.yaml --node cp-1",
+		"katlctl operations list":     "katlctl operations list --config cluster.yaml --node cp-1",
+		"katlctl node":                "katlctl node status cp-1 --config cluster.yaml",
+		"katlctl node status":         "katlctl node status cp-1 --config cluster.yaml",
+		"katlctl node reboot":         "katlctl node reboot cp-1 --config cluster.yaml",
+		"katlctl node upgrade":        "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml",
+		"katlctl node apply":          "katlctl node apply cp-1 --config cluster.yaml",
+		"katlctl node apply validate": "katlctl node apply validate --config cluster.yaml --node cp-1",
+		"katlctl node apply status":   "katlctl node apply status --node cp-1",
+		"katlctl node wipe":           "katlctl node wipe worker-1 --config cluster.yaml --kubeconfig kubeconfig",
 	}
 	var visit func(*cobra.Command)
 	visit = func(command *cobra.Command) {
@@ -247,19 +257,24 @@ type hostUpgradeReport struct {
 var katlOSReleasePattern = regexp.MustCompile(`^[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 
 func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := hostUpgradeOptions{actor: "katlctl node upgrade", waitTimeout: 30 * time.Minute, output: "json"}
+	opts := hostUpgradeOptions{actor: "katlctl node upgrade", waitTimeout: 30 * time.Minute, output: "text"}
 	cmd := &cobra.Command{
-		Use:   "upgrade VERSION",
+		Use:   "upgrade VERSION [NODE]",
 		Short: "Upgrade one KatlOS node and verify its next boot",
 		Long: `Upgrade one KatlOS node to a published KatlOS release, reboot it, and verify that it returns healthy.
 
 Use the same ClusterConfig used to install the node. --endpoint can override its recorded address when DHCP or local routing changed. A saved katlctl context is optional shorthand for repeated commands.`,
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(2),
 		RunE: func(command *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return command.Help()
 			}
 			opts.version = args[0]
+			if len(args) == 2 {
+				if err := selectHostNode(&opts.target.nodeName, args[1:]); err != nil {
+					return err
+				}
+			}
 			return runHostUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
@@ -270,14 +285,13 @@ Use the same ClusterConfig used to install the node. --endpoint can override its
 	cmd.Flags().Lookup("actor").Hidden = true
 	cmd.Flags().BoolVar(&opts.plan, "plan", false, "validate without accepting an operation")
 	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
-	cmd.Flags().Lookup("output").Hidden = true
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	return cmd
 }
 
 func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr io.Writer) error {
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
@@ -324,7 +338,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		if node == "" {
 			node = target.endpoint
 		}
-		return writeJSON(stdout, hostUpgradeReport{Node: node, Version: opts.version, Image: request.ImageURL, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy})
+		return writeHostUpgradeReport(stdout, opts.output, hostUpgradeReport{Node: node, Version: opts.version, Image: request.ImageURL, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy})
 	}
 	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 		ApiVersion:                  operation.APIVersion,
@@ -349,23 +363,23 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		report.Node = target.endpoint
 	}
 	if opts.plan {
-		return writeJSON(stdout, report)
+		return writeHostUpgradeReport(stdout, opts.output, report)
 	}
 	terminal, err := waitAcceptedOperationStatus(ctx, conn.Client, accepted, opts.waitTimeout, stderr)
 	if err != nil {
 		report.Result = "failed"
-		_ = writeJSON(stdout, report)
+		_ = writeHostUpgradeReport(stdout, opts.output, report)
 		return err
 	}
 	if err := operationResultError(terminal); err != nil {
 		report.Result = terminal.GetResult()
-		_ = writeJSON(stdout, report)
+		_ = writeHostUpgradeReport(stdout, opts.output, report)
 		return err
 	}
 	agentStart := status.GetAgentStartId()
 	if err := requestNodeReboot(ctx, conn.Client, opts.actor, status.GetMachineId(), request.CandidateGenerationID); err != nil {
 		report.Result = "staged"
-		_ = writeJSON(stdout, report)
+		_ = writeHostUpgradeReport(stdout, opts.output, report)
 		return fmt.Errorf("reboot node %s: %w", report.Node, err)
 	}
 	_ = conn.Close()
@@ -376,14 +390,30 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		report.Result = "failed"
 		report.Rebooted = true
 		report.BootHealth = "failed"
-		_ = writeJSON(stdout, report)
+		_ = writeHostUpgradeReport(stdout, opts.output, report)
 		return err
 	}
 	_ = verifiedConn.Close()
 	report.Result = operation.ResultSucceeded
 	report.Rebooted = true
 	report.BootHealth = generation.HealthStateHealthy
-	return writeJSON(stdout, report)
+	return writeHostUpgradeReport(stdout, opts.output, report)
+}
+
+func writeHostUpgradeReport(stdout io.Writer, output string, report hostUpgradeReport) error {
+	if output == "json" {
+		return writeJSON(stdout, report)
+	}
+	if report.Result == "planned" {
+		_, err := fmt.Fprintf(stdout, "%s can upgrade to KatlOS %s\n", report.Node, report.Version)
+		return err
+	}
+	if report.Result == operation.ResultSucceeded {
+		_, err := fmt.Fprintf(stdout, "%s runs KatlOS %s; health %s\n", report.Node, report.Version, report.BootHealth)
+		return err
+	}
+	_, err := fmt.Fprintf(stdout, "%s KatlOS %s upgrade result: %s\n", report.Node, report.Version, report.Result)
+	return err
 }
 
 func katlOSVersion(input string) (string, error) {
@@ -441,7 +471,7 @@ type wipeClusterOptions struct {
 }
 
 func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
-	opts := wipeClusterOptions{command: commandName, output: "json"}
+	opts := wipeClusterOptions{command: commandName, output: "text"}
 	cmd := &cobra.Command{
 		Use:   "wipe",
 		Short: "Destructively reset cluster nodes for installer-media reinstall",
@@ -454,6 +484,8 @@ func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, comman
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("inventory").Hidden = true
+	cmd.Flags().Lookup("context-file").Hidden = true
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "select every node in the inventory")
 	cmd.Flags().BoolVar(&opts.allowPartial, "allow-partial-cluster", false, "allow a partial cluster target set")
@@ -462,15 +494,15 @@ func newWipeClusterCommand(ctx context.Context, stdout, stderr io.Writer, comman
 	cmd.Flags().BoolVar(&opts.planOnly, "plan", false, "print the destructive wipe plan without accepting node-local operations")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after nodes accept their operations")
 	cmd.Flags().StringVar(&opts.timeout, "timeout", "30m", "operation and wait timeout duration")
-	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
 	cmd.Flags().Var(&opts.selectedNodes, "node", "inventory node name to wipe; may be repeated")
 	return cmd
 }
 
 func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
@@ -489,6 +521,7 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 		return err
 	}
 	report := newWipeClusterReport(opts.planOnly, partial, targets)
+	report.Output = opts.output
 	report.Command = opts.command
 	if partial && !opts.allowPartial {
 		report.Refusals = append(report.Refusals, "partial cluster wipe requires --allow-partial-cluster")
@@ -576,13 +609,16 @@ type wipeNodeOptions struct {
 }
 
 func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandName string) *cobra.Command {
-	opts := wipeNodeOptions{command: commandName, output: "json"}
+	opts := wipeNodeOptions{command: commandName, output: "text"}
 	cmd := &cobra.Command{
 		Use:   "wipe NODE",
 		Short: "Remove one node and reset it for installer-media reinstall",
 		Long:  "Remove one worker from Kubernetes and erase its KatlOS boot artifacts. The node must boot installer media or PXE before it can be used again.",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return command.Help()
+			}
 			opts.selectedNodes.values = []string{args[0]}
 			return runWipeNodeOptions(ctx, opts, stdout, stderr)
 		},
@@ -590,6 +626,8 @@ func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandNa
 	cmd.Flags().StringVar(&opts.inventoryPath, "inventory", "", "path to cluster inventory")
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("inventory").Hidden = true
+	cmd.Flags().Lookup("context-file").Hidden = true
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
 	cmd.Flags().StringVar(&opts.kubeconfigPath, "kubeconfig", "", "path to operator kubeconfig")
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
@@ -597,14 +635,14 @@ func newWipeNodeCommand(ctx context.Context, stdout, stderr io.Writer, commandNa
 	cmd.Flags().BoolVar(&opts.planOnly, "plan", false, "print the destructive wipe plan without accepting node-local operation")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
 	cmd.Flags().StringVar(&opts.timeout, "timeout", "30m", "operation and wait timeout duration")
-	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
 	return cmd
 }
 
 func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if len(opts.selectedNodes.values) != 1 {
 		return fmt.Errorf("exactly one --node is required")
@@ -626,6 +664,7 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return err
 	}
 	report := newWipeNodeReport(opts.planOnly, partial, target)
+	report.Output = opts.output
 	report.Command = opts.command
 	if target.SystemRole == inventory.RoleControlPlane {
 		report.KubernetesCleanup = "refused"
@@ -766,6 +805,7 @@ func overlayWipeContext(inv inventory.Inventory, configPath, contextName string)
 }
 
 type wipeClusterReport struct {
+	Output              string                          `json:"-"`
 	APIVersion          string                          `json:"apiVersion"`
 	Kind                string                          `json:"kind"`
 	Command             string                          `json:"command"`
@@ -1083,6 +1123,9 @@ func closeAgentConnection(conn cluster.AgentConnection) error {
 }
 
 func printWipeClusterReport(stdout io.Writer, report wipeClusterReport) error {
+	if report.Output == "text" {
+		return printWipeText(stdout, report)
+	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal cluster wipe report: %w", err)
@@ -1092,12 +1135,50 @@ func printWipeClusterReport(stdout io.Writer, report wipeClusterReport) error {
 }
 
 func printWipeNodeReport(stdout io.Writer, report wipeNodeReport) error {
+	if report.Output == "text" {
+		return printWipeText(stdout, report.wipeClusterReport)
+	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal wipe node report: %w", err)
 	}
 	_, err = stdout.Write(append(data, '\n'))
 	return err
+}
+
+func printWipeText(stdout io.Writer, report wipeClusterReport) error {
+	action := "wipe"
+	if report.Plan {
+		action = "wipe plan"
+	}
+	fmt.Fprintf(stdout, "%s:\n", action)
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NODE\tROLE\tADDRESS\tRESULT")
+	results := make(map[string]string, len(report.Nodes))
+	for _, node := range report.Nodes {
+		result := node.Result
+		if result == "" && node.Accepted {
+			result = "accepted"
+		}
+		if result == "" {
+			result = "planned"
+		}
+		results[node.Node] = result
+	}
+	for _, target := range report.Targets {
+		result := results[target.Name]
+		if result == "" {
+			result = "planned"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", target.Name, target.SystemRole, target.Address, result)
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	for _, refusal := range report.Refusals {
+		fmt.Fprintf(stdout, "Refused: %s\n", refusal)
+	}
+	return nil
 }
 
 type wipeNodeCleanupResult struct {
@@ -1207,7 +1288,7 @@ type configTopologyOptions struct {
 }
 
 func newConfigTopologyCommand(stdout, stderr io.Writer) *cobra.Command {
-	opts := configTopologyOptions{output: "json"}
+	opts := configTopologyOptions{output: "text"}
 	cmd := &cobra.Command{
 		Use:   "topology",
 		Short: "Print the resolved workstation topology",
@@ -1217,22 +1298,35 @@ func newConfigTopologyCommand(stdout, stderr io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("context-file").Hidden = true
 	cmd.Flags().StringVar(&opts.contextName, "context", "", "context name")
-	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
 	return cmd
 }
 
 func runConfigTopology(opts configTopologyOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "json" && opts.output != "text" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	resolved, err := workstation.ResolveTopology(workstation.ResolveRequest{
 		ConfigPath:  opts.configPath,
 		ContextName: opts.contextName,
 	})
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no saved katlctl contexts; create one with 'katlctl context save --config cluster.yaml'")
+		}
 		return err
+	}
+	if opts.output == "text" {
+		w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintf(w, "Context:\t%s\nCluster:\t%s\n", resolved.ContextName, resolved.ClusterName)
+		fmt.Fprintln(w, "NODE\tROLE\tENDPOINT")
+		for _, node := range resolved.Nodes {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", node.Name, node.SystemRole, node.ManagementEndpoint)
+		}
+		return w.Flush()
 	}
 	data, err := json.MarshalIndent(resolved, "", "  ")
 	if err != nil {
@@ -1282,18 +1376,24 @@ type configValidationReport struct {
 }
 
 func newConfigValidateCommand(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	output := "text"
+	cmd := &cobra.Command{
 		Use:   "validate SOURCE",
 		Short: "Validate and resolve a cluster config without writing a bundle",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runConfigValidate(args[0], stdout, stderr)
+			return runConfigValidate(args[0], output, stdout, stderr)
 		},
 	}
+	cmd.Flags().StringVarP(&output, "output", "o", output, "output format: text or json")
+	return cmd
 }
 
-func runConfigValidate(sourcePath string, stdout, stderr io.Writer) error {
+func runConfigValidate(sourcePath, output string, stdout, stderr io.Writer) error {
 	_ = stderr
+	if output != "text" && output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", output)
+	}
 	_, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
 		SourcePath:     sourcePath,
 		KatlctlVersion: version,
@@ -1313,6 +1413,10 @@ func runConfigValidate(sourcePath string, stdout, stderr io.Writer) error {
 		Source:      sourcePath,
 		ClusterName: result.Manifest.ClusterName,
 		Nodes:       nodes,
+	}
+	if output == "text" {
+		_, err := fmt.Fprintf(stdout, "%s is valid for cluster %s (%d node(s))\n", sourcePath, report.ClusterName, len(report.Nodes))
+		return err
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
@@ -1519,12 +1623,17 @@ type configApplyOptions struct {
 var configApplyNow = func() time.Time { return time.Now().UTC() }
 
 func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl node apply", output: "json"}
+	opts := configApplyOptions{mode: generation.ApplyModeAuto, actor: "katlctl node apply", output: "text"}
 	cmd := &cobra.Command{
-		Use:   "apply",
+		Use:   "apply [NODE]",
 		Short: "Validate or apply node configuration",
-		Args:  rejectUnknownSubcommand,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if err := selectHostNode(&opts.nodeConfig.nodeName, args); err != nil {
+					return err
+				}
+			}
 			return runConfigApply(ctx, opts, stdout, stderr)
 		},
 	}
@@ -1545,8 +1654,11 @@ func newConfigApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 			flag.Hidden = true
 		}
 	}
+	validateCmd.Hidden = true
 	cmd.AddCommand(validateCmd)
-	cmd.AddCommand(newConfigApplyStatusCommand(ctx, stdout, stderr))
+	statusCmd := newConfigApplyStatusCommand(ctx, stdout, stderr)
+	statusCmd.Hidden = true
+	cmd.AddCommand(statusCmd)
 	return cmd
 }
 
@@ -1554,9 +1666,10 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	if opts.waitTimeout == 0 {
 		opts.waitTimeout = 30 * time.Minute
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "node address override: IP, hostname, host:port, or tcp:// URL")
 	cmd.Flags().StringVar(&opts.workstationConfig, "context-file", "", "workstation context file path")
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "optional saved context created by 'katlctl context save'")
 	addNodeConfigInputFlags(cmd, &opts.nodeConfig)
 	cmd.Flags().StringVar(&opts.mode, "mode", opts.mode, "apply mode: auto, live, or next-boot")
 	cmd.Flags().StringVar(&opts.candidateGeneration, "candidate-generation", "", "candidate generation id")
@@ -1568,15 +1681,17 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
+	cmd.Flags().Lookup("actor").Hidden = true
+	cmd.Flags().Lookup("source-id").Hidden = true
 	cmd.Flags().BoolVar(&opts.plan, "plan", opts.plan, "validate and plan without accepting an operation")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
 	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
-	cmd.Flags().StringVar(&opts.output, "output", "json", "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
 }
 
 func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr io.Writer) error {
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
@@ -1588,8 +1703,12 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if strings.TrimSpace(opts.nodeConfig.configPath) == "" {
 		return fmt.Errorf("--config is required")
 	}
+	targetConfig := opts.nodeConfig.configPath
+	if isRenderedNodeConfig(targetConfig) {
+		targetConfig = ""
+	}
 	target, err := resolveManagementTarget(managementTargetOptions{
-		configPath: opts.workstationConfig, contextName: opts.contextName,
+		clusterConfigPath: targetConfig, configPath: opts.workstationConfig, contextName: opts.contextName,
 		nodeName: opts.nodeConfig.nodeName, endpoint: opts.endpoint,
 	})
 	if err != nil {
@@ -1628,6 +1747,16 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		})
 		if err != nil {
 			return err
+		}
+		if opts.output == "text" {
+			if !result.Accepted {
+				return fmt.Errorf("configuration for %s was rejected: %s", opts.nodeConfig.nodeName, firstNonEmpty(result.FailureReason, strings.Join(result.Diagnostics, "; ")))
+			}
+			fmt.Fprintf(stdout, "%s configuration is valid; apply mode %s\n", opts.nodeConfig.nodeName, result.AcceptedApplyMode)
+			for _, diagnostic := range result.Diagnostics {
+				fmt.Fprintf(stdout, "- %s\n", diagnostic)
+			}
+			return nil
 		}
 		publicResult := proto.Clone(result).(*agentapi.ConfigValidationResult)
 		publicResult.RequestDigest = ""
@@ -1700,7 +1829,29 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	if opts.noWait {
 		return writeOperationAccepted(stdout, accepted)
 	}
-	return waitAcceptedOperation(ctx, conn.Client, accepted, opts.waitTimeout, stdout, stderr)
+	terminal, err := waitAcceptedOperationStatus(ctx, conn.Client, accepted, opts.waitTimeout, stderr)
+	if opts.output == "json" {
+		if writeErr := writeMutationOperationStatus(stdout, terminal); writeErr != nil {
+			return writeErr
+		}
+	} else if terminal != nil {
+		fmt.Fprintf(stdout, "%s configuration result: %s (phase %s)\n", opts.nodeConfig.nodeName, terminal.GetResult(), terminal.GetPhase())
+	}
+	if err != nil {
+		return err
+	}
+	return operationResultError(terminal)
+}
+
+func isRenderedNodeConfig(path string) bool {
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return false
+	}
+	var identity struct {
+		Kind string `yaml:"kind"`
+	}
+	return yaml.Unmarshal(data, &identity) == nil && identity.Kind == configapply.NodeConfigurationChangeKind
 }
 
 func nodeConfigYAML(opts nodeConfigInputOptions, mode string) ([]byte, bool, error) {
@@ -1997,6 +2148,9 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 	cmd.Flags().BoolVar(&opts.overwriteKubeconfig, "overwrite-kubeconfig", false, "overwrite different existing kubeconfig")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "validate and print the bootstrap plan without running kubeadm")
 	cmd.Flags().StringVar(&opts.vmtestTranscriptDir, "vmtest-transcript-dir", "", "directory for per-node vmtest agent transcript artifacts")
+	for _, name := range []string{"control-plane-endpoint", "join-worker", "kubernetes-bundle", "vmtest-transcript-dir"} {
+		cmd.Flags().Lookup(name).Hidden = true
+	}
 	cmd.Flags().Var(&opts.addresses, "node-address", "node address override in node=address form")
 	cmd.Flags().Var(&opts.bootstrapManifestPaths, "bootstrap-manifest", "ordered Kubernetes manifest file or bundle to apply after API readiness")
 	cmd.Flags().Var(&opts.bootstrapPreWaitValues, "bootstrap-pre-wait", "pre-manifest wait: api-ready, nodes-ready, resource-exists[:namespace]:kind/name, condition[:namespace]:kind/name:Condition, rollout-status[:namespace]:kind/name, or pods-ready[:namespace]:selector")
@@ -2129,15 +2283,11 @@ func printBootstrapResult(stdout io.Writer, result cluster.Result) {
 		}
 	}
 	for _, phase := range result.Phases {
-		operationFields := ""
-		if phase.OperationID != "" {
-			operationFields = fmt.Sprintf(" operation-id=%s", phase.OperationID)
-		}
 		if phase.Node != "" {
-			fmt.Fprintf(stdout, "phase=%s node=%s status=%s%s\n", phase.Name, phase.Node, phase.Status, operationFields)
+			fmt.Fprintf(stdout, "phase=%s node=%s status=%s\n", phase.Name, phase.Node, phase.Status)
 			continue
 		}
-		fmt.Fprintf(stdout, "phase=%s status=%s%s\n", phase.Name, phase.Status, operationFields)
+		fmt.Fprintf(stdout, "phase=%s status=%s\n", phase.Name, phase.Status)
 	}
 	if result.NextStep != "" {
 		fmt.Fprintf(stdout, "next: %s\n", result.NextStep)

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -97,6 +97,9 @@ func TestEveryCommandHelpShowsOneMinimumInvocation(t *testing.T) {
 	var commands []*cobra.Command
 	var collect func(*cobra.Command)
 	collect = func(command *cobra.Command) {
+		if command.Hidden {
+			return
+		}
 		commands = append(commands, command)
 		for _, child := range command.Commands() {
 			collect(child)
@@ -117,6 +120,10 @@ func TestEveryCommandHelpShowsOneMinimumInvocation(t *testing.T) {
 		if !strings.HasPrefix(example, path) {
 			t.Errorf("%s example = %q, want command path prefix", path, example)
 		}
+		argv := strings.Fields(example)
+		if len(argv) == 0 || argv[0] != "katlctl" {
+			t.Errorf("%s example = %q, want a parseable katlctl invocation", path, example)
+		}
 		var help bytes.Buffer
 		command.SetOut(&help)
 		if err := command.Help(); err != nil {
@@ -125,6 +132,35 @@ func TestEveryCommandHelpShowsOneMinimumInvocation(t *testing.T) {
 		}
 		if !strings.Contains(help.String(), "Examples:\n"+example+"\n") {
 			t.Errorf("%s help does not show its minimum invocation:\n%s", path, help.String())
+		}
+	}
+}
+
+func TestRoutineRemoteExamplesDeclareClusterConfig(t *testing.T) {
+	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
+	for _, path := range []string{
+		"cluster bootstrap", "cluster status", "cluster wipe", "kubernetes upgrade",
+		"node apply", "node reboot", "node status", "node upgrade", "node wipe",
+		"operations list", "operations status",
+	} {
+		command, _, err := root.Find(strings.Fields(path))
+		if err != nil {
+			t.Fatalf("find %s: %v", path, err)
+		}
+		if !strings.Contains(command.Example, "--config cluster.yaml") {
+			t.Errorf("%s minimum invocation silently depends on workstation state: %s", command.CommandPath(), command.Example)
+		}
+	}
+}
+
+func TestLocalMinimumInvocationsExecute(t *testing.T) {
+	for _, args := range [][]string{{"version"}, {"config", "schema"}, {"context", "path"}} {
+		var stdout, stderr bytes.Buffer
+		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
+			t.Errorf("katlctl %s: %v", strings.Join(args, " "), err)
+		}
+		if stdout.Len() == 0 || stderr.Len() != 0 {
+			t.Errorf("katlctl %s stdout=%q stderr=%q", strings.Join(args, " "), stdout.String(), stderr.String())
 		}
 	}
 }
@@ -151,13 +187,42 @@ func TestClusterBootstrapHelpLeadsWithUnifiedConfigInput(t *testing.T) {
 	}
 }
 
+func TestPublicHelpHidesInternalOperationAndTestInputs(t *testing.T) {
+	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
+	var visit func(*cobra.Command)
+	visit = func(command *cobra.Command) {
+		if command.Hidden {
+			return
+		}
+		var help bytes.Buffer
+		command.SetOut(&help)
+		if err := command.Help(); err != nil {
+			t.Errorf("%s help: %v", command.CommandPath(), err)
+			return
+		}
+		for _, internal := range []string{"--vmtest-transcript-dir", "--kubernetes-bundle", "--actor", "--source-id", "--candidate-generation", "--active-generation", "--config-name", "--rollout-id"} {
+			if strings.Contains(help.String(), internal) {
+				t.Errorf("%s exposes internal input %s", command.CommandPath(), internal)
+			}
+		}
+		for _, child := range command.Commands() {
+			visit(child)
+		}
+	}
+	visit(root)
+}
+
 func TestConfigInputFlagsUseOneName(t *testing.T) {
 	want := map[string]bool{
+		"katlctl cluster status":      true,
 		"katlctl context save":        true,
 		"katlctl cluster bootstrap":   true,
 		"katlctl cluster wipe":        true,
 		"katlctl config render-node":  true,
 		"katlctl install apply":       true,
+		"katlctl kubernetes upgrade":  true,
+		"katlctl operations list":     true,
+		"katlctl operations status":   true,
 		"katlctl node apply":          true,
 		"katlctl node apply validate": true,
 		"katlctl node reboot":         true,
@@ -197,10 +262,10 @@ func TestCommandGroupsExposeOneSupportedPath(t *testing.T) {
 		forbidden []string
 	}{
 		{group: "node", required: []string{"apply", "reboot", "status", "upgrade", "wipe"}},
-		{group: "cluster", required: []string{"bootstrap", "wipe"}, forbidden: []string{"enroll", "kubeadm-control-plane-config"}},
-		{group: "kubernetes", required: []string{"apply-config", "upgrade"}},
+		{group: "cluster", required: []string{"bootstrap", "status", "wipe"}, forbidden: []string{"enroll", "kubeadm-control-plane-config"}},
+		{group: "kubernetes", required: []string{"upgrade"}, forbidden: []string{"apply-config"}},
 		{group: "config", required: []string{"bundle", "init", "schema", "validate"}, forbidden: []string{"apply", "path", "topology"}},
-		{group: "context", required: []string{"path", "save", "show"}},
+		{group: "context", required: []string{"current", "list", "path", "save", "show", "use"}},
 	}
 	for _, test := range tests {
 		t.Run(test.group, func(t *testing.T) {
@@ -269,7 +334,6 @@ func TestNestedCommandTyposFailWithSuggestions(t *testing.T) {
 		{args: []string{"node", "upgade"}, command: "upgade", suggestion: "upgrade"},
 		{args: []string{"kubernetes", "upgrde"}, command: "upgrde", suggestion: "upgrade"},
 		{args: []string{"operations", "stats"}, command: "stats", suggestion: "status"},
-		{args: []string{"node", "apply", "valdte"}, command: "valdte", suggestion: "validate"},
 	}
 	for _, test := range tests {
 		t.Run(strings.Join(test.args, " "), func(t *testing.T) {
@@ -295,13 +359,26 @@ func TestHostUpgradeWithoutVersionPrintsHelp(t *testing.T) {
 	if err := run(context.Background(), []string{"node", "upgrade"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
-	for _, want := range []string{"Usage:", "katlctl node upgrade VERSION", "katlctl node upgrade 2026.7.0 --config cluster.yaml --node cp-1"} {
+	for _, want := range []string{"Usage:", "katlctl node upgrade VERSION", "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
 		}
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRequiredArgumentCommandsPrintHelpWhenEmpty(t *testing.T) {
+	for _, args := range [][]string{{"node", "upgrade"}, {"node", "wipe"}, {"kubernetes", "upgrade"}, {"operations", "status"}} {
+		var stdout, stderr bytes.Buffer
+		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
+			t.Errorf("katlctl %s: %v", strings.Join(args, " "), err)
+			continue
+		}
+		if !strings.Contains(stdout.String(), "Usage:") || stderr.Len() != 0 {
+			t.Errorf("katlctl %s stdout=%q stderr=%q", strings.Join(args, " "), stdout.String(), stderr.String())
+		}
 	}
 }
 
@@ -321,7 +398,7 @@ func TestHostUpgradeHelpLeadsWithClusterConfig(t *testing.T) {
 			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
 		}
 	}
-	for _, hidden := range []string{"--actor", "--context-file", "--no-wait", "--output"} {
+	for _, hidden := range []string{"--actor", "--context-file", "--no-wait"} {
 		if strings.Contains(stdout.String(), hidden) {
 			t.Fatalf("stdout = %q, exposes internal flag %q", stdout.String(), hidden)
 		}
@@ -372,6 +449,17 @@ func TestManagementTargetMissingSourceExplainsRecovery(t *testing.T) {
 	}
 }
 
+func TestClusterCommandsMissingSourceExplainRecovery(t *testing.T) {
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(t.TempDir(), "missing-katlctl.yaml"))
+	for _, args := range [][]string{{"cluster", "status"}, {"kubernetes", "upgrade", "v1.36.1", "--plan"}} {
+		var stdout, stderr bytes.Buffer
+		err := run(context.Background(), args, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "use --config cluster.yaml") {
+			t.Errorf("katlctl %s error = %v", strings.Join(args, " "), err)
+		}
+	}
+}
+
 func TestManagementEndpointAcceptsOperatorAddressForms(t *testing.T) {
 	tests := map[string]string{
 		"192.0.2.44":            "192.0.2.44:9443",
@@ -396,7 +484,7 @@ func TestManagementEndpointAcceptsOperatorAddressForms(t *testing.T) {
 func TestOutputFormatValidation(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{"context", "show", "--output", "yaml"}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), `--output = "yaml", want json`) {
+	if err == nil || !strings.Contains(err.Error(), `--output = "yaml", want text or json`) {
 		t.Fatalf("run() error = %v, want output validation", err)
 	}
 	if stdout.Len() != 0 {
@@ -600,7 +688,7 @@ func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"config", "validate", sourcePath, "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 	}
 	if stderr.Len() != 0 {
@@ -733,6 +821,7 @@ clusters:
 	err := run(context.Background(), []string{
 		"context", "show",
 		"--context", "stage",
+		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
@@ -1164,6 +1253,7 @@ func TestWipeClusterRefusesPartialTargetWithoutOverride(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"cluster", "wipe",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--node", "cp-1",
 		"--client-request-id", "wipe-req",
@@ -1198,6 +1288,7 @@ func TestWipeClusterPlanPrintsNodeLocalOperations(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"cluster", "wipe",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--all",
 		"--plan",
@@ -1238,6 +1329,7 @@ func TestWipeClusterPlanAcceptsClusterConfig(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"cluster", "wipe", "--config", sourcePath,
+		"--output", "json",
 		"--all",
 		"--plan",
 	}, &stdout, &stderr)
@@ -1280,6 +1372,7 @@ clusters:
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"cluster", "wipe",
+		"--output", "json",
 		"--context-file", configPath,
 		"--all",
 		"--plan",
@@ -1311,6 +1404,7 @@ func TestWipeClusterSubmitsDestructiveResetToAllNodes(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"cluster", "wipe",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--all",
 		"--client-request-id", "wipe-req",
@@ -1358,11 +1452,11 @@ func TestWipeNodeRequiresExactlyOneTarget(t *testing.T) {
 		"--client-request-id", "wipe-node-req",
 		"--kubeconfig", "admin.conf",
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "accepts 1 arg") {
-		t.Fatalf("run() error = %v, want exact node target validation", err)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
 	}
-	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %s, want empty", stdout.String())
+	if !strings.Contains(stdout.String(), "Usage:") {
+		t.Fatalf("stdout = %s, want help", stdout.String())
 	}
 }
 
@@ -1386,6 +1480,7 @@ func TestNodeWipeSubmitsWithNodeActor(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "wipe", "worker-1",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--kubeconfig", "admin.conf",
 		"--client-request-id", "cluster-wipe-node-req",
@@ -1430,6 +1525,7 @@ func TestWipeNodePlanPrintsUnknownKubernetesCleanupWithoutKubeconfig(t *testing.
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "wipe", "worker-1",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--plan",
 		"--client-request-id", "wipe-node-req",
@@ -1481,6 +1577,7 @@ clusters:
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "wipe", "worker-1",
+		"--output", "json",
 		"--context-file", configPath,
 		"--plan",
 	}, &stdout, &stderr)
@@ -1516,6 +1613,7 @@ func TestWipeNodeSubmitsAfterKubernetesCleanup(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "wipe", "worker-1",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--kubeconfig", "admin.conf",
 		"--client-request-id", "wipe-node-req",
@@ -1576,6 +1674,7 @@ func TestWipeNodeReportsRecoveryRequiredBeforeLocalReset(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "wipe", "worker-1",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--kubeconfig", "admin.conf",
 		"--client-request-id", "wipe-node-req",
@@ -1619,6 +1718,7 @@ func TestWipeNodeRefusesControlPlaneBeforeMutation(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "wipe", "cp-1",
+		"--output", "json",
 		"--inventory", inventoryPath,
 		"--kubeconfig", "admin.conf",
 		"--client-request-id", "wipe-node-req",
@@ -1713,6 +1813,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 		"--mode", generation.ApplyModeNextBoot,
 		"--candidate-generation", "generation-1",
 		"--client-request-id", "req-stage",
+		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
@@ -1745,7 +1846,7 @@ func TestHostUpgradeVersionStagesRebootsAndVerifiesHealth(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "upgrade", "v2026.7.0-alpha.9", "--config", writeClusterConfig(t), "--node", "cp-1", "--timeout", "1m"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "upgrade", "v2026.7.0-alpha.9", "--config", writeClusterConfig(t), "--node", "cp-1", "--timeout", "1m", "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	request := fake.submitRequest.GetHostUpgrade()
@@ -1797,6 +1898,7 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 		"--config", configPath,
 		"--candidate-generation", "generation-auto",
 		"--client-request-id", "req-auto",
+		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
@@ -1843,6 +1945,7 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 		"--mode", generation.ApplyModeNextBoot,
 		"--candidate-generation", "generation-plan",
 		"--client-request-id", "req-plan",
+		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
@@ -1896,6 +1999,7 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 		"--desired-version", "2",
 		"--candidate-generation", "generation-bundle",
 		"--client-request-id", "req-bundle",
+		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
@@ -2033,7 +2137,7 @@ func TestAddressOverrideValidation(t *testing.T) {
 	}
 }
 
-func TestPrintBootstrapResultIncludesOperationReference(t *testing.T) {
+func TestPrintBootstrapResultHidesOperationReference(t *testing.T) {
 	var stdout bytes.Buffer
 	printBootstrapResult(&stdout, cluster.Result{Phases: []cluster.Phase{{
 		Name:        "bootstrap-init",
@@ -2041,7 +2145,7 @@ func TestPrintBootstrapResultIncludesOperationReference(t *testing.T) {
 		Status:      "failed",
 		OperationID: "bootstrap-init-1",
 	}}})
-	if got := stdout.String(); !strings.Contains(got, "operation-id=bootstrap-init-1") || strings.Contains(got, "digest") {
+	if got := stdout.String(); strings.Contains(got, "operation-id") || strings.Contains(got, "digest") || !strings.Contains(got, "phase=bootstrap-init node=cp-1 status=failed") {
 		t.Fatalf("stdout = %q", got)
 	}
 }

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -38,27 +39,29 @@ type operationClient interface {
 }
 
 type operationStatusOptions struct {
-	endpoint    string
-	configPath  string
-	contextName string
-	nodeName    string
-	operationID string
-	diagnostics string
-	watch       bool
-	timeout     time.Duration
-	output      string
+	clusterConfig string
+	endpoint      string
+	configPath    string
+	contextName   string
+	nodeName      string
+	operationID   string
+	diagnostics   string
+	watch         bool
+	timeout       time.Duration
+	output        string
 }
 
 type operationListOptions struct {
-	endpoint    string
-	configPath  string
-	contextName string
-	nodeName    string
-	activeOnly  bool
-	limit       int32
-	diagnostics string
-	timeout     time.Duration
-	output      string
+	clusterConfig string
+	endpoint      string
+	configPath    string
+	contextName   string
+	nodeName      string
+	activeOnly    bool
+	limit         int32
+	diagnostics   string
+	timeout       time.Duration
+	output        string
 }
 
 func newOperationCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
@@ -69,29 +72,40 @@ func newOperationCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.C
 }
 
 func newOperationStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := operationStatusOptions{diagnostics: "normal", timeout: 30 * time.Minute, output: "json"}
+	opts := operationStatusOptions{diagnostics: "normal", timeout: 30 * time.Minute, output: "text"}
 	cmd := &cobra.Command{
-		Use:   "status",
+		Use:   "status [OPERATION_ID]",
 		Short: "Query or follow one accepted KatlOS operation",
-		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if strings.TrimSpace(opts.operationID) != "" {
+					return fmt.Errorf("OPERATION_ID cannot be combined with --operation-id")
+				}
+				opts.operationID = args[0]
+			} else if strings.TrimSpace(opts.operationID) == "" {
+				return command.Help()
+			}
 			return runOperationStatus(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
+	cmd.Flags().StringVar(&opts.clusterConfig, "config", "", "ClusterConfig YAML or Katl config bundle")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "node address override: IP, hostname, host:port, or tcp:// URL")
 	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "optional saved context created by 'katlctl context save'")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name from --config or a saved context; optional for one node")
 	cmd.Flags().StringVar(&opts.operationID, "operation-id", "", "accepted operation id")
+	cmd.Flags().Lookup("operation-id").Hidden = true
 	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
 	cmd.Flags().BoolVar(&opts.watch, "watch", false, "follow the operation until it reaches terminal state")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall status or watch timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	return cmd
 }
 
 func newOperationListCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := operationListOptions{limit: 20, diagnostics: "normal", timeout: 15 * time.Second, output: "json"}
+	opts := operationListOptions{limit: 20, diagnostics: "normal", timeout: 15 * time.Second, output: "text"}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List current and recent KatlOS operations",
@@ -100,22 +114,24 @@ func newOperationListCommand(ctx context.Context, stdout, stderr io.Writer) *cob
 			return runOperationList(ctx, opts, stdout, stderr)
 		},
 	}
-	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "katlc agent TCP endpoint host:port")
+	cmd.Flags().StringVar(&opts.clusterConfig, "config", "", "ClusterConfig YAML or Katl config bundle")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "node address override: IP, hostname, host:port, or tcp:// URL")
 	cmd.Flags().StringVar(&opts.configPath, "context-file", "", "workstation context file path")
-	cmd.Flags().StringVar(&opts.contextName, "context", "", "katlctl context name")
-	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name in the selected context")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "optional saved context created by 'katlctl context save'")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "node name from --config or a saved context; optional for one node")
 	cmd.Flags().BoolVar(&opts.activeOnly, "active", false, "show only non-terminal operations")
 	cmd.Flags().Int32Var(&opts.limit, "limit", opts.limit, "maximum operations to return")
 	cmd.Flags().StringVar(&opts.diagnostics, "diagnostics", opts.diagnostics, "diagnostics detail: normal or verbose")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "list request timeout")
-	cmd.Flags().StringVar(&opts.output, "output", opts.output, "output format: json")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	return cmd
 }
 
 func runOperationList(ctx context.Context, opts operationListOptions, stdout, stderr io.Writer) error {
 	_ = stderr
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if opts.limit < 1 || opts.limit > 100 {
 		return fmt.Errorf("--limit must be between 1 and 100")
@@ -127,7 +143,7 @@ func runOperationList(ctx context.Context, opts operationListOptions, stdout, st
 		return fmt.Errorf("--timeout must be positive")
 	}
 	target, err := resolveManagementTarget(managementTargetOptions{
-		configPath: opts.configPath, contextName: opts.contextName, nodeName: opts.nodeName,
+		clusterConfigPath: opts.clusterConfig, configPath: opts.configPath, contextName: opts.contextName, nodeName: opts.nodeName,
 		endpoint: opts.endpoint,
 	})
 	if err != nil {
@@ -151,6 +167,18 @@ func runOperationList(ctx context.Context, opts operationListOptions, stdout, st
 	for _, status := range response.GetOperations() {
 		status.RequestDigest = ""
 	}
+	if opts.output == "text" {
+		w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tKIND\tPHASE\tRESULT\tUPDATED")
+		for _, status := range response.GetOperations() {
+			result := status.GetResult()
+			if result == "" {
+				result = "running"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", status.GetOperationId(), status.GetOperationKind(), status.GetPhase(), result, status.GetUpdatedAt())
+		}
+		return w.Flush()
+	}
 	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(response)
 	if err != nil {
 		return fmt.Errorf("marshal operations: %w", err)
@@ -160,8 +188,8 @@ func runOperationList(ctx context.Context, opts operationListOptions, stdout, st
 }
 
 func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout, stderr io.Writer) error {
-	if opts.output != "json" {
-		return fmt.Errorf("--output = %q, want json", opts.output)
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	if strings.TrimSpace(opts.operationID) == "" {
 		return fmt.Errorf("--operation-id is required")
@@ -173,7 +201,7 @@ func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout
 		return fmt.Errorf("--timeout must be positive")
 	}
 	target, err := resolveManagementTarget(managementTargetOptions{
-		configPath: opts.configPath, contextName: opts.contextName, nodeName: opts.nodeName,
+		clusterConfigPath: opts.clusterConfig, configPath: opts.configPath, contextName: opts.contextName, nodeName: opts.nodeName,
 		endpoint: opts.endpoint,
 	})
 	if err != nil {
@@ -199,17 +227,17 @@ func runOperationStatus(ctx context.Context, opts operationStatusOptions, stdout
 		return fmt.Errorf("agent returned an empty operation status")
 	}
 	if !opts.watch {
-		return writeOperationStatus(stdout, status)
+		return writeOperationStatus(stdout, opts.output, status)
 	}
 	if status.GetTerminal() {
-		if err := writeOperationStatus(stdout, status); err != nil {
+		if err := writeOperationStatus(stdout, opts.output, status); err != nil {
 			return err
 		}
 		return operationResultError(status)
 	}
 
 	status, err = followOperation(requestCtx, conn.Client, request, status, stderr)
-	if writeErr := writeOperationStatus(stdout, status); writeErr != nil {
+	if writeErr := writeOperationStatus(stdout, opts.output, status); writeErr != nil {
 		return writeErr
 	}
 	if err != nil {
@@ -293,12 +321,26 @@ func followOperation(ctx context.Context, client operationClient, request *agent
 	}
 }
 
-func writeOperationStatus(stdout io.Writer, status *agentapi.OperationStatus) error {
+func writeOperationStatus(stdout io.Writer, output string, status *agentapi.OperationStatus) error {
 	if status == nil {
 		return fmt.Errorf("agent returned an empty operation status")
 	}
 	publicStatus := proto.Clone(status).(*agentapi.OperationStatus)
 	publicStatus.RequestDigest = ""
+	if output == "text" {
+		result := publicStatus.GetResult()
+		if result == "" {
+			result = "running"
+		}
+		if _, err := fmt.Fprintf(stdout, "%s %s: phase=%s result=%s\n", publicStatus.GetOperationId(), publicStatus.GetOperationKind(), publicStatus.GetPhase(), result); err != nil {
+			return err
+		}
+		if next := strings.TrimSpace(publicStatus.GetNextAction()); next != "" {
+			_, err := fmt.Fprintf(stdout, "Next action: %s\n", next)
+			return err
+		}
+		return nil
+	}
 	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(publicStatus)
 	if err != nil {
 		return fmt.Errorf("marshal operation status: %w", err)

--- a/cmd/katlctl/operation_test.go
+++ b/cmd/katlctl/operation_test.go
@@ -45,6 +45,7 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 				"--endpoint", "node.test:9443",
 				"--operation-id", "operation-1",
 				"--diagnostics", "verbose",
+				"--output", "json",
 			}, &stdout, &stderr)
 			if err != nil {
 				t.Fatalf("run() error = %v", err)
@@ -78,7 +79,7 @@ func TestOperationsListDiscoversRecentWork(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{"operations", "list", "--endpoint", "node:9443", "--active", "--limit", "5"}, &stdout, &stderr)
+	err := run(context.Background(), []string{"operations", "list", "--endpoint", "node:9443", "--active", "--limit", "5", "--output", "json"}, &stdout, &stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,6 +95,25 @@ func TestOperationsListDiscoversRecentWork(t *testing.T) {
 	}
 	if client.operationsRequest == nil || !client.operationsRequest.ActiveOnly || client.operationsRequest.Limit != 5 {
 		t.Fatalf("list request = %#v", client.operationsRequest)
+	}
+}
+
+func TestOperationsListTargetsClusterConfigWithoutContext(t *testing.T) {
+	client := &fakeKatlcAgentClient{operations: &agentapi.ListOperationsResponse{}}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("endpoint = %q", endpoint)
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"operations", "list", "--config", writeClusterConfig(t)}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "ID") || client.operationsRequest == nil {
+		t.Fatalf("stdout=%q request=%#v", stdout.String(), client.operationsRequest)
 	}
 }
 
@@ -159,8 +179,6 @@ func TestFollowOperationTimeoutReturnsLastStatus(t *testing.T) {
 
 func TestOperationStatusValidatesFlags(t *testing.T) {
 	for _, args := range [][]string{
-		{"operations", "status"},
-		{"operations", "status", "--endpoint", "node:9443"},
 		{"operations", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--diagnostics", "everything"},
 		{"operations", "status", "--endpoint", "node:9443", "--operation-id", "op-1", "--timeout", "0s"},
 	} {
@@ -182,7 +200,7 @@ func TestOperationWatchReturnsFailureAfterStatus(t *testing.T) {
 	t.Cleanup(func() { dialKatlcAgent = oldDial })
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), []string{"operations", "status", "--endpoint", "node:9443", "--operation-id", "operation-1", "--watch"}, &stdout, &stderr)
+	err := run(context.Background(), []string{"operations", "status", "--endpoint", "node:9443", "--operation-id", "operation-1", "--watch", "--output", "json"}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "disk mutation requires recovery") {
 		t.Fatalf("run() error = %v", err)
 	}

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -203,7 +204,57 @@ func TestContextSaveCreatesReachableContext(t *testing.T) {
 	}
 }
 
-func TestConfigApplyUsesContextAndDerivesBookkeeping(t *testing.T) {
+func TestContextListCurrentAndUse(t *testing.T) {
+	path := writeKatlctlConfig(t, `currentContext: lab
+contexts:
+- name: lab
+  cluster: lab
+- name: stage
+  cluster: stage
+clusters:
+- name: lab
+  nodes:
+  - name: cp-1
+    managementEndpoint: 192.0.2.11:9443
+    systemRole: control-plane
+- name: stage
+  nodes:
+  - name: cp-1
+    managementEndpoint: 192.0.2.21:9443
+    systemRole: control-plane
+`)
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"context", "list", "--context-file", path}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	fields := strings.Fields(stdout.String())
+	if !slices.Contains(fields, "*") || !slices.Contains(fields, "lab") || !slices.Contains(fields, "stage") {
+		t.Fatalf("context list = %q", stdout.String())
+	}
+	stdout.Reset()
+	if err := run(context.Background(), []string{"context", "use", "stage", "--context-file", path}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	if err := run(context.Background(), []string{"context", "current", "--context-file", path}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "stage" {
+		t.Fatalf("current context = %q", got)
+	}
+}
+
+func TestContextMissingFileExplainsHowToCreateOne(t *testing.T) {
+	t.Setenv("KATLCTL_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"context", "list"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "katlctl context save --config cluster.yaml") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestConfigApplyUsesClusterConfigAndDerivesBookkeeping(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "katlctl.yaml")
 	cfg := workstation.Config{CurrentContext: "lab", Contexts: []workstation.Context{{Name: "lab", Cluster: "lab"}}, Clusters: []workstation.Cluster{{
@@ -229,7 +280,7 @@ func TestConfigApplyUsesContextAndDerivesBookkeeping(t *testing.T) {
 	t.Cleanup(func() { configApplyNow = oldNow })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "apply", "--config", writeClusterConfig(t), "--context-file", configPath, "--node", "cp-1"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "apply", "cp-1", "--config", writeClusterConfig(t), "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstderr=%s", err, stderr.String())
 	}
 	if fake.validateRequest == nil || fake.validateRequest.CandidateGenerationId != "config-42" {

--- a/cmd/katlctl/target.go
+++ b/cmd/katlctl/target.go
@@ -122,6 +122,31 @@ func readManagementInventory(path string) (inventory.Inventory, error) {
 	return bundle.Manifest.Cluster.BootstrapInventory, nil
 }
 
+func resolveClusterConfigTopology(path string) (workstation.ResolvedTopology, error) {
+	inv, err := readManagementInventory(path)
+	if err != nil {
+		return workstation.ResolvedTopology{}, err
+	}
+	resolved, err := workstation.ResolveTopology(workstation.ResolveRequest{ExplicitInventory: &inv})
+	if err != nil {
+		return workstation.ResolvedTopology{}, err
+	}
+	data, err := os.ReadFile(strings.TrimSpace(path))
+	if err != nil {
+		return workstation.ResolvedTopology{}, fmt.Errorf("read --config %s: %w", path, err)
+	}
+	if source, sourceErr := configbundle.DecodeSource(bytes.NewReader(data)); sourceErr == nil {
+		resolved.ClusterName = strings.TrimSpace(source.Metadata.Name)
+		return resolved, nil
+	}
+	bundle, err := configbundle.ReadBundle(bytes.NewReader(data), "")
+	if err != nil {
+		return workstation.ResolvedTopology{}, fmt.Errorf("read --config %s: %w", path, err)
+	}
+	resolved.ClusterName = strings.TrimSpace(bundle.Manifest.ClusterName)
+	return resolved, nil
+}
+
 func targetFromInventory(inv inventory.Inventory, selected string) (managementTarget, error) {
 	selected = strings.TrimSpace(selected)
 	if selected == "" {

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -461,7 +461,7 @@ request internally; operators do not maintain a second configuration schema.
 Optionally plan the exact per-node runtime request through the node agent:
 
 ```text
-katlctl node apply --config ./cluster.yaml --node cp-1 --plan
+katlctl node apply cp-1 --config ./cluster.yaml --plan
 ```
 
 `katlctl` derives the source version, candidate generation, management endpoint,
@@ -472,10 +472,9 @@ If the source has already been compiled, use the bundle instead of
 recompiling it:
 
 ```text
-katlctl node apply \
-  --config ./katl-lab.katlcfg \
-  --node cp-1 \
-  --plan
+katlctl node apply cp-1 \
+	--config ./katl-lab.katlcfg \
+	--plan
 ```
 
 Remove `--plan` to submit the accepted plan. The default `--mode auto` uses

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -60,10 +60,10 @@ or recent node work later with:
 
 ```sh
 katlctl operations list \
-  --node cp-1
+  --config ./cluster.yaml --node cp-1
 ```
 
-`katlctl operations status --operation-id ID` remains an advanced diagnostic
+`katlctl operations status ID` remains an advanced diagnostic
 path for one exact record. Use `--diagnostics verbose` when normal redacted
 status is insufficient.
 

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -63,12 +63,18 @@ Inspect the resolved context after saving it:
 
 ```sh
 katlctl context show
+katlctl context list
 katlctl node status cp-1
 ```
 
 The save command has already performed the agent health check. Normal management
 commands now need only `--node`; `--context` selects a non-current cluster.
 An explicit `--endpoint` remains available when operating without a saved
+context.
+
+Use `katlctl context current` to print the selection and `katlctl context use
+NAME` to switch between saved clusters. `katlctl cluster status --config
+./cluster.yaml` summarizes every configured node without requiring a saved
 context.
 
 ## Routine Host Management

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -68,7 +68,7 @@ unclear, discover the affected node's current and recent operations:
 
 ```sh
 katlctl operations list \
-  --node cp-1
+  --config ./cluster.yaml --node cp-1
 ```
 
 ## Establish Cluster Networking

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -28,9 +28,8 @@ An optional plan compiles the selected node configuration and asks the node to
 validate it without accepting an operation:
 
 ```sh
-katlctl node apply --config ./cluster.yaml \
-  --node cp-1 \
-  --plan
+katlctl node apply cp-1 --config ./cluster.yaml \
+	--plan
 ```
 
 Validation reports the changed domains and accepted apply mode without
@@ -41,7 +40,7 @@ intend to constrain that policy; unsafe requests are refused.
 If the source has already been compiled, pass the bundle through the same flag:
 
 ```sh
-katlctl node apply --config ./katl-lab.katlcfg --node cp-1 --plan
+katlctl node apply cp-1 --config ./katl-lab.katlcfg --plan
 ```
 
 Katl derives and verifies the bundle's integrity metadata from the file.
@@ -51,7 +50,7 @@ Katl derives and verifies the bundle's integrity metadata from the file.
 Run the same arguments without `--plan`:
 
 ```sh
-katlctl node apply --config ./cluster.yaml --node cp-1
+katlctl node apply cp-1 --config ./cluster.yaml
 ```
 
 `katlctl` resolves the selected workstation context, reads the node credential,
@@ -60,21 +59,11 @@ validates the change, follows the durable apply, and exits only after a terminal
 result. Require `terminal: true` and `result: succeeded`. If `recoveryRequired`
 is true, stop and follow `failureReason` and `nextAction`.
 
-## Check Generation Status
+## Check Status
 
-Query the candidate through the agent:
-
-```sh
-katlctl node apply status \
-  --node cp-1
-```
-
-The command selects the node's current generation automatically. Pass
-`--generation` only to inspect an older or staged generation. For a live change,
-require committed state and healthy config-apply evidence.
-For a next-boot change, require committed staged state, reboot in a controlled
-window, then require the candidate to become healthy after
-`katl-boot-complete.target`.
+Use `katlctl node status cp-1 --config ./cluster.yaml` for the current healthy
+generation. Use `katlctl operations list --config ./cluster.yaml --node cp-1`
+when diagnosing an accepted or recently completed configuration operation.
 
 On-node evidence remains available under:
 

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -18,7 +18,7 @@ at `/run/katl/console/rendered.txt` for collection over SSH.
 | Installed node does not complete boot | boot console; boot-health and handoff services |
 | Agent cannot be reached | network path to TCP 9443; `katlc-agent.service`; token file mapping |
 | Bootstrap or join fails | `katlctl` phase output; node operation record; kubelet/containerd/kubeadm journals |
-| Config apply stalls or rolls back | `katlctl node apply status`; generation and operation records |
+| Config apply stalls or rolls back | `katlctl node status` and `katlctl operations list`; generation and operation records |
 | Host upgrade does not stage or boot | host-upgrade operation; boot selection; boot-health journal |
 | Wipe is refused | wipe JSON refusals; selected topology; Kubernetes cleanup diagnostics |
 
@@ -44,7 +44,7 @@ katlctl operations list \
   --endpoint affected-node.example.test:9443
 ```
 
-Use `katlctl operations status --operation-id ID --diagnostics verbose` when an
+Use `katlctl operations status ID --diagnostics verbose` when an
 exact record needs deeper inspection.
 
 If the agent is unavailable, use SSH as a break-glass evidence path and read

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -20,7 +20,7 @@ orchestrate availability across several hosts.
 ## Plan
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 --config ./cluster.yaml --node cp-1 --plan
+katlctl node upgrade v2026.7.0-alpha.9 cp-1 --config ./cluster.yaml --plan
 ```
 
 A plan response has no durable mutation and does not reboot the node.
@@ -34,7 +34,7 @@ component metadata before changing the inactive slot.
 Run the command without `--plan`:
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 --config ./cluster.yaml --node cp-1
+katlctl node upgrade v2026.7.0-alpha.9 cp-1 --config ./cluster.yaml
 ```
 
 For repeated day-two commands, `katlctl context save --config ./cluster.yaml`
@@ -43,9 +43,9 @@ cluster configuration operators must maintain.
 
 `katlctl` follows staging progress, asks the node agent to reboot,
 waits for the agent to restart, and requires the selected generation to be
-committed, booted, and healthy. A successful JSON result has `rebooted: true`
-and `bootHealth: healthy`. Check workload availability before upgrading another
-host.
+committed, booted, and healthy. The default result is concise text; use
+`--output json` when automation needs the structured `rebooted` and
+`bootHealth` fields. Check workload availability before upgrading another host.
 
 ## Failure Boundary
 

--- a/docs/operations/upgrade-kubernetes.md
+++ b/docs/operations/upgrade-kubernetes.md
@@ -8,7 +8,7 @@ upgrade node`.
 
 ## Preconditions
 
-- every node is reachable through the selected `katlctl` workstation context;
+- every node in the retained `ClusterConfig` is reachable;
 - every node reports either the common source version or the selected target
   version on a committed, healthy generation;
 - no other mutating Katl operation is active;
@@ -23,11 +23,11 @@ release; operators do not supply the bundle identity.
 
 ```sh
 katlctl kubernetes upgrade \
-  v1.36.1 --plan
+  v1.36.1 --config ./cluster.yaml --plan
 ```
 
-By default, `katlctl` uses the current context in its workstation configuration.
-Use `--context NAME`, `--context-file PATH`, or `--inventory PATH` when needed.
+The retained `ClusterConfig` is the normal topology source. A saved context is
+optional shorthand: use `--context NAME` after `katlctl context save`.
 
 The plan connects to every node, reads its current healthy generation and
 Kubernetes payload, derives the control-plane/worker order, and asks every
@@ -44,7 +44,7 @@ internally. An unavailable version fails before any node operation is accepted.
 Run the same command without `--plan`:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1
+katlctl kubernetes upgrade v1.36.1 --config ./cluster.yaml
 ```
 
 The command itself authorizes the rollout; there is no additional confirmation
@@ -62,7 +62,7 @@ The default path neither cordons nor drains nodes. To prevent new pods from
 being scheduled onto the node during its upgrade, opt into temporary cordoning:
 
 ```sh
-katlctl kubernetes upgrade v1.36.1 \
+katlctl kubernetes upgrade v1.36.1 --config ./cluster.yaml \
   --cordon --kubeconfig ./kubeconfig
 ```
 

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -18,15 +18,15 @@ before accepting the operation.
 - stop if a control-plane or etcd member is expected to remain part of the same
   cluster.
 
-The current workstation context is the normal saved topology source. Pass a
-retained `ClusterConfig` or PXE/offline config bundle
-through `--config` when operating without a saved context. `--inventory`
-remains available for expert recovery tooling.
+The retained `ClusterConfig` or PXE/offline config bundle is the normal topology
+source. A saved workstation context is optional shorthand for repeated work;
+the lower-level inventory input is reserved for recovery tooling.
 
 ## Plan a Whole-Cluster Wipe
 
 ```sh
 katlctl cluster wipe \
+  --config ./cluster.yaml \
   --plan \
   --all
 ```
@@ -37,7 +37,7 @@ preserved surface, and refusal.
 Execute only when the cluster is intentionally being discarded:
 
 ```sh
-katlctl cluster wipe --all
+katlctl cluster wipe --config ./cluster.yaml --all
 ```
 
 The command follows every node-local destructive reset and reports each
@@ -58,7 +58,7 @@ After saving it, the workstation context supplies topology, so
 the source can be omitted:
 
 ```sh
-katlctl node wipe worker-1 --kubeconfig ./kubeconfig
+katlctl node wipe worker-1 --config ./cluster.yaml --kubeconfig ./kubeconfig
 ```
 
 Execution requires `--kubeconfig` so Katl can remove the Kubernetes Node first.


### PR DESCRIPTION
Makes ClusterConfig the normal input across lifecycle commands, adds text-first output and complete context and cluster status workflows, hides internal controls, and strengthens executable CLI contract tests.