### PR TITLE
bootstrap: restore the installed operator journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,14 @@ directly from the same cluster source:
 
 ```sh
 katlctl cluster bootstrap --config ./cluster.yaml \
-  --init-node cp-1 \
-  --kubeconfig-out ./kubeconfig \
-  --overwrite-kubeconfig
+  --init-node cp-1
 ```
 
 The node agent fetches the selected Kubernetes OCI bundle, verifies its
 manifest and layer digests, stages the sysext, creates generation 1, and runs
-the bounded kubeadm operation. Katl then hands the Kubernetes API and
-kubeconfig to the operator.
+the bounded kubeadm operation. Katl reports phase changes and writes the
+operator kubeconfig to `./kubeconfig`; rerunning the unchanged command resumes
+an interrupted bootstrap.
 
 ## Configuration and upgrades
 

--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -368,6 +368,7 @@ func runWriteRuntimeRoot(args []string, stdout, stderr io.Writer, cfg config) er
 		SHA256:           digest,
 		Compression:      "zstd",
 		Generation:       cfg.Generation,
+		Version:          cfg.Version,
 		Architecture:     cfg.Architecture,
 		RuntimeInterface: "katl-runtime-1",
 		CompatibleBoot: &bootCompat{
@@ -790,7 +791,7 @@ func runWriteKatlOSIndex(args []string, stdout, stderr io.Writer, cfg config) er
 				Format:       rootMeta.Format,
 				SizeBytes:    rootMeta.SizeBytes,
 				SHA256:       rootMeta.SHA256,
-				Version:      firstNonEmpty(rootMeta.Generation, rootMeta.Version, *buildID),
+				Version:      firstNonEmpty(rootMeta.Version, *version, rootMeta.Generation, *buildID),
 				Architecture: rootMeta.Architecture,
 				Compatibility: katlosCompatibility{
 					RuntimeInterface: rootMeta.RuntimeInterface,

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -313,6 +313,7 @@ func TestMetadataWriters(t *testing.T) {
 	sysext := writeTestFile(t, workDir, "katl-kubernetes.raw", "kubernetes sysext")
 	env := []string{
 		"KATL_BUILD_COMMIT=test-build",
+		"KATL_VERSION=0.1.0",
 		"KATL_ARCHITECTURE=x86_64",
 	}
 
@@ -325,6 +326,9 @@ func TestMetadataWriters(t *testing.T) {
 	readTestJSON(t, runtimeRoot+".json", &rootMetadata)
 	if rootMetadata.Name != "runtime-root" || rootMetadata.SHA256 != runtimeSHA || rootMetadata.Compression != "zstd" {
 		t.Fatalf("runtime root metadata = %#v, sha stdout %q", rootMetadata, runtimeSHA)
+	}
+	if rootMetadata.Version != "0.1.0" || rootMetadata.Generation != "test-build" {
+		t.Fatalf("runtime root identity = version %q generation %q", rootMetadata.Version, rootMetadata.Generation)
 	}
 	if rootMetadata.CompatibleBoot == nil || rootMetadata.CompatibleBoot.Kind != "uki" {
 		t.Fatalf("runtime root boot compatibility = %#v", rootMetadata.CompatibleBoot)
@@ -415,6 +419,9 @@ func TestMetadataWriters(t *testing.T) {
 	readTestJSON(t, indexPath, &index)
 	if index.Kind != "KatlOSImage" || len(index.Components) != 2 {
 		t.Fatalf("KatlOS index = %#v", index)
+	}
+	if index.Components[0].Version != "0.1.0" {
+		t.Fatalf("runtime component version = %q, want release version", index.Components[0].Version)
 	}
 	if index.Components[0].Compatibility.Boot == nil || index.Components[1].Compatibility.RuntimeRoot == nil {
 		t.Fatalf("KatlOS component compatibility = %#v", index.Components)

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -2124,10 +2124,11 @@ type clusterBootstrapOptions struct {
 	bootstrapWaitValues                    stringList
 	bootstrapStableEndpoint                string
 	bootstrapStableEndpointBeforeManifests bool
+	verbose                                bool
 }
 
 func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	opts := clusterBootstrapOptions{}
+	opts := clusterBootstrapOptions{kubeconfigOut: "kubeconfig"}
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Bootstrap Kubernetes from a ClusterConfig or config bundle",
@@ -2144,7 +2145,7 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 	cmd.Flags().StringVar(&opts.joinWorker, "join-worker", "", "join one fresh worker to an already initialized cluster without rerunning kubeadm init")
 	cmd.Flags().StringVar(&opts.controlPlaneEndpoint, "control-plane-endpoint", "", "control-plane endpoint host:port")
 	cmd.Flags().StringVar(&opts.kubernetesBundle, "kubernetes-bundle", "", "Kubernetes OCI bundle image reference; an @sha256 manifest pin is optional")
-	cmd.Flags().StringVar(&opts.kubeconfigOut, "kubeconfig-out", "", "operator kubeconfig output path")
+	cmd.Flags().StringVar(&opts.kubeconfigOut, "kubeconfig-out", opts.kubeconfigOut, "operator kubeconfig output path")
 	cmd.Flags().BoolVar(&opts.overwriteKubeconfig, "overwrite-kubeconfig", false, "overwrite different existing kubeconfig")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "validate and print the bootstrap plan without running kubeadm")
 	cmd.Flags().StringVar(&opts.vmtestTranscriptDir, "vmtest-transcript-dir", "", "directory for per-node vmtest agent transcript artifacts")
@@ -2157,6 +2158,7 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 	cmd.Flags().Var(&opts.bootstrapWaitValues, "bootstrap-wait", "post-bootstrap wait: api-ready, nodes-ready, resource-exists[:namespace]:kind/name, condition[:namespace]:kind/name:Condition, rollout-status[:namespace]:kind/name, or pods-ready[:namespace]:selector")
 	cmd.Flags().StringVar(&opts.bootstrapStableEndpoint, "bootstrap-stable-endpoint", "", "stable API endpoint host:port to wait for before writing kubeconfig")
 	cmd.Flags().BoolVar(&opts.bootstrapStableEndpointBeforeManifests, "bootstrap-stable-endpoint-before-manifests", false, "wait for stable API endpoint before applying bootstrap manifests")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "show operation IDs and recovery details with bootstrap progress")
 	return cmd
 }
 
@@ -2192,7 +2194,9 @@ func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdo
 		if strings.TrimSpace(opts.vmtestTranscriptDir) != "" {
 			return fmt.Errorf("--join-worker requires katlc agent transport")
 		}
-		result, err := runAgentWorkerJoin(ctx, request, strings.TrimSpace(opts.joinWorker), agentBootstrapDependencies())
+		deps := agentBootstrapDependencies()
+		deps.Progress = bootstrapProgressWriter(stderr, opts.verbose)
+		result, err := runAgentWorkerJoin(ctx, request, strings.TrimSpace(opts.joinWorker), deps)
 		printBootstrapResult(stdout, result)
 		return err
 	}
@@ -2200,10 +2204,42 @@ func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdo
 	if strings.TrimSpace(opts.vmtestTranscriptDir) != "" {
 		result, err = runBootstrap(ctx, request, bootstrapDependencies(opts.vmtestTranscriptDir))
 	} else {
-		result, err = runAgentBootstrap(ctx, request, agentBootstrapDependencies())
+		deps := agentBootstrapDependencies()
+		deps.Progress = bootstrapProgressWriter(stderr, opts.verbose)
+		result, err = runAgentBootstrap(ctx, request, deps)
 	}
 	printBootstrapResult(stdout, result)
 	return err
+}
+
+func bootstrapProgressWriter(stderr io.Writer, verbose bool) func(cluster.AgentBootstrapProgress) {
+	return func(progress cluster.AgentBootstrapProgress) {
+		fmt.Fprint(stderr, "katlctl cluster bootstrap")
+		if progress.Node != "" {
+			fmt.Fprintf(stderr, " node=%s", progress.Node)
+		}
+		if progress.Kind != "" {
+			fmt.Fprintf(stderr, " operation=%s", progress.Kind)
+		}
+		fmt.Fprintf(stderr, " phase=%s", progress.Phase)
+		if progress.Terminal {
+			fmt.Fprintf(stderr, " result=%s", fallbackText(progress.Result, "completed"))
+		}
+		if verbose && progress.OperationID != "" {
+			fmt.Fprintf(stderr, " operation-id=%s", progress.OperationID)
+		}
+		if verbose && progress.NextAction != "" {
+			fmt.Fprintf(stderr, " next=%q", progress.NextAction)
+		}
+		fmt.Fprintln(stderr)
+	}
+}
+
+func fallbackText(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, error) {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -953,6 +953,37 @@ func TestClusterBootstrapParsesFlagsAndPrintsNextStep(t *testing.T) {
 	}
 }
 
+func TestClusterBootstrapDefaultsKubeconfigAndPrintsProgress(t *testing.T) {
+	inventoryPath := writeInventory(t)
+	var got cluster.Request
+	old := runAgentBootstrap
+	runAgentBootstrap = func(_ context.Context, request cluster.Request, deps cluster.AgentBootstrapDependencies) (cluster.Result, error) {
+		got = request
+		deps.Progress(cluster.AgentBootstrapProgress{Node: "cp-1", OperationID: "bootstrap-init-1", Kind: "bootstrap-init", Phase: "kubeadm-init", NextAction: "wait for kubeadm"})
+		return cluster.Result{Plan: inventory.Plan{InitNode: "cp-1", Nodes: []inventory.PlannedNode{{Name: "cp-1"}}}, DryRun: true}, nil
+	}
+	t.Cleanup(func() { runAgentBootstrap = old })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"cluster", "bootstrap",
+		"--inventory", inventoryPath,
+		"--dry-run",
+		"--verbose",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if got.KubeconfigOut != "kubeconfig" {
+		t.Fatalf("KubeconfigOut = %q, want kubeconfig", got.KubeconfigOut)
+	}
+	for _, want := range []string{"node=cp-1", "operation=bootstrap-init", "phase=kubeadm-init", "operation-id=bootstrap-init-1", `next="wait for kubeadm"`} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("progress missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
 func TestClusterBootstrapDefaultsToAgentBootstrap(t *testing.T) {
 	inventoryPath := writeInventory(t)
 	var got cluster.Request

--- a/cmd/katlctl/operation.go
+++ b/cmd/katlctl/operation.go
@@ -165,6 +165,7 @@ func runOperationList(ctx context.Context, opts operationListOptions, stdout, st
 		return err
 	}
 	for _, status := range response.GetOperations() {
+		status.ClientRequestId = ""
 		status.RequestDigest = ""
 	}
 	if opts.output == "text" {
@@ -326,6 +327,7 @@ func writeOperationStatus(stdout io.Writer, output string, status *agentapi.Oper
 		return fmt.Errorf("agent returned an empty operation status")
 	}
 	publicStatus := proto.Clone(status).(*agentapi.OperationStatus)
+	publicStatus.ClientRequestId = ""
 	publicStatus.RequestDigest = ""
 	if output == "text" {
 		result := publicStatus.GetResult()
@@ -355,6 +357,7 @@ func writeMutationOperationStatus(stdout io.Writer, status *agentapi.OperationSt
 	}
 	publicStatus := proto.Clone(status).(*agentapi.OperationStatus)
 	publicStatus.OperationId = ""
+	publicStatus.ClientRequestId = ""
 	publicStatus.RequestDigest = ""
 	data, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(publicStatus)
 	if err != nil {

--- a/cmd/katlctl/operation_test.go
+++ b/cmd/katlctl/operation_test.go
@@ -23,6 +23,7 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 			client := &fakeKatlcAgentClient{operationStatus: &agentapi.OperationStatus{
 				OperationId:             "operation-1",
 				OperationKind:           kind,
+				ClientRequestId:         "internal-request-1",
 				RequestDigest:           strings.Repeat("a", 64),
 				Phase:                   "complete",
 				Terminal:                true,
@@ -57,8 +58,8 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 			if got.GetOperationKind() != kind || !got.GetRecoveryRequired() || got.GetFailureReason() != "operator recovery is required" {
 				t.Fatalf("status = %#v", &got)
 			}
-			if got.GetRequestDigest() != "" || strings.Contains(stdout.String(), "requestDigest") {
-				t.Fatalf("status exposed request digest: %s", stdout.String())
+			if got.GetClientRequestId() != "" || got.GetRequestDigest() != "" || strings.Contains(stdout.String(), "clientRequestId") || strings.Contains(stdout.String(), "requestDigest") {
+				t.Fatalf("status exposed internal request identity: %s", stdout.String())
 			}
 			if client.operationRequest.GetExpectedRequestDigest() != "" || client.operationRequest.GetIncludeDiagnostics() != "verbose" {
 				t.Fatalf("request = %#v", client.operationRequest)
@@ -69,8 +70,8 @@ func TestOperationStatusQueriesEveryOperationKind(t *testing.T) {
 
 func TestOperationsListDiscoversRecentWork(t *testing.T) {
 	client := &fakeKatlcAgentClient{operations: &agentapi.ListOperationsResponse{Operations: []*agentapi.OperationStatus{
-		{OperationId: "active-1", OperationKind: "host-upgrade", RequestDigest: strings.Repeat("a", 64), Phase: "download"},
-		{OperationId: "done-1", OperationKind: "generation-apply", RequestDigest: strings.Repeat("b", 64), Phase: "complete", Terminal: true, Result: "succeeded"},
+		{OperationId: "active-1", OperationKind: "host-upgrade", ClientRequestId: "internal-active", RequestDigest: strings.Repeat("a", 64), Phase: "download"},
+		{OperationId: "done-1", OperationKind: "generation-apply", ClientRequestId: "internal-done", RequestDigest: strings.Repeat("b", 64), Phase: "complete", Terminal: true, Result: "succeeded"},
 	}}}
 	oldDial := dialKatlcAgent
 	dialKatlcAgent = func(context.Context, string) (katlcAgentConnection, error) {
@@ -90,8 +91,8 @@ func TestOperationsListDiscoversRecentWork(t *testing.T) {
 	if len(got.Operations) != 2 || got.Operations[0].OperationId != "active-1" {
 		t.Fatalf("operations = %#v", got.Operations)
 	}
-	if strings.Contains(stdout.String(), "requestDigest") {
-		t.Fatalf("operations exposed request digest: %s", stdout.String())
+	if strings.Contains(stdout.String(), "clientRequestId") || strings.Contains(stdout.String(), "requestDigest") {
+		t.Fatalf("operations exposed internal request identity: %s", stdout.String())
 	}
 	if client.operationsRequest == nil || !client.operationsRequest.ActiveOnly || client.operationsRequest.Limit != 5 {
 		t.Fatalf("list request = %#v", client.operationsRequest)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -425,15 +425,16 @@ management endpoints, bootstrap directly from the same source:
 
 ```text
 katlctl cluster bootstrap --config ./cluster.yaml \
-  --init-node cp-1 \
-  --kubeconfig-out kubeconfig \
-  --overwrite-kubeconfig
+  --init-node cp-1
 ```
 
 Katl compiles the source internally to obtain the control-plane endpoint, node
 topology, roles, kubeadm references, Kubernetes version, and OCI bundle
 selection. `--node-address node=address` remains available for an
 operator-observed address that differs from the compiled source.
+Bootstrap reports phase changes while it runs and writes `./kubeconfig` by
+default. Rerun the unchanged command to resume observing an interrupted
+bootstrap; add `--verbose` for operation IDs and recovery details.
 
 The management API is intentionally credential-free on Katl's supported
 trusted home-lab network. Bootstrap requires no enrollment or token exchange.

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -34,8 +34,7 @@ running kubeadm:
 ```sh
 katlctl cluster bootstrap --config ./cluster.yaml \
   --dry-run \
-  --init-node cp-1 \
-  --kubeconfig-out ./kubeconfig
+  --init-node cp-1
 ```
 
 No enrollment or management credential is required. Use `--node-address
@@ -52,19 +51,24 @@ Run the same command without `--dry-run`:
 
 ```sh
 katlctl cluster bootstrap --config ./cluster.yaml \
-  --init-node cp-1 \
-  --kubeconfig-out ./kubeconfig \
-  --overwrite-kubeconfig
+  --init-node cp-1
 ```
 
 The normal sequence verifies and stages the Kubernetes sysext, initializes the
 first control plane, creates join material, joins remaining nodes, checks
 post-kubeadm health, commits generation 1, and writes the operator kubeconfig.
-Save the command output and resulting kubeconfig.
+By default the kubeconfig is written to `./kubeconfig`. Use
+`--kubeconfig-out` to choose another path, or `--overwrite-kubeconfig` when an
+existing file is intentionally being replaced.
+
+The command prints each node and operation phase as it changes. Add `--verbose`
+to include operation IDs and the agent's current recovery guidance.
 
 Bootstrap waits for its submitted operations, and their node-local records
-remain queryable afterward. If the workstation disconnects or a result is
-unclear, discover the affected node's current and recent operations:
+remain queryable afterward. Rerunning the same command with the same config
+resumes observation of matching in-flight bootstrap operations instead of
+submitting duplicates. If a result is unclear, discover the affected node's
+current and recent operations:
 
 ```sh
 katlctl operations list \
@@ -81,7 +85,6 @@ conditions:
 ```sh
 katlctl cluster bootstrap --config ./cluster.yaml \
   --init-node cp-1 \
-  --kubeconfig-out ./kubeconfig \
   --bootstrap-manifest ./cni.yaml \
   --bootstrap-wait nodes-ready
 ```
@@ -110,8 +113,10 @@ endpoint, and node readiness matches the chosen CNI stage.
 
 ## Failure Boundary
 
-Do not assume rerunning bootstrap is safe. If kubeadm or API mutation began,
-host generation rollback does not erase it. Preserve the command result and follow
-[Troubleshoot KatlOS](troubleshoot.md). Kubernetes upgrades use the separate
+Rerunning the unchanged bootstrap command is the supported way to resume an
+interrupted invocation. Do not change cluster intent merely to bypass a failed
+operation: if kubeadm or API mutation began, host generation rollback does not
+erase it. Preserve the command result and follow [Troubleshoot
+KatlOS](troubleshoot.md). Kubernetes upgrades use the separate
 [Upgrade Kubernetes](upgrade-kubernetes.md) workflow. Additional-control-plane
 repair and general reconciliation remain unsupported alpha operations.

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -31,11 +31,21 @@ const (
 type AgentBootstrapDependencies struct {
 	Connector       AgentConnector
 	Actor           string
-	Now             func() time.Time
 	WatchTimeout    time.Duration
 	PollInterval    time.Duration
 	OperationWait   time.Duration
 	BootstrapRunner BootstrapRunner
+	Progress        func(AgentBootstrapProgress)
+}
+
+type AgentBootstrapProgress struct {
+	Node        string
+	OperationID string
+	Kind        string
+	Phase       string
+	Terminal    bool
+	Result      string
+	NextAction  string
 }
 
 type AgentConnector interface {
@@ -53,6 +63,7 @@ type AgentClient interface {
 	SubmitOperation(context.Context, *agentapi.SubmitOperationRequest, ...grpc.CallOption) (*agentapi.OperationAccepted, error)
 	CreateWorkerJoinMaterial(context.Context, *agentapi.CreateWorkerJoinMaterialRequest, ...grpc.CallOption) (*agentapi.CreateWorkerJoinMaterialResponse, error)
 	GetOperation(context.Context, *agentapi.GetOperationRequest, ...grpc.CallOption) (*agentapi.OperationStatus, error)
+	ListOperations(context.Context, *agentapi.ListOperationsRequest, ...grpc.CallOption) (*agentapi.ListOperationsResponse, error)
 	WatchOperation(context.Context, *agentapi.WatchOperationRequest, ...grpc.CallOption) (agentapi.KatlcAgent_WatchOperationClient, error)
 }
 
@@ -107,6 +118,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 		return Result{}, err
 	}
 	result := Result{Plan: plan, DryRun: request.DryRun}
+	emitAgentProgress(deps, AgentBootstrapProgress{Phase: "planning"})
 	result.addPhase("plan", "", "", "passed")
 	bootstrap, err := prepareBootstrap(mergeBootstrap(planBootstrap(plan.Bootstrap), request.Bootstrap))
 	if err != nil {
@@ -121,6 +133,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	if deps.Connector == nil {
 		return result, errors.New("katlc agent connector is required")
 	}
+	emitAgentProgress(deps, AgentBootstrapProgress{Phase: "checking-node-readiness"})
 	statuses, err := checkAgentReadiness(ctx, plan, deps.Connector)
 	if err != nil {
 		result.addPhase("readiness", "", "", "failed")
@@ -141,6 +154,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 		return result, err
 	}
 	status := statuses[initNode.Name]
+	emitAgentProgress(deps, AgentBootstrapProgress{Node: initNode.Name, Kind: agentBootstrapInitKind, Phase: "submitting"})
 	initResult, err := submitAndWaitBootstrapInit(ctx, initNode, plan, status, deps)
 	if err != nil {
 		result.addOperationPhase("bootstrap-init", initNode.Name, inventory.ActionInit, "failed", initResult.Operation)
@@ -148,6 +162,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	}
 	result.addOperationPhase("bootstrap-init", initNode.Name, inventory.ActionInit, "passed", initResult.Operation)
 	for _, node := range controlPlaneJoinNodes(plan) {
+		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, Kind: "bootstrap-join-control-plane", Phase: "creating-join-material"})
 		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, deps)
 		if err != nil {
 			result.addPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "failed")
@@ -161,6 +176,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 		result.addOperationPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "passed", operationRef)
 	}
 	for _, node := range workerNodes(plan) {
+		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, Kind: "bootstrap-join-worker", Phase: "creating-join-material"})
 		material, err := createWorkerJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, deps)
 		if err != nil {
 			result.addPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "failed")
@@ -175,6 +191,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	}
 	stableEndpointReady := false
 	if bootstrap.enabled() {
+		emitAgentProgress(deps, AgentBootstrapProgress{Phase: "applying-bootstrap-manifests"})
 		bootstrapResult, err := deps.BootstrapRunner.RunUserBootstrap(ctx, BootstrapRequest{
 			Server:         bootstrapServer(initNode, plan),
 			StableEndpoint: bootstrap.StableEndpoint,
@@ -191,6 +208,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 		stableEndpointReady = bootstrapResult.StableEndpointReady
 		result.addPhase("user-bootstrap", "", "", "passed")
 	}
+	emitAgentProgress(deps, AgentBootstrapProgress{Phase: "writing-kubeconfig"})
 	kubeconfigResult, err := kubeconfig.Write(kubeconfig.Request{
 		Path:      request.KubeconfigOut,
 		Overwrite: request.OverwriteKubeconfig,
@@ -330,9 +348,6 @@ func readinessFromStatuses(plan inventory.Plan, statuses map[string]*agentapi.No
 			if required != "" && !contains(status.GetSupportedOperationKinds(), required) {
 				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "katlc-agent", Message: fmt.Sprintf("%s operation is not supported", required)})
 			}
-			if status.GetOperationLockHeld() {
-				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "katlc-agent", Message: fmt.Sprintf("operation lock is held by %s", strings.Join(status.GetActiveOperationIds(), ","))})
-			}
 			if strings.TrimSpace(status.GetMachineId()) == "" {
 				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "machine-id", Message: "node did not report a machine identity"})
 			}
@@ -367,12 +382,20 @@ func submitAndWaitBootstrapInit(ctx context.Context, node inventory.PlannedNode,
 	}
 	defer closeAgent(conn)
 	req := bootstrapInitRequest(node, plan, status, deps)
-	accepted, err := conn.Client.SubmitOperation(ctx, req)
+	accepted, resumed, err := resumeBootstrapOperation(ctx, conn.Client, req.ClientRequestId, req.OperationKind)
+	if err != nil {
+		return bootstrapInitResult{}, err
+	}
+	if !resumed {
+		accepted, err = conn.Client.SubmitOperation(ctx, req)
+	} else {
+		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, OperationID: accepted.GetOperationId(), Kind: req.OperationKind, Phase: "resuming"})
+	}
 	if err != nil {
 		return bootstrapInitResult{}, fmt.Errorf("submit operation: %w", err)
 	}
 	result := bootstrapInitResult{Operation: operationReference{ID: accepted.GetOperationId()}}
-	final, err := waitOperationTerminal(ctx, conn.Client, accepted, deps)
+	final, err := waitOperationTerminal(ctx, node.Name, conn.Client, accepted, deps)
 	if err != nil {
 		return result, err
 	}
@@ -457,12 +480,20 @@ func submitAndWaitJoin(ctx context.Context, node inventory.PlannedNode, plan inv
 	req := bootstrapOperationRequest(node, plan, status, deps, kind)
 	req.Bootstrap.JoinMaterialRef = strings.TrimSpace(material.Ref)
 	req.Bootstrap.WorkerJoinMaterial = material.Material
-	accepted, err := conn.Client.SubmitOperation(ctx, req)
+	accepted, resumed, err := resumeBootstrapOperation(ctx, conn.Client, req.ClientRequestId, req.OperationKind)
+	if err != nil {
+		return operationReference{}, err
+	}
+	if !resumed {
+		accepted, err = conn.Client.SubmitOperation(ctx, req)
+	} else {
+		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, OperationID: accepted.GetOperationId(), Kind: req.OperationKind, Phase: "resuming"})
+	}
 	if err != nil {
 		return operationReference{}, fmt.Errorf("submit operation: %w", err)
 	}
 	operationRef := operationReference{ID: accepted.GetOperationId()}
-	final, err := waitOperationTerminal(ctx, conn.Client, accepted, deps)
+	final, err := waitOperationTerminal(ctx, node.Name, conn.Client, accepted, deps)
 	if err != nil {
 		return operationRef, err
 	}
@@ -483,7 +514,7 @@ func bootstrapOperationRequest(node inventory.PlannedNode, plan inventory.Plan, 
 	return &agentapi.SubmitOperationRequest{
 		ApiVersion:                  agentAPIVersion,
 		Kind:                        agentSubmitOperationKind,
-		ClientRequestId:             clientRequestID(node, deps.now()),
+		ClientRequestId:             clientRequestID(node, plan, kind),
 		OperationKind:               kind,
 		Actor:                       valueOrDefault(deps.Actor, "katlctl cluster bootstrap"),
 		ExpectedMachineId:           strings.TrimSpace(status.GetMachineId()),
@@ -514,7 +545,7 @@ func requiredAgentOperationKind(action inventory.BootstrapAction) string {
 	}
 }
 
-func waitOperationTerminal(ctx context.Context, client AgentClient, accepted *agentapi.OperationAccepted, deps AgentBootstrapDependencies) (*agentapi.OperationStatus, error) {
+func waitOperationTerminal(ctx context.Context, node string, client AgentClient, accepted *agentapi.OperationAccepted, deps AgentBootstrapDependencies) (*agentapi.OperationStatus, error) {
 	if accepted == nil || strings.TrimSpace(accepted.GetOperationId()) == "" {
 		return nil, fmt.Errorf("agent did not return an operation id")
 	}
@@ -526,7 +557,28 @@ func waitOperationTerminal(ctx context.Context, client AgentClient, accepted *ag
 	}
 	status := accepted.GetInitialStatus()
 	seq := int32(0)
+	lastProgress := ""
+	emitStatus := func(status *agentapi.OperationStatus) {
+		if status == nil {
+			return
+		}
+		progress := strings.Join([]string{status.GetOperationId(), status.GetOperationKind(), status.GetPhase(), fmt.Sprint(status.GetTerminal()), status.GetResult()}, "\x00")
+		if progress == lastProgress {
+			return
+		}
+		lastProgress = progress
+		emitAgentProgress(deps, AgentBootstrapProgress{
+			Node:        node,
+			OperationID: status.GetOperationId(),
+			Kind:        status.GetOperationKind(),
+			Phase:       status.GetPhase(),
+			Terminal:    status.GetTerminal(),
+			Result:      status.GetResult(),
+			NextAction:  status.GetNextAction(),
+		})
+	}
 	if status != nil {
+		emitStatus(status)
 		seq = status.GetLatestJournalSeq()
 		if status.GetTerminal() {
 			return status, nil
@@ -553,6 +605,7 @@ func waitOperationTerminal(ctx context.Context, client AgentClient, accepted *ag
 			seq = event.GetJournalSeq()
 			if event.GetStatus() != nil {
 				status = event.GetStatus()
+				emitStatus(status)
 			}
 			if event.GetTerminal() {
 				if status == nil {
@@ -572,12 +625,19 @@ func waitOperationTerminal(ctx context.Context, client AgentClient, accepted *ag
 			return polled, nil
 		}
 		status = polled
+		emitStatus(status)
 		seq = polled.GetLatestJournalSeq()
 		select {
 		case <-waitCtx.Done():
 			return status, waitCtx.Err()
 		case <-time.After(valueOrDefaultDuration(deps.PollInterval, 250*time.Millisecond)):
 		}
+	}
+}
+
+func emitAgentProgress(deps AgentBootstrapDependencies, progress AgentBootstrapProgress) {
+	if deps.Progress != nil {
+		deps.Progress(progress)
 	}
 }
 
@@ -588,16 +648,39 @@ func closeAgent(conn AgentConnection) error {
 	return conn.Close()
 }
 
-func clientRequestID(node inventory.PlannedNode, now time.Time) string {
-	sum := sha256.Sum256([]byte(node.Name + "\x00" + node.Address + "\x00" + now.UTC().Format(time.RFC3339Nano)))
+func clientRequestID(node inventory.PlannedNode, plan inventory.Plan, kind string) string {
+	identity := strings.Join([]string{
+		node.Name,
+		kind,
+		string(node.SystemRole),
+		node.KubernetesVersion,
+		node.KubeadmConfig.Ref,
+		node.KubeadmConfig.Path,
+		plan.ControlPlaneEndpoint,
+		plan.KubernetesBundleSource,
+		plan.KubernetesBundleRef,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(identity))
 	return "katlctl-" + node.Name + "-" + hex.EncodeToString(sum[:])[:12]
 }
 
-func (deps AgentBootstrapDependencies) now() time.Time {
-	if deps.Now != nil {
-		return deps.Now().UTC()
+func resumeBootstrapOperation(ctx context.Context, client AgentClient, clientRequestID, kind string) (*agentapi.OperationAccepted, bool, error) {
+	response, err := client.ListOperations(ctx, &agentapi.ListOperationsRequest{Limit: 100})
+	if err != nil {
+		return nil, false, fmt.Errorf("list operations before %s: %w", kind, err)
 	}
-	return time.Now().UTC()
+	for _, status := range response.GetOperations() {
+		if status.GetClientRequestId() != clientRequestID || status.GetOperationKind() != kind {
+			continue
+		}
+		return &agentapi.OperationAccepted{
+			OperationId:   status.GetOperationId(),
+			OperationKind: status.GetOperationKind(),
+			RequestDigest: status.GetRequestDigest(),
+			InitialStatus: status,
+		}, true, nil
+	}
+	return nil, false, nil
 }
 
 func bootstrapProfileRef(node inventory.PlannedNode) string {

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"google.golang.org/grpc"
 )
@@ -210,7 +211,6 @@ func TestRunAgentBootstrapSubmitsInitOperationAndWaits(t *testing.T) {
 	}, AgentBootstrapDependencies{
 		Connector:    connector,
 		Actor:        "test-actor",
-		Now:          func() time.Time { return time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC) },
 		WatchTimeout: time.Second,
 	})
 	if err != nil {
@@ -234,6 +234,67 @@ func TestRunAgentBootstrapSubmitsInitOperationAndWaits(t *testing.T) {
 	}
 	if result.Kubeconfig.Path != out || result.Kubeconfig.Server != "https://api.katl.test:6443" {
 		t.Fatalf("kubeconfig result = %#v", result.Kubeconfig)
+	}
+}
+
+func TestRunAgentBootstrapResumesInterruptedInit(t *testing.T) {
+	inv := validSingleNodeInventory()
+	plan, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestID := clientRequestID(plan.Nodes[0], plan, agentBootstrapInitKind)
+	status := &agentapi.OperationStatus{
+		OperationId:     "bootstrap-init-existing",
+		OperationKind:   agentBootstrapInitKind,
+		ClientRequestId: requestID,
+		RequestDigest:   strings.Repeat("a", 64),
+		Phase:           "kubeadm-init",
+		Terminal:        true,
+		Result:          operation.ResultSucceeded,
+	}
+	client := &fakeAgentClient{
+		status:       readyAgentStatus("machine-cp-1"),
+		listResponse: &agentapi.ListOperationsResponse{Operations: []*agentapi.OperationStatus{status}},
+		getStatus: &agentapi.OperationStatus{
+			OperationId:     status.OperationId,
+			OperationKind:   status.OperationKind,
+			ClientRequestId: status.ClientRequestId,
+			RequestDigest:   status.RequestDigest,
+			Terminal:        true,
+			Result:          operation.ResultSucceeded,
+			AdminKubeconfig: adminKubeconfig(),
+		},
+	}
+	out := filepath.Join(t.TempDir(), "kubeconfig")
+	result, err := RunAgentBootstrap(context.Background(), Request{
+		Inventory:           inv,
+		KubeconfigOut:       out,
+		OverwriteKubeconfig: true,
+	}, AgentBootstrapDependencies{Connector: newFakeAgentConnector(map[string]*fakeAgentClient{"cp-1": client})})
+	if err != nil {
+		t.Fatalf("RunAgentBootstrap() error = %v", err)
+	}
+	if len(client.submitRequests) != 0 {
+		t.Fatalf("resumed bootstrap submitted %d new operations", len(client.submitRequests))
+	}
+	if result.Kubeconfig.Path != out || result.Phases[len(result.Phases)-2].OperationID != status.OperationId {
+		t.Fatalf("resumed result = %+v", result)
+	}
+}
+
+func TestBootstrapRequestIdentityIgnoresTransportAddressOverride(t *testing.T) {
+	inv := validSingleNodeInventory()
+	before, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: inv, AddressOverride: map[string]string{"cp-1": "192.0.2.99"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := clientRequestID(after.Nodes[0], after, agentBootstrapInitKind), clientRequestID(before.Nodes[0], before, agentBootstrapInitKind); got != want {
+		t.Fatalf("request identity changed with transport address: %q != %q", got, want)
 	}
 }
 
@@ -493,6 +554,8 @@ type fakeAgentClient struct {
 	events                 []*agentapi.OperationEvent
 	getStatus              *agentapi.OperationStatus
 	getErr                 error
+	listResponse           *agentapi.ListOperationsResponse
+	listErr                error
 	watchErr               error
 }
 
@@ -551,6 +614,16 @@ func (c *fakeAgentClient) GetOperation(context.Context, *agentapi.GetOperationRe
 		return c.getStatus, nil
 	}
 	return &agentapi.OperationStatus{OperationId: "operation-1", Terminal: true, Result: "succeeded"}, nil
+}
+
+func (c *fakeAgentClient) ListOperations(context.Context, *agentapi.ListOperationsRequest, ...grpc.CallOption) (*agentapi.ListOperationsResponse, error) {
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+	if c.listResponse != nil {
+		return c.listResponse, nil
+	}
+	return &agentapi.ListOperationsResponse{}, nil
 }
 
 func (c *fakeAgentClient) WatchOperation(context.Context, *agentapi.WatchOperationRequest, ...grpc.CallOption) (agentapi.KatlcAgent_WatchOperationClient, error) {

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -19,7 +19,7 @@ import (
 
 const validationActivationPath = "/run/extensions/katl-kubernetes.raw"
 
-const defaultNetworkdFile = "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n"
+const defaultNetworkdFile = "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\n"
 
 type selectedKubernetes struct {
 	version        string

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -55,7 +55,7 @@ func TestCompileClusterPlan(t *testing.T) {
 		t.Fatalf("hostname confext = %#v", hostname)
 	}
 	authorizedKeys := nativeFile(cp.NativeEtcFiles, "/etc/ssh/authorized_keys/katl")
-	if authorizedKeys == nil || authorizedKeys.Mode != 0o600 || authorizedKeys.Content != sshKey+"\n" {
+	if authorizedKeys == nil || authorizedKeys.Mode != 0o644 || authorizedKeys.Content != sshKey+"\n" {
 		t.Fatalf("authorized keys confext = %#v", authorizedKeys)
 	}
 	if len(cp.InstallManifest.Node.Identity.SSH.AuthorizedKeys) != 1 {
@@ -141,6 +141,22 @@ func TestCompileAllowsMissingAddressAndAppliesOverride(t *testing.T) {
 	}
 	if len(plan.AddressOverrides) != 1 || plan.AddressOverrides[0].Node != "worker-1" || plan.AddressOverrides[0].Address != "10.0.0.99" {
 		t.Fatalf("address overrides = %#v", plan.AddressOverrides)
+	}
+}
+
+func TestCompileDefaultDHCPUsesStableMACIdentity(t *testing.T) {
+	config := validConfig()
+	config.Spec.Defaults.Networkd.Files = nil
+	config.Spec.Nodes[0].Overrides.Networkd.Files = nil
+	plan, err := Compile(CompileRequest{Config: config, KubeadmConfigs: validKubeadmConfigs("v1.36.1")})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	for _, node := range plan.Nodes {
+		files := node.InstallManifest.Node.Networkd.Files
+		if len(files) != 1 || !strings.Contains(files[0].Content, "[DHCPv4]\nClientIdentifier=mac") {
+			t.Fatalf("%s default network = %#v", node.Name, files)
+		}
 	}
 }
 

--- a/internal/installer/clusterplan/testdata/basic.golden.json
+++ b/internal/installer/clusterplan/testdata/basic.golden.json
@@ -111,7 +111,7 @@
         {
           "path": "/etc/ssh/authorized_keys/katl",
           "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
-          "mode": 384
+          "mode": 420
         },
         {
           "path": "/etc/systemd/network/10-common.network",
@@ -230,7 +230,7 @@
         {
           "path": "/etc/ssh/authorized_keys/katl",
           "content": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example\n",
-          "mode": 384
+          "mode": 420
         },
         {
           "path": "/etc/systemd/network/10-common.network",

--- a/internal/installer/configdomain/configdomain.go
+++ b/internal/installer/configdomain/configdomain.go
@@ -38,9 +38,12 @@ func NativeEtcFiles(request RenderRequest) ([]confext.NativeEtcFile, error) {
 	files = append(files, confext.NativeEtcFile{
 		Path:    "/etc/ssh/authorized_keys/katl",
 		Content: identity.AuthorizedKeys,
-		Mode:    0o600,
-		UID:     0,
-		GID:     0,
+		// sshd reads AuthorizedKeysFile after dropping to the target user on
+		// Fedora. Public keys are not secrets; keep the root-owned file
+		// immutable to katl while allowing the account to read it.
+		Mode: 0o644,
+		UID:  0,
+		GID:  0,
 	})
 	ref := request.Manifest.Node.Kubernetes.Kubeadm.ConfigRef
 	var kubeadm *kubeadmconfig.Plan

--- a/internal/installer/configdomain/configdomain_test.go
+++ b/internal/installer/configdomain/configdomain_test.go
@@ -55,9 +55,6 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 			t.Fatalf("files[%d].Path = %q, want %q", i, files[i].Path, path)
 		}
 		wantMode := os.FileMode(0o644)
-		if path == "/etc/ssh/authorized_keys/katl" {
-			wantMode = 0o600
-		}
 		if files[i].Mode != wantMode || files[i].UID != 0 || files[i].GID != 0 {
 			t.Fatalf("files[%d] mode/owner = %04o %d:%d", i, files[i].Mode, files[i].UID, files[i].GID)
 		}
@@ -80,7 +77,7 @@ func TestNativeEtcFilesRendersKnownDomains(t *testing.T) {
 	if kubernetes["payloadVersion"] != "v1.36.1" || kubernetes["activationPath"] != "/run/extensions/katl-kubernetes.raw" {
 		t.Fatalf("metadata kubernetes = %#v", kubernetes)
 	}
-	if files[3].Mode != 0o600 || !strings.Contains(files[3].Content, "ssh-ed25519") {
+	if files[3].Mode != 0o644 || !strings.Contains(files[3].Content, "ssh-ed25519") {
 		t.Fatalf("authorized keys file = %#v", files[3])
 	}
 	if !strings.Contains(files[4].Content, "net.ipv4.ip_forward = 1") {

--- a/internal/installer/generation/state.go
+++ b/internal/installer/generation/state.go
@@ -466,6 +466,7 @@ func stateDirs() []StateDir {
 		{Path: KubernetesSource, Mode: 0o755},
 		{Path: "/var/lib/katl/ssh", Mode: 0o755},
 		{Path: "/var/lib/katl/ssh/host-keys", Mode: 0o700},
+		{Path: "/var/lib/katl/home", Mode: 0o755},
 		{Path: "/var/lib/katl/home/katl", Mode: 0o700},
 		{Path: "/var/lib/containerd", Mode: 0o755},
 		{Path: "/var/lib/etcd", Mode: 0o755},

--- a/internal/installer/generation/state_test.go
+++ b/internal/installer/generation/state_test.go
@@ -45,6 +45,8 @@ WantedBy=local-fs.target
 		"d /var/lib/katl/cluster 0750 root root -",
 		"d /var/lib/katl/config-requests 0750 root root -",
 		"d /var/lib/katl/kubernetes/etc-kubernetes 0755 root root -",
+		"d /var/lib/katl/home 0755 root root -",
+		"d /var/lib/katl/home/katl 0700 katl katl -",
 		"d /var/lib/containerd 0755 root root -",
 		"d /var/lib/etcd 0755 root root -",
 		"d /var/lib/kubelet 0755 root root -",

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -853,7 +853,10 @@ func (rebootStep) Run(ctx context.Context, install *Context) error {
 	if err := install.Commands.Run(ctx, "sync"); err != nil {
 		return fmt.Errorf("sync install state: %w", err)
 	}
-	if err := install.Commands.Run(ctx, "systemctl", "--no-block", "reboot"); err != nil {
+	// Leave the handoff API alive briefly after persisting reboot-requested so
+	// operators can observe the terminal state before the installer disappears.
+	// A transient timer keeps the delay outside the installer state machine.
+	if err := install.Commands.Run(ctx, "systemd-run", "--unit=katl-installer-reboot", "--on-active=2s", "systemctl", "--no-block", "reboot"); err != nil {
 		return fmt.Errorf("request system reboot: %w", err)
 	}
 	return nil

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -92,7 +92,7 @@ func TestRebootPersistsStatusBeforeRequest(t *testing.T) {
 
 	want := []CommandCall{
 		{Name: "sync"},
-		{Name: "systemctl", Args: []string{"--no-block", "reboot"}},
+		{Name: "systemd-run", Args: []string{"--unit=katl-installer-reboot", "--on-active=2s", "systemctl", "--no-block", "reboot"}},
 	}
 	if !reflect.DeepEqual(commands.calls, want) {
 		t.Fatalf("command calls = %#v, want %#v", commands.calls, want)
@@ -387,7 +387,7 @@ func TestRunnerRecordsCheckpointsWithoutCommands(t *testing.T) {
 	if targetStatus.State != installstatus.StateRebootRequested || targetStatus.InstalledGeneration != "2026.06.04-000" || !targetStatus.WipeTargetAccepted {
 		t.Fatalf("target status = %#v", targetStatus)
 	}
-	if got := commandNames(commands.Calls); got != "sync systemctl" {
+	if got := commandNames(commands.Calls); got != "sync systemd-run" {
 		t.Fatalf("command calls = %q, want sync and reboot request", got)
 	}
 }
@@ -1642,7 +1642,7 @@ func (r *rebootCommandRunner) Run(_ context.Context, name string, args ...string
 	if len(r.store.Statuses) > 0 && name == "sync" {
 		r.statusAtSync = r.store.Statuses[len(r.store.Statuses)-1].State
 	}
-	if name != "systemctl" {
+	if name != "systemd-run" {
 		return nil
 	}
 	if len(r.store.Statuses) > 0 {

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -1008,6 +1008,7 @@ func operationStatus(record operation.OperationRecord, includeDiagnostics bool) 
 	return &agentapi.OperationStatus{
 		OperationId:             record.OperationID,
 		OperationKind:           record.OperationKind,
+		ClientRequestId:         record.ClientRequestID,
 		RequestDigest:           record.RequestDigest,
 		Phase:                   record.Phase,
 		PhaseIndex:              int32(record.PhaseIndex),

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -89,7 +89,7 @@ func TestListOperationsFiltersActiveRecords(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(response.Operations) != 1 || response.Operations[0].OperationId != active.OperationID {
+	if len(response.Operations) != 1 || response.Operations[0].OperationId != active.OperationID || response.Operations[0].ClientRequestId != active.ClientRequestID {
 		t.Fatalf("operations = %#v", response.Operations)
 	}
 }

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -1927,6 +1927,7 @@ type OperationStatus struct {
 	PreviousGenerationId    string                 `protobuf:"bytes,26,opt,name=previous_generation_id,json=previousGenerationId,proto3" json:"previous_generation_id,omitempty"`
 	ConfigApplyPhase        string                 `protobuf:"bytes,27,opt,name=config_apply_phase,json=configApplyPhase,proto3" json:"config_apply_phase,omitempty"`
 	ChangedDomains          []string               `protobuf:"bytes,28,rep,name=changed_domains,json=changedDomains,proto3" json:"changed_domains,omitempty"`
+	ClientRequestId         string                 `protobuf:"bytes,29,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -2155,6 +2156,13 @@ func (x *OperationStatus) GetChangedDomains() []string {
 		return x.ChangedDomains
 	}
 	return nil
+}
+
+func (x *OperationStatus) GetClientRequestId() string {
+	if x != nil {
+		return x.ClientRequestId
+	}
+	return ""
 }
 
 type DiagnosticArtifact struct {
@@ -3375,7 +3383,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x16ListOperationsResponse\x12>\n" +
 	"\n" +
 	"operations\x18\x01 \x03(\v2\x1e.katl.agent.v1.OperationStatusR\n" +
-	"operations\"\xd8\t\n" +
+	"operations\"\x84\n" +
+	"\n" +
 	"\x0fOperationStatus\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\x12%\n" +
 	"\x0eoperation_kind\x18\x02 \x01(\tR\roperationKind\x12%\n" +
@@ -3408,7 +3417,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x10admin_kubeconfig\x18\x19 \x01(\tR\x0fadminKubeconfig\x124\n" +
 	"\x16previous_generation_id\x18\x1a \x01(\tR\x14previousGenerationId\x12,\n" +
 	"\x12config_apply_phase\x18\x1b \x01(\tR\x10configApplyPhase\x12'\n" +
-	"\x0fchanged_domains\x18\x1c \x03(\tR\x0echangedDomains\"\x9c\x01\n" +
+	"\x0fchanged_domains\x18\x1c \x03(\tR\x0echangedDomains\x12*\n" +
+	"\x11client_request_id\x18\x1d \x01(\tR\x0fclientRequestId\"\x9c\x01\n" +
 	"\x12DiagnosticArtifact\x12\x1f\n" +
 	"\vartifact_id\x18\x01 \x01(\tR\n" +
 	"artifactId\x12\x12\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -253,6 +253,7 @@ message OperationStatus {
   string previous_generation_id = 26;
   string config_apply_phase = 27;
   repeated string changed_domains = 28;
+  string client_request_id = 29;
 }
 
 message DiagnosticArtifact {

--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -140,20 +140,32 @@ func (c Collector) collectGeneration(snapshot *Snapshot) {
 		return
 	}
 	snapshot.Generation = id
-	spec, status, err := generation.ReadGeneration(root, id)
+	bootedSpec, status, err := generation.ReadGeneration(root, id)
 	if err != nil {
 		return
 	}
-	if version := strings.TrimSpace(spec.RuntimeVersion); version != "" {
+	if version := strings.TrimSpace(bootedSpec.RuntimeVersion); version != "" {
 		snapshot.Version = version
 	}
-	for _, extension := range spec.Sysexts {
+	snapshot.GenerationHealth = status.HealthState
+
+	softwareSpec := bootedSpec
+	target := strings.TrimSpace(selection.TargetBootGenerationID)
+	if target != "" && target != id {
+		snapshot.NextGeneration = target
+		// Bootstrap and online lifecycle operations activate their candidate
+		// before arming it for boot. Report the selected software immediately,
+		// while keeping the booted and next-boot generations distinct.
+		if spec, _, targetErr := generation.ReadGeneration(root, target); targetErr == nil {
+			softwareSpec = spec
+		}
+	}
+	for _, extension := range softwareSpec.Sysexts {
 		if extension.Name == "kubernetes" {
 			snapshot.KubernetesVersion = strings.TrimSpace(extension.PayloadVersion)
 			break
 		}
 	}
-	snapshot.GenerationHealth = status.HealthState
 }
 
 func cleanRoot(root string) string {

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -20,6 +20,7 @@ type Snapshot struct {
 	State                  string
 	CurrentStep            string
 	Generation             string
+	NextGeneration         string
 	GenerationHealth       string
 	DestructiveMutation    bool
 	LastError              string

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -166,6 +166,105 @@ func TestCollectorReadsInstalledVersionsFromBootedGeneration(t *testing.T) {
 	}
 }
 
+func TestCollectorReportsLiveBootstrapCandidateBeforeReboot(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	booted := testConsoleGeneration(t, root, "0", "2026.7.0-alpha.16", "", now)
+	candidate := testConsoleGeneration(t, root, "bootstrap-init-candidate", "2026.7.0-alpha.16", "v1.36.1", now.Add(time.Minute))
+	if err := generation.WriteBootSelection(root, generation.BootSelectionRecord{
+		APIVersion:             generation.APIVersion,
+		Kind:                   generation.BootSelectionKind,
+		DefaultGenerationID:    booted.GenerationID,
+		BootedGenerationID:     booted.GenerationID,
+		TargetBootGenerationID: candidate.GenerationID,
+		UpdatedAt:              now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "etc", "kubernetes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc", "kubernetes", "kubelet.conf"), []byte("configured\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	collector := Collector{
+		Mode:       ModeRuntime,
+		Version:    "binary-version",
+		Root:       root,
+		Hostname:   func() (string, error) { return "cp-1", nil },
+		Interfaces: func() ([]net.Interface, error) { return nil, nil },
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if snapshot.Generation != "0" || snapshot.NextGeneration != "bootstrap-init-candidate" {
+		t.Fatalf("generation = %q, next = %q", snapshot.Generation, snapshot.NextGeneration)
+	}
+	if snapshot.Version != "2026.7.0-alpha.16" || snapshot.KubernetesVersion != "v1.36.1" || !snapshot.KubernetesBootstrapped {
+		t.Fatalf("software state = KatlOS %q, Kubernetes %q, bootstrapped=%t", snapshot.Version, snapshot.KubernetesVersion, snapshot.KubernetesBootstrapped)
+	}
+	rendered := string(renderDashboard(&snapshot, nil, 80, 20, false))
+	for _, want := range []string{"Generation: 0", "Next boot:  bootstrap-init-candidate", "Version:    v1.36.1", "Bootstrapped"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("render missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func testConsoleGeneration(t *testing.T, root, id, runtimeVersion, kubernetesVersion string, now time.Time) generation.GenerationSpec {
+	t.Helper()
+	extensions := []generation.ExtensionRef(nil)
+	if kubernetesVersion != "" {
+		extensions = append(extensions, generation.ExtensionRef{
+			Name:            "kubernetes",
+			Path:            "/var/lib/katl/generations/" + id + "/sysext/kubernetes.raw",
+			ActivationPath:  "/run/extensions/katl-kubernetes.raw",
+			SHA256:          strings.Repeat("b", 64),
+			ArtifactVersion: kubernetesVersion + "-katl.1",
+			PayloadVersion:  kubernetesVersion,
+			Architecture:    "x86_64",
+			Compatibility: generation.ExtensionCompatibility{
+				RuntimeInterfaces: []string{"katl-runtime-1"},
+			},
+		})
+	}
+	record, err := generation.NewFirstInstallRecord(generation.FirstInstallRequest{
+		GenerationID:          id,
+		RuntimeVersion:        runtimeVersion,
+		RuntimeInterface:      "katl-runtime-1",
+		RuntimeArchitecture:   "x86_64",
+		RootSlot:              "root-a",
+		RootPartitionUUID:     "11111111-2222-3333-4444-555555555555",
+		RuntimeArtifactSHA256: strings.Repeat("a", 64),
+		UKIPath:               "/efi/EFI/Linux/katl-" + id + ".efi",
+		Sysexts:               extensions,
+		GeneratedConfext: generation.GeneratedConfext{
+			Name:           "katl-node",
+			Path:           "/var/lib/katl/generations/" + id + "/confext",
+			ActivationPath: "/run/confexts/katl-node",
+			SHA256:         strings.Repeat("c", 64),
+			Compatibility: generation.ConfextCompatibility{
+				ID:           "katl",
+				VersionID:    runtimeVersion,
+				ConfextLevel: 1,
+			},
+		},
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := generation.SpecFromRecord(record)
+	status, err := generation.NewGenerationStatus(spec, generation.CommitStateCommitted, generation.BootStateGood, generation.HealthStateHealthy, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := generation.WriteGeneration(root, spec, status); err != nil {
+		t.Fatal(err)
+	}
+	return spec
+}
+
 func TestRenderInstallerDashboard(t *testing.T) {
 	snapshot := Snapshot{
 		Mode:                ModeInstaller,
@@ -238,7 +337,7 @@ func TestRenderRuntimeFailure(t *testing.T) {
 		Network:           []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Status", "Host", "Kubernetes", "Needs repair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation: 4", "Error:", "boot health check failed", "SSH: root@192.0.2.20"} {
+	for _, want := range []string{"Status", "Host", "Kubernetes", "Needs repair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation: 4", "Error:", "boot health check failed", "SSH: katl@192.0.2.20"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
@@ -409,6 +508,30 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 	for number, line := range strings.Split(strings.TrimSuffix(got, "\n"), "\n") {
 		if len([]rune(line)) > 40 {
 			t.Fatalf("line %d width = %d: %q", number+1, len([]rune(line)), line)
+		}
+	}
+}
+
+func TestTerminalRenderClearsPendingAutowrapOnEveryRow(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:       ModeRuntime,
+		Hostname:   "cp-with-a-long-name",
+		Version:    "2026.7.0-alpha.15",
+		Generation: "generation-with-a-long-identifier",
+		Network: []NetworkInterface{{
+			Name:      "enp1s0",
+			Addresses: []string{"2001:db8:1234:5678::10/64", "192.0.2.10/24"},
+		}},
+	}
+	got := renderDashboard(&snapshot, testJournal{[]byte(strings.Repeat("j", 40))}, 40, 30, true)
+	for index, value := range got {
+		if value == '\n' && (index == 0 || got[index-1] != '\r') {
+			t.Fatalf("terminal row %d lacks carriage return before line feed: %q", index, got[max(0, index-8):index+1])
+		}
+	}
+	for number, line := range strings.Split(strings.TrimSuffix(string(got), "\r\n"), "\r\n") {
+		if width := visibleWidth(line); width > 40 {
+			t.Fatalf("line %d width = %d: %q", number+1, width, line)
 		}
 	}
 }

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -197,6 +197,7 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 	line.finish()
 	if remaining := render.contentRows - render.row; journal != nil && remaining > 0 {
 		render.journalState = NewJournalWriter(render.output.tail(remaining))
+		render.journalState.color = render.color
 		journal.WriteTail(&render.journalState)
 		render.output.position += render.journalState.output.position
 		render.row += render.journalState.rows
@@ -211,8 +212,8 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 	footer.writeString("Ctrl+Alt+F2: console")
 	if snapshot.SSHEnabled {
 		if address := firstIPv4(snapshot.Network); address != "" {
-			if visibleWidth("Ctrl+Alt+F2: console | SSH: root@")+visibleWidth(address) <= render.output.width {
-				footer.writeString(" | SSH: root@")
+			if visibleWidth("Ctrl+Alt+F2: console | SSH: katl@")+visibleWidth(address) <= render.output.width {
+				footer.writeString(" | SSH: katl@")
 				footer.writeString(address)
 			} else {
 				footer.writeString(" | SSH enabled")
@@ -260,6 +261,7 @@ func (render *Renderer) writeRuntimeStatusPane(snapshot *Snapshot) {
 		{label: "Node", value: fallback(snapshot.Hostname, "Unknown")},
 		{label: "KatlOS", value: fallback(snapshot.Version, "Unknown")},
 		{label: "Generation", value: fallback(snapshot.Generation, "Unknown")},
+		{label: "Next boot", value: fallback(snapshot.NextGeneration, "-")},
 	}
 	rightFields := [...]paneField{
 		{label: "State", value: kubernetesState, style: kubernetesStyle},
@@ -473,6 +475,7 @@ func runtimeKubernetesState(snapshot *Snapshot) (string, string) {
 type JournalWriter struct {
 	output RenderTarget
 	rows   int
+	color  bool
 }
 
 // NewJournalWriter binds a bounded journal writer to a fixed render target. It
@@ -521,6 +524,7 @@ func (writer *JournalWriter) WriteLine(value []byte) bool {
 func (writer *JournalWriter) writeLine(value []byte) int {
 	remaining := writer.RowsRemaining()
 	line := newLine(&writer.output)
+	line.color = writer.color
 	rows := 0
 	wrote := false
 	for position := 0; position < len(value); {
@@ -536,6 +540,7 @@ func (writer *JournalWriter) writeLine(value []byte) int {
 				return rows
 			}
 			line = newLine(&writer.output)
+			line.color = writer.color
 			if r == '\n' {
 				continue
 			}
@@ -706,6 +711,12 @@ func (l *lineWriter) end() {
 		if l.color {
 			l.output.writeString(styleReset)
 		}
+	}
+	// A character in the terminal's final column leaves autowrap pending. A
+	// carriage return clears that state before the line feed, so one rendered
+	// row always consumes exactly one terminal row.
+	if l.color {
+		l.output.writeByte('\r')
 	}
 	l.output.writeByte('\n')
 }

--- a/internal/scriptstest/build_katlos_install_image_test.go
+++ b/internal/scriptstest/build_katlos_install_image_test.go
@@ -68,6 +68,7 @@ func TestBuildKatlOSInstallImageUsesGoMetadata(t *testing.T) {
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(),
 		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"KATL_MKOSI_BUILD_DIR="+workDir,
 		"KATL_VERSION=0.1.0",
 		"KATL_ARCHITECTURE=x86_64",
 		"KATL_KATLOS_IMAGE="+output,

--- a/internal/scriptstest/installer_iso_scripts_test.go
+++ b/internal/scriptstest/installer_iso_scripts_test.go
@@ -158,6 +158,42 @@ func TestMkosiInstallerISOUsesBuilder(t *testing.T) {
 	}
 	katlosImage := writeArtifact(t, buildDir, "katlos-install-2026.7.0-dev.1-x86_64.squashfs", "katlos")
 	writeKatlosImageSidecars(t, katlosImage, "2026.7.0-dev.1")
+	runtimeRoot := writeArtifact(t, buildDir, "katl-runtime-root.squashfs", "runtime root")
+	runtimeRootSHA := fileSHA256(t, runtimeRoot)
+	writeJSONFile(t, runtimeRoot+".json", map[string]any{
+		"name":             "runtime-root",
+		"kind":             "runtime-root",
+		"format":           "squashfs",
+		"path":             filepath.Base(runtimeRoot),
+		"sizeBytes":        int64(len("runtime root")),
+		"sha256":           runtimeRootSHA,
+		"compression":      "zstd",
+		"generation":       "test-build",
+		"version":          "2026.7.0-dev.1",
+		"architecture":     "x86_64",
+		"runtimeInterface": "katl-runtime-1",
+		"compatibleBoot": map[string]any{
+			"kind":             "uki",
+			"runtimeInterface": "katl-runtime-1",
+		},
+	})
+	runtimeUKI := writeArtifact(t, buildDir, "katl-runtime.efi", "runtime uki")
+	writeJSONFile(t, runtimeUKI+".json", map[string]any{
+		"name":             "runtime-uki",
+		"kind":             "runtime-uki",
+		"format":           "uki",
+		"path":             filepath.Base(runtimeUKI),
+		"sizeBytes":        int64(len("runtime uki")),
+		"sha256":           fileSHA256(t, runtimeUKI),
+		"version":          "2026.7.0-dev.1",
+		"architecture":     "x86_64",
+		"runtimeInterface": "katl-runtime-1",
+		"compatibleRuntime": map[string]any{
+			"interface":      "katl-runtime-1",
+			"artifactPath":   filepath.Base(runtimeRoot),
+			"artifactSHA256": runtimeRootSHA,
+		},
+	})
 	preserveFile(t, filepath.Join(repo, "_build", "mkosi", "katl-installer.packages.tsv"))
 	seedInstallerRPMCache(t, repo)
 	podmanArgs := filepath.Join(tmp, "podman-args.txt")
@@ -172,6 +208,7 @@ fi
 printf '%s\n' "$@" > "$KATL_FAKE_PODMAN_ARGS"
 `)
 	writeFakeExecutable(t, bin, "rpm", "printf 'systemd\\t0:259.6-1.fc44.x86_64\\n'\n")
+	writeFakeExecutable(t, bin, "mksquashfs", "printf 'katlos image\\n' >\"$2\"\n")
 	cmd := exec.Command(filepath.Join(repo, "scripts", "mkosi"), "build-installer-iso")
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(),
@@ -184,6 +221,9 @@ printf '%s\n' "$@" > "$KATL_FAKE_PODMAN_ARGS"
 	)
 	if result, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("scripts/mkosi build-installer-iso failed: %v\n%s", err, result)
+	}
+	if got := string(mustReadFile(t, katlosImage)); got != "katlos image\n" {
+		t.Fatalf("embedded KatlOS prerequisite was not rebuilt: %q", got)
 	}
 	args := readLinesForScripts(t, podmanArgs)
 	for _, want := range []string{

--- a/internal/vmtest/first_install_world.go
+++ b/internal/vmtest/first_install_world.go
@@ -37,6 +37,7 @@ type FirstInstallWorldInput struct {
 	InstallManifest   string
 	ConfigBundle      string
 	KubernetesVersion string
+	SSHAuthorizedKey  string
 	Mode              FirstInstallWorldMode
 	UseInstalledESP   bool
 	TargetDiskSize    string
@@ -852,7 +853,7 @@ func ResolveFirstInstallWorldInput(scenario *WorldScenario, repo string, spec No
 	input.UseInstalledESP = true
 	if input.InstallManifest == "" {
 		if input.ConfigBundle == "" {
-			bundlePath, manifestPath, err := writeFirstInstallWorldBundleSource(scenario, repo, spec, index, input.Mode == FirstInstallWorldGuestHandoff, input.KubernetesVersion)
+			bundlePath, manifestPath, err := writeFirstInstallWorldBundleSource(scenario, repo, spec, index, input.Mode == FirstInstallWorldGuestHandoff, input.KubernetesVersion, input.SSHAuthorizedKey)
 			if err != nil {
 				return input, err
 			}
@@ -992,7 +993,7 @@ func (index mkosiArtifactIndex) artifact(kind string) (mkosiArtifact, bool) {
 	return mkosiArtifact{}, false
 }
 
-func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, spec NodeSpec, index mkosiArtifactIndex, bindInstallMedia bool, requestedKubernetesVersion string) (string, string, error) {
+func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, spec NodeSpec, index mkosiArtifactIndex, bindInstallMedia bool, requestedKubernetesVersion, sshAuthorizedKey string) (string, string, error) {
 	image, ok := index.artifact("katlos-install-image")
 	if !ok {
 		var err error
@@ -1053,6 +1054,10 @@ func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, sp
 	}
 	nodes = append(nodes, firstInstallWorldSourceNode(spec.Name, spec.Role, "/dev/disk/by-id/virtio-katl-root"))
 
+	sshAuthorizedKey = strings.TrimSpace(sshAuthorizedKey)
+	if sshAuthorizedKey == "" {
+		sshAuthorizedKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"
+	}
 	sourceSpec := map[string]any{
 		"controlPlaneEndpoint": "api.katl.test:6443",
 		"kubernetes": map[string]any{
@@ -1061,7 +1066,7 @@ func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, sp
 		"defaults": map[string]any{
 			"identity": map[string]any{
 				"ssh": map[string]any{
-					"authorizedKeys": []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"},
+					"authorizedKeys": []string{sshAuthorizedKey},
 				},
 			},
 			"networkd": map[string]any{

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -86,6 +86,7 @@ type operationBackedSmokeInputs struct {
 	WorkerMAC              string
 	WorkerInstall          firstInstallProvenance
 	KubernetesVersion      string
+	SSHPrivateKey          string
 	WorldProvenance        multiNodeWorldProvenancePaths
 }
 
@@ -235,6 +236,7 @@ func planOperationBackedWorldSmokeRunNamed(world vmtest.World, repo, kubernetesV
 			WorkerMAC:              worker.Node.MACAddress,
 			WorkerInstall:          firstInstallProvenanceFromPublished(workerPublished),
 			KubernetesVersion:      firstString(kubernetesVersion, "v1.36.1"),
+			SSHPrivateKey:          filepath.Join(vmtest.WorldFixtureCacheDir(world), "ssh", "id_ed25519"),
 			WorldProvenance:        multiNodeWorldProvenanceForSpecs(world, repo, twoNodeWorldRuntimeSpecs()),
 		},
 	}, nil
@@ -425,6 +427,13 @@ func runOperationBackedBootstrapSmoke(t *testing.T, smoke operationBackedSmokeRu
 			t.Fatalf("wait for %s katlc agent TCP endpoint: %v", endpoint.name, err)
 		}
 	}
+	for _, node := range nodes {
+		if err := assertOperatorSSH(ctx, inputs.SSHPrivateKey, node.Result.IPAddress); err != nil {
+			collectTwoNodeDiagnostics("", nodes...)
+			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+			t.Fatalf("%s operator SSH: %v", node.Name, err)
+		}
+	}
 	if err := writeOperationBackedArtifactManifest(artifactManifestPath, result, inputs, nodes, operationBackedArtifacts{
 		Inventory:            inventoryPath,
 		Kubeconfig:           kubeconfigPath,
@@ -574,8 +583,33 @@ func runOperationBackedBootstrapSmoke(t *testing.T, smoke operationBackedSmokeRu
 		t.Fatalf("kubectl nodes did not converge: %v\n%s", err, output)
 	}
 	assertKubeconfigOutput(t, kubeconfigPath, kubeconfigMetadataPath, "https://"+cpAddress+":6443")
+	for _, node := range []struct {
+		running    vmtest.RunningInstalledRuntimeNode
+		generation string
+	}{{cpNode, cpRecord.CandidateGenerationID}, {workerNode, workerRecord.CandidateGenerationID}} {
+		if err := rebootIntoGeneration(ctx, node.running, node.generation); err != nil {
+			collectTwoNodeDiagnostics("", nodes...)
+			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+			t.Fatalf("reboot %s into bootstrap generation: %v", node.running.Name, err)
+		}
+		if err := activateNodeCNIFixture(ctx, node.running, cniFixtures[node.running.Name]); err != nil {
+			t.Fatalf("reactivate %s CNI fixture after bootstrap reboot: %v", node.running.Name, err)
+		}
+		if err := waitForBootstrapRuntimeAfterReboot(ctx, node.running, node.generation); err != nil {
+			t.Fatalf("verify %s bootstrap runtime after reboot: %v", node.running.Name, err)
+		}
+		if err := assertOperatorSSH(ctx, inputs.SSHPrivateKey, node.running.Result.IPAddress); err != nil {
+			t.Fatalf("%s operator SSH after reboot: %v", node.running.Name, err)
+		}
+	}
+	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(result.RunDir, "kubectl-after-bootstrap-reboot.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
+		collectKubectlDiagnostics(kubeconfigPath, result.RunDir)
+		collectTwoNodeDiagnostics("", nodes...)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("cluster did not return after bootstrap generation reboot: %v", err)
+	}
 	if proveUpgrade {
-		if err := runTwoNodeKubeadmUpgradeProof(t, ctx, smoke, cpNode, workerNode, cpAddress, workerAddress, cpRecord, workerRecord, cniFixtures, kubeconfigPath, evidenceDir); err != nil {
+		if err := runTwoNodeKubeadmUpgradeProof(t, ctx, smoke, cpNode, workerNode, cpAddress, workerAddress, kubeconfigPath, evidenceDir); err != nil {
 			collectKubectlDiagnostics(kubeconfigPath, result.RunDir)
 			collectTwoNodeDiagnostics("", nodes...)
 			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
@@ -589,22 +623,11 @@ func runOperationBackedBootstrapSmoke(t *testing.T, smoke operationBackedSmokeRu
 	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
 }
 
-func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke operationBackedSmokeRun, cpNode, workerNode vmtest.RunningInstalledRuntimeNode, cpAddress, workerAddress string, cpBootstrap, workerBootstrap operation.OperationRecord, cniFixtures map[string]nodeCNIFixture, kubeconfigPath, evidenceDir string) error {
+func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke operationBackedSmokeRun, cpNode, workerNode vmtest.RunningInstalledRuntimeNode, cpAddress, workerAddress, kubeconfigPath, evidenceDir string) error {
 	t.Helper()
 	const targetVersion = "v1.36.1"
 	if smoke.Inputs.KubernetesVersion != "v1.36.0" {
 		return fmt.Errorf("upgrade proof requires base v1.36.0, got %s", smoke.Inputs.KubernetesVersion)
-	}
-	for _, node := range []struct {
-		running    vmtest.RunningInstalledRuntimeNode
-		generation string
-	}{{cpNode, cpBootstrap.CandidateGenerationID}, {workerNode, workerBootstrap.CandidateGenerationID}} {
-		if err := rebootIntoGeneration(ctx, node.running, node.generation); err != nil {
-			return fmt.Errorf("reboot %s into bootstrap generation: %w", node.running.Name, err)
-		}
-		if err := activateNodeCNIFixture(ctx, node.running, cniFixtures[node.running.Name]); err != nil {
-			return fmt.Errorf("reactivate %s CNI fixture after bootstrap reboot: %w", node.running.Name, err)
-		}
 	}
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(evidenceDir, "kubectl-before-upgrade.txt"), 5*time.Minute, "node/cp-1", "node/worker-1"); err != nil {
 		return fmt.Errorf("wait for cluster readiness after bootstrap generation reboot: %w", err)
@@ -971,6 +994,45 @@ func rebootIntoGeneration(ctx context.Context, node vmtest.RunningInstalledRunti
 		}
 	}
 	return fmt.Errorf("node %s did not boot generation %s", node.Name, generationID)
+}
+
+func waitForBootstrapRuntimeAfterReboot(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, generationID string) error {
+	deadline := time.Now().Add(3 * time.Minute)
+	var last string
+	for {
+		result, err := runNodeCommandWithRetry(ctx, node, []string{
+			"systemctl", "is-active", "kubelet.service", "containerd.service", "katlc-agent.service", "sshd.service",
+		}, 16<<10)
+		if err == nil && result.ExitStatus == 0 {
+			connector := cluster.TCPAgentConnector{DialTimeout: 5 * time.Second}
+			connection, connectErr := connector.Connect(ctx, inventory.PlannedNode{
+				Name: node.Name, Address: node.Result.IPAddress, Access: inventory.Access{Method: "agent"},
+			})
+			if connectErr == nil {
+				status, statusErr := connection.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+				_ = connection.Close()
+				if statusErr == nil && status.GetCurrentGenerationId() == generationID {
+					return nil
+				}
+				if statusErr != nil {
+					last = statusErr.Error()
+				} else {
+					last = fmt.Sprintf("current generation %q, want %q", status.GetCurrentGenerationId(), generationID)
+				}
+			}
+		} else if err != nil {
+			last = err.Error()
+		} else {
+			last = strings.TrimSpace(string(result.Stdout) + " " + string(result.Stderr))
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("Kubernetes services and generation did not become active: %s", last)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 func operationBackedVMConfigForRun(run operationBackedSmokeRun, mac string, cid uint32) vmtest.VMConfig {
@@ -2490,6 +2552,43 @@ func bootstrapCommandError(err error, output string) error {
 		}
 	}
 	return nil
+}
+
+func assertOperatorSSH(ctx context.Context, privateKey, address string) error {
+	privateKey = strings.TrimSpace(privateKey)
+	address = strings.TrimSpace(address)
+	if privateKey == "" || address == "" {
+		return fmt.Errorf("SSH private key and node address are required")
+	}
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		command := exec.CommandContext(ctx, "ssh",
+			"-o", "BatchMode=yes",
+			"-o", "IdentitiesOnly=yes",
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "ConnectTimeout=5",
+			"-i", privateKey,
+			"katl@"+address,
+			"test \"$(id -un)\" = katl && "+
+				"test \"$SHELL\" = /usr/bin/bash && test -x /usr/bin/bash && "+
+				"test \"$PWD\" = /var/lib/katl/home/katl && "+
+				"test \"$(stat -c %a /var/lib/katl/home)\" = 755 && "+
+				"test -r /etc/ssh/authorized_keys/katl && test ! -w /etc/ssh/authorized_keys/katl && "+
+				"touch .katl-ssh-test && rm .katl-ssh-test",
+		)
+		output, err := command.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("SSH login failed: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func readNodeFileWithRetry(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, path string, maxBytes uint32, timeout time.Duration) ([]byte, error) {

--- a/internal/vmtest/scenarios/cluster_bootstrap_world_fixture_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_world_fixture_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -30,6 +31,11 @@ func ensurePublishedRuntimeFixturesForWorld(world vmtest.World, repo string, spe
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	input := vmtest.DefaultFirstInstallWorldInputFromEnv(vmtest.FirstInstallWorldPreseed, katlctlEnvBool("KATL_FIRST_INSTALL_USE_INSTALLED_ESP"))
+	_, authorizedKey, err := ensureWorldSSHKey(world)
+	if err != nil {
+		return err
+	}
+	input.SSHAuthorizedKey = authorizedKey
 	if value := strings.TrimSpace(os.Getenv("KATL_VMTEST_KUBERNETES_BUNDLE")); value != "" {
 		image, err := kubernetesbundle.ParseImageReference(value)
 		if err != nil {
@@ -44,6 +50,26 @@ func ensurePublishedRuntimeFixturesForWorld(world vmtest.World, repo string, spe
 		KVM:                        kvm,
 		RequireInstallerProvenance: true,
 	})
+}
+
+func ensureWorldSSHKey(world vmtest.World) (string, string, error) {
+	privateKey := filepath.Join(vmtest.WorldFixtureCacheDir(world), "ssh", "id_ed25519")
+	publicKey := privateKey + ".pub"
+	if data, err := os.ReadFile(publicKey); err == nil && strings.TrimSpace(string(data)) != "" {
+		return privateKey, strings.TrimSpace(string(data)), nil
+	}
+	if err := os.MkdirAll(filepath.Dir(privateKey), 0o700); err != nil {
+		return "", "", err
+	}
+	command := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "katl-vmtest", "-f", privateKey)
+	if output, err := command.CombinedOutput(); err != nil {
+		return "", "", fmt.Errorf("generate VM SSH key: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	data, err := os.ReadFile(publicKey)
+	if err != nil {
+		return "", "", err
+	}
+	return privateKey, strings.TrimSpace(string(data)), nil
 }
 
 func failWorldFixtureSetup(t *testing.T, world vmtest.World, scenarioName string, err error) {

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/network/80-katl-installer-dhcp.network
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/network/80-katl-installer-dhcp.network
@@ -4,3 +4,6 @@ Type=ether
 [Network]
 DHCP=yes
 IPv6AcceptRA=yes
+
+[DHCPv4]
+ClientIdentifier=mac

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/tmpfiles.d/katl-state.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/tmpfiles.d/katl-state.conf
@@ -16,6 +16,7 @@ d /var/lib/katl/kubernetes 0755 root root -
 d /var/lib/katl/kubernetes/etc-kubernetes 0755 root root -
 d /var/lib/katl/ssh 0755 root root -
 d /var/lib/katl/ssh/host-keys 0700 root root -
+d /var/lib/katl/home 0755 root root -
 d /var/lib/katl/home/katl 0700 katl katl -
 d /var/lib/containerd 0755 root root -
 d /var/lib/etcd 0755 root root -

--- a/scripts/build-katlos-install-image
+++ b/scripts/build-katlos-install-image
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-build_dir="$repo_root/_build/mkosi"
+build_dir="${KATL_MKOSI_BUILD_DIR:-$repo_root/_build/mkosi}"
+if [[ "$build_dir" != /* ]]; then
+    build_dir="$repo_root/$build_dir"
+fi
 version="${KATL_VERSION:-0.0.0-dev}"
 build_id="${KATL_BUILD_COMMIT:-${KATL_VERSION:-0.0.0-dev}}"
 architecture="${KATL_ARCHITECTURE:-$(uname -m)}"
@@ -26,10 +29,10 @@ need() {
     command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
 }
 
-under_repo() {
+under_build_dir() {
     local label="$1"
     local path="$2"
-    [[ "$path" == "$repo_root"/* ]] || fail "$label must be under repository root: $path"
+    [[ "$path" == "$build_dir"/* ]] || fail "$label must be under mkosi build directory: $path"
 }
 
 mkosi_artifacts() {
@@ -52,9 +55,8 @@ case "$image_role" in
         fail "unsupported KatlOS image role: $image_role"
         ;;
 esac
-under_repo "KatlOS image output" "$output"
-under_repo "KatlOS image assembly root" "$work_root"
-[[ "$work_root" == "$build_dir"/* ]] || fail "KatlOS image assembly root must be under _build/mkosi: $work_root"
+under_build_dir "KatlOS image output" "$output"
+under_build_dir "KatlOS image assembly root" "$work_root"
 
 rm -rf -- "$work_root"
 mkdir -p \

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -478,10 +478,9 @@ else
                 echo "error: build-installer-iso does not accept mkosi arguments" >&2
                 exit 2
             fi
-            install_image="$(KATL_KATLOS_IMAGE_ROLE=install katlos_image_output)"
-            if [[ ! -f "$install_image" || ! -f "$install_image.json" || ! -f "$install_image.sha256" ]]; then
-                KATL_KATLOS_IMAGE_ROLE=install "$repo_root/scripts/mkosi" build-katlos-install-image
-            fi
+            # Always enter the source-fingerprinted target. It returns quickly on a
+            # real cache hit and refreshes a stale payload before the ISO embeds it.
+            KATL_KATLOS_IMAGE_ROLE=install "$repo_root/scripts/mkosi" build-katlos-install-image
             emit_installer_iso=1
             installer_package_set=_build/mkosi/katl-installer.packages.tsv
             cache_target=installer-iso


### PR DESCRIPTION
Fix the fresh-install operator journey across SSH, bootstrap, reboot, DHCP continuity, dashboard state, and release metadata. Bootstrap now reports progress, writes kubeconfig by default, and resumes an interrupted matching operation. The root causes were inaccessible state-directory traversal, invocation-specific operation identity, stale embedded/runtime state, terminal autowrap, and differing DHCP client identity across installer and KatlOS. The installed VM journey now exercises real katlctl, SSH, generation reboot, service health, and Kubernetes reconvergence.