### PR TITLE
console: harden bounded dashboard rendering

### DIFF
--- a/cmd/katl-console/main.go
+++ b/cmd/katl-console/main.go
@@ -161,7 +161,11 @@ type journalRing struct {
 	count int
 }
 
-const journalLineCapacity = 1024
+const (
+	journalLineCapacity = 1024
+	journalScanCapacity = 256 << 10
+	journalTruncated    = "… [truncated]"
+)
 
 func newJournalRing(limit int) *journalRing {
 	storage := make([]byte, limit*journalLineCapacity)
@@ -179,8 +183,8 @@ func (r *journalRing) Add(line []byte) {
 		return
 	}
 	r.mu.Lock()
-	index, target := r.nextLineLocked(len(line))
-	copy(target, line)
+	index, target := r.nextLineLocked(min(len(line), journalLineCapacity))
+	copyBoundedJournalLine(target, line)
 	r.lines[index] = compactJournalTimestamp(target)
 	r.mu.Unlock()
 }
@@ -191,8 +195,8 @@ func (r *journalRing) AddString(line string) {
 		return
 	}
 	r.mu.Lock()
-	_, target := r.nextLineLocked(len(line))
-	copy(target, line)
+	_, target := r.nextLineLocked(min(len(line), journalLineCapacity))
+	copyBoundedJournalLine(target, []byte(line))
 	r.mu.Unlock()
 }
 
@@ -204,12 +208,21 @@ func (r *journalRing) nextLineLocked(length int) (int, []byte) {
 	} else {
 		r.count++
 	}
-	if cap(r.lines[index]) < length {
-		r.lines[index] = make([]byte, length)
-	} else {
-		r.lines[index] = r.lines[index][:length]
-	}
+	r.lines[index] = r.lines[index][:min(length, journalLineCapacity)]
 	return index, r.lines[index]
+}
+
+func copyBoundedJournalLine(target, line []byte) {
+	if len(line) <= len(target) {
+		copy(target, line)
+		return
+	}
+	prefix := max(len(target)-len(journalTruncated), 0)
+	for prefix > 0 && prefix < len(line) && line[prefix]&0xc0 == 0x80 {
+		prefix--
+	}
+	copied := copy(target, line[:prefix])
+	copy(target[copied:], journalTruncated)
 }
 
 func compactJournalTimestamp(line []byte) []byte {
@@ -328,7 +341,9 @@ func followJournal(ctx context.Context, ring *journalRing) {
 type commandContext func(context.Context, string, ...string) *exec.Cmd
 
 func streamJournal(ctx context.Context, ring *journalRing, command commandContext) error {
-	cmd := command(ctx, "journalctl", journalctlArgs...)
+	streamContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cmd := command(streamContext, "journalctl", journalctlArgs...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -347,11 +362,17 @@ func streamJournal(ctx context.Context, ring *journalRing, command commandContex
 		close(done)
 	}()
 	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 4096), 256<<10)
+	scanner.Buffer(make([]byte, 4096), journalScanCapacity)
 	for scanner.Scan() {
 		ring.Add(scanner.Bytes())
 	}
 	scanErr := scanner.Err()
+	if scanErr != nil {
+		cancel()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}
 	waitErr := cmd.Wait()
 	<-done
 	if scanErr != nil {

--- a/cmd/katl-console/main.go
+++ b/cmd/katl-console/main.go
@@ -137,7 +137,7 @@ func writeSnapshot(path string, data []byte) error {
 	}
 	temporaryPath := temporary.Name()
 	defer os.Remove(temporaryPath)
-	if err := temporary.Chmod(0o644); err != nil {
+	if err := temporary.Chmod(0o600); err != nil {
 		temporary.Close()
 		return err
 	}

--- a/cmd/katl-console/main_test.go
+++ b/cmd/katl-console/main_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/katl-dev/katl/internal/operatorconsole"
 )
@@ -22,6 +26,45 @@ func TestJournalRingIsBounded(t *testing.T) {
 	if rows != 2 || string(got) != "two\nthree\n" {
 		t.Fatalf("WriteTail() = %q, %d rows", got, rows)
 	}
+}
+
+func TestJournalRingTruncatesOversizedEntries(t *testing.T) {
+	ring := newJournalRing(1)
+	ring.Add([]byte(strings.Repeat("x", journalLineCapacity) + "SECRET-TAIL"))
+	if got := len(ring.lines[0]); got != journalLineCapacity {
+		t.Fatalf("journal slot length = %d", got)
+	}
+	writer := operatorconsole.NewJournalWriter(operatorconsole.NewRenderTarget(make([]byte, 4096), 128, 10))
+	ring.WriteTail(&writer)
+	got := string(writer.Bytes())
+	if !strings.Contains(got, journalTruncated) || strings.Contains(got, "SECRET-TAIL") {
+		t.Fatalf("truncated journal entry = %q", got)
+	}
+}
+
+func TestStreamJournalCancelsFollowerAfterOversizedLine(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	command := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestJournalOversizeHelper")
+		cmd.Env = append(os.Environ(), "KATL_JOURNAL_OVERSIZE_HELPER=1")
+		return cmd
+	}
+	err := streamJournal(ctx, newJournalRing(1), command)
+	if err == nil || !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("streamJournal() error = %v", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("streamJournal() waited for the context deadline: %v", ctx.Err())
+	}
+}
+
+func TestJournalOversizeHelper(t *testing.T) {
+	if os.Getenv("KATL_JOURNAL_OVERSIZE_HELPER") != "1" {
+		return
+	}
+	_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", journalScanCapacity+4096))
+	select {}
 }
 
 func TestJournalUsesDateTimeTimestamps(t *testing.T) {

--- a/cmd/katl-console/main_test.go
+++ b/cmd/katl-console/main_test.go
@@ -72,18 +72,22 @@ func TestJournalRingCompactsDateTimeTimestamps(t *testing.T) {
 	}
 }
 
-func TestJournalRingReusesPreallocatedLines(t *testing.T) {
+func TestJournalRingReusesBoundedSlots(t *testing.T) {
 	ring := newJournalRing(2)
 	line := []byte("2026-07-17T18:02:03.123456+01:00 " + strings.Repeat("x", journalLineCapacity-39))
 	storage := make([]byte, 4096)
-	allocations := testing.AllocsPerRun(1000, func() {
+	for range 1000 {
 		ring.Add(line)
 		writer := operatorconsole.NewJournalWriter(operatorconsole.NewRenderTarget(storage, 80, 2))
 		ring.WriteTail(&writer)
-		_ = writer.Bytes()
-	})
-	if allocations != 0 {
-		t.Fatalf("journal add/render allocations = %v, want 0", allocations)
+		if len(writer.Bytes()) == 0 {
+			t.Fatal("journal slot rendered empty content")
+		}
+	}
+	for index, slot := range ring.lines {
+		if cap(slot) > journalLineCapacity {
+			t.Fatalf("slot %d capacity = %d", index, cap(slot))
+		}
 	}
 }
 

--- a/cmd/katl-console/main_test.go
+++ b/cmd/katl-console/main_test.go
@@ -176,4 +176,11 @@ func TestWriteSnapshotReplacesFile(t *testing.T) {
 	if string(data) != "second\n" {
 		t.Fatalf("snapshot = %q", data)
 	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("snapshot permissions = %o", got)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sys v0.44.0
 	google.golang.org/grpc v1.81.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/generation"
@@ -12,22 +13,29 @@ import (
 )
 
 type Collector struct {
-	Mode        Mode
-	Version     string
-	Root        string
-	StatusPath  string
-	HandoffPath string
-	Hostname    func() (string, error)
-	Interfaces  func() ([]net.Interface, error)
-	Addrs       func(net.Interface) ([]net.Addr, error)
+	Mode                  Mode
+	Version               string
+	Root                  string
+	StatusPath            string
+	HandoffPath           string
+	ManagementAddress     string
+	Hostname              func() (string, error)
+	Interfaces            func() ([]net.Interface, error)
+	Addrs                 func(net.Interface) ([]net.Addr, error)
+	DefaultRouteInterface func() (string, error)
 }
 
+const (
+	maxDisplayInterfaces = 3
+	maxDisplayAddresses  = 2
+)
+
 func (c Collector) Collect(snapshot *Snapshot) {
-	network := snapshot.Network
+	interfaces := snapshot.DisplayInterfaces
 	*snapshot = Snapshot{
-		Mode:    c.Mode,
-		Version: strings.TrimSpace(c.Version),
-		Network: network[:0],
+		Mode:              c.Mode,
+		Version:           strings.TrimSpace(c.Version),
+		DisplayInterfaces: interfaces[:0],
 	}
 	if c.Hostname == nil {
 		c.Hostname = os.Hostname
@@ -38,10 +46,15 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	if c.Addrs == nil {
 		c.Addrs = func(iface net.Interface) ([]net.Addr, error) { return iface.Addrs() }
 	}
+	if c.DefaultRouteInterface == nil {
+		c.DefaultRouteInterface = func() (string, error) {
+			return readDefaultRouteInterface(rooted(c.Root, "/proc/net/route"))
+		}
+	}
 	if hostname, err := c.Hostname(); err == nil {
 		snapshot.Hostname = hostname
 	}
-	snapshot.Network = c.collectNetwork(snapshot.Network)
+	snapshot.ManagementAddress, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces = c.collectNetwork(snapshot.DisplayInterfaces)
 	snapshot.SSHEnabled = c.Mode == ModeRuntime || fileExists(rooted(c.Root, "/etc/katl/installer-ssh.enabled"))
 
 	statusPath := c.StatusPath
@@ -88,10 +101,15 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	}
 }
 
-func (c Collector) collectNetwork(result []NetworkInterface) []NetworkInterface {
+func (c Collector) collectNetwork(result []NetworkInterface) (string, []NetworkInterface, int) {
 	interfaces, err := c.Interfaces()
 	if err != nil {
-		return result[:0]
+		return "", result[:0], 0
+	}
+	management := normalizeManagementAddress(c.ManagementAddress)
+	preferredInterface := ""
+	if management == "" {
+		preferredInterface, _ = c.DefaultRouteInterface()
 	}
 	if cap(result) < len(interfaces) {
 		result = make([]NetworkInterface, 0, len(interfaces))
@@ -99,31 +117,109 @@ func (c Collector) collectNetwork(result []NetworkInterface) []NetworkInterface 
 		result = result[:0]
 	}
 	for _, iface := range interfaces {
-		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 || virtualInterface(iface.Name) {
 			continue
 		}
+		addresses, err := c.Addrs(iface)
+		if err != nil {
+			continue
+		}
+		usable := make([]string, 0, len(addresses))
+		for _, address := range addresses {
+			ip, _, parseErr := net.ParseCIDR(address.String())
+			if parseErr != nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+				continue
+			}
+			usable = append(usable, address.String())
+			if management == "" && iface.Name == preferredInterface && ip.To4() != nil {
+				management = ip.String()
+			}
+			if preferredInterface == "" && management != "" && ip.String() == management {
+				preferredInterface = iface.Name
+			}
+		}
+		if len(usable) == 0 && iface.Name != preferredInterface {
+			continue
+		}
+		sort.Slice(usable, func(i, j int) bool {
+			leftIPv4 := strings.Contains(usable[i], ".")
+			rightIPv4 := strings.Contains(usable[j], ".")
+			if leftIPv4 != rightIPv4 {
+				return leftIPv4
+			}
+			return usable[i] < usable[j]
+		})
 		index := len(result)
 		result = result[:index+1]
 		addressesBuffer := result[index].Addresses[:0]
-		result[index] = NetworkInterface{Name: iface.Name, Addresses: addressesBuffer}
-		item := &result[index]
-		addresses, err := c.Addrs(iface)
-		if err == nil {
-			if cap(item.Addresses) < len(addresses) {
-				item.Addresses = make([]string, 0, len(addresses))
-			}
-			for _, address := range addresses {
-				ip, _, err := net.ParseCIDR(address.String())
-				if err != nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
-					continue
-				}
-				item.Addresses = append(item.Addresses, address.String())
-			}
+		if cap(addressesBuffer) < min(len(usable), maxDisplayAddresses) {
+			addressesBuffer = make([]string, 0, min(len(usable), maxDisplayAddresses))
 		}
-		sort.Strings(item.Addresses)
+		addressesBuffer = append(addressesBuffer, usable[:min(len(usable), maxDisplayAddresses)]...)
+		result[index] = NetworkInterface{
+			Name:                iface.Name,
+			Addresses:           addressesBuffer,
+			AdditionalAddresses: max(len(usable)-maxDisplayAddresses, 0),
+		}
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
-	return result
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name == preferredInterface {
+			return true
+		}
+		if result[j].Name == preferredInterface {
+			return false
+		}
+		return result[i].Name < result[j].Name
+	})
+	omitted := max(len(result)-maxDisplayInterfaces, 0)
+	return management, result[:min(len(result), maxDisplayInterfaces)], omitted
+}
+
+func normalizeManagementAddress(value string) string {
+	value = strings.TrimSpace(value)
+	if slash := strings.IndexByte(value, '/'); slash >= 0 {
+		value = value[:slash]
+	}
+	ip := net.ParseIP(value)
+	if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+		return ""
+	}
+	return ip.String()
+}
+
+func virtualInterface(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, prefix := range []string{"cilium", "lxc", "veth", "docker", "br-", "virbr", "flannel", "cali", "dummy", "kube", "tun", "tap"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func readDefaultRouteInterface(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	selected := ""
+	metric := uint64(^uint32(0))
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 8 || fields[1] != "00000000" || fields[7] != "00000000" {
+			continue
+		}
+		flags, flagsErr := strconv.ParseUint(fields[3], 16, 32)
+		candidateMetric, metricErr := strconv.ParseUint(fields[6], 10, 32)
+		if flagsErr != nil || metricErr != nil || flags&0x1 == 0 || candidateMetric >= metric {
+			continue
+		}
+		selected, metric = fields[0], candidateMetric
+	}
+	if selected == "" {
+		return "", os.ErrNotExist
+	}
+	return selected, nil
 }
 
 func (c Collector) collectGeneration(snapshot *Snapshot) {

--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/katl-dev/katl/internal/installer/generation"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
@@ -23,6 +24,7 @@ type Collector struct {
 	Interfaces            func() ([]net.Interface, error)
 	Addrs                 func(net.Interface) ([]net.Addr, error)
 	DefaultRouteInterface func() (string, error)
+	Now                   func() time.Time
 }
 
 const (
@@ -34,8 +36,10 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	interfaces := snapshot.DisplayInterfaces
 	*snapshot = Snapshot{
 		Mode:              c.Mode,
-		Version:           strings.TrimSpace(c.Version),
 		DisplayInterfaces: interfaces[:0],
+	}
+	if c.Mode == ModeInstaller {
+		snapshot.Version = strings.TrimSpace(c.Version)
 	}
 	if c.Hostname == nil {
 		c.Hostname = os.Hostname
@@ -50,6 +54,9 @@ func (c Collector) Collect(snapshot *Snapshot) {
 		c.DefaultRouteInterface = func() (string, error) {
 			return readDefaultRouteInterface(rooted(c.Root, "/proc/net/route"))
 		}
+	}
+	if c.Now == nil {
+		c.Now = time.Now
 	}
 	if hostname, err := c.Hostname(); err == nil {
 		snapshot.Hostname = hostname
@@ -69,13 +76,18 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	if err == nil {
 		snapshot.State = record.State
 		snapshot.CurrentStep = record.CurrentStep
-		snapshot.Generation = record.InstalledGeneration
+		if c.Mode == ModeInstaller {
+			snapshot.Generation = record.InstalledGeneration
+		}
 		snapshot.DestructiveMutation = record.DestructiveMutation
 		snapshot.LastError = record.LastError
 		snapshot.RetryHint = record.RetryHint
 		snapshot.UpdatedAt = record.UpdatedAt
 	} else if !errors.Is(err, os.ErrNotExist) {
 		snapshot.StatusError = err.Error()
+	}
+	if statusCanBecomeStale(snapshot.State) && !snapshot.UpdatedAt.IsZero() && c.Now().Sub(snapshot.UpdatedAt) > 10*time.Minute {
+		snapshot.StatusStale = true
 	}
 	if snapshot.State == "" {
 		if c.Mode == ModeInstaller {
@@ -94,10 +106,21 @@ func (c Collector) Collect(snapshot *Snapshot) {
 			if snapshot.State == "starting-installer" {
 				snapshot.State = installstatus.StateWaitingForConfig
 			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			snapshot.HandoffError = "installer handoff is unreadable; restart the installer handoff service"
 		}
 	} else {
-		snapshot.KubernetesBootstrapped = fileExists(rooted(c.Root, "/etc/kubernetes/kubelet.conf"))
+		snapshot.KubernetesConfigured = fileExists(rooted(c.Root, "/etc/kubernetes/kubelet.conf"))
 		c.collectGeneration(snapshot)
+	}
+}
+
+func statusCanBecomeStale(state string) bool {
+	switch state {
+	case installstatus.StateRunning, installstatus.StateRuntimeBootedNotReady:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -226,6 +249,7 @@ func (c Collector) collectGeneration(snapshot *Snapshot) {
 	root := cleanRoot(c.Root)
 	selection, err := generation.ReadBootSelection(root)
 	if err != nil {
+		snapshot.GenerationError = "generation metadata is unavailable; inspect the KatlOS generation store"
 		return
 	}
 	id := strings.TrimSpace(selection.BootedGenerationID)
@@ -233,35 +257,56 @@ func (c Collector) collectGeneration(snapshot *Snapshot) {
 		id = strings.TrimSpace(selection.DefaultGenerationID)
 	}
 	if id == "" {
+		snapshot.GenerationError = "generation metadata does not identify the running KatlOS generation"
 		return
 	}
-	snapshot.Generation = id
 	bootedSpec, status, err := generation.ReadGeneration(root, id)
 	if err != nil {
+		snapshot.GenerationError = "running generation metadata is unreadable; inspect the KatlOS generation store"
 		return
 	}
-	if version := strings.TrimSpace(bootedSpec.RuntimeVersion); version != "" {
-		snapshot.Version = version
-	}
+	snapshot.CurrentSoftware = softwareFromSpec(bootedSpec)
 	snapshot.GenerationHealth = status.HealthState
 
-	softwareSpec := bootedSpec
+	nextID := strings.TrimSpace(selection.TargetBootGenerationID)
+	if nextID == "" {
+		nextID = strings.TrimSpace(selection.DefaultGenerationID)
+	}
+	if nextID == "" || nextID == id {
+		snapshot.NextBootSoftware = snapshot.CurrentSoftware
+	} else if spec, _, nextErr := generation.ReadGeneration(root, nextID); nextErr == nil {
+		snapshot.NextBootSoftware = softwareFromSpec(spec)
+	} else {
+		snapshot.NextBootSoftware = Software{Generation: nextID}
+		snapshot.GenerationError = "next-boot generation metadata is unreadable; inspect the KatlOS generation store"
+	}
+
+	snapshot.LiveSoftware = snapshot.CurrentSoftware
 	target := strings.TrimSpace(selection.TargetBootGenerationID)
 	if target != "" && target != id {
-		snapshot.NextGeneration = target
 		// Bootstrap and online lifecycle operations activate their candidate
 		// before arming it for boot. Report the selected software immediately,
 		// while keeping the booted and next-boot generations distinct.
 		if spec, _, targetErr := generation.ReadGeneration(root, target); targetErr == nil {
-			softwareSpec = spec
+			snapshot.LiveSoftware = softwareFromSpec(spec)
+		} else if snapshot.GenerationError == "" {
+			snapshot.GenerationError = "live-selected generation metadata is unreadable; inspect the KatlOS generation store"
 		}
 	}
-	for _, extension := range softwareSpec.Sysexts {
+}
+
+func softwareFromSpec(spec generation.GenerationSpec) Software {
+	software := Software{
+		Generation:    strings.TrimSpace(spec.GenerationID),
+		KatlOSVersion: strings.TrimSpace(spec.RuntimeVersion),
+	}
+	for _, extension := range spec.Sysexts {
 		if extension.Name == "kubernetes" {
-			snapshot.KubernetesVersion = strings.TrimSpace(extension.PayloadVersion)
+			software.KubernetesVersion = strings.TrimSpace(extension.PayloadVersion)
 			break
 		}
 	}
+	return software
 }
 
 func cleanRoot(root string) string {

--- a/internal/operatorconsole/frame.go
+++ b/internal/operatorconsole/frame.go
@@ -116,8 +116,12 @@ func (viewport *Viewport) advance(rows int) {
 // engine and paints only cells inside the viewport.
 func (viewport *Viewport) Write(text string, options WrapOptions) WriteResult {
 	start := viewport.y
-	if viewport.frame == nil || viewport.bounds.Width == 0 || viewport.rowsRemaining() == 0 || text == "" {
+	if viewport.frame == nil || viewport.bounds.Width == 0 || text == "" {
 		return WriteResult{}
+	}
+	if viewport.rowsRemaining() == 0 {
+		viewport.markTruncated(options.Style)
+		return WriteResult{Truncated: true}
 	}
 	options.FirstIndent = min(max(options.FirstIndent, 0), viewport.bounds.Width-1)
 	options.ContinuationIndent = min(max(options.ContinuationIndent, 0), viewport.bounds.Width-1)

--- a/internal/operatorconsole/frame.go
+++ b/internal/operatorconsole/frame.go
@@ -1,0 +1,380 @@
+package operatorconsole
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/rivo/uniseg"
+)
+
+const maxGlyphBytes = 64
+
+// Style is a semantic terminal style serialized after layout is complete.
+type Style = string
+
+// Cell is one terminal cell in a rendered frame. Wide graphemes occupy this
+// cell and one or more private continuation cells.
+type Cell struct {
+	Glyph string
+	Style Style
+
+	continuation bool
+	span         int
+}
+
+// Frame is a fixed terminal-cell canvas. Content can only be painted through a
+// bounded Viewport.
+type Frame struct {
+	Cells  []Cell
+	Width  int
+	Height int
+}
+
+// Rect describes a bounded region within a Frame.
+type Rect struct {
+	X, Y          int
+	Width, Height int
+}
+
+// WrapOptions selects the shared text layout behavior for a viewport.
+type WrapOptions struct {
+	Style              Style
+	WordWrap           bool
+	FirstIndent        int
+	ContinuationIndent int
+}
+
+// WriteResult reports the physical rows consumed and whether content exceeded
+// the viewport's bottom edge.
+type WriteResult struct {
+	Rows      int
+	Truncated bool
+}
+
+// Viewport is the only text-painting surface. Its cursor and every grapheme are
+// clipped to bounds before the Frame is modified.
+type Viewport struct {
+	frame  *Frame
+	bounds Rect
+	x, y   int
+	used   int
+}
+
+func newFrame(width, height int) Frame {
+	width, height = renderDimensions(width, height)
+	return Frame{Cells: make([]Cell, width*height), Width: width, Height: height}
+}
+
+func (frame *Frame) reset() {
+	for index := range frame.Cells {
+		frame.Cells[index] = Cell{}
+	}
+}
+
+// NewViewport returns a viewport intersected with the frame. Invalid or empty
+// rectangles become inert viewports.
+func NewViewport(frame *Frame, bounds Rect) Viewport {
+	if frame == nil {
+		return Viewport{}
+	}
+	if bounds.X < 0 {
+		bounds.Width += bounds.X
+		bounds.X = 0
+	}
+	if bounds.Y < 0 {
+		bounds.Height += bounds.Y
+		bounds.Y = 0
+	}
+	bounds.Width = min(max(bounds.Width, 0), max(frame.Width-bounds.X, 0))
+	bounds.Height = min(max(bounds.Height, 0), max(frame.Height-bounds.Y, 0))
+	return Viewport{frame: frame, bounds: bounds}
+}
+
+func (viewport *Viewport) sub(bounds Rect) Viewport {
+	bounds.X += viewport.bounds.X
+	bounds.Y += viewport.bounds.Y
+	bounds.Width = min(bounds.Width, viewport.bounds.Width-bounds.X+viewport.bounds.X)
+	bounds.Height = min(bounds.Height, viewport.bounds.Height-bounds.Y+viewport.bounds.Y)
+	return NewViewport(viewport.frame, bounds)
+}
+
+func (viewport *Viewport) rowsRemaining() int {
+	return max(viewport.bounds.Height-viewport.y, 0)
+}
+
+func (viewport *Viewport) rowsUsed() int {
+	return viewport.used
+}
+
+func (viewport *Viewport) advance(rows int) {
+	viewport.y = min(viewport.y+max(rows, 0), viewport.bounds.Height)
+	viewport.x = 0
+	viewport.used = max(viewport.used, viewport.y)
+}
+
+// Write lays out sanitized display graphemes through the shared word/hard-wrap
+// engine and paints only cells inside the viewport.
+func (viewport *Viewport) Write(text string, options WrapOptions) WriteResult {
+	start := viewport.y
+	if viewport.frame == nil || viewport.bounds.Width == 0 || viewport.rowsRemaining() == 0 || text == "" {
+		return WriteResult{}
+	}
+	options.FirstIndent = min(max(options.FirstIndent, 0), viewport.bounds.Width-1)
+	options.ContinuationIndent = min(max(options.ContinuationIndent, 0), viewport.bounds.Width-1)
+	viewport.x = options.FirstIndent
+	wrote := false
+	pendingSpaces := 0
+	inWord := false
+	iterator := displayIterator{text: text, state: -1}
+	for {
+		token, ok := iterator.next()
+		if !ok {
+			break
+		}
+		if token.newline {
+			pendingSpaces = 0
+			inWord = false
+			if !viewport.nextLine(options.ContinuationIndent) {
+				viewport.markTruncated(options.Style)
+				return viewport.writeResult(start, true)
+			}
+			wrote = true
+			continue
+		}
+		if token.space {
+			pendingSpaces++
+			inWord = false
+			continue
+		}
+
+		indent := options.ContinuationIndent
+		if viewport.y == start {
+			indent = options.FirstIndent
+		}
+		if options.WordWrap && !inWord {
+			wordWidth := token.width + iterator.nextWordWidth()
+			spaces := pendingSpaces
+			if viewport.x == indent {
+				spaces = 0
+			}
+			lineWidth := viewport.bounds.Width - indent
+			if viewport.x+spaces+wordWidth > viewport.bounds.Width && (wordWidth <= lineWidth || viewport.x > indent) {
+				if !viewport.nextLine(options.ContinuationIndent) {
+					viewport.markTruncated(options.Style)
+					return viewport.writeResult(start, true)
+				}
+				pendingSpaces = 0
+			}
+		}
+		for pendingSpaces > 0 && viewport.x > indent {
+			if !viewport.paint(displayToken{glyph: " ", width: 1}, options.Style, options.ContinuationIndent) {
+				viewport.markTruncated(options.Style)
+				return viewport.writeResult(start, true)
+			}
+			pendingSpaces--
+			wrote = true
+		}
+		pendingSpaces = 0
+		if !viewport.paint(token, options.Style, options.ContinuationIndent) {
+			viewport.markTruncated(options.Style)
+			return viewport.writeResult(start, true)
+		}
+		wrote = true
+		inWord = true
+	}
+	if wrote {
+		viewport.y++
+		viewport.x = 0
+		viewport.used = max(viewport.used, viewport.y)
+	}
+	return viewport.writeResult(start, false)
+}
+
+func (viewport *Viewport) writeResult(start int, truncated bool) WriteResult {
+	return WriteResult{Rows: max(viewport.used-start, 0), Truncated: truncated}
+}
+
+func (viewport *Viewport) paint(token displayToken, style Style, continuationIndent int) bool {
+	if token.width <= 0 {
+		viewport.appendZeroWidth(token.glyph)
+		return true
+	}
+	if token.width > viewport.bounds.Width-continuationIndent {
+		token = displayToken{glyph: "�", width: 1}
+	}
+	if viewport.x+token.width > viewport.bounds.Width {
+		if !viewport.nextLine(continuationIndent) {
+			return false
+		}
+	}
+	if viewport.y >= viewport.bounds.Height {
+		return false
+	}
+	viewport.frame.setGlyph(viewport.bounds.X+viewport.x, viewport.bounds.Y+viewport.y, token.glyph, token.width, style)
+	viewport.x += token.width
+	viewport.used = max(viewport.used, viewport.y+1)
+	return true
+}
+
+func (viewport *Viewport) appendZeroWidth(glyph string) {
+	if viewport.x == 0 || viewport.y >= viewport.bounds.Height || len(viewport.frame.Cells) < viewport.frame.Width*viewport.frame.Height {
+		return
+	}
+	index := (viewport.bounds.Y+viewport.y)*viewport.frame.Width + viewport.bounds.X + viewport.x - 1
+	for index >= 0 && viewport.frame.Cells[index].continuation {
+		index--
+	}
+	if index < 0 || len(viewport.frame.Cells[index].Glyph)+len(glyph) > maxGlyphBytes {
+		return
+	}
+	viewport.frame.Cells[index].Glyph += glyph
+}
+
+func (viewport *Viewport) nextLine(indent int) bool {
+	if viewport.y+1 >= viewport.bounds.Height {
+		viewport.y = viewport.bounds.Height - 1
+		viewport.x = viewport.bounds.Width
+		return false
+	}
+	viewport.y++
+	viewport.x = min(max(indent, 0), viewport.bounds.Width-1)
+	viewport.used = max(viewport.used, viewport.y+1)
+	return true
+}
+
+func (viewport *Viewport) markTruncated(style Style) {
+	if viewport.frame == nil || viewport.bounds.Width == 0 || viewport.bounds.Height == 0 {
+		return
+	}
+	viewport.frame.setGlyph(viewport.bounds.X+viewport.bounds.Width-1, viewport.bounds.Y+viewport.bounds.Height-1, "…", 1, style)
+}
+
+func (frame *Frame) setGlyph(x, y int, glyph string, width int, style Style) {
+	if x < 0 || y < 0 || y >= frame.Height || x+width > frame.Width || width < 1 || len(frame.Cells) < frame.Width*frame.Height {
+		return
+	}
+	frame.clearGlyphAt(x, y)
+	for offset := 1; offset < width; offset++ {
+		frame.clearGlyphAt(x+offset, y)
+	}
+	index := y*frame.Width + x
+	frame.Cells[index] = Cell{Glyph: glyph, Style: style, span: width}
+	for offset := 1; offset < width; offset++ {
+		frame.Cells[index+offset] = Cell{Style: style, continuation: true}
+	}
+}
+
+func (frame *Frame) clearGlyphAt(x, y int) {
+	index := y*frame.Width + x
+	cell := frame.Cells[index]
+	if cell.continuation {
+		start := index
+		for start > y*frame.Width && frame.Cells[start].continuation {
+			start--
+		}
+		span := max(frame.Cells[start].span, 1)
+		for offset := range span {
+			frame.Cells[start+offset] = Cell{}
+		}
+		return
+	}
+	span := max(cell.span, 1)
+	for offset := 0; offset < span && index+offset < (y+1)*frame.Width; offset++ {
+		frame.Cells[index+offset] = Cell{}
+	}
+}
+
+type displayToken struct {
+	glyph   string
+	width   int
+	space   bool
+	newline bool
+}
+
+type displayIterator struct {
+	text  string
+	state int
+}
+
+func (iterator *displayIterator) next() (displayToken, bool) {
+	for len(iterator.text) > 0 {
+		if iterator.text[0] == '\x1b' {
+			iterator.text = iterator.text[skipTerminalSequence(iterator.text):]
+			iterator.state = -1
+			continue
+		}
+		cluster, rest, width, state := uniseg.FirstGraphemeClusterInString(iterator.text, iterator.state)
+		iterator.text, iterator.state = rest, state
+		value, size := utf8.DecodeRuneInString(cluster)
+		if value == utf8.RuneError && size == 1 {
+			return displayToken{glyph: "�", width: 1}, true
+		}
+		if value == '\n' || value == '\r' {
+			return displayToken{newline: true}, true
+		}
+		if value == '\t' || unicode.IsSpace(value) {
+			return displayToken{glyph: " ", width: 1, space: true}, true
+		}
+		if unicode.IsControl(value) {
+			continue
+		}
+		if len(cluster) > maxGlyphBytes {
+			return displayToken{glyph: "�", width: 1}, true
+		}
+		return displayToken{glyph: cluster, width: width}, true
+	}
+	return displayToken{}, false
+}
+
+func (iterator displayIterator) nextWordWidth() int {
+	width := 0
+	for {
+		token, ok := iterator.next()
+		if !ok || token.space || token.newline {
+			return width
+		}
+		width += token.width
+	}
+}
+
+func skipTerminalSequence(value string) int {
+	if len(value) < 2 {
+		return len(value)
+	}
+	switch value[1] {
+	case '[':
+		for index := 2; index < len(value); index++ {
+			if value[index] >= 0x40 && value[index] <= 0x7e {
+				return index + 1
+			}
+		}
+		return len(value)
+	case ']':
+		for index := 2; index < len(value); index++ {
+			if value[index] == '\a' {
+				return index + 1
+			}
+			if value[index] == '\x1b' && index+1 < len(value) && value[index+1] == '\\' {
+				return index + 2
+			}
+		}
+		return len(value)
+	default:
+		_, size := utf8.DecodeRuneInString(value[1:])
+		return min(1+size, len(value))
+	}
+}
+
+func displayWidth(value string) int {
+	width := 0
+	iterator := displayIterator{text: value, state: -1}
+	for {
+		token, ok := iterator.next()
+		if !ok {
+			return width
+		}
+		if !token.newline {
+			width += token.width
+		}
+	}
+}

--- a/internal/operatorconsole/handoff.go
+++ b/internal/operatorconsole/handoff.go
@@ -73,7 +73,7 @@ func ReadHandoff(path string) (Handoff, error) {
 
 func validateHandoff(record Handoff) error {
 	parsed, err := url.Parse(strings.TrimSpace(record.URL))
-	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return fmt.Errorf("handoff URL must be an absolute HTTP or HTTPS endpoint")
 	}
 	if !strings.HasSuffix(parsed.Path, "/v1/config-bundle") {

--- a/internal/operatorconsole/handoff.go
+++ b/internal/operatorconsole/handoff.go
@@ -3,6 +3,7 @@ package operatorconsole
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,9 @@ func WriteHandoff(path, url string) error {
 	}
 	if strings.TrimSpace(url) == "" {
 		return fmt.Errorf("handoff URL is required")
+	}
+	if err := validateHandoff(record); err != nil {
+		return err
 	}
 	data, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
@@ -61,5 +65,22 @@ func ReadHandoff(path string) (Handoff, error) {
 	if err := json.Unmarshal(data, &record); err != nil {
 		return Handoff{}, fmt.Errorf("decode handoff projection: %w", err)
 	}
+	if err := validateHandoff(record); err != nil {
+		return Handoff{}, fmt.Errorf("validate handoff projection: %w", err)
+	}
 	return record, nil
+}
+
+func validateHandoff(record Handoff) error {
+	parsed, err := url.Parse(strings.TrimSpace(record.URL))
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("handoff URL must be an absolute HTTP or HTTPS endpoint")
+	}
+	if !strings.HasSuffix(parsed.Path, "/v1/config-bundle") {
+		return fmt.Errorf("handoff URL must identify the config-bundle endpoint")
+	}
+	if record.UpdatedAt.IsZero() {
+		return fmt.Errorf("handoff updatedAt is required")
+	}
+	return nil
 }

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -12,26 +12,59 @@ const (
 )
 
 type Snapshot struct {
-	Mode                   Mode
-	Version                string
-	KubernetesVersion      string
-	KubernetesBootstrapped bool
-	Hostname               string
-	State                  string
-	CurrentStep            string
-	Generation             string
-	NextGeneration         string
-	GenerationHealth       string
-	DestructiveMutation    bool
-	LastError              string
-	RetryHint              string
-	Handoff                Handoff
-	ManagementAddress      string
-	DisplayInterfaces      []NetworkInterface
-	AdditionalInterfaces   int
-	SSHEnabled             bool
-	UpdatedAt              time.Time
-	StatusError            string
+	Mode                 Mode
+	Version              string
+	Hostname             string
+	State                string
+	CurrentStep          string
+	Generation           string
+	GenerationHealth     string
+	CurrentSoftware      Software
+	NextBootSoftware     Software
+	LiveSoftware         Software
+	KubernetesConfigured bool
+	DestructiveMutation  bool
+	LastError            string
+	RetryHint            string
+	Handoff              Handoff
+	ManagementAddress    string
+	DisplayInterfaces    []NetworkInterface
+	AdditionalInterfaces int
+	SSHEnabled           bool
+	UpdatedAt            time.Time
+	StatusStale          bool
+	StatusError          string
+	HandoffError         string
+	GenerationError      string
+}
+
+type Software struct {
+	Generation        string
+	KatlOSVersion     string
+	KubernetesVersion string
+}
+
+type PresentationState string
+
+const (
+	PresentationHealthy     PresentationState = "healthy"
+	PresentationProgressing PresentationState = "progressing"
+	PresentationDegraded    PresentationState = "degraded"
+	PresentationFailed      PresentationState = "failed"
+	PresentationUnknown     PresentationState = "unknown"
+)
+
+type Presentation struct {
+	State PresentationState
+	Label string
+}
+
+type DashboardModel struct {
+	Host       Presentation
+	Kubernetes Presentation
+	Current    Software
+	NextBoot   Software
+	Live       Software
 }
 
 type NetworkInterface struct {

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -26,15 +26,18 @@ type Snapshot struct {
 	LastError              string
 	RetryHint              string
 	Handoff                Handoff
-	Network                []NetworkInterface
+	ManagementAddress      string
+	DisplayInterfaces      []NetworkInterface
+	AdditionalInterfaces   int
 	SSHEnabled             bool
 	UpdatedAt              time.Time
 	StatusError            string
 }
 
 type NetworkInterface struct {
-	Name      string
-	Addresses []string
+	Name                string
+	Addresses           []string
+	AdditionalAddresses int
 }
 
 type Handoff struct {

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -205,8 +205,8 @@ func TestCollectorReportsLiveBootstrapCandidateBeforeReboot(t *testing.T) {
 		t.Fatalf("software state = KatlOS %q, Kubernetes %q, bootstrapped=%t", snapshot.Version, snapshot.KubernetesVersion, snapshot.KubernetesBootstrapped)
 	}
 	rendered := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Generation: 0", "Next boot:  bootstrap-init-candidate", "Version:    v1.36.1", "Bootstrapped"} {
-		if !strings.Contains(rendered, want) {
+	for _, want := range []string{"Generation:0", "Nextboot:bootstrap-init-candidate", "Version:v1.36.1", "Bootstrapped"} {
+		if !containsIgnoringLayout(rendered, want) {
 			t.Fatalf("render missing %q:\n%s", want, rendered)
 		}
 	}
@@ -281,17 +281,17 @@ func TestRenderInstallerDashboard(t *testing.T) {
 	got := string(renderDashboard(&snapshot, journal, 80, 25, false))
 	for _, want := range []string{
 		"KatlOS Installer",
-		"State:        Installing",
-		"Network:      enp1s0: 192.0.2.10/24",
-		"Media:        2026.7.0-alpha.9",
-		"Disk changes: started - do not power off",
-		"Configure:    http://192.0.2.10:8080/v1/config-bundle",
-		"Run:          katlctl config init cluster.yaml --installer 192.0.2.10",
+		"State:Installing",
+		"Network:enp1s0:192.0.2.10/24",
+		"Media:2026.7.0-alpha.9",
+		"Diskchanges:started-donotpoweroff",
+		"Configure:http://192.0.2.10:8080/v1/config-bundle",
+		"Run:katlctlconfiginitcluster.yaml--installer192.0.2.10",
 		"Journal",
 		"installing root",
-		"Ctrl+Alt+F2: console | SSH disabled",
+		"Ctrl+Alt+F2:console|SSHdisabled",
 	} {
-		if !strings.Contains(got, want) {
+		if !containsIgnoringLayout(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
 	}
@@ -317,8 +317,8 @@ func TestRenderInstallerCommandUsesHandoffURLWithoutIPv4(t *testing.T) {
 		Network: []NetworkInterface{{Name: "enp1s0", Addresses: []string{"2001:db8::10/64"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 100, 18, false))
-	want := "Run:          katlctl config init cluster.yaml --installer http://[2001:db8::10]:8080"
-	if !strings.Contains(got, want) {
+	want := "Run:katlctlconfiginitcluster.yaml--installerhttp://[2001:db8::10]:8080"
+	if !containsIgnoringLayout(got, want) {
 		t.Fatalf("render missing %q:\n%s", want, got)
 	}
 }
@@ -338,8 +338,8 @@ func TestRenderRuntimeFailure(t *testing.T) {
 		Network:           []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Status", "Host", "Kubernetes", "Needs repair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation: 4", "Error:", "boot health check failed", "SSH: katl@192.0.2.20"} {
-		if !strings.Contains(got, want) {
+	for _, want := range []string{"Status", "Host", "Kubernetes", "Needsrepair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation:4", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
+		if !containsIgnoringLayout(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
 	}
@@ -354,8 +354,8 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 		CurrentStep:      "Reboot",
 	}
 	plain := string(renderDashboard(&snapshot, nil, 80, 15, false))
-	for _, want := range []string{"KatlOS\n", "Status\n", "State:      OK", "Generation: 0", "Journal"} {
-		if !strings.Contains(plain, want) {
+	for _, want := range []string{"KatlOS", "Status", "State:OK", "Generation:0", "Journal"} {
+		if !containsIgnoringLayout(plain, want) {
 			t.Fatalf("plain render missing %q:\n%s", want, plain)
 		}
 	}
@@ -393,11 +393,11 @@ func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
 		t.Fatalf("split title row = %q", lines[splitRow])
 	}
 	stateRow := lines[splitRow+1]
-	if !strings.Contains(stateRow, "State:      OK") || !strings.Contains(stateRow, "│State:      Bootstrapped") {
+	if !containsIgnoringLayout(stateRow, "State:OK") || !containsIgnoringLayout(stateRow, "│State:Bootstrapped") {
 		t.Fatalf("split state row = %q", stateRow)
 	}
 	versionRow := lines[splitRow+2]
-	if !strings.Contains(versionRow, "Node:       cp-1") || !strings.Contains(versionRow, "│Version:    v1.36.1") {
+	if !containsIgnoringLayout(versionRow, "Node:cp-1") || !containsIgnoringLayout(versionRow, "│Version:v1.36.1") {
 		t.Fatalf("split version row = %q", versionRow)
 	}
 	if !strings.Contains(got, "latest journal event") {
@@ -405,7 +405,7 @@ func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
 	}
 }
 
-func TestRenderRuntimeSubPanesWrapOverflowIndependently(t *testing.T) {
+func TestRenderRuntimeStacksPanesAtNarrowWidths(t *testing.T) {
 	hostname := "cp-with-a-deliberately-long-hostname.example.test"
 	version := "v1.36.1-with-a-deliberately-long-build-identifier"
 	generationID := "generation-with-a-deliberately-long-identifier"
@@ -419,11 +419,11 @@ func TestRenderRuntimeSubPanesWrapOverflowIndependently(t *testing.T) {
 		Generation:             generationID,
 		GenerationHealth:       "healthy",
 	}
-	plain := string(renderDashboard(&snapshot, nil, 40, 40, false))
-	colored := string(renderDashboard(&snapshot, nil, 40, 40, true))
+	plain := string(renderDashboard(&snapshot, nil, 40, 60, false))
+	colored := string(renderDashboard(&snapshot, nil, 40, 60, true))
 	for name, output := range map[string]string{"plain": plain, "colored": colored} {
-		if strings.Contains(output, "~") {
-			t.Fatalf("%s render truncated overflow:\n%s", name, output)
+		if strings.Contains(output, "│") || strings.Contains(output, "…") {
+			t.Fatalf("%s narrow render used split panes or truncated content:\n%s", name, output)
 		}
 		for number, line := range strings.Split(strings.TrimSuffix(output, "\n"), "\n") {
 			if width := visibleWidth(line); width > 40 {
@@ -432,26 +432,27 @@ func TestRenderRuntimeSubPanesWrapOverflowIndependently(t *testing.T) {
 		}
 	}
 
-	lines := strings.Split(strings.TrimSuffix(plain, "\n"), "\n")
-	splitRow := lineIndexContaining(lines, "Host")
-	networkRow := lineIndexContaining(lines, "Network:")
-	journalRow := lineIndex(lines, "Journal")
-	if splitRow < 0 || networkRow <= splitRow || journalRow <= networkRow {
-		t.Fatalf("missing nested panes:\n%s", plain)
+	hostRow := strings.Index(plain, "Host")
+	kubernetesRow := strings.Index(plain, "Kubernetes")
+	networkRow := strings.Index(plain, "Network:")
+	journalRow := strings.Index(plain, "Journal")
+	if hostRow < 0 || kubernetesRow <= hostRow || networkRow <= kubernetesRow || journalRow <= networkRow {
+		t.Fatalf("unexpected stacked pane order:\n%s", plain)
 	}
-	var left, right strings.Builder
-	for _, line := range lines[splitRow:networkRow] {
-		divider := strings.IndexRune(line, '│')
-		if divider < 0 || len([]rune(line[:divider])) != 19 {
-			t.Fatalf("unstable divider in %q", line)
-		}
-		left.WriteString(strings.ReplaceAll(line[:divider], " ", ""))
-		right.WriteString(strings.ReplaceAll(line[divider+len("│"):], " ", ""))
-	}
-	for value, side := range map[string]string{hostname: left.String(), generationID: left.String(), version: right.String()} {
-		if !strings.Contains(side, value) {
+	for _, value := range []string{hostname, generationID, version} {
+		if !containsIgnoringLayout(plain, value) {
 			t.Fatalf("wrapped panes lost %q:\n%s", value, plain)
 		}
+	}
+}
+
+func TestRenderRuntimeUsesSplitPanesOnlyAtWideBreakpoint(t *testing.T) {
+	snapshot := Snapshot{Mode: ModeRuntime, State: installstatus.StateKubeadmReady}
+	if narrow := string(renderDashboard(&snapshot, nil, wideLayoutWidth-1, 24, false)); strings.Contains(narrow, "│") {
+		t.Fatalf("narrow render contains divider:\n%s", narrow)
+	}
+	if wide := string(renderDashboard(&snapshot, nil, wideLayoutWidth, 24, false)); !strings.Contains(wide, "│") {
+		t.Fatalf("wide render lacks divider:\n%s", wide)
 	}
 }
 
@@ -471,6 +472,14 @@ func lineIndexContaining(lines []string, value string) int {
 		}
 	}
 	return -1
+}
+
+func containsIgnoringLayout(value, want string) bool {
+	normalize := func(input string) string {
+		replacer := strings.NewReplacer(" ", "", "\t", "", "\r", "", "\n", "", "│", "")
+		return replacer.Replace(input)
+	}
+	return strings.Contains(normalize(value), normalize(want))
 }
 
 func TestRenderRebootHidesRedundantProgress(t *testing.T) {
@@ -590,7 +599,7 @@ func emulateTerminal(t *testing.T, data []byte, width, height int) terminalState
 	}
 	for position := 0; position < len(data); {
 		if data[position] == '\x1b' {
-			next := skipANSIBytes(data, position)
+			next := position + skipTerminalSequence(string(data[position:]))
 			sequence := string(data[position:next])
 			switch sequence {
 			case "\x1b[H":
@@ -653,8 +662,8 @@ func TestJournalLineWrapsAndStripsANSI(t *testing.T) {
 		t.Fatalf("JournalWriter.WriteLine() = %q, rows=%d", got, rows)
 	}
 	for number, line := range strings.Split(strings.TrimSuffix(string(got), "\n"), "\n") {
-		if len([]rune(line)) > 40 {
-			t.Fatalf("line %d width = %d: %q", number+1, len([]rune(line)), line)
+		if width := visibleWidth(line); width > 40 {
+			t.Fatalf("line %d width = %d: %q", number+1, width, line)
 		}
 	}
 	if joined := strings.ReplaceAll(string(got), "\n", ""); joined != strings.TrimSuffix(string(value), "\x1b[31m") {
@@ -662,44 +671,180 @@ func TestJournalLineWrapsAndStripsANSI(t *testing.T) {
 	}
 }
 
-func TestRendererReusesBuffer(t *testing.T) {
+func TestViewportMeasuresDisplayGraphemes(t *testing.T) {
+	value := "界e\u0301👩‍💻" + string([]byte{0xff})
+	if got, want := displayWidth(value), 6; got != want {
+		t.Fatalf("display width = %d, want %d", got, want)
+	}
+	frame := newFrame(5, 2)
+	viewport := NewViewport(&frame, Rect{Width: 5, Height: 2})
+	result := viewport.Write(value, WrapOptions{})
+	if result.Truncated || result.Rows != 2 {
+		t.Fatalf("write result = %#v", result)
+	}
+	if got := frameText(&frame, Rect{Width: 5, Height: 2}); got != "界é👩‍💻�" {
+		t.Fatalf("painted graphemes = %q", got)
+	}
+	assertGraphemesFit(t, &frame, Rect{Width: 5, Height: 2})
+}
+
+func TestViewportPreservesLongValuesAndMarksVerticalOverflow(t *testing.T) {
+	value := strings.Repeat("abcdefghij", 8)
+	frame := newFrame(7, 20)
+	viewport := NewViewport(&frame, Rect{Width: 7, Height: 20})
+	if result := viewport.Write(value, WrapOptions{WordWrap: true}); result.Truncated {
+		t.Fatalf("value unexpectedly truncated: %#v", result)
+	}
+	if got := frameText(&frame, Rect{Width: 7, Height: 20}); got != value {
+		t.Fatalf("painted value changed: %q", got)
+	}
+
+	shortFrame := newFrame(4, 1)
+	short := NewViewport(&shortFrame, Rect{Width: 4, Height: 1})
+	if result := short.Write("abcdefgh", WrapOptions{}); !result.Truncated {
+		t.Fatalf("overflow result = %#v", result)
+	}
+	if got := shortFrame.Cells[3].Glyph; got != "…" {
+		t.Fatalf("truncation cell = %q", got)
+	}
+}
+
+func TestFieldsPanesAndJournalShareCellWrapping(t *testing.T) {
+	value := strings.Repeat("界e\u0301👩‍💻", 12)
+	paintField := func() string {
+		frame := newFrame(12, 24)
+		viewport := NewViewport(&frame, Rect{Width: 12, Height: 24})
+		writeField(&viewport, "", value, "")
+		return frameText(&frame, Rect{Width: 12, Height: 24})
+	}
+	paintPane := func() string {
+		frame := newFrame(12, 24)
+		viewport := NewViewport(&frame, Rect{Width: 12, Height: 24})
+		writePane(&viewport, "", []paneField{{value: value}})
+		return frameText(&frame, Rect{Width: 12, Height: 24})
+	}
+	paintJournal := func() string {
+		frame := newFrame(12, 24)
+		viewport := NewViewport(&frame, Rect{Width: 12, Height: 24})
+		writer := newJournalWriter(viewport)
+		writer.WriteLine([]byte(value))
+		return frameText(&frame, Rect{Width: 12, Height: 24})
+	}
+	if field, pane, journal := paintField(), paintPane(), paintJournal(); field != value || pane != field || journal != field {
+		t.Fatalf("shared wrapping changed content: field=%q pane=%q journal=%q", field, pane, journal)
+	}
+}
+
+func TestWidePaneDividerIsPaintedAfterBoundedContent(t *testing.T) {
+	renderer := NewRenderer(NewRenderTarget(make([]byte, RenderCapacity(80, 40)), 80, 40), false)
+	content := NewViewport(&renderer.frame, Rect{Width: 80, Height: 38})
+	snapshot := Snapshot{
+		Mode:              ModeRuntime,
+		Hostname:          strings.Repeat("host界\x1b[31m", 30),
+		Version:           strings.Repeat("version", 30),
+		Generation:        strings.Repeat("generation", 30),
+		KubernetesVersion: strings.Repeat("v1.36.1👩‍💻", 30),
+	}
+	renderer.writeRuntimeStatus(&content, &snapshot)
+	divider := (content.bounds.Width - 1) / 2
+	for row := 0; row < content.rowsUsed(); row++ {
+		if got := renderer.frame.Cells[row*renderer.frame.Width+divider].Glyph; got != "│" {
+			t.Fatalf("divider row %d = %q", row, got)
+		}
+	}
+}
+
+func FuzzViewportBounds(f *testing.F) {
+	seeds := []string{
+		"plain text",
+		"界e\u0301👩‍💻",
+		"before\x1b[31mred\x1b[0mafter",
+		string([]byte{'a', 0xff, 'b'}),
+		strings.Repeat("x", 256),
+	}
+	for index, seed := range seeds {
+		for _, width := range []uint8{0, 39, 70, 71, 119} {
+			f.Add(seed, width, uint8(1+index))
+		}
+	}
+	f.Fuzz(func(t *testing.T, value string, widthSeed, heightSeed uint8) {
+		width := int(widthSeed%120) + 1
+		height := int(heightSeed%32) + 1
+		frame := newFrame(width+2, height+2)
+		for index := range frame.Cells {
+			frame.Cells[index] = Cell{Glyph: "#", span: 1}
+		}
+		bounds := Rect{X: 1, Y: 1, Width: width, Height: height}
+		viewport := NewViewport(&frame, bounds)
+		viewport.Write(value, WrapOptions{WordWrap: true})
+		for y := range frame.Height {
+			for x := range frame.Width {
+				inside := x >= bounds.X && x < bounds.X+bounds.Width && y >= bounds.Y && y < bounds.Y+bounds.Height
+				if !inside && frame.Cells[y*frame.Width+x].Glyph != "#" {
+					t.Fatalf("viewport modified sentinel at %d,%d", x, y)
+				}
+			}
+		}
+		assertGraphemesFit(t, &frame, bounds)
+	})
+}
+
+func frameText(frame *Frame, bounds Rect) string {
+	var text strings.Builder
+	for y := bounds.Y; y < bounds.Y+bounds.Height; y++ {
+		for x := bounds.X; x < bounds.X+bounds.Width; x++ {
+			cell := frame.Cells[y*frame.Width+x]
+			if !cell.continuation {
+				text.WriteString(cell.Glyph)
+			}
+		}
+	}
+	return text.String()
+}
+
+func assertGraphemesFit(t *testing.T, frame *Frame, bounds Rect) {
+	t.Helper()
+	for y := bounds.Y; y < bounds.Y+bounds.Height; y++ {
+		for x := bounds.X; x < bounds.X+bounds.Width; x++ {
+			cell := frame.Cells[y*frame.Width+x]
+			if cell.Glyph == "" || cell.continuation {
+				continue
+			}
+			if cell.span < 1 || x+cell.span > bounds.X+bounds.Width {
+				t.Fatalf("grapheme %q at %d,%d spans outside viewport", cell.Glyph, x, y)
+			}
+		}
+	}
+}
+
+func TestRendererBoundsArbitraryContentAtSupportedWidths(t *testing.T) {
 	snapshot := Snapshot{
 		Mode:                   ModeRuntime,
 		State:                  installstatus.StateKubeadmReady,
-		Hostname:               "cp-1",
-		Version:                "2026.7.0-alpha.15",
-		Generation:             "4",
+		Hostname:               "控制面-e\u0301-👩‍💻\x1b[31m-node",
+		Version:                strings.Repeat("version", 20),
+		Generation:             string([]byte{'g', 'e', 'n', 0xff}),
 		GenerationHealth:       "healthy",
-		KubernetesVersion:      "v1.36.1",
+		KubernetesVersion:      strings.Repeat("v1.36.1", 20),
 		KubernetesBootstrapped: true,
 		SSHEnabled:             true,
 		Network: []NetworkInterface{{
-			Name:      "enp1s0",
+			Name:      strings.Repeat("interface", 12),
 			Addresses: []string{"10.1.2.254/24", "fd00::254/64"},
 		}},
 	}
-	journal := testJournal{[]byte("journal line")}
-	for _, color := range []bool{false, true} {
-		name := "plain"
-		if color {
-			name = "color"
+	journal := testJournal{[]byte("日志 e\u0301 👩‍💻 \x1b[31m" + strings.Repeat("payload", 20))}
+	for width := 1; width <= 120; width++ {
+		got := string(renderDashboard(&snapshot, journal, width, 32, false))
+		lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+		if len(lines) != 32 {
+			t.Fatalf("width %d rendered %d rows", width, len(lines))
 		}
-		t.Run(name, func(t *testing.T) {
-			storage := make([]byte, RenderCapacity(80, 25))
-			renderer := NewRenderer(NewRenderTarget(storage, 80, 25), color)
-			buffer := renderer.Render(&snapshot, &journal)
-			start := &buffer[0]
-
-			allocations := testing.AllocsPerRun(1000, func() {
-				buffer = renderer.Render(&snapshot, &journal)
-			})
-			if allocations != 0 {
-				t.Fatalf("Renderer.Render() allocations = %v, want 0", allocations)
+		for row, line := range lines {
+			if gotWidth := visibleWidth(line); gotWidth > width {
+				t.Fatalf("width %d row %d occupies %d cells: %q", width, row, gotWidth, line)
 			}
-			if &buffer[0] != start {
-				t.Fatal("Renderer.Render() replaced owned storage")
-			}
-		})
+		}
 	}
 }
 

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/katl-dev/katl/internal/installer/generation"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
@@ -512,7 +513,7 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 	}
 }
 
-func TestTerminalRenderClearsPendingAutowrapOnEveryRow(t *testing.T) {
+func TestTerminalRenderDoesNotScrollCompletedFrame(t *testing.T) {
 	snapshot := Snapshot{
 		Mode:       ModeRuntime,
 		Hostname:   "cp-with-a-long-name",
@@ -523,17 +524,88 @@ func TestTerminalRenderClearsPendingAutowrapOnEveryRow(t *testing.T) {
 			Addresses: []string{"2001:db8:1234:5678::10/64", "192.0.2.10/24"},
 		}},
 	}
-	got := renderDashboard(&snapshot, testJournal{[]byte(strings.Repeat("j", 40))}, 40, 30, true)
-	for index, value := range got {
-		if value == '\n' && (index == 0 || got[index-1] != '\r') {
-			t.Fatalf("terminal row %d lacks carriage return before line feed: %q", index, got[max(0, index-8):index+1])
-		}
+	const width, height = 40, 30
+	got := renderDashboard(&snapshot, testJournal{[]byte(strings.Repeat("j", width))}, width, height, true)
+	terminal := emulateTerminal(t, got, width, height)
+	if terminal.scrolls != 0 {
+		t.Fatalf("completed frame scrolled %d times", terminal.scrolls)
 	}
-	for number, line := range strings.Split(strings.TrimSuffix(string(got), "\r\n"), "\r\n") {
-		if width := visibleWidth(line); width > 40 {
-			t.Fatalf("line %d width = %d: %q", number+1, width, line)
-		}
+	if row := strings.TrimSpace(string(terminal.rows[0])); row != "KatlOS" {
+		t.Fatalf("first terminal row = %q", row)
 	}
+	if row := strings.TrimSpace(string(terminal.rows[height-1])); !strings.HasPrefix(row, "Ctrl+Alt+F2: console") {
+		t.Fatalf("footer terminal row = %q", row)
+	}
+}
+
+type terminalState struct {
+	rows    [][]rune
+	row     int
+	column  int
+	pending bool
+	scrolls int
+}
+
+func emulateTerminal(t *testing.T, data []byte, width, height int) terminalState {
+	t.Helper()
+	state := terminalState{rows: make([][]rune, height)}
+	for index := range state.rows {
+		state.rows[index] = []rune(strings.Repeat(" ", width))
+	}
+	for position := 0; position < len(data); {
+		if data[position] == '\x1b' {
+			next := skipANSIBytes(data, position)
+			sequence := string(data[position:next])
+			switch sequence {
+			case "\x1b[H":
+				state.row, state.column, state.pending = 0, 0, false
+			case "\x1b[2J":
+				for row := range state.rows {
+					for column := range state.rows[row] {
+						state.rows[row][column] = ' '
+					}
+				}
+			}
+			position = next
+			continue
+		}
+		switch data[position] {
+		case '\r':
+			state.column, state.pending = 0, false
+			position++
+			continue
+		case '\n':
+			state.row++
+			state.pending = false
+			if state.row == height {
+				copy(state.rows, state.rows[1:])
+				state.rows[height-1] = []rune(strings.Repeat(" ", width))
+				state.row--
+				state.scrolls++
+			}
+			position++
+			continue
+		}
+		value, size := utf8.DecodeRune(data[position:])
+		if state.pending {
+			state.row++
+			state.column, state.pending = 0, false
+			if state.row == height {
+				copy(state.rows, state.rows[1:])
+				state.rows[height-1] = []rune(strings.Repeat(" ", width))
+				state.row--
+				state.scrolls++
+			}
+		}
+		state.rows[state.row][state.column] = value
+		if state.column == width-1 {
+			state.pending = true
+		} else {
+			state.column++
+		}
+		position += size
+	}
+	return state
 }
 
 func TestJournalLineWrapsAndStripsANSI(t *testing.T) {

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -177,6 +177,135 @@ func TestReadDefaultRouteInterface(t *testing.T) {
 	}
 }
 
+func TestCollectorSurfacesCorruptHandoff(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "handoff.json")
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collector := Collector{
+		Mode:        ModeInstaller,
+		Root:        root,
+		HandoffPath: path,
+		Interfaces:  func() ([]net.Interface, error) { return nil, nil },
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if snapshot.HandoffError == "" || snapshot.Handoff.URL != "" {
+		t.Fatalf("corrupt handoff snapshot = %#v", snapshot)
+	}
+	rendered := string(renderDashboard(&snapshot, nil, 80, 18, false))
+	if !containsIgnoringLayout(rendered, "Handoffread:installerhandoffisunreadable") {
+		t.Fatalf("corrupt handoff not visible:\n%s", rendered)
+	}
+}
+
+func TestCollectorDoesNotPresentBinaryVersionForCorruptGeneration(t *testing.T) {
+	root := t.TempDir()
+	path, err := generation.BootSelectionPath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collector := Collector{
+		Mode:       ModeRuntime,
+		Version:    "console-binary-version",
+		Root:       root,
+		Interfaces: func() ([]net.Interface, error) { return nil, nil },
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if snapshot.GenerationError == "" || snapshot.Version != "" || snapshot.CurrentSoftware.KatlOSVersion != "" {
+		t.Fatalf("corrupt generation snapshot = %#v", snapshot)
+	}
+	rendered := string(renderDashboard(&snapshot, nil, 80, 20, false))
+	if strings.Contains(rendered, "console-binary-version") || !containsIgnoringLayout(rendered, "Generationread:generationmetadataisunavailable") || !strings.Contains(rendered, "Unknown") {
+		t.Fatalf("corrupt generation presentation:\n%s", rendered)
+	}
+}
+
+func TestCollectorMarksStaleInstallingState(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	statusPath := filepath.Join(root, "status.json")
+	if err := installstatus.WriteFile(statusPath, installstatus.New(installstatus.StateRunning, now.Add(-11*time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+	collector := Collector{
+		Mode:        ModeInstaller,
+		Root:        root,
+		StatusPath:  statusPath,
+		HandoffPath: filepath.Join(root, "missing-handoff.json"),
+		Interfaces:  func() ([]net.Interface, error) { return nil, nil },
+		Now:         func() time.Time { return now },
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if !snapshot.StatusStale {
+		t.Fatalf("stale snapshot = %#v", snapshot)
+	}
+	rendered := string(renderDashboard(&snapshot, nil, 80, 18, false))
+	if strings.Contains(rendered, "Installing") || !containsIgnoringLayout(rendered, "Unknown(stalestatus)") || !containsIgnoringLayout(rendered, "Statusstale:") {
+		t.Fatalf("stale state presentation:\n%s", rendered)
+	}
+}
+
+func TestRuntimePresentationStatesFailClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  string
+		health string
+		stale  bool
+		want   PresentationState
+		style  Style
+	}{
+		{name: "healthy", state: installstatus.StateKubeadmReady, health: generation.HealthStateHealthy, want: PresentationHealthy, style: styleGood},
+		{name: "deferred", state: installstatus.StateKubeadmReady, health: generation.HealthStateDeferred, want: PresentationProgressing, style: styleWarn},
+		{name: "unknown health", state: installstatus.StateKubeadmReady, health: generation.HealthStateUnknown, want: PresentationUnknown, style: styleDim},
+		{name: "unfamiliar health", state: installstatus.StateKubeadmReady, health: "mystery", want: PresentationUnknown, style: styleDim},
+		{name: "unfamiliar state", state: "future-runtime-state", health: generation.HealthStateHealthy, want: PresentationUnknown, style: styleDim},
+		{name: "stale", state: installstatus.StateKubeadmReady, health: generation.HealthStateHealthy, stale: true, want: PresentationUnknown, style: styleDim},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			presentation := NewDashboardModel(&Snapshot{Mode: ModeRuntime, State: test.state, GenerationHealth: test.health, StatusStale: test.stale}).Host
+			if presentation.State != test.want {
+				t.Fatalf("presentation = %#v, want %q", presentation, test.want)
+			}
+			if got := presentationStyle(presentation.State); got != test.style {
+				t.Fatalf("presentation style = %q, want %q", got, test.style)
+			}
+		})
+	}
+}
+
+func TestKubernetesConfigurationIsNotPresentedAsHealthy(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:                 ModeRuntime,
+		State:                installstatus.StateWaitingForClusterBootstrap,
+		LiveSoftware:         Software{Generation: "4", KubernetesVersion: "v1.36.1"},
+		KubernetesConfigured: true,
+	}
+	presentation := NewDashboardModel(&snapshot).Kubernetes
+	if presentation.State != PresentationProgressing || presentation.Label != "Configured" {
+		t.Fatalf("Kubernetes presentation = %#v", presentation)
+	}
+}
+
+func TestPendingGenerationHealthIsWarningNotFailure(t *testing.T) {
+	for _, health := range []string{generation.HealthStateUnknown, generation.HealthStateDeferred} {
+		label := healthLabel(health)
+		if style := healthStyle(label); style != styleWarn {
+			t.Fatalf("health %q label %q style = %q", health, label, style)
+		}
+	}
+}
+
 func interfaceNames(interfaces []NetworkInterface) []string {
 	names := make([]string, len(interfaces))
 	for index := range interfaces {
@@ -257,8 +386,8 @@ func TestCollectorReadsInstalledVersionsFromBootedGeneration(t *testing.T) {
 	}
 	var snapshot Snapshot
 	collector.Collect(&snapshot)
-	if snapshot.Version != "2026.7.0-alpha.12" || snapshot.KubernetesVersion != "v1.36.1" || !snapshot.KubernetesBootstrapped {
-		t.Fatalf("installed state = KatlOS %q, Kubernetes %q, bootstrapped=%t", snapshot.Version, snapshot.KubernetesVersion, snapshot.KubernetesBootstrapped)
+	if snapshot.CurrentSoftware.KatlOSVersion != "2026.7.0-alpha.12" || snapshot.LiveSoftware.KubernetesVersion != "v1.36.1" || !snapshot.KubernetesConfigured {
+		t.Fatalf("installed state = current %#v, live %#v, configured=%t", snapshot.CurrentSoftware, snapshot.LiveSoftware, snapshot.KubernetesConfigured)
 	}
 }
 
@@ -293,14 +422,14 @@ func TestCollectorReportsLiveBootstrapCandidateBeforeReboot(t *testing.T) {
 	}
 	var snapshot Snapshot
 	collector.Collect(&snapshot)
-	if snapshot.Generation != "0" || snapshot.NextGeneration != "bootstrap-init-candidate" {
-		t.Fatalf("generation = %q, next = %q", snapshot.Generation, snapshot.NextGeneration)
+	if snapshot.CurrentSoftware.Generation != "0" || snapshot.NextBootSoftware.Generation != "bootstrap-init-candidate" || snapshot.LiveSoftware.Generation != "bootstrap-init-candidate" {
+		t.Fatalf("software provenance = current %#v, next %#v, live %#v", snapshot.CurrentSoftware, snapshot.NextBootSoftware, snapshot.LiveSoftware)
 	}
-	if snapshot.Version != "2026.7.0-alpha.16" || snapshot.KubernetesVersion != "v1.36.1" || !snapshot.KubernetesBootstrapped {
-		t.Fatalf("software state = KatlOS %q, Kubernetes %q, bootstrapped=%t", snapshot.Version, snapshot.KubernetesVersion, snapshot.KubernetesBootstrapped)
+	if snapshot.CurrentSoftware.KatlOSVersion != "2026.7.0-alpha.16" || snapshot.LiveSoftware.KubernetesVersion != "v1.36.1" || !snapshot.KubernetesConfigured {
+		t.Fatalf("software state = current %#v, live %#v, configured=%t", snapshot.CurrentSoftware, snapshot.LiveSoftware, snapshot.KubernetesConfigured)
 	}
 	rendered := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Generation:0", "Nextboot:bootstrap-init-candidate", "Version:v1.36.1", "Bootstrapped"} {
+	for _, want := range []string{"Current:generation0", "Nextboot:generationbootstrap-init-candidate", "Liveselected:generationbootstrap-init-candidate", "Version:v1.36.1", "Configured"} {
 		if !containsIgnoringLayout(rendered, want) {
 			t.Fatalf("render missing %q:\n%s", want, rendered)
 		}
@@ -448,21 +577,22 @@ func TestRenderInstallerCommandPreservesCanonicalEndpoint(t *testing.T) {
 
 func TestRenderRuntimeFailure(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:              ModeRuntime,
-		Version:           "2026.7.0-alpha.9",
-		KubernetesVersion: "v1.36.1",
-		Hostname:          "cp-1",
-		State:             installstatus.StateRuntimeFailedNeedsRepair,
-		Generation:        "4",
-		GenerationHealth:  "unhealthy",
-		LastError:         "boot health check failed",
-		RetryHint:         "inspect the previous generation",
-		SSHEnabled:        true,
-		ManagementAddress: "192.0.2.20",
-		DisplayInterfaces: []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
+		Mode:                 ModeRuntime,
+		Hostname:             "cp-1",
+		State:                installstatus.StateRuntimeFailedNeedsRepair,
+		CurrentSoftware:      Software{Generation: "4", KatlOSVersion: "2026.7.0-alpha.9"},
+		NextBootSoftware:     Software{Generation: "4", KatlOSVersion: "2026.7.0-alpha.9"},
+		LiveSoftware:         Software{Generation: "4", KatlOSVersion: "2026.7.0-alpha.9", KubernetesVersion: "v1.36.1"},
+		GenerationHealth:     "unhealthy",
+		KubernetesConfigured: true,
+		LastError:            "boot health check failed",
+		RetryHint:            "inspect the previous generation",
+		SSHEnabled:           true,
+		ManagementAddress:    "192.0.2.20",
+		DisplayInterfaces:    []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Status", "Host", "Kubernetes", "Needsrepair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation:4", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
+	for _, want := range []string{"Status", "Host", "Kubernetes", "Needsrepair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Current:generation4", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
 		if !containsIgnoringLayout(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
@@ -514,12 +644,14 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 	snapshot := Snapshot{
 		Mode:             ModeRuntime,
 		State:            installstatus.StateKubeadmReady,
-		Generation:       "0",
+		CurrentSoftware:  Software{Generation: "0"},
+		NextBootSoftware: Software{Generation: "0"},
+		LiveSoftware:     Software{Generation: "0"},
 		GenerationHealth: "healthy",
 		CurrentStep:      "Reboot",
 	}
 	plain := string(renderDashboard(&snapshot, nil, 80, 15, false))
-	for _, want := range []string{"KatlOS", "Status", "State:OK", "Generation:0", "Journal"} {
+	for _, want := range []string{"KatlOS", "Status", "State:Healthy", "Current:generation0", "Journal"} {
 		if !containsIgnoringLayout(plain, want) {
 			t.Fatalf("plain render missing %q:\n%s", want, plain)
 		}
@@ -537,14 +669,14 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 
 func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:                   ModeRuntime,
-		Version:                "2026.7.0-alpha.12",
-		KubernetesVersion:      "v1.36.1",
-		KubernetesBootstrapped: true,
-		Hostname:               "cp-1",
-		State:                  installstatus.StateWaitingForClusterBootstrap,
-		Generation:             "4",
-		GenerationHealth:       "healthy",
+		Mode:                 ModeRuntime,
+		CurrentSoftware:      Software{Generation: "4", KatlOSVersion: "2026.7.0-alpha.12"},
+		NextBootSoftware:     Software{Generation: "4", KatlOSVersion: "2026.7.0-alpha.12"},
+		LiveSoftware:         Software{Generation: "4", KatlOSVersion: "2026.7.0-alpha.12", KubernetesVersion: "v1.36.1"},
+		KubernetesConfigured: true,
+		Hostname:             "cp-1",
+		State:                installstatus.StateWaitingForClusterBootstrap,
+		GenerationHealth:     "healthy",
 	}
 	got := string(renderDashboard(&snapshot, testJournal{[]byte("latest journal event")}, 80, 18, false))
 	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
@@ -558,7 +690,7 @@ func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
 		t.Fatalf("split title row = %q", lines[splitRow])
 	}
 	stateRow := lines[splitRow+1]
-	if !containsIgnoringLayout(stateRow, "State:OK") || !containsIgnoringLayout(stateRow, "│State:Bootstrapped") {
+	if !containsIgnoringLayout(stateRow, "State:Healthy") || !containsIgnoringLayout(stateRow, "│State:Configured") {
 		t.Fatalf("split state row = %q", stateRow)
 	}
 	versionRow := lines[splitRow+2]
@@ -575,14 +707,14 @@ func TestRenderRuntimeStacksPanesAtNarrowWidths(t *testing.T) {
 	version := "v1.36.1-with-a-deliberately-long-build-identifier"
 	generationID := "generation-with-a-deliberately-long-identifier"
 	snapshot := Snapshot{
-		Mode:                   ModeRuntime,
-		Version:                "2026.7.0-alpha.12-with-a-long-build-identifier",
-		KubernetesVersion:      version,
-		KubernetesBootstrapped: true,
-		Hostname:               hostname,
-		State:                  installstatus.StateWaitingForClusterBootstrap,
-		Generation:             generationID,
-		GenerationHealth:       "healthy",
+		Mode:                 ModeRuntime,
+		CurrentSoftware:      Software{Generation: generationID, KatlOSVersion: "2026.7.0-alpha.12-with-a-long-build-identifier"},
+		NextBootSoftware:     Software{Generation: generationID, KatlOSVersion: "2026.7.0-alpha.12-with-a-long-build-identifier"},
+		LiveSoftware:         Software{Generation: generationID, KatlOSVersion: "2026.7.0-alpha.12-with-a-long-build-identifier", KubernetesVersion: version},
+		KubernetesConfigured: true,
+		Hostname:             hostname,
+		State:                installstatus.StateWaitingForClusterBootstrap,
+		GenerationHealth:     "healthy",
 	}
 	plain := string(renderDashboard(&snapshot, nil, 40, 60, false))
 	colored := string(renderDashboard(&snapshot, nil, 40, 60, true))
@@ -726,10 +858,11 @@ func TestRenderDimensionsAreCapped(t *testing.T) {
 
 func TestTerminalRenderDoesNotScrollCompletedFrame(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:       ModeRuntime,
-		Hostname:   "cp-with-a-long-name",
-		Version:    "2026.7.0-alpha.15",
-		Generation: "generation-with-a-long-identifier",
+		Mode:             ModeRuntime,
+		Hostname:         "cp-with-a-long-name",
+		CurrentSoftware:  Software{Generation: "generation-with-a-long-identifier", KatlOSVersion: "2026.7.0-alpha.15"},
+		NextBootSoftware: Software{Generation: "generation-with-a-long-identifier", KatlOSVersion: "2026.7.0-alpha.15"},
+		LiveSoftware:     Software{Generation: "generation-with-a-long-identifier", KatlOSVersion: "2026.7.0-alpha.15"},
 		DisplayInterfaces: []NetworkInterface{{
 			Name:      "enp1s0",
 			Addresses: []string{"2001:db8:1234:5678::10/64", "192.0.2.10/24"},
@@ -905,11 +1038,21 @@ func TestWidePaneDividerIsPaintedAfterBoundedContent(t *testing.T) {
 	renderer := NewRenderer(NewRenderTarget(make([]byte, RenderCapacity(80, 40)), 80, 40), false)
 	content := NewViewport(&renderer.frame, Rect{Width: 80, Height: 38})
 	snapshot := Snapshot{
-		Mode:              ModeRuntime,
-		Hostname:          strings.Repeat("host界\x1b[31m", 30),
-		Version:           strings.Repeat("version", 30),
-		Generation:        strings.Repeat("generation", 30),
-		KubernetesVersion: strings.Repeat("v1.36.1👩‍💻", 30),
+		Mode:     ModeRuntime,
+		Hostname: strings.Repeat("host界\x1b[31m", 30),
+		CurrentSoftware: Software{
+			Generation:    strings.Repeat("generation", 30),
+			KatlOSVersion: strings.Repeat("version", 30),
+		},
+		NextBootSoftware: Software{
+			Generation:    strings.Repeat("generation", 30),
+			KatlOSVersion: strings.Repeat("version", 30),
+		},
+		LiveSoftware: Software{
+			Generation:        strings.Repeat("generation", 30),
+			KatlOSVersion:     strings.Repeat("version", 30),
+			KubernetesVersion: strings.Repeat("v1.36.1👩‍💻", 30),
+		},
 	}
 	renderer.writeRuntimeStatus(&content, &snapshot)
 	divider := (content.bounds.Width - 1) / 2
@@ -985,16 +1128,16 @@ func assertGraphemesFit(t *testing.T, frame *Frame, bounds Rect) {
 
 func TestRendererBoundsArbitraryContentAtSupportedWidths(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:                   ModeRuntime,
-		State:                  installstatus.StateKubeadmReady,
-		Hostname:               "控制面-e\u0301-👩‍💻\x1b[31m-node",
-		Version:                strings.Repeat("version", 20),
-		Generation:             string([]byte{'g', 'e', 'n', 0xff}),
-		GenerationHealth:       "healthy",
-		KubernetesVersion:      strings.Repeat("v1.36.1", 20),
-		KubernetesBootstrapped: true,
-		SSHEnabled:             true,
-		ManagementAddress:      "10.1.2.254",
+		Mode:                 ModeRuntime,
+		State:                installstatus.StateKubeadmReady,
+		Hostname:             "控制面-e\u0301-👩‍💻\x1b[31m-node",
+		CurrentSoftware:      Software{Generation: string([]byte{'g', 'e', 'n', 0xff}), KatlOSVersion: strings.Repeat("version", 20)},
+		NextBootSoftware:     Software{Generation: string([]byte{'g', 'e', 'n', 0xff}), KatlOSVersion: strings.Repeat("version", 20)},
+		LiveSoftware:         Software{Generation: string([]byte{'g', 'e', 'n', 0xff}), KatlOSVersion: strings.Repeat("version", 20), KubernetesVersion: strings.Repeat("v1.36.1", 20)},
+		GenerationHealth:     "healthy",
+		KubernetesConfigured: true,
+		SSHEnabled:           true,
+		ManagementAddress:    "10.1.2.254",
 		DisplayInterfaces: []NetworkInterface{{
 			Name:      strings.Repeat("interface", 12),
 			Addresses: []string{"10.1.2.254/24", "fd00::254/64"},

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -369,7 +369,7 @@ func TestRenderInstallerDashboard(t *testing.T) {
 		CurrentStep:         "InstallRootSlot",
 		DestructiveMutation: true,
 		Handoff:             Handoff{URL: "http://192.0.2.10:8080/v1/config-bundle"},
-		ManagementAddress:   "192.0.2.10",
+		ManagementAddress:   "192.0.2.99",
 		DisplayInterfaces:   []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
 	}
 	journal := testJournal{[]byte("old line"), []byte("installing root\x1b[31m"), []byte("latest line")}
@@ -415,6 +415,33 @@ func TestRenderInstallerCommandUsesHandoffURLWithoutIPv4(t *testing.T) {
 	want := "Run:katlctlconfiginitcluster.yaml--installerhttp://[2001:db8::10]:8080"
 	if !containsIgnoringLayout(got, want) {
 		t.Fatalf("render missing %q:\n%s", want, got)
+	}
+}
+
+func TestRenderInstallerCommandPreservesCanonicalEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{name: "https custom port", url: "https://192.0.2.50:8443/v1/config-bundle", want: "https://192.0.2.50:8443"},
+		{name: "http custom port", url: "http://192.0.2.50:9090/v1/config-bundle", want: "http://192.0.2.50:9090"},
+		{name: "hostname", url: "http://installer.example.test:8080/v1/config-bundle", want: "http://installer.example.test:8080"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := Snapshot{
+				Mode:              ModeInstaller,
+				State:             installstatus.StateWaitingForConfig,
+				ManagementAddress: "192.0.2.10",
+				Handoff:           Handoff{URL: test.url},
+			}
+			got := string(renderDashboard(&snapshot, nil, 100, 18, false))
+			want := "Run:katlctlconfiginitcluster.yaml--installer" + test.want
+			if !containsIgnoringLayout(got, want) {
+				t.Fatalf("render missing %q:\n%s", want, got)
+			}
+		})
 	}
 }
 

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -70,24 +70,118 @@ func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 			}
 			return nil, nil
 		},
+		DefaultRouteInterface: func() (string, error) { return "enp1s0", nil },
 	}
 	var snapshot Snapshot
 	collector.Collect(&snapshot)
 	if snapshot.State != installstatus.StateRunning || snapshot.CurrentStep != "InstallRootSlot" || !snapshot.DestructiveMutation {
 		t.Fatalf("snapshot status = %#v", snapshot)
 	}
-	if len(snapshot.Network) != 1 || strings.Join(snapshot.Network[0].Addresses, ",") != "192.0.2.10/24" {
-		t.Fatalf("snapshot network = %#v", snapshot.Network)
+	if snapshot.ManagementAddress != "192.0.2.10" || len(snapshot.DisplayInterfaces) != 1 || strings.Join(snapshot.DisplayInterfaces[0].Addresses, ",") != "192.0.2.10/24" {
+		t.Fatalf("snapshot network = %#v", snapshot.DisplayInterfaces)
 	}
 	if snapshot.Handoff.URL != "http://192.0.2.10:8080/v1/config-bundle" {
 		t.Fatalf("snapshot handoff = %#v", snapshot)
 	}
-	network := &snapshot.Network[0]
-	address := &snapshot.Network[0].Addresses[0]
+	network := &snapshot.DisplayInterfaces[0]
+	address := &snapshot.DisplayInterfaces[0].Addresses[0]
 	collector.Collect(&snapshot)
-	if &snapshot.Network[0] != network || &snapshot.Network[0].Addresses[0] != address {
+	if &snapshot.DisplayInterfaces[0] != network || &snapshot.DisplayInterfaces[0].Addresses[0] != address {
 		t.Fatal("Collect() did not reuse snapshot network storage")
 	}
+}
+
+func TestCollectorCuratesManagementNetwork(t *testing.T) {
+	interfaces := []net.Interface{
+		{Name: "cilium_host", Flags: net.FlagUp},
+		{Name: "veth1234", Flags: net.FlagUp},
+		{Name: "eno4", Flags: net.FlagUp},
+		{Name: "eno2", Flags: net.FlagUp},
+		{Name: "eno1", Flags: net.FlagUp},
+		{Name: "ens3", Flags: net.FlagUp},
+		{Name: "eno3", Flags: net.FlagUp},
+		{Name: "unused0", Flags: net.FlagUp},
+	}
+	addresses := map[string][]net.Addr{
+		"cilium_host": {testAddr("10.0.0.1/32")},
+		"veth1234":    {testAddr("10.0.0.2/32")},
+		"ens3":        {testAddr("192.0.2.10/24"), testAddr("2001:db8::10/64"), testAddr("2001:db8::11/64")},
+		"eno1":        {testAddr("192.0.2.11/24")},
+		"eno2":        {testAddr("192.0.2.12/24")},
+		"eno3":        {testAddr("192.0.2.13/24")},
+		"eno4":        {testAddr("192.0.2.14/24")},
+	}
+	collector := Collector{
+		Mode:       ModeRuntime,
+		Interfaces: func() ([]net.Interface, error) { return interfaces, nil },
+		Addrs:      func(iface net.Interface) ([]net.Addr, error) { return addresses[iface.Name], nil },
+		DefaultRouteInterface: func() (string, error) {
+			return "ens3", nil
+		},
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if snapshot.ManagementAddress != "192.0.2.10" {
+		t.Fatalf("management address = %q", snapshot.ManagementAddress)
+	}
+	if got := interfaceNames(snapshot.DisplayInterfaces); strings.Join(got, ",") != "ens3,eno1,eno2" {
+		t.Fatalf("display interfaces = %v", got)
+	}
+	if snapshot.AdditionalInterfaces != 2 || snapshot.DisplayInterfaces[0].AdditionalAddresses != 1 {
+		t.Fatalf("network omissions = interfaces %d, addresses %#v", snapshot.AdditionalInterfaces, snapshot.DisplayInterfaces[0])
+	}
+	rendered := string(renderDashboard(&snapshot, nil, 80, 24, false))
+	for _, want := range []string{"SSH:katl@192.0.2.10", "+1address", "+2interfaces"} {
+		if !containsIgnoringLayout(rendered, want) {
+			t.Fatalf("network render missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "cilium") || strings.Contains(rendered, "veth") {
+		t.Fatalf("network render exposed virtual interfaces:\n%s", rendered)
+	}
+}
+
+func TestCollectorPrefersKnownManagementAddress(t *testing.T) {
+	collector := Collector{
+		Mode:              ModeRuntime,
+		ManagementAddress: "192.0.2.99/24",
+		Interfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Name: "ens3", Flags: net.FlagUp}, {Name: "eno2", Flags: net.FlagUp}}, nil
+		},
+		Addrs: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "eno2" {
+				return []net.Addr{testAddr("192.0.2.99/24")}, nil
+			}
+			return []net.Addr{testAddr("192.0.2.10/24")}, nil
+		},
+		DefaultRouteInterface: func() (string, error) { return "ens3", nil },
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if snapshot.ManagementAddress != "192.0.2.99" || snapshot.DisplayInterfaces[0].Name != "eno2" {
+		t.Fatalf("known management selection = %#v", snapshot)
+	}
+}
+
+func TestReadDefaultRouteInterface(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "route")
+	data := "Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT\n" +
+		"eno2 00000000 010200C0 0003 0 0 200 00000000 0 0 0\n" +
+		"ens3 00000000 010200C0 0003 0 0 100 00000000 0 0 0\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readDefaultRouteInterface(path); err != nil || got != "ens3" {
+		t.Fatalf("default route = %q, %v", got, err)
+	}
+}
+
+func interfaceNames(interfaces []NetworkInterface) []string {
+	names := make([]string, len(interfaces))
+	for index := range interfaces {
+		names[index] = interfaces[index].Name
+	}
+	return names
 }
 
 func TestCollectorReadsInstalledVersionsFromBootedGeneration(t *testing.T) {
@@ -275,7 +369,8 @@ func TestRenderInstallerDashboard(t *testing.T) {
 		CurrentStep:         "InstallRootSlot",
 		DestructiveMutation: true,
 		Handoff:             Handoff{URL: "http://192.0.2.10:8080/v1/config-bundle"},
-		Network:             []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
+		ManagementAddress:   "192.0.2.10",
+		DisplayInterfaces:   []NetworkInterface{{Name: "enp1s0", Addresses: []string{"192.0.2.10/24"}}},
 	}
 	journal := testJournal{[]byte("old line"), []byte("installing root\x1b[31m"), []byte("latest line")}
 	got := string(renderDashboard(&snapshot, journal, 80, 25, false))
@@ -311,10 +406,10 @@ func TestRenderInstallerDashboard(t *testing.T) {
 
 func TestRenderInstallerCommandUsesHandoffURLWithoutIPv4(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:    ModeInstaller,
-		State:   installstatus.StateWaitingForConfig,
-		Handoff: Handoff{URL: "http://[2001:db8::10]:8080/v1/config-bundle"},
-		Network: []NetworkInterface{{Name: "enp1s0", Addresses: []string{"2001:db8::10/64"}}},
+		Mode:              ModeInstaller,
+		State:             installstatus.StateWaitingForConfig,
+		Handoff:           Handoff{URL: "http://[2001:db8::10]:8080/v1/config-bundle"},
+		DisplayInterfaces: []NetworkInterface{{Name: "enp1s0", Addresses: []string{"2001:db8::10/64"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 100, 18, false))
 	want := "Run:katlctlconfiginitcluster.yaml--installerhttp://[2001:db8::10]:8080"
@@ -335,7 +430,8 @@ func TestRenderRuntimeFailure(t *testing.T) {
 		LastError:         "boot health check failed",
 		RetryHint:         "inspect the previous generation",
 		SSHEnabled:        true,
-		Network:           []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
+		ManagementAddress: "192.0.2.20",
+		DisplayInterfaces: []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 80, 20, false))
 	for _, want := range []string{"Status", "Host", "Kubernetes", "Needsrepair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation:4", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
@@ -500,7 +596,7 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 		State:     installstatus.StateWaitingForConfig,
 		LastError: "installer diagnostic has a deliberately-long-unbroken-value-with-tail-marker",
 		Handoff:   Handoff{URL: "http://[2001:db8:1234:5678::10]:8080/v1/config-bundle"},
-		Network: []NetworkInterface{{
+		DisplayInterfaces: []NetworkInterface{{
 			Name:      "enp1s0",
 			Addresses: []string{"2001:db8:1234:5678::10/64", "192.0.2.10/24"},
 		}},
@@ -524,9 +620,10 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 
 func TestRenderUsesActualUndersizedTerminal(t *testing.T) {
 	snapshot := Snapshot{
-		Mode:  ModeInstaller,
-		State: "starting-installer",
-		Network: []NetworkInterface{{
+		Mode:              ModeInstaller,
+		State:             "starting-installer",
+		ManagementAddress: "192.0.2.10",
+		DisplayInterfaces: []NetworkInterface{{
 			Name:      "enp1s0",
 			Addresses: []string{"192.0.2.10/24"},
 		}},
@@ -564,7 +661,7 @@ func TestTerminalRenderDoesNotScrollCompletedFrame(t *testing.T) {
 		Hostname:   "cp-with-a-long-name",
 		Version:    "2026.7.0-alpha.15",
 		Generation: "generation-with-a-long-identifier",
-		Network: []NetworkInterface{{
+		DisplayInterfaces: []NetworkInterface{{
 			Name:      "enp1s0",
 			Addresses: []string{"2001:db8:1234:5678::10/64", "192.0.2.10/24"},
 		}},
@@ -828,7 +925,8 @@ func TestRendererBoundsArbitraryContentAtSupportedWidths(t *testing.T) {
 		KubernetesVersion:      strings.Repeat("v1.36.1", 20),
 		KubernetesBootstrapped: true,
 		SSHEnabled:             true,
-		Network: []NetworkInterface{{
+		ManagementAddress:      "10.1.2.254",
+		DisplayInterfaces: []NetworkInterface{{
 			Name:      strings.Repeat("interface", 12),
 			Addresses: []string{"10.1.2.254/24", "fd00::254/64"},
 		}},

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -513,6 +513,42 @@ func TestRenderWrapsOperatorContentAtNarrowWidth(t *testing.T) {
 	}
 }
 
+func TestRenderUsesActualUndersizedTerminal(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:  ModeInstaller,
+		State: "starting-installer",
+		Network: []NetworkInterface{{
+			Name:      "enp1s0",
+			Addresses: []string{"192.0.2.10/24"},
+		}},
+	}
+	const width, height = 20, 8
+	got := string(renderDashboard(&snapshot, nil, width, height, false))
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+	if len(lines) != height {
+		t.Fatalf("rendered rows = %d, want %d:\n%s", len(lines), height, got)
+	}
+	for number, line := range lines {
+		if visibleWidth(line) > width {
+			t.Fatalf("line %d exceeds actual width: %q", number+1, line)
+		}
+	}
+	for _, want := range []string{"KatlOS", "Starting installer", "192.0.2.10", "F2: console"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("compact render missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderDimensionsAreCapped(t *testing.T) {
+	if got, want := RenderCapacity(maximumWidth+1, maximumHeight+1), RenderCapacity(maximumWidth, maximumHeight); got != want {
+		t.Fatalf("oversized render capacity = %d, want %d", got, want)
+	}
+	if got, want := RenderCapacity(20, 8), 8*(20*utf8.UTFMax+32); got != want {
+		t.Fatalf("undersized render capacity = %d, want %d", got, want)
+	}
+}
+
 func TestTerminalRenderDoesNotScrollCompletedFrame(t *testing.T) {
 	snapshot := Snapshot{
 		Mode:       ModeRuntime,

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -464,6 +465,47 @@ func TestRenderRuntimeFailure(t *testing.T) {
 	for _, want := range []string{"Status", "Host", "Kubernetes", "Needsrepair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Generation:4", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
 		if !containsIgnoringLayout(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderReservesFailureAndRecoveryAtShortHeight(t *testing.T) {
+	interfaces := make([]NetworkInterface, 20)
+	for index := range interfaces {
+		interfaces[index] = NetworkInterface{
+			Name:      "interface-" + strconv.Itoa(index),
+			Addresses: []string{"192.0.2." + strconv.Itoa(index+1) + "/24"},
+		}
+	}
+	snapshot := Snapshot{
+		Mode:              ModeInstaller,
+		State:             installstatus.StateFailedAfterMutation,
+		Version:           strings.Repeat("version", 20),
+		DisplayInterfaces: interfaces,
+		Handoff:           Handoff{URL: "https://192.0.2.10:8443/v1/config-bundle"},
+		LastError:         "disk write failed",
+		RetryHint:         "boot recovery media",
+	}
+	got := string(renderDashboard(&snapshot, testJournal{[]byte("journal noise")}, 40, minimumHeight, false))
+	for _, want := range []string{"Installationfailed", "Error:diskwritefailed", "Nextaction:bootrecoverymedia", "…"} {
+		if !containsIgnoringLayout(got, want) {
+			t.Fatalf("short failure render missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderBudgetsEachActiveAlert(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:        ModeRuntime,
+		State:       installstatus.StateRuntimeFailedNeedsRepair,
+		LastError:   strings.Repeat("failure ", 80),
+		RetryHint:   strings.Repeat("recover ", 80),
+		StatusError: strings.Repeat("corrupt ", 80),
+	}
+	got := string(renderDashboard(&snapshot, nil, 40, minimumHeight, false))
+	for _, label := range []string{"Error:", "Nextaction:", "Statusread:"} {
+		if !containsIgnoringLayout(got, label) {
+			t.Fatalf("budgeted alerts missing %q:\n%s", label, got)
 		}
 	}
 }

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -857,6 +857,57 @@ func TestRenderUsesActualUndersizedTerminal(t *testing.T) {
 	}
 }
 
+func TestRenderCompactPrioritizesRecoveryGuidance(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{name: "below minimum width", width: minimumWidth - 1, height: minimumHeight},
+		{name: "below minimum height", width: minimumWidth, height: minimumHeight - 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := Snapshot{
+				Mode:            ModeRuntime,
+				LastError:       "runtime failed",
+				RetryHint:       "boot recovery media",
+				StatusError:     "status unreadable",
+				StatusStale:     true,
+				HandoffError:    "handoff unreadable",
+				GenerationError: "generation unreadable",
+			}
+			got := string(renderDashboard(&snapshot, nil, test.width, test.height, false))
+			for _, want := range []string{
+				"Error:runtime failed",
+				"Next action:boot recovery media",
+				"Status read:status unreadable",
+				"Status stale:state has not updated",
+				"Handoff read:handoff unreadable",
+				"Generation read:generation unreadable",
+			} {
+				if !containsIgnoringLayout(got, want) {
+					t.Fatalf("compact render missing %q:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderVeryNarrowCompactShowsRecoveryText(t *testing.T) {
+	snapshot := Snapshot{
+		Mode:      ModeInstaller,
+		LastError: "disk write failed",
+		RetryHint: "boot recovery media",
+	}
+	got := string(renderDashboard(&snapshot, nil, 20, 8, false))
+	for _, want := range []string{"Error:disk write failed", "Next action:boot recovery media"} {
+		if !containsIgnoringLayout(got, want) {
+			t.Fatalf("very narrow compact render missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderDimensionsAreCapped(t *testing.T) {
 	if got, want := RenderCapacity(maximumWidth+1, maximumHeight+1), RenderCapacity(maximumWidth, maximumHeight); got != want {
 		t.Fatalf("oversized render capacity = %d, want %d", got, want)

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -51,6 +51,16 @@ func TestReadHandoffRejectsSemanticallyCorruptRecord(t *testing.T) {
 	}
 }
 
+func TestValidateHandoffRejectsHostlessURL(t *testing.T) {
+	record := Handoff{
+		URL:       "http://:8080/v1/config-bundle",
+		UpdatedAt: time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+	}
+	if err := validateHandoff(record); err == nil || !strings.Contains(err.Error(), "absolute HTTP or HTTPS") {
+		t.Fatalf("validateHandoff() error = %v", err)
+	}
+}
+
 func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 	root := t.TempDir()
 	statusPath := filepath.Join(root, "status.json")

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -41,6 +41,16 @@ func TestWriteAndReadHandoff(t *testing.T) {
 	}
 }
 
+func TestReadHandoffRejectsSemanticallyCorruptRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handoff.json")
+	if err := os.WriteFile(path, []byte(`{"url":"file:///tmp/config"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadHandoff(path); err == nil || !strings.Contains(err.Error(), "absolute HTTP or HTTPS") {
+		t.Fatalf("ReadHandoff() error = %v", err)
+	}
+}
+
 func TestCollectorReadsInstallerStateAndNetwork(t *testing.T) {
 	root := t.TempDir()
 	statusPath := filepath.Join(root, "status.json")

--- a/internal/operatorconsole/presentation.go
+++ b/internal/operatorconsole/presentation.go
@@ -1,0 +1,175 @@
+package operatorconsole
+
+import (
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	installstatus "github.com/katl-dev/katl/internal/installer/status"
+)
+
+// NewDashboardModel translates collected node facts into explicit operator
+// presentation states before layout begins.
+func NewDashboardModel(snapshot *Snapshot) DashboardModel {
+	return DashboardModel{
+		Host:       presentHost(snapshot),
+		Kubernetes: presentKubernetes(snapshot),
+		Current:    snapshot.CurrentSoftware,
+		NextBoot:   snapshot.NextBootSoftware,
+		Live:       snapshot.LiveSoftware,
+	}
+}
+
+func presentInstaller(snapshot *Snapshot) Presentation {
+	if snapshot.StatusStale {
+		return Presentation{State: PresentationUnknown, Label: "Unknown (stale status)"}
+	}
+	if snapshot.StatusError != "" {
+		return Presentation{State: PresentationUnknown, Label: "Unknown"}
+	}
+	switch snapshot.State {
+	case installstatus.StateFailedBeforeMutation, installstatus.StateFailedAfterMutation, installstatus.StateInstallRefused:
+		return Presentation{State: PresentationFailed, Label: stateLabel(snapshot.State)}
+	case installstatus.StateRebootRequested:
+		return Presentation{State: PresentationHealthy, Label: stateLabel(snapshot.State)}
+	case "starting-installer", installstatus.StateRunning, installstatus.StateWaitingForConfig, installstatus.StateDebugHold:
+		return Presentation{State: PresentationProgressing, Label: stateLabel(snapshot.State)}
+	default:
+		return Presentation{State: PresentationUnknown, Label: stateLabel(snapshot.State)}
+	}
+}
+
+func presentHost(snapshot *Snapshot) Presentation {
+	if snapshot.StatusStale {
+		return Presentation{State: PresentationUnknown, Label: "Unknown (stale status)"}
+	}
+	if snapshot.StatusError != "" || snapshot.GenerationError != "" {
+		return Presentation{State: PresentationUnknown, Label: "Unknown"}
+	}
+	if snapshot.State == installstatus.StateRuntimeFailedNeedsRepair {
+		return Presentation{State: PresentationFailed, Label: "Needs repair"}
+	}
+	if snapshot.LastError != "" {
+		return Presentation{State: PresentationDegraded, Label: "Degraded"}
+	}
+	switch strings.ToLower(strings.TrimSpace(snapshot.GenerationHealth)) {
+	case generation.HealthStateUnhealthy:
+		return Presentation{State: PresentationFailed, Label: "Generation failed"}
+	case generation.HealthStateDeferred:
+		return Presentation{State: PresentationProgressing, Label: "Health deferred"}
+	case generation.HealthStateUnknown:
+		return Presentation{State: PresentationUnknown, Label: "Health unknown"}
+	case generation.HealthStateHealthy:
+		switch snapshot.State {
+		case installstatus.StateKubeadmReady, installstatus.StateWaitingForClusterBootstrap:
+			return Presentation{State: PresentationHealthy, Label: "Healthy"}
+		case "starting-runtime", installstatus.StateRuntimeBootedNotReady:
+			return Presentation{State: PresentationProgressing, Label: stateLabel(snapshot.State)}
+		default:
+			return Presentation{State: PresentationUnknown, Label: "Unknown (" + fallback(snapshot.State, "state") + ")"}
+		}
+	case "":
+		switch snapshot.State {
+		case "starting-runtime", installstatus.StateRuntimeBootedNotReady:
+			return Presentation{State: PresentationProgressing, Label: stateLabel(snapshot.State)}
+		default:
+			return Presentation{State: PresentationUnknown, Label: "Unknown"}
+		}
+	default:
+		return Presentation{State: PresentationUnknown, Label: "Unknown health"}
+	}
+}
+
+func presentKubernetes(snapshot *Snapshot) Presentation {
+	if snapshot.StatusStale || snapshot.StatusError != "" || snapshot.GenerationError != "" {
+		return Presentation{State: PresentationUnknown, Label: "Unknown"}
+	}
+	if snapshot.State == installstatus.StateRuntimeFailedNeedsRepair {
+		return Presentation{State: PresentationFailed, Label: "Unavailable"}
+	}
+	if snapshot.LiveSoftware.KubernetesVersion == "" {
+		return Presentation{State: PresentationUnknown, Label: "Not installed"}
+	}
+	if snapshot.KubernetesConfigured {
+		return Presentation{State: PresentationProgressing, Label: "Configured"}
+	}
+	switch snapshot.State {
+	case installstatus.StateKubeadmReady, installstatus.StateWaitingForClusterBootstrap:
+		return Presentation{State: PresentationProgressing, Label: "Ready for bootstrap"}
+	case "starting-runtime", installstatus.StateRuntimeBootedNotReady:
+		return Presentation{State: PresentationProgressing, Label: "Waiting for KatlOS"}
+	default:
+		return Presentation{State: PresentationUnknown, Label: "Unknown"}
+	}
+}
+
+func presentationStyle(state PresentationState) Style {
+	switch state {
+	case PresentationHealthy:
+		return styleGood
+	case PresentationProgressing, PresentationDegraded:
+		return styleWarn
+	case PresentationFailed:
+		return styleBad
+	default:
+		return styleDim
+	}
+}
+
+func stateLabel(state string) string {
+	switch state {
+	case "starting-installer":
+		return "Starting installer"
+	case "starting-runtime":
+		return "Starting KatlOS"
+	case "running":
+		return "Installing"
+	case "debug-hold":
+		return "Debug hold; installation disabled"
+	case "waiting-for-config":
+		return "Waiting for configuration"
+	case "install-refused":
+		return "Installation refused"
+	case "failed-before-mutation":
+		return "Installation failed; disk unchanged"
+	case "failed-after-mutation":
+		return "Installation failed; repair required"
+	case "reboot-requested":
+		return "Installation complete; rebooting"
+	case "kubeadm-ready":
+		return "Ready for Kubernetes bootstrap"
+	case "waiting-for-cluster-bootstrap":
+		return "Waiting for Kubernetes bootstrap"
+	case "runtime-booted-not-ready":
+		return "KatlOS booted; not ready"
+	case "runtime-failed-needs-repair":
+		return "KatlOS needs repair"
+	default:
+		return fallback(state, "Unknown")
+	}
+}
+
+func healthLabel(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return ""
+	case "healthy", "good", "ok", "success":
+		return "OK"
+	case "unhealthy", "failed", "failure":
+		return "FAILED"
+	default:
+		return strings.ToUpper(strings.TrimSpace(value))
+	}
+}
+
+func healthStyle(value string) Style {
+	if value == "" {
+		return ""
+	}
+	if value == "OK" {
+		return styleGood
+	}
+	if value == "FAILED" {
+		return styleBad
+	}
+	return styleWarn
+}

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -2,7 +2,6 @@ package operatorconsole
 
 import (
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -11,15 +10,15 @@ const (
 	minimumHeight   = 12
 	maximumWidth    = 512
 	maximumHeight   = 256
+	wideLayoutWidth = 72
 	fieldWidth      = 14
-	panelFieldWidth = 12
 
-	styleReset = "\x1b[0m"
-	styleTitle = "\x1b[1;36m"
-	styleGood  = "\x1b[1;32m"
-	styleWarn  = "\x1b[1;33m"
-	styleBad   = "\x1b[1;31m"
-	styleDim   = "\x1b[2m"
+	styleReset Style = "\x1b[0m"
+	styleTitle Style = "\x1b[1;36m"
+	styleGood  Style = "\x1b[1;32m"
+	styleWarn  Style = "\x1b[1;33m"
+	styleBad   Style = "\x1b[1;31m"
+	styleDim   Style = "\x1b[2m"
 )
 
 const clearScreen = "\x1b[H\x1b[2J"
@@ -30,442 +29,269 @@ type Journal interface {
 	WriteTail(*JournalWriter)
 }
 
-// RenderCapacity returns enough capacity for a complete render without growth.
-// UTFMax accounts for every terminal cell containing a four-byte UTF-8 rune.
+// RenderCapacity returns a useful initial serialization buffer size. Layout is
+// bounded by a cell Frame, so unusually long grapheme encodings may grow this
+// byte buffer without escaping the fixed terminal geometry.
 func RenderCapacity(width, height int) int {
 	width, height = renderDimensions(width, height)
 	return height * (width*utf8.UTFMax + 32)
 }
 
-// RenderTarget owns fixed storage and its terminal geometry. Writers start at
-// the top-left and may reset the cursor, but they never grow the storage.
+// RenderTarget supplies reusable serialization storage and physical geometry.
 type RenderTarget struct {
-	storage  []byte
-	width    int
-	rows     int
-	position int
+	storage []byte
+	width   int
+	rows    int
 }
 
-// NewRenderTarget binds fixed storage to a terminal-sized region.
+// NewRenderTarget binds storage to a terminal-sized region.
 func NewRenderTarget(storage []byte, width, rows int) RenderTarget {
 	return RenderTarget{storage: storage, width: width, rows: rows}
 }
 
-func (target *RenderTarget) reset() {
-	target.position = 0
-}
-
-func (target *RenderTarget) bytes() []byte {
-	return target.storage[:target.position]
-}
-
-func (target *RenderTarget) writeByte(value byte) {
-	if target.position >= len(target.storage) {
-		panic("operatorconsole: render capacity exhausted")
-	}
-	target.storage[target.position] = value
-	target.position++
-}
-
-func (target *RenderTarget) writeString(value string) {
-	if len(value) > len(target.storage)-target.position {
-		panic("operatorconsole: render capacity exhausted")
-	}
-	target.position += copy(target.storage[target.position:], value)
-}
-
-func (target *RenderTarget) writeRune(value rune) {
-	if value < utf8.RuneSelf {
-		target.writeByte(byte(value))
-		return
-	}
-	if utf8.RuneLen(value) > len(target.storage)-target.position {
-		panic("operatorconsole: render capacity exhausted")
-	}
-	target.position += utf8.EncodeRune(target.storage[target.position:], value)
-}
-
-func (target *RenderTarget) truncate(position int) {
-	target.position = position
-}
-
-func (target *RenderTarget) tail(rows int) RenderTarget {
-	return RenderTarget{
-		storage: target.storage[target.position:],
-		width:   target.width,
-		rows:    rows,
-	}
-}
-
-// Renderer owns fixed output storage, terminal geometry, cursor state and line
-// writers. Render always starts at the top-left of that storage and never grows
-// it; callers replace the renderer when the terminal dimensions change.
+// Renderer paints a bounded terminal-cell frame and serializes it only after
+// all content and defensive dividers have been placed.
 type Renderer struct {
-	output       RenderTarget
-	contentRows  int
-	row          int
-	color        bool
-	lineState    lineWriter
-	wrappedState wrappedWriter
-	journalState JournalWriter
+	frame  Frame
+	output []byte
+	color  bool
 }
 
-// NewRenderer binds a renderer to a fixed render target.
+// NewRenderer binds a reusable frame and serialization buffer to a target.
 func NewRenderer(target RenderTarget, color bool) Renderer {
-	target.width, target.rows = renderDimensions(target.width, target.rows)
-	required := RenderCapacity(target.width, target.rows)
-	if len(target.storage) < required {
-		panic("operatorconsole: renderer storage is smaller than RenderCapacity")
-	}
-	target.storage = target.storage[:required]
+	width, height := renderDimensions(target.width, target.rows)
 	return Renderer{
-		output:      target,
-		contentRows: target.rows - 1,
-		color:       color,
+		frame:  newFrame(width, height),
+		output: target.storage[:0],
+		color:  color,
 	}
 }
 
-// MatchesDimensions reports whether the renderer owns storage for the given
-// terminal geometry.
+// MatchesDimensions reports whether the renderer owns a frame for the given
+// physical terminal geometry.
 func (render *Renderer) MatchesDimensions(width, height int) bool {
 	width, height = renderDimensions(width, height)
-	return render.output.width == width && render.output.rows == height && len(render.output.storage) >= RenderCapacity(width, height)
+	return render.frame.Width == width && render.frame.Height == height
 }
 
-// Render writes a complete dashboard from the top-left of the owned storage.
-// Colour renderers include the terminal cursor-home and clear sequence.
+// Render paints a complete dashboard. Colour output ends with a carriage
+// return on the bottom row; plain snapshots retain their final newline.
 func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
-	render.output.reset()
-	render.row = 0
-	if render.color {
-		render.output.writeString(clearScreen)
-	}
-	if render.output.width < minimumWidth || render.output.rows < minimumHeight {
-		return render.renderCompact(snapshot)
-	}
-
-	line := render.line()
-	line.style(styleTitle)
-	line.writeString("KatlOS")
-	if snapshot.Mode == ModeInstaller {
-		line.writeString(" Installer")
-	}
-	line.resetStyle()
-	line.finish()
-
-	line = render.line()
-	line.style(styleDim)
-	for range min(render.output.width, 72) {
-		line.writeByte('=')
-	}
-	line.resetStyle()
-	line.finish()
-
-	if snapshot.Mode == ModeRuntime {
-		render.writePaneHeading("Status")
-		render.writeRuntimeStatusPane(snapshot)
-		render.writeNetwork(snapshot.Network)
+	render.frame.reset()
+	if render.frame.Width < minimumWidth || render.frame.Height < minimumHeight {
+		render.paintCompact(snapshot)
 	} else {
-		render.writeInstallerStatus(snapshot)
+		render.paintDashboard(snapshot, journal)
+	}
+	render.paintFooter(snapshot)
+	render.output = serializeFrame(render.output[:0], &render.frame, render.frame.Height, render.color, true)
+	return render.output
+}
+
+func (render *Renderer) paintCompact(snapshot *Snapshot) {
+	content := NewViewport(&render.frame, Rect{Width: render.frame.Width, Height: max(render.frame.Height-1, 0)})
+	content.Write("KatlOS", WrapOptions{Style: styleTitle, WordWrap: true})
+	content.Write(stateLabel(snapshot.State), WrapOptions{Style: stateStyle(snapshot.State), WordWrap: true})
+	if address := firstIPv4(snapshot.Network); address != "" {
+		content.Write(address, WrapOptions{WordWrap: true})
+	}
+}
+
+func (render *Renderer) paintDashboard(snapshot *Snapshot, journal Journal) {
+	title := "KatlOS"
+	if snapshot.Mode == ModeInstaller {
+		title += " Installer"
+	}
+	titleViewport := NewViewport(&render.frame, Rect{Width: render.frame.Width, Height: 1})
+	titleViewport.Write(title, WrapOptions{Style: styleTitle})
+	divider := NewViewport(&render.frame, Rect{Y: 1, Width: min(render.frame.Width, 72), Height: 1})
+	divider.Write(strings.Repeat("=", divider.bounds.Width), WrapOptions{Style: styleDim})
+
+	content := NewViewport(&render.frame, Rect{Y: 2, Width: render.frame.Width, Height: render.frame.Height - 3})
+	if snapshot.Mode == ModeRuntime {
+		writeHeading(&content, "Status")
+		render.writeRuntimeStatus(&content, snapshot)
+		writeNetwork(&content, snapshot.Network)
+	} else {
+		writeInstallerStatus(&content, snapshot)
 	}
 	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
-		field := render.wrappedField("Disk changes")
+		value, style := "not started", Style("")
 		if snapshot.DestructiveMutation {
-			field.style(styleWarn)
-			field.writeString("started - do not power off")
-			field.resetStyle()
-		} else {
-			field.writeString("not started")
+			value, style = "started - do not power off", styleWarn
 		}
-		field.finish()
+		writeField(&content, "Disk changes", value, style)
 	}
 	if snapshot.Handoff.URL != "" {
-		render.wrappedField("Configure").writeString(snapshot.Handoff.URL).finish()
-		field := render.wrappedField("Run")
-		field.writeString("katlctl config init cluster.yaml --installer ")
-		if address := firstIPv4(snapshot.Network); address != "" {
-			field.writeString(address)
-		} else {
-			field.writeString(installerBaseURL(snapshot.Handoff.URL))
-		}
-		field.finish()
+		writeField(&content, "Configure", snapshot.Handoff.URL, "")
+		writeField(&content, "Run", "katlctl config init cluster.yaml --installer "+installerCommandEndpoint(snapshot), "")
 	}
-	render.writeWrappedField("Error", snapshot.LastError, styleBad)
-	render.writeWrappedField("Next action", snapshot.RetryHint, styleWarn)
-	render.writeWrappedField("Status read", snapshot.StatusError, styleWarn)
+	writeOptionalField(&content, "Error", snapshot.LastError, styleBad)
+	writeOptionalField(&content, "Next action", snapshot.RetryHint, styleWarn)
+	writeOptionalField(&content, "Status read", snapshot.StatusError, styleWarn)
 
-	render.finishBlank()
-	line = render.line()
-	line.style(styleTitle)
-	line.writeString("Journal")
-	line.resetStyle()
-	line.finish()
-	if remaining := render.contentRows - render.row; journal != nil && remaining > 0 {
-		render.journalState = NewJournalWriter(render.output.tail(remaining))
-		render.journalState.color = render.color
-		journal.WriteTail(&render.journalState)
-		render.output.position += render.journalState.output.position
-		render.row += render.journalState.rows
+	if content.rowsRemaining() > 0 {
+		content.advance(1)
 	}
-	for render.row < render.contentRows {
-		render.finishBlank()
+	if content.rowsRemaining() > 0 {
+		writeHeading(&content, "Journal")
 	}
+	if journal != nil && content.rowsRemaining() > 0 {
+		journalViewport := content.sub(Rect{Y: content.y, Width: content.bounds.Width, Height: content.rowsRemaining()})
+		writer := newJournalWriter(journalViewport)
+		journal.WriteTail(&writer)
+		content.advance(writer.RowsWritten())
+	}
+}
 
-	footer := newLine(&render.output)
-	footer.color = render.color
-	footer.style(styleDim)
-	footer.writeString("Ctrl+Alt+F2: console")
-	if snapshot.SSHEnabled {
-		if address := firstIPv4(snapshot.Network); address != "" {
-			if visibleWidth("Ctrl+Alt+F2: console | SSH: katl@")+visibleWidth(address) <= render.output.width {
-				footer.writeString(" | SSH: katl@")
-				footer.writeString(address)
-			} else {
-				footer.writeString(" | SSH enabled")
-			}
+func (render *Renderer) paintFooter(snapshot *Snapshot) {
+	footerText := "Ctrl+Alt+F2: console"
+	if render.frame.Width < minimumWidth || render.frame.Height < minimumHeight {
+		footerText = "F2: console"
+	} else if snapshot.SSHEnabled {
+		if address := firstIPv4(snapshot.Network); address != "" && displayWidth(footerText+" | SSH: katl@"+address) <= render.frame.Width {
+			footerText += " | SSH: katl@" + address
 		} else {
-			footer.writeString(" | SSH enabled")
+			footerText += " | SSH enabled"
 		}
 	} else if snapshot.Mode == ModeInstaller {
-		footer.writeString(" | SSH disabled")
+		footerText += " | SSH disabled"
 	}
-	footer.resetStyle()
-	footer.endFrame()
-	return render.output.bytes()
-}
-
-func (render *Renderer) renderCompact(snapshot *Snapshot) []byte {
-	line := render.line()
-	line.style(styleTitle).writeString("KatlOS").resetStyle()
-	line.finish()
-
-	if render.row < render.contentRows {
-		line = render.line()
-		line.style(stateStyle(snapshot.State)).writeString(stateLabel(snapshot.State)).resetStyle()
-		line.finish()
-	}
-	if address := firstIPv4(snapshot.Network); address != "" && render.row < render.contentRows {
-		render.line().writeString(address).finish()
-	}
-	for render.row < render.contentRows {
-		render.finishBlank()
-	}
-
-	footer := newLine(&render.output)
-	footer.color = render.color
-	footer.style(styleDim).writeString("F2: console").resetStyle()
-	footer.endFrame()
-	return render.output.bytes()
-}
-
-type pane struct {
-	title  string
-	fields []paneField
+	footer := NewViewport(&render.frame, Rect{Y: render.frame.Height - 1, Width: render.frame.Width, Height: 1})
+	footer.Write(footerText, WrapOptions{Style: styleDim})
 }
 
 type paneField struct {
 	label string
 	value string
-	style string
+	style Style
 }
 
-type paneFieldState struct {
-	field    paneField
-	position int
-	first    bool
-	done     bool
-}
-
-func (render *Renderer) writePaneHeading(title string) {
-	line := render.line()
-	line.style(styleTitle).writeString(title).resetStyle()
-	line.finish()
-}
-
-func (render *Renderer) writeRuntimeStatusPane(snapshot *Snapshot) {
+func (render *Renderer) writeRuntimeStatus(content *Viewport, snapshot *Snapshot) {
 	hostState, hostStyle := runtimeHostState(snapshot)
 	kubernetesState, kubernetesStyle := runtimeKubernetesState(snapshot)
-	leftFields := [...]paneField{
+	host := []paneField{
 		{label: "State", value: hostState, style: hostStyle},
 		{label: "Node", value: fallback(snapshot.Hostname, "Unknown")},
 		{label: "KatlOS", value: fallback(snapshot.Version, "Unknown")},
 		{label: "Generation", value: fallback(snapshot.Generation, "Unknown")},
 		{label: "Next boot", value: fallback(snapshot.NextGeneration, "-")},
 	}
-	rightFields := [...]paneField{
+	kubernetes := []paneField{
 		{label: "State", value: kubernetesState, style: kubernetesStyle},
 		{label: "Version", value: fallback(snapshot.KubernetesVersion, "Not installed")},
 	}
-	render.writeSplitPanes(
-		pane{title: "Host", fields: leftFields[:]},
-		pane{title: "Kubernetes", fields: rightFields[:]},
-	)
+	if content.bounds.Width < wideLayoutWidth {
+		writePane(content, "Host", host)
+		writePane(content, "Kubernetes", kubernetes)
+		return
+	}
+
+	start := content.y
+	dividerX := (content.bounds.Width - 1) / 2
+	left := content.sub(Rect{Y: start, Width: dividerX, Height: content.rowsRemaining()})
+	right := content.sub(Rect{X: dividerX + 1, Y: start, Width: content.bounds.Width - dividerX - 1, Height: content.rowsRemaining()})
+	writePane(&left, "Host", host)
+	writePane(&right, "Kubernetes", kubernetes)
+	used := max(left.rowsUsed(), right.rowsUsed())
+	content.advance(used)
+	// Decorations are painted after pane content. Even malformed input cannot
+	// move them because each pane was clipped to its own viewport.
+	for offset := range used {
+		render.frame.setGlyph(content.bounds.X+dividerX, content.bounds.Y+start+offset, "│", 1, styleDim)
+	}
 }
 
-func (render *Renderer) writeInstallerStatus(snapshot *Snapshot) {
-	field := render.wrappedField("State")
-	field.style(stateStyle(snapshot.State))
-	field.writeString(stateLabel(snapshot.State))
-	field.resetStyle()
-	field.finish()
-	if snapshot.Hostname != "" {
-		render.wrappedField("Node").writeString(snapshot.Hostname).finish()
+func writePane(viewport *Viewport, title string, fields []paneField) {
+	writeHeading(viewport, title)
+	for _, field := range fields {
+		writeField(viewport, field.label, field.value, field.style)
 	}
-	render.writeNetwork(snapshot.Network)
+}
+
+func writeInstallerStatus(content *Viewport, snapshot *Snapshot) {
+	writeField(content, "State", stateLabel(snapshot.State), stateStyle(snapshot.State))
+	if snapshot.Hostname != "" {
+		writeField(content, "Node", snapshot.Hostname, "")
+	}
+	writeNetwork(content, snapshot.Network)
 	if snapshot.Version != "" {
-		render.wrappedField("Media").writeString(snapshot.Version).finish()
+		writeField(content, "Media", snapshot.Version, "")
 	}
 	if snapshot.State == "running" && snapshot.CurrentStep != "" {
-		render.wrappedField("Progress").writeString(snapshot.CurrentStep).finish()
+		writeField(content, "Progress", snapshot.CurrentStep, "")
 	}
-	if snapshot.Generation == "" {
-		return
-	}
-	field = render.wrappedField("Generation")
-	field.writeString(snapshot.Generation)
-	if health := healthLabel(snapshot.GenerationHealth); health != "" {
-		field.writeString("  health=")
-		field.style(healthStyle(health))
-		field.writeString(health)
-		field.resetStyle()
-	}
-	field.finish()
-}
-
-func (render *Renderer) writeSplitPanes(left, right pane) {
-	if render.row >= render.contentRows {
-		return
-	}
-	divider := (render.output.width - 1) / 2
-	line := render.line()
-	line.style(styleTitle)
-	line.writeUntil(left.title, divider)
-	line.resetStyle()
-	line.padTo(divider)
-	line.style(styleDim).writeRune('│').resetStyle()
-	line.style(styleTitle)
-	line.writeUntil(right.title, render.output.width)
-	line.resetStyle()
-	line.finish()
-
-	count := max(len(left.fields), len(right.fields))
-	for index := 0; index < count && render.row < render.contentRows; index++ {
-		leftState := paneFieldState{first: true, done: index >= len(left.fields)}
-		if !leftState.done {
-			leftState.field = left.fields[index]
+	if snapshot.Generation != "" {
+		value := snapshot.Generation
+		if health := healthLabel(snapshot.GenerationHealth); health != "" {
+			value += "  health=" + health
 		}
-		rightState := paneFieldState{first: true, done: index >= len(right.fields)}
-		if !rightState.done {
-			rightState.field = right.fields[index]
-		}
-		for (!leftState.done || !rightState.done) && render.row < render.contentRows {
-			line = render.line()
-			render.writePaneFieldSegment(line, &leftState, 0, divider)
-			line.padTo(divider)
-			line.style(styleDim).writeRune('│').resetStyle()
-			render.writePaneFieldSegment(line, &rightState, divider+1, render.output.width)
-			line.finish()
-		}
+		writeField(content, "Generation", value, healthStyle(healthLabel(snapshot.GenerationHealth)))
 	}
 }
 
-func (render *Renderer) writePaneFieldSegment(line *lineWriter, state *paneFieldState, start, end int) {
-	if state.done || end <= start {
+func writeNetwork(content *Viewport, network []NetworkInterface) {
+	if len(network) == 0 {
+		writeField(content, "Network", "waiting for an active interface", "")
 		return
 	}
-	line.padTo(start)
-	labelWidth := min(panelFieldWidth, end-start-1)
-	if labelWidth < 1 {
-		state.done = true
-		return
-	}
-	if state.first {
-		line.writeUntil(state.field.label, start+labelWidth-1)
-		if line.columns < start+labelWidth {
-			line.writeByte(':')
+	for index, iface := range network {
+		label := ""
+		if index == 0 {
+			label = "Network"
 		}
-		state.first = false
-	}
-	line.padTo(start + labelWidth)
-	if line.columns >= end {
-		return
-	}
-
-	state.position = skipVisibleSpace(state.field.value, state.position)
-	if state.position >= len(state.field.value) {
-		state.done = true
-		return
-	}
-	segmentEnd, next := paneSegment(state.field.value, state.position, end-line.columns)
-	if state.field.style != "" {
-		line.style(state.field.style)
-	}
-	line.writeString(state.field.value[state.position:segmentEnd])
-	if state.field.style != "" {
-		line.resetStyle()
-	}
-	state.position = next
-	state.done = skipVisibleSpace(state.field.value, state.position) >= len(state.field.value)
-}
-
-func paneSegment(value string, position, available int) (int, int) {
-	scan := position
-	end := position
-	lastSpace := -1
-	visible := 0
-	for scan < len(value) && visible < available {
-		r, next, ok := nextVisibleString(value, scan)
-		if !ok {
-			return len(value), len(value)
+		value := iface.Name + ": configuring"
+		if len(iface.Addresses) > 0 {
+			value = iface.Name + ": " + strings.Join(iface.Addresses, ", ")
 		}
-		if r == '\n' {
-			return scan, next
-		}
-		if unicode.IsSpace(r) {
-			lastSpace = scan
-		}
-		end = next
-		scan = next
-		visible++
-	}
-	if scan >= len(value) {
-		return end, end
-	}
-	if lastSpace > position {
-		return lastSpace, skipVisibleSpace(value, lastSpace)
-	}
-	return end, end
-}
-
-func skipVisibleSpace(value string, position int) int {
-	for position < len(value) {
-		r, next, ok := nextVisibleString(value, position)
-		if !ok || (!unicode.IsSpace(r) && r != '\n') {
-			return position
-		}
-		position = next
-	}
-	return position
-}
-
-func (line *lineWriter) padTo(column int) {
-	for line.columns < column {
-		line.writeByte(' ')
+		writeField(content, label, value, "")
 	}
 }
 
-func (line *lineWriter) writeUntil(value string, end int) {
-	for position := 0; position < len(value) && line.columns < end; {
-		r, next, ok := nextVisibleString(value, position)
-		position = next
-		if !ok || r == '\n' {
+func writeHeading(viewport *Viewport, value string) {
+	if viewport.rowsRemaining() == 0 {
+		return
+	}
+	heading := viewport.sub(Rect{Y: viewport.y, Width: viewport.bounds.Width, Height: 1})
+	heading.Write(value, WrapOptions{Style: styleTitle})
+	viewport.advance(1)
+}
+
+func writeOptionalField(viewport *Viewport, label, value string, style Style) {
+	if strings.TrimSpace(value) != "" {
+		writeField(viewport, label, value, style)
+	}
+}
+
+func writeField(viewport *Viewport, label, value string, style Style) {
+	if viewport.rowsRemaining() == 0 {
+		return
+	}
+	if viewport.bounds.Width < 28 && label != "" {
+		labelView := viewport.sub(Rect{Y: viewport.y, Width: viewport.bounds.Width, Height: 1})
+		labelView.Write(label, WrapOptions{Style: styleDim})
+		viewport.advance(1)
+		if viewport.rowsRemaining() == 0 {
 			return
 		}
-		line.writeRune(r)
+		valueView := viewport.sub(Rect{X: 2, Y: viewport.y, Width: max(viewport.bounds.Width-2, 0), Height: viewport.rowsRemaining()})
+		result := valueView.Write(value, WrapOptions{Style: style, WordWrap: true})
+		viewport.advance(max(result.Rows, 1))
+		return
 	}
+
+	labelWidth := 0
+	if label != "" {
+		labelWidth = min(fieldWidth, max(viewport.bounds.Width-1, 0))
+		labelView := viewport.sub(Rect{Y: viewport.y, Width: labelWidth, Height: 1})
+		labelView.Write(label+":", WrapOptions{})
+	}
+	valueView := viewport.sub(Rect{X: labelWidth, Y: viewport.y, Width: viewport.bounds.Width - labelWidth, Height: viewport.rowsRemaining()})
+	result := valueView.Write(value, WrapOptions{Style: style, WordWrap: true})
+	viewport.advance(max(result.Rows, 1))
 }
 
-func runtimeHostState(snapshot *Snapshot) (string, string) {
+func runtimeHostState(snapshot *Snapshot) (string, Style) {
 	if snapshot.State == "runtime-failed-needs-repair" {
 		return "Needs repair", styleBad
 	}
@@ -481,7 +307,7 @@ func runtimeHostState(snapshot *Snapshot) (string, string) {
 	return "Running", styleGood
 }
 
-func runtimeKubernetesState(snapshot *Snapshot) (string, string) {
+func runtimeKubernetesState(snapshot *Snapshot) (string, Style) {
 	if snapshot.KubernetesVersion == "" {
 		return "Not installed", styleWarn
 	}
@@ -499,482 +325,117 @@ func runtimeKubernetesState(snapshot *Snapshot) (string, string) {
 	}
 }
 
-// JournalWriter owns the bounded journal region within a dashboard render.
-// Journal implementations write logical lines without access to output storage.
+// JournalWriter renders logical journal entries through the same bounded
+// viewport and grapheme wrapper used by every dashboard field and pane.
 type JournalWriter struct {
-	output RenderTarget
-	rows   int
-	color  bool
+	frame      *Frame
+	viewport   Viewport
+	output     []byte
+	standalone bool
 }
 
-// NewJournalWriter binds a bounded journal writer to a fixed render target. It
-// is primarily useful for testing journal sources independently.
+// NewJournalWriter binds a journal writer to a standalone render target.
 func NewJournalWriter(target RenderTarget) JournalWriter {
-	target.width, target.rows = renderDimensions(target.width, target.rows)
-	target.reset()
-	return JournalWriter{output: target}
+	width, rows := renderDimensions(target.width, target.rows)
+	frame := newFrame(width, rows)
+	return JournalWriter{
+		frame:      &frame,
+		viewport:   NewViewport(&frame, Rect{Width: width, Height: rows}),
+		output:     target.storage[:0],
+		standalone: true,
+	}
 }
 
-// Bytes returns the journal output written into owned storage.
+func newJournalWriter(viewport Viewport) JournalWriter {
+	return JournalWriter{frame: viewport.frame, viewport: viewport}
+}
+
+// Bytes returns standalone journal output.
 func (writer *JournalWriter) Bytes() []byte {
-	return writer.output.bytes()
+	if !writer.standalone {
+		return nil
+	}
+	writer.output = serializeFrame(writer.output[:0], writer.frame, writer.RowsWritten(), false, false)
+	return writer.output
 }
 
-// RowsWritten reports the number of physical terminal rows written.
+// RowsWritten reports the number of physical rows consumed.
 func (writer *JournalWriter) RowsWritten() int {
-	return writer.rows
+	return writer.viewport.rowsUsed()
 }
 
-// RowsRemaining reports how many physical terminal rows remain available.
+// RowsRemaining reports how many physical rows remain.
 func (writer *JournalWriter) RowsRemaining() int {
-	return writer.output.rows - writer.rows
+	return writer.viewport.rowsRemaining()
 }
 
-// LineRows reports how many physical terminal rows a logical line needs in
-// this journal region.
+// LineRows measures a journal entry through the shared hard-wrap engine.
 func (writer *JournalWriter) LineRows(value []byte) int {
-	return journalLineRows(value, writer.output.width)
+	frame := Frame{Width: writer.viewport.bounds.Width, Height: maximumHeight}
+	measure := NewViewport(&frame, Rect{Width: frame.Width, Height: frame.Height})
+	return measure.Write(string(value), WrapOptions{}).Rows
 }
 
-// WriteLine sanitizes and wraps one logical journal line. It returns false
-// when the journal pane has no room for another line.
+// WriteLine sanitizes and hard-wraps one logical journal line.
 func (writer *JournalWriter) WriteLine(value []byte) bool {
-	if writer.RowsRemaining() <= 0 {
+	if writer.RowsRemaining() == 0 {
 		return false
 	}
-	written := writer.writeLine(value)
-	writer.rows += written
-	return true
+	return writer.viewport.Write(string(value), WrapOptions{}).Rows > 0
 }
 
-func (writer *JournalWriter) writeLine(value []byte) int {
-	remaining := writer.RowsRemaining()
-	line := newLine(&writer.output)
-	line.color = writer.color
-	rows := 0
-	wrote := false
-	for position := 0; position < len(value); {
-		r, next, ok := nextVisibleBytes(value, position)
-		position = next
-		if !ok {
-			break
-		}
-		if r == '\n' || line.columns == writer.output.width {
-			line.end()
-			rows++
-			if rows == remaining {
-				return rows
-			}
-			line = newLine(&writer.output)
-			line.color = writer.color
-			if r == '\n' {
-				continue
-			}
-		}
-		line.writeRune(r)
-		wrote = true
+func serializeFrame(output []byte, frame *Frame, rows int, color, clear bool) []byte {
+	rows = min(max(rows, 0), frame.Height)
+	if color && clear {
+		output = append(output, clearScreen...)
 	}
-	if wrote && rows < remaining {
-		line.end()
-		rows++
-	}
-	return rows
-}
-
-func journalLineRows(value []byte, width int) int {
-	width, _ = renderDimensions(width, 1)
-	columns := 0
-	rows := 0
-	wrote := false
-	for position := 0; position < len(value); {
-		r, next, ok := nextVisibleBytes(value, position)
-		position = next
-		if !ok {
-			break
-		}
-		if r == '\n' || columns == width {
-			rows++
-			columns = 0
-			if r == '\n' {
-				continue
-			}
-		}
-		columns++
-		wrote = true
-	}
-	if wrote {
-		rows++
-	}
-	return rows
-}
-
-func (r *Renderer) line() *lineWriter {
-	if r.row >= r.contentRows {
-		r.lineState = lineWriter{owner: r}
-		return &r.lineState
-	}
-	r.lineState = newLine(&r.output)
-	r.lineState.owner = r
-	r.lineState.color = r.color
-	return &r.lineState
-}
-
-func (r *Renderer) fieldLine(label string) *lineWriter {
-	line := r.line()
-	if !line.active {
-		return line
-	}
-	line.writeString(label)
-	if label != "" {
-		line.writeByte(':')
-	}
-	for line.columns < fieldWidth {
-		line.writeByte(' ')
-	}
-	return line
-}
-
-func (r *Renderer) continuationLine() *lineWriter {
-	line := r.line()
-	if !line.active {
-		return line
-	}
-	for range fieldWidth {
-		line.writeByte(' ')
-	}
-	return line
-}
-
-func (r *Renderer) finishLine(line *lineWriter) {
-	if r.row < r.contentRows {
-		line.end()
-	}
-	r.row++
-}
-
-func (r *Renderer) finishBlank() {
-	r.line().finish()
-}
-
-type lineWriter struct {
-	owner     *Renderer
-	output    *RenderTarget
-	lastRune  int
-	columns   int
-	truncated bool
-	active    bool
-	color     bool
-}
-
-func newLine(output *RenderTarget) lineWriter {
-	return lineWriter{output: output, lastRune: output.position, active: true}
-}
-
-func (l *lineWriter) style(value string) *lineWriter {
-	if l.active && l.color {
-		l.output.writeString(value)
-	}
-	return l
-}
-
-func (l *lineWriter) resetStyle() *lineWriter {
-	return l.style(styleReset)
-}
-
-func (l *lineWriter) writeByte(value byte) *lineWriter {
-	if !l.active || l.truncated {
-		return l
-	}
-	if l.columns == l.output.width {
-		l.truncated = true
-		return l
-	}
-	l.lastRune = l.output.position
-	l.output.writeByte(value)
-	l.columns++
-	return l
-}
-
-func (l *lineWriter) writeString(value string) *lineWriter {
-	for position := 0; position < len(value) && !l.truncated && l.active; {
-		r, next, ok := nextVisibleString(value, position)
-		position = next
-		if !ok {
-			break
-		}
-		if l.columns == l.output.width {
-			l.truncated = true
-			return l
-		}
-		l.writeRune(r)
-	}
-	return l
-}
-
-func (l *lineWriter) writeRune(r rune) *lineWriter {
-	if !l.active || l.truncated || l.columns == l.output.width {
-		return l
-	}
-	l.lastRune = l.output.position
-	l.output.writeRune(r)
-	l.columns++
-	return l
-}
-
-func (l *lineWriter) finish() {
-	l.owner.finishLine(l)
-}
-
-func (l *lineWriter) end() {
-	l.finishOutput()
-	// A character in the terminal's final column leaves autowrap pending. A
-	// carriage return clears that state before the line feed, so one rendered
-	// row always consumes exactly one terminal row.
-	if l.color {
-		l.output.writeByte('\r')
-	}
-	l.output.writeByte('\n')
-}
-
-func (l *lineWriter) endFrame() {
-	l.finishOutput()
-	if l.color {
-		// The footer occupies the terminal's bottom row. Leave the cursor on that
-		// row and clear pending autowrap without emitting a line feed that would
-		// scroll the completed frame.
-		l.output.writeByte('\r')
-		return
-	}
-	l.output.writeByte('\n')
-}
-
-func (l *lineWriter) finishOutput() {
-	if !l.active {
-		return
-	}
-	if l.truncated {
-		l.output.truncate(l.lastRune)
-		l.output.writeByte('~')
-		if l.color {
-			l.output.writeString(styleReset)
-		}
-	}
-}
-
-type wrappedWriter struct {
-	render       *Renderer
-	line         *lineWriter
-	activeStyle  string
-	pendingSpace int
-}
-
-func (r *Renderer) wrappedField(label string) *wrappedWriter {
-	r.wrappedState = wrappedWriter{render: r, line: r.fieldLine(label)}
-	return &r.wrappedState
-}
-
-func (w *wrappedWriter) writeString(value string) *wrappedWriter {
-	for position := 0; position < len(value); {
-		r, next, ok := nextVisibleString(value, position)
-		if !ok {
-			break
-		}
-		if r == '\n' {
-			position = next
-			w.pendingSpace = 0
-			w.continueLine()
-			continue
-		}
-		if unicode.IsSpace(r) {
-			position = next
-			w.pendingSpace++
-			continue
-		}
-
-		wordStart := position
-		wordEnd := position
-		wordWidth := 0
-		for scan := position; scan < len(value); {
-			wordRune, wordNext, wordOK := nextVisibleString(value, scan)
-			if !wordOK || wordRune == '\n' || unicode.IsSpace(wordRune) {
+	for row := range rows {
+		last := -1
+		for column := frame.Width - 1; column >= 0; column-- {
+			cell := frame.Cells[row*frame.Width+column]
+			if cell.Glyph != "" || cell.continuation {
+				last = column
 				break
 			}
-			wordWidth++
-			wordEnd = wordNext
-			scan = wordNext
 		}
-		if wordEnd == wordStart {
-			position = next
-			continue
-		}
-		w.writeWord(value[wordStart:wordEnd], wordWidth)
-		position = wordEnd
-	}
-	return w
-}
-
-func (w *wrappedWriter) writeWord(word string, wordWidth int) {
-	contentStart := fieldWidth
-	if w.line.columns > contentStart && w.pendingSpace > 0 && wordWidth <= w.render.output.width-contentStart && w.line.columns+w.pendingSpace+wordWidth > w.render.output.width {
-		w.continueLine()
-	}
-	if w.line.columns > contentStart {
-		for range w.pendingSpace {
-			if w.line.columns == w.render.output.width {
-				w.continueLine()
-				break
+		activeStyle := Style("")
+		for column := 0; column <= last; column++ {
+			cell := frame.Cells[row*frame.Width+column]
+			if cell.continuation {
+				continue
 			}
-			w.line.writeRune(' ')
-		}
-	}
-	w.pendingSpace = 0
-	for position := 0; position < len(word); {
-		r, next, ok := nextVisibleString(word, position)
-		position = next
-		if !ok {
-			break
-		}
-		if w.line.columns == w.render.output.width {
-			w.continueLine()
-		}
-		w.line.writeRune(r)
-	}
-}
-
-func (w *wrappedWriter) continueLine() {
-	w.line.finish()
-	w.line = w.render.continuationLine()
-	if w.activeStyle != "" {
-		w.line.style(w.activeStyle)
-	}
-}
-
-func (w *wrappedWriter) style(value string) *wrappedWriter {
-	w.activeStyle = value
-	w.line.style(value)
-	return w
-}
-
-func (w *wrappedWriter) resetStyle() *wrappedWriter {
-	w.line.resetStyle()
-	w.activeStyle = ""
-	return w
-}
-
-func (w *wrappedWriter) finish() {
-	w.line.finish()
-}
-
-func (render *Renderer) writeNetwork(network []NetworkInterface) {
-	if len(network) == 0 {
-		render.wrappedField("Network").writeString("waiting for an active interface").finish()
-		return
-	}
-	for index, iface := range network {
-		label := ""
-		if index == 0 {
-			label = "Network"
-		}
-		field := render.wrappedField(label)
-		field.writeString(iface.Name)
-		if len(iface.Addresses) == 0 {
-			field.writeString(": configuring")
-		} else {
-			field.writeString(": ")
-			for addressIndex, address := range iface.Addresses {
-				if addressIndex > 0 {
-					field.writeString(", ")
+			if cell.Glyph == "" {
+				if activeStyle != "" && color {
+					output = append(output, string(styleReset)...)
+					activeStyle = ""
 				}
-				field.writeString(address)
+				output = append(output, ' ')
+				continue
 			}
+			if color && cell.Style != activeStyle {
+				if activeStyle != "" {
+					output = append(output, string(styleReset)...)
+				}
+				if cell.Style != "" {
+					output = append(output, string(cell.Style)...)
+				}
+				activeStyle = cell.Style
+			}
+			output = append(output, cell.Glyph...)
 		}
-		field.finish()
-	}
-}
-
-func (render *Renderer) writeWrappedField(label, value, style string) {
-	if value == "" {
-		return
-	}
-	field := render.wrappedField(label)
-	if style != "" {
-		field.style(style)
-	}
-	field.writeString(value)
-	if style != "" {
-		field.resetStyle()
-	}
-	field.finish()
-}
-
-func nextVisibleString(value string, position int) (rune, int, bool) {
-	for position < len(value) {
-		if value[position] == '\x1b' {
-			position = skipANSIString(value, position)
-			continue
+		if activeStyle != "" && color {
+			output = append(output, string(styleReset)...)
 		}
-		r, size := utf8.DecodeRuneInString(value[position:])
-		position += size
-		if r == '\t' {
-			return ' ', position, true
-		}
-		if r == '\n' || !unicode.IsControl(r) {
-			return r, position, true
+		if color {
+			output = append(output, '\r')
+			if row < rows-1 {
+				output = append(output, '\n')
+			}
+		} else {
+			output = append(output, '\n')
 		}
 	}
-	return 0, position, false
-}
-
-func nextVisibleBytes(value []byte, position int) (rune, int, bool) {
-	for position < len(value) {
-		if value[position] == '\x1b' {
-			position = skipANSIBytes(value, position)
-			continue
-		}
-		r, size := utf8.DecodeRune(value[position:])
-		position += size
-		if r == '\t' {
-			return ' ', position, true
-		}
-		if r == '\n' || !unicode.IsControl(r) {
-			return r, position, true
-		}
-	}
-	return 0, position, false
-}
-
-func skipANSIString(value string, position int) int {
-	return skipANSI(value[position:], position)
-}
-
-func skipANSIBytes(value []byte, position int) int {
-	if len(value)-position < 2 {
-		return len(value)
-	}
-	if value[position+1] != '[' {
-		return position + 2
-	}
-	for index := position + 2; index < len(value); index++ {
-		if value[index] >= 0x40 && value[index] <= 0x7e {
-			return index + 1
-		}
-	}
-	return len(value)
-}
-
-func skipANSI(value string, offset int) int {
-	if len(value) < 2 {
-		return offset + len(value)
-	}
-	if value[1] != '[' {
-		return offset + 2
-	}
-	for index := 2; index < len(value); index++ {
-		if value[index] >= 0x40 && value[index] <= 0x7e {
-			return offset + index + 1
-		}
-	}
-	return offset + len(value)
+	return output
 }
 
 func stateLabel(state string) string {
@@ -1010,7 +471,7 @@ func stateLabel(state string) string {
 	}
 }
 
-func stateStyle(state string) string {
+func stateStyle(state string) Style {
 	switch state {
 	case "failed-before-mutation", "failed-after-mutation", "install-refused", "runtime-failed-needs-repair":
 		return styleBad
@@ -1034,7 +495,10 @@ func healthLabel(value string) string {
 	}
 }
 
-func healthStyle(value string) string {
+func healthStyle(value string) Style {
+	if value == "" {
+		return ""
+	}
 	if value == "OK" {
 		return styleGood
 	}
@@ -1042,18 +506,7 @@ func healthStyle(value string) string {
 }
 
 func visibleWidth(value string) int {
-	width := 0
-	for position := 0; position < len(value); {
-		r, next, ok := nextVisibleString(value, position)
-		position = next
-		if !ok {
-			break
-		}
-		if r != '\n' {
-			width++
-		}
-	}
-	return width
+	return displayWidth(value)
 }
 
 func firstIPv4(network []NetworkInterface) string {
@@ -1069,6 +522,13 @@ func firstIPv4(network []NetworkInterface) string {
 		}
 	}
 	return ""
+}
+
+func installerCommandEndpoint(snapshot *Snapshot) string {
+	if address := firstIPv4(snapshot.Network); address != "" {
+		return address
+	}
+	return installerBaseURL(snapshot.Handoff.URL)
 }
 
 func installerBaseURL(value string) string {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -110,30 +110,33 @@ func (render *Renderer) paintDashboard(snapshot *Snapshot, journal Journal) {
 	divider := NewViewport(&render.frame, Rect{Y: 1, Width: min(render.frame.Width, 72), Height: 1})
 	divider.Write(strings.Repeat("=", divider.bounds.Width), WrapOptions{Style: styleDim})
 
-	content := NewViewport(&render.frame, Rect{Y: 2, Width: render.frame.Width, Height: render.frame.Height - 3})
+	contentRect := Rect{Y: 2, Width: render.frame.Width, Height: render.frame.Height - 3}
+	alerts := activeAlerts(snapshot)
+	reservedAlerts := min(measureAlertRows(contentRect.Width, alerts), max(contentRect.Height-1, 0))
+	normal := NewViewport(&render.frame, Rect{Y: contentRect.Y, Width: contentRect.Width, Height: contentRect.Height - reservedAlerts})
 	if snapshot.Mode == ModeRuntime {
-		writeHeading(&content, "Status")
-		render.writeRuntimeStatus(&content, snapshot)
-		writeNetwork(&content, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces)
+		writeHeading(&normal, "Status")
+		render.writeRuntimeStatus(&normal, snapshot)
+		writeNetwork(&normal, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces)
 	} else {
-		writeInstallerStatus(&content, snapshot)
+		writeInstallerStatus(&normal, snapshot)
 	}
 	if snapshot.Mode == ModeInstaller && snapshot.State == "running" {
 		value, style := "not started", Style("")
 		if snapshot.DestructiveMutation {
 			value, style = "started - do not power off", styleWarn
 		}
-		writeField(&content, "Disk changes", value, style)
+		writeField(&normal, "Disk changes", value, style)
 	}
 	if snapshot.Handoff.URL != "" {
-		writeField(&content, "Configure", snapshot.Handoff.URL, "")
-		writeField(&content, "Run", "katlctl config init cluster.yaml --installer "+installerCommandEndpoint(snapshot.Handoff.URL), "")
+		writeField(&normal, "Configure", snapshot.Handoff.URL, "")
+		writeField(&normal, "Run", "katlctl config init cluster.yaml --installer "+installerCommandEndpoint(snapshot.Handoff.URL), "")
 	}
-	writeOptionalField(&content, "Error", snapshot.LastError, styleBad)
-	writeOptionalField(&content, "Next action", snapshot.RetryHint, styleWarn)
-	writeOptionalField(&content, "Status read", snapshot.StatusError, styleWarn)
 
-	if content.rowsRemaining() > 0 {
+	content := NewViewport(&render.frame, contentRect)
+	content.advance(normal.rowsUsed())
+	writeAlerts(&content, alerts)
+	if content.rowsRemaining() > 1 {
 		content.advance(1)
 	}
 	if content.rowsRemaining() > 0 {
@@ -144,6 +147,55 @@ func (render *Renderer) paintDashboard(snapshot *Snapshot, journal Journal) {
 		writer := newJournalWriter(journalViewport)
 		journal.WriteTail(&writer)
 		content.advance(writer.RowsWritten())
+	}
+}
+
+type alertSpec struct {
+	label string
+	value string
+	style Style
+}
+
+func activeAlerts(snapshot *Snapshot) []alertSpec {
+	alerts := make([]alertSpec, 0, 3)
+	if strings.TrimSpace(snapshot.LastError) != "" {
+		alerts = append(alerts, alertSpec{label: "Error", value: snapshot.LastError, style: styleBad})
+	}
+	if strings.TrimSpace(snapshot.RetryHint) != "" {
+		alerts = append(alerts, alertSpec{label: "Next action", value: snapshot.RetryHint, style: styleWarn})
+	}
+	if strings.TrimSpace(snapshot.StatusError) != "" {
+		alerts = append(alerts, alertSpec{label: "Status read", value: snapshot.StatusError, style: styleWarn})
+	}
+	return alerts
+}
+
+func measureAlertRows(width int, alerts []alertSpec) int {
+	if len(alerts) == 0 {
+		return 0
+	}
+	width, _ = renderDimensions(width, 1)
+	frame := Frame{Width: width, Height: maximumHeight}
+	viewport := NewViewport(&frame, Rect{Width: width, Height: maximumHeight})
+	for _, alert := range alerts {
+		writeField(&viewport, alert.label, alert.value, alert.style)
+	}
+	return viewport.rowsUsed()
+}
+
+func writeAlerts(viewport *Viewport, alerts []alertSpec) {
+	for index, alert := range alerts {
+		if viewport.rowsRemaining() == 0 {
+			return
+		}
+		remainingAlerts := len(alerts) - index - 1
+		frame := Frame{Width: viewport.bounds.Width, Height: maximumHeight}
+		measure := NewViewport(&frame, Rect{Width: viewport.bounds.Width, Height: maximumHeight})
+		writeField(&measure, alert.label, alert.value, alert.style)
+		height := min(max(measure.rowsUsed(), 1), max(viewport.rowsRemaining()-remainingAlerts, 1))
+		alertViewport := viewport.sub(Rect{Y: viewport.y, Width: viewport.bounds.Width, Height: height})
+		writeField(&alertViewport, alert.label, alert.value, alert.style)
+		viewport.advance(max(alertViewport.rowsUsed(), 1))
 	}
 }
 
@@ -267,6 +319,7 @@ func pluralCount(count int, singular, plural string) string {
 
 func writeHeading(viewport *Viewport, value string) {
 	if viewport.rowsRemaining() == 0 {
+		viewport.markTruncated(styleTitle)
 		return
 	}
 	heading := viewport.sub(Rect{Y: viewport.y, Width: viewport.bounds.Width, Height: 1})
@@ -274,14 +327,9 @@ func writeHeading(viewport *Viewport, value string) {
 	viewport.advance(1)
 }
 
-func writeOptionalField(viewport *Viewport, label, value string, style Style) {
-	if strings.TrimSpace(value) != "" {
-		writeField(viewport, label, value, style)
-	}
-}
-
 func writeField(viewport *Viewport, label, value string, style Style) {
 	if viewport.rowsRemaining() == 0 {
+		viewport.markTruncated(style)
 		return
 	}
 	if viewport.bounds.Width < 28 && label != "" {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -14,7 +14,7 @@ const (
 	maximumWidth    = 512
 	maximumHeight   = 256
 	wideLayoutWidth = 72
-	fieldWidth      = 14
+	fieldWidth      = 18
 
 	styleReset Style = "\x1b[0m"
 	styleTitle Style = "\x1b[1;36m"
@@ -94,7 +94,11 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 func (render *Renderer) paintCompact(snapshot *Snapshot) {
 	content := NewViewport(&render.frame, Rect{Width: render.frame.Width, Height: max(render.frame.Height-1, 0)})
 	content.Write("KatlOS", WrapOptions{Style: styleTitle, WordWrap: true})
-	content.Write(stateLabel(snapshot.State), WrapOptions{Style: stateStyle(snapshot.State), WordWrap: true})
+	presentation := presentInstaller(snapshot)
+	if snapshot.Mode == ModeRuntime {
+		presentation = NewDashboardModel(snapshot).Host
+	}
+	content.Write(presentation.Label, WrapOptions{Style: presentationStyle(presentation.State), WordWrap: true})
 	if address := snapshot.ManagementAddress; address != "" {
 		content.Write(address, WrapOptions{WordWrap: true})
 	}
@@ -157,7 +161,7 @@ type alertSpec struct {
 }
 
 func activeAlerts(snapshot *Snapshot) []alertSpec {
-	alerts := make([]alertSpec, 0, 3)
+	alerts := make([]alertSpec, 0, 6)
 	if strings.TrimSpace(snapshot.LastError) != "" {
 		alerts = append(alerts, alertSpec{label: "Error", value: snapshot.LastError, style: styleBad})
 	}
@@ -166,6 +170,15 @@ func activeAlerts(snapshot *Snapshot) []alertSpec {
 	}
 	if strings.TrimSpace(snapshot.StatusError) != "" {
 		alerts = append(alerts, alertSpec{label: "Status read", value: snapshot.StatusError, style: styleWarn})
+	}
+	if snapshot.StatusStale {
+		alerts = append(alerts, alertSpec{label: "Status stale", value: "state has not updated recently; verify the active KatlOS operation", style: styleWarn})
+	}
+	if snapshot.HandoffError != "" {
+		alerts = append(alerts, alertSpec{label: "Handoff read", value: snapshot.HandoffError, style: styleWarn})
+	}
+	if snapshot.GenerationError != "" {
+		alerts = append(alerts, alertSpec{label: "Generation read", value: snapshot.GenerationError, style: styleWarn})
 	}
 	return alerts
 }
@@ -223,18 +236,18 @@ type paneField struct {
 }
 
 func (render *Renderer) writeRuntimeStatus(content *Viewport, snapshot *Snapshot) {
-	hostState, hostStyle := runtimeHostState(snapshot)
-	kubernetesState, kubernetesStyle := runtimeKubernetesState(snapshot)
+	model := NewDashboardModel(snapshot)
 	host := []paneField{
-		{label: "State", value: hostState, style: hostStyle},
+		{label: "State", value: model.Host.Label, style: presentationStyle(model.Host.State)},
 		{label: "Node", value: fallback(snapshot.Hostname, "Unknown")},
-		{label: "KatlOS", value: fallback(snapshot.Version, "Unknown")},
-		{label: "Generation", value: fallback(snapshot.Generation, "Unknown")},
-		{label: "Next boot", value: fallback(snapshot.NextGeneration, "-")},
+		{label: "Current", value: softwareLabel(model.Current)},
+		{label: "Next boot", value: softwareLabel(model.NextBoot)},
+		{label: "Live selected", value: softwareLabel(model.Live)},
 	}
 	kubernetes := []paneField{
-		{label: "State", value: kubernetesState, style: kubernetesStyle},
-		{label: "Version", value: fallback(snapshot.KubernetesVersion, "Not installed")},
+		{label: "State", value: model.Kubernetes.Label, style: presentationStyle(model.Kubernetes.State)},
+		{label: "Version", value: fallback(model.Live.KubernetesVersion, "Not installed")},
+		{label: "Live generation", value: fallback(model.Live.Generation, "Unknown")},
 	}
 	if content.bounds.Width < wideLayoutWidth {
 		writePane(content, "Host", host)
@@ -257,6 +270,20 @@ func (render *Renderer) writeRuntimeStatus(content *Viewport, snapshot *Snapshot
 	}
 }
 
+func softwareLabel(software Software) string {
+	parts := make([]string, 0, 2)
+	if software.Generation != "" {
+		parts = append(parts, "generation "+software.Generation)
+	}
+	if software.KatlOSVersion != "" {
+		parts = append(parts, "KatlOS "+software.KatlOSVersion)
+	}
+	if len(parts) == 0 {
+		return "Unknown"
+	}
+	return strings.Join(parts, ", ")
+}
+
 func writePane(viewport *Viewport, title string, fields []paneField) {
 	writeHeading(viewport, title)
 	for _, field := range fields {
@@ -265,7 +292,8 @@ func writePane(viewport *Viewport, title string, fields []paneField) {
 }
 
 func writeInstallerStatus(content *Viewport, snapshot *Snapshot) {
-	writeField(content, "State", stateLabel(snapshot.State), stateStyle(snapshot.State))
+	presentation := presentInstaller(snapshot)
+	writeField(content, "State", presentation.Label, presentationStyle(presentation.State))
 	if snapshot.Hostname != "" {
 		writeField(content, "Node", snapshot.Hostname, "")
 	}
@@ -354,40 +382,6 @@ func writeField(viewport *Viewport, label, value string, style Style) {
 	valueView := viewport.sub(Rect{X: labelWidth, Y: viewport.y, Width: viewport.bounds.Width - labelWidth, Height: viewport.rowsRemaining()})
 	result := valueView.Write(value, WrapOptions{Style: style, WordWrap: true})
 	viewport.advance(max(result.Rows, 1))
-}
-
-func runtimeHostState(snapshot *Snapshot) (string, Style) {
-	if snapshot.State == "runtime-failed-needs-repair" {
-		return "Needs repair", styleBad
-	}
-	if health := healthLabel(snapshot.GenerationHealth); health != "" {
-		return health, healthStyle(health)
-	}
-	if snapshot.State == "starting-runtime" {
-		return "Starting", styleWarn
-	}
-	if snapshot.State == "runtime-booted-not-ready" {
-		return "Not ready", styleWarn
-	}
-	return "Running", styleGood
-}
-
-func runtimeKubernetesState(snapshot *Snapshot) (string, Style) {
-	if snapshot.KubernetesVersion == "" {
-		return "Not installed", styleWarn
-	}
-	if snapshot.State == "runtime-failed-needs-repair" {
-		return "Unavailable", styleBad
-	}
-	if snapshot.KubernetesBootstrapped {
-		return "Bootstrapped", styleGood
-	}
-	switch snapshot.State {
-	case "kubeadm-ready", "waiting-for-cluster-bootstrap":
-		return "Ready for bootstrap", styleGood
-	default:
-		return "Waiting for KatlOS", styleWarn
-	}
 }
 
 // JournalWriter renders logical journal entries through the same bounded
@@ -501,73 +495,6 @@ func serializeFrame(output []byte, frame *Frame, rows int, color, clear bool) []
 		}
 	}
 	return output
-}
-
-func stateLabel(state string) string {
-	switch state {
-	case "starting-installer":
-		return "Starting installer"
-	case "starting-runtime":
-		return "Starting KatlOS"
-	case "running":
-		return "Installing"
-	case "debug-hold":
-		return "Debug hold; installation disabled"
-	case "waiting-for-config":
-		return "Waiting for configuration"
-	case "install-refused":
-		return "Installation refused"
-	case "failed-before-mutation":
-		return "Installation failed; disk unchanged"
-	case "failed-after-mutation":
-		return "Installation failed; repair required"
-	case "reboot-requested":
-		return "Installation complete; rebooting"
-	case "kubeadm-ready":
-		return "Ready for Kubernetes bootstrap"
-	case "waiting-for-cluster-bootstrap":
-		return "Waiting for Kubernetes bootstrap"
-	case "runtime-booted-not-ready":
-		return "KatlOS booted; not ready"
-	case "runtime-failed-needs-repair":
-		return "KatlOS needs repair"
-	default:
-		return fallback(state, "Unknown")
-	}
-}
-
-func stateStyle(state string) Style {
-	switch state {
-	case "failed-before-mutation", "failed-after-mutation", "install-refused", "runtime-failed-needs-repair":
-		return styleBad
-	case "kubeadm-ready", "waiting-for-cluster-bootstrap":
-		return styleGood
-	default:
-		return styleWarn
-	}
-}
-
-func healthLabel(value string) string {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "":
-		return ""
-	case "healthy", "good", "ok", "success":
-		return "OK"
-	case "unhealthy", "failed", "failure":
-		return "FAILED"
-	default:
-		return strings.ToUpper(strings.TrimSpace(value))
-	}
-}
-
-func healthStyle(value string) Style {
-	if value == "" {
-		return ""
-	}
-	if value == "OK" {
-		return styleGood
-	}
-	return styleBad
 }
 
 func visibleWidth(value string) int {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -225,7 +225,7 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 		footer.writeString(" | SSH disabled")
 	}
 	footer.resetStyle()
-	footer.end()
+	footer.endFrame()
 	return render.output.bytes()
 }
 
@@ -702,6 +702,29 @@ func (l *lineWriter) finish() {
 }
 
 func (l *lineWriter) end() {
+	l.finishOutput()
+	// A character in the terminal's final column leaves autowrap pending. A
+	// carriage return clears that state before the line feed, so one rendered
+	// row always consumes exactly one terminal row.
+	if l.color {
+		l.output.writeByte('\r')
+	}
+	l.output.writeByte('\n')
+}
+
+func (l *lineWriter) endFrame() {
+	l.finishOutput()
+	if l.color {
+		// The footer occupies the terminal's bottom row. Leave the cursor on that
+		// row and clear pending autowrap without emitting a line feed that would
+		// scroll the completed frame.
+		l.output.writeByte('\r')
+		return
+	}
+	l.output.writeByte('\n')
+}
+
+func (l *lineWriter) finishOutput() {
 	if !l.active {
 		return
 	}
@@ -712,13 +735,6 @@ func (l *lineWriter) end() {
 			l.output.writeString(styleReset)
 		}
 	}
-	// A character in the terminal's final column leaves autowrap pending. A
-	// carriage return clears that state before the line feed, so one rendered
-	// row always consumes exactly one terminal row.
-	if l.color {
-		l.output.writeByte('\r')
-	}
-	l.output.writeByte('\n')
 }
 
 type wrappedWriter struct {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -94,12 +94,15 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 func (render *Renderer) paintCompact(snapshot *Snapshot) {
 	content := NewViewport(&render.frame, Rect{Width: render.frame.Width, Height: max(render.frame.Height-1, 0)})
 	content.Write("KatlOS", WrapOptions{Style: styleTitle, WordWrap: true})
+	writeCompactAlerts(&content, activeAlerts(snapshot))
 	presentation := presentInstaller(snapshot)
 	if snapshot.Mode == ModeRuntime {
 		presentation = NewDashboardModel(snapshot).Host
 	}
-	content.Write(presentation.Label, WrapOptions{Style: presentationStyle(presentation.State), WordWrap: true})
-	if address := snapshot.ManagementAddress; address != "" {
+	if content.rowsRemaining() > 0 {
+		content.Write(presentation.Label, WrapOptions{Style: presentationStyle(presentation.State), WordWrap: true})
+	}
+	if address := snapshot.ManagementAddress; address != "" && content.rowsRemaining() > 0 {
 		content.Write(address, WrapOptions{WordWrap: true})
 	}
 }
@@ -209,6 +212,22 @@ func writeAlerts(viewport *Viewport, alerts []alertSpec) {
 		alertViewport := viewport.sub(Rect{Y: viewport.y, Width: viewport.bounds.Width, Height: height})
 		writeField(&alertViewport, alert.label, alert.value, alert.style)
 		viewport.advance(max(alertViewport.rowsUsed(), 1))
+	}
+}
+
+func writeCompactAlerts(viewport *Viewport, alerts []alertSpec) {
+	for index, alert := range alerts {
+		if viewport.rowsRemaining() == 0 {
+			return
+		}
+		remainingAlerts := len(alerts) - index - 1
+		frame := Frame{Width: viewport.bounds.Width, Height: maximumHeight}
+		measure := NewViewport(&frame, Rect{Width: viewport.bounds.Width, Height: maximumHeight})
+		measure.Write(alert.label+": "+alert.value, WrapOptions{Style: alert.style, WordWrap: true})
+		height := min(max(measure.rowsUsed(), 1), max(viewport.rowsRemaining()-remainingAlerts, 1))
+		alertViewport := viewport.sub(Rect{Y: viewport.y, Width: viewport.bounds.Width, Height: height})
+		result := alertViewport.Write(alert.label+": "+alert.value, WrapOptions{Style: alert.style, WordWrap: true})
+		viewport.advance(max(result.Rows, 1))
 	}
 }
 

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -1,6 +1,7 @@
 package operatorconsole
 
 import (
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -92,7 +93,7 @@ func (render *Renderer) paintCompact(snapshot *Snapshot) {
 	content := NewViewport(&render.frame, Rect{Width: render.frame.Width, Height: max(render.frame.Height-1, 0)})
 	content.Write("KatlOS", WrapOptions{Style: styleTitle, WordWrap: true})
 	content.Write(stateLabel(snapshot.State), WrapOptions{Style: stateStyle(snapshot.State), WordWrap: true})
-	if address := firstIPv4(snapshot.Network); address != "" {
+	if address := snapshot.ManagementAddress; address != "" {
 		content.Write(address, WrapOptions{WordWrap: true})
 	}
 }
@@ -111,7 +112,7 @@ func (render *Renderer) paintDashboard(snapshot *Snapshot, journal Journal) {
 	if snapshot.Mode == ModeRuntime {
 		writeHeading(&content, "Status")
 		render.writeRuntimeStatus(&content, snapshot)
-		writeNetwork(&content, snapshot.Network)
+		writeNetwork(&content, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces)
 	} else {
 		writeInstallerStatus(&content, snapshot)
 	}
@@ -149,7 +150,7 @@ func (render *Renderer) paintFooter(snapshot *Snapshot) {
 	if render.frame.Width < minimumWidth || render.frame.Height < minimumHeight {
 		footerText = "F2: console"
 	} else if snapshot.SSHEnabled {
-		if address := firstIPv4(snapshot.Network); address != "" && displayWidth(footerText+" | SSH: katl@"+address) <= render.frame.Width {
+		if address := snapshot.ManagementAddress; address != "" && displayWidth(footerText+" | SSH: katl@"+address) <= render.frame.Width {
 			footerText += " | SSH: katl@" + address
 		} else {
 			footerText += " | SSH enabled"
@@ -214,7 +215,7 @@ func writeInstallerStatus(content *Viewport, snapshot *Snapshot) {
 	if snapshot.Hostname != "" {
 		writeField(content, "Node", snapshot.Hostname, "")
 	}
-	writeNetwork(content, snapshot.Network)
+	writeNetwork(content, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces)
 	if snapshot.Version != "" {
 		writeField(content, "Media", snapshot.Version, "")
 	}
@@ -230,7 +231,7 @@ func writeInstallerStatus(content *Viewport, snapshot *Snapshot) {
 	}
 }
 
-func writeNetwork(content *Viewport, network []NetworkInterface) {
+func writeNetwork(content *Viewport, network []NetworkInterface, additional int) {
 	if len(network) == 0 {
 		writeField(content, "Network", "waiting for an active interface", "")
 		return
@@ -244,8 +245,22 @@ func writeNetwork(content *Viewport, network []NetworkInterface) {
 		if len(iface.Addresses) > 0 {
 			value = iface.Name + ": " + strings.Join(iface.Addresses, ", ")
 		}
+		if iface.AdditionalAddresses > 0 {
+			value += "  + " + pluralCount(iface.AdditionalAddresses, "address", "addresses")
+		}
 		writeField(content, label, value, "")
 	}
+	if additional > 0 {
+		writeField(content, "", "+ "+pluralCount(additional, "interface", "interfaces"), styleDim)
+	}
+}
+
+func pluralCount(count int, singular, plural string) string {
+	label := plural
+	if count == 1 {
+		label = singular
+	}
+	return strconv.Itoa(count) + " " + label
 }
 
 func writeHeading(viewport *Viewport, value string) {
@@ -509,23 +524,8 @@ func visibleWidth(value string) int {
 	return displayWidth(value)
 }
 
-func firstIPv4(network []NetworkInterface) string {
-	for _, iface := range network {
-		for _, address := range iface.Addresses {
-			if strings.IndexByte(address, '.') < 0 {
-				continue
-			}
-			if slash := strings.IndexByte(address, '/'); slash >= 0 {
-				return address[:slash]
-			}
-			return address
-		}
-	}
-	return ""
-}
-
 func installerCommandEndpoint(snapshot *Snapshot) string {
-	if address := firstIPv4(snapshot.Network); address != "" {
+	if address := snapshot.ManagementAddress; address != "" {
 		return address
 	}
 	return installerBaseURL(snapshot.Handoff.URL)

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -1,6 +1,8 @@
 package operatorconsole
 
 import (
+	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -125,7 +127,7 @@ func (render *Renderer) paintDashboard(snapshot *Snapshot, journal Journal) {
 	}
 	if snapshot.Handoff.URL != "" {
 		writeField(&content, "Configure", snapshot.Handoff.URL, "")
-		writeField(&content, "Run", "katlctl config init cluster.yaml --installer "+installerCommandEndpoint(snapshot), "")
+		writeField(&content, "Run", "katlctl config init cluster.yaml --installer "+installerCommandEndpoint(snapshot.Handoff.URL), "")
 	}
 	writeOptionalField(&content, "Error", snapshot.LastError, styleBad)
 	writeOptionalField(&content, "Next action", snapshot.RetryHint, styleWarn)
@@ -524,11 +526,15 @@ func visibleWidth(value string) int {
 	return displayWidth(value)
 }
 
-func installerCommandEndpoint(snapshot *Snapshot) string {
-	if address := snapshot.ManagementAddress; address != "" {
-		return address
+func installerCommandEndpoint(value string) string {
+	baseURL := installerBaseURL(value)
+	parsed, err := url.Parse(baseURL)
+	if err == nil && parsed.Scheme == "http" && parsed.Port() == "8080" && parsed.User == nil && parsed.Path == "" && parsed.RawQuery == "" && parsed.Fragment == "" {
+		if address := net.ParseIP(parsed.Hostname()); address != nil && address.To4() != nil {
+			return address.String()
+		}
 	}
-	return installerBaseURL(snapshot.Handoff.URL)
+	return baseURL
 }
 
 func installerBaseURL(value string) string {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -9,6 +9,8 @@ import (
 const (
 	minimumWidth    = 40
 	minimumHeight   = 12
+	maximumWidth    = 512
+	maximumHeight   = 256
 	fieldWidth      = 14
 	panelFieldWidth = 12
 
@@ -138,6 +140,9 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 	if render.color {
 		render.output.writeString(clearScreen)
 	}
+	if render.output.width < minimumWidth || render.output.rows < minimumHeight {
+		return render.renderCompact(snapshot)
+	}
 
 	line := render.line()
 	line.style(styleTitle)
@@ -225,6 +230,30 @@ func (render *Renderer) Render(snapshot *Snapshot, journal Journal) []byte {
 		footer.writeString(" | SSH disabled")
 	}
 	footer.resetStyle()
+	footer.endFrame()
+	return render.output.bytes()
+}
+
+func (render *Renderer) renderCompact(snapshot *Snapshot) []byte {
+	line := render.line()
+	line.style(styleTitle).writeString("KatlOS").resetStyle()
+	line.finish()
+
+	if render.row < render.contentRows {
+		line = render.line()
+		line.style(stateStyle(snapshot.State)).writeString(stateLabel(snapshot.State)).resetStyle()
+		line.finish()
+	}
+	if address := firstIPv4(snapshot.Network); address != "" && render.row < render.contentRows {
+		render.line().writeString(address).finish()
+	}
+	for render.row < render.contentRows {
+		render.finishBlank()
+	}
+
+	footer := newLine(&render.output)
+	footer.color = render.color
+	footer.style(styleDim).writeString("F2: console").resetStyle()
 	footer.endFrame()
 	return render.output.bytes()
 }
@@ -481,10 +510,7 @@ type JournalWriter struct {
 // NewJournalWriter binds a bounded journal writer to a fixed render target. It
 // is primarily useful for testing journal sources independently.
 func NewJournalWriter(target RenderTarget) JournalWriter {
-	if target.width < minimumWidth {
-		target.width = minimumWidth
-	}
-	target.rows = max(target.rows, 0)
+	target.width, target.rows = renderDimensions(target.width, target.rows)
 	target.reset()
 	return JournalWriter{output: target}
 }
@@ -556,9 +582,7 @@ func (writer *JournalWriter) writeLine(value []byte) int {
 }
 
 func journalLineRows(value []byte, width int) int {
-	if width < minimumWidth {
-		width = minimumWidth
-	}
+	width, _ = renderDimensions(width, 1)
 	columns := 0
 	rows := 0
 	wrote := false
@@ -1063,5 +1087,5 @@ func fallback(value, fallback string) string {
 }
 
 func renderDimensions(width, height int) (int, int) {
-	return max(width, minimumWidth), max(height, minimumHeight)
+	return min(max(width, 1), maximumWidth), min(max(height, 1), maximumHeight)
 }


### PR DESCRIPTION
## Summary

- render the operator dashboard through terminal-cell-aware bounded viewports, with responsive narrow layouts and a frame that cannot scroll or cross pane boundaries
- curate management networking, preserve canonical installer endpoints, and keep recovery guidance visible under constrained geometry
- report runtime provenance and uncertain state truthfully, while bounding journal ingestion and protecting persisted snapshots

## Why

The dashboard relied on several independent rune-based wrapping paths over a full-width byte writer. Correctness therefore depended on every caller calculating pane segments perfectly, while narrow terminals, noisy runtime data, and malformed state could still overflow, hide recovery actions, or imply false health. A shared cell frame and bounded viewport now enforce layout invariants centrally.
