### PR TITLE
katlctl: add node shutdown management

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,15 +236,16 @@ bootstrap. Pass a node name in a larger cluster:
 ```sh
 katlctl node status cp-1 --config ./cluster.yaml
 katlctl node reboot cp-1 --config ./cluster.yaml
+katlctl node shutdown cp-1 --config ./cluster.yaml
 ```
 
 An optional workstation context created with `katlctl context save --config
 ./cluster.yaml` shortens repeated commands; it is not a prerequisite.
 
-Status and reboot results are concise text by default. Add `--output json` for
-automation. Reboot honors any generation already staged for the next boot and
-waits for a new agent instance to report healthy; `--no-wait` deliberately
-detaches after the reboot is scheduled.
+Results are concise text by default. Add `--output json` for automation. Reboot
+honors any generation already staged for the next boot and waits for a new
+agent instance to report healthy. Shutdown waits for the management API to go
+offline. `--no-wait` deliberately detaches after either action is scheduled.
 
 Host upgrades take a release version and select the node from `ClusterConfig`.
 `katlctl` resolves the published image, stages it, reboots the node, and waits

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -31,6 +31,13 @@ type hostRebootOptions struct {
 	output  string
 }
 
+type hostShutdownOptions struct {
+	target  managementTargetOptions
+	timeout time.Duration
+	noWait  bool
+	output  string
+}
+
 type hostStatusReport struct {
 	Node          string `json:"node"`
 	Endpoint      string `json:"endpoint"`
@@ -47,6 +54,13 @@ type hostRebootReport struct {
 	Generation string `json:"generation"`
 	Health     string `json:"health,omitempty"`
 }
+
+type hostShutdownReport struct {
+	Node   string `json:"node"`
+	Result string `json:"result"`
+}
+
+var hostShutdownPollInterval = 500 * time.Millisecond
 
 func newHostStatusCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := hostStatusOptions{timeout: 15 * time.Second, output: hostOutputText}
@@ -83,6 +97,29 @@ func newHostRebootCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.
 	addManagementTargetFlags(cmd, &opts.target)
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "time to wait for the host to return healthy")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the host schedules the reboot")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
+	return cmd
+}
+
+func newHostShutdownCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := hostShutdownOptions{timeout: 2 * time.Minute, output: hostOutputText}
+	cmd := &cobra.Command{
+		Use:   "shutdown [NODE]",
+		Short: "Shut down one KatlOS node",
+		Long: `Shut down one KatlOS node and wait for its management API to stop.
+
+Use the same ClusterConfig used to install the node. --endpoint can override its recorded address when DHCP or local routing changed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := selectHostNode(&opts.target.nodeName, args); err != nil {
+				return err
+			}
+			return runHostShutdown(ctx, opts, stdout, stderr)
+		},
+	}
+	addManagementTargetFlags(cmd, &opts.target)
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "time to wait for the management API to stop")
+	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the host schedules the shutdown")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
 	return cmd
 }
@@ -182,6 +219,83 @@ func runHostReboot(ctx context.Context, opts hostRebootOptions, stdout, stderr i
 	return writeHostReboot(stdout, opts.output, report)
 }
 
+func runHostShutdown(ctx context.Context, opts hostShutdownOptions, stdout, stderr io.Writer) error {
+	if err := validateHostOutput(opts.output); err != nil {
+		return err
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	target, err := resolveManagementTarget(opts.target)
+	if err != nil {
+		return err
+	}
+	node := hostTargetName(target)
+	requestCtx, cancelRequest := context.WithTimeout(ctx, opts.timeout)
+	conn, err := dialKatlcAgent(requestCtx, target.endpoint)
+	if err != nil {
+		cancelRequest()
+		return fmt.Errorf("connect to %s at %s: %w", node, target.endpoint, err)
+	}
+	status, err := conn.Client.GetNodeStatus(requestCtx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		_ = conn.Close()
+		cancelRequest()
+		return fmt.Errorf("read status from %s: %w", node, err)
+	}
+	accepted, err := conn.Client.Shutdown(requestCtx, &agentapi.ShutdownRequest{
+		ApiVersion:        generation.APIVersion,
+		Kind:              "ShutdownRequest",
+		Actor:             "katlctl node shutdown",
+		ExpectedMachineId: status.GetMachineId(),
+	})
+	_ = conn.Close()
+	cancelRequest()
+	if err != nil {
+		return fmt.Errorf("schedule shutdown for %s: %w", node, err)
+	}
+	if !accepted.GetScheduled() {
+		return fmt.Errorf("%s did not schedule shutdown", node)
+	}
+
+	report := hostShutdownReport{Node: node, Result: "scheduled"}
+	if opts.noWait {
+		return writeHostShutdown(stdout, opts.output, report)
+	}
+	_, _ = fmt.Fprintf(stderr, "Shutdown scheduled for %s; waiting for its management API to stop...\n", node)
+	waitCtx, cancelWait := context.WithTimeout(ctx, opts.timeout)
+	err = waitNodeOffline(waitCtx, target.endpoint)
+	cancelWait()
+	if err != nil {
+		return fmt.Errorf("%s did not shut down: %w", node, err)
+	}
+	report.Result = "offline"
+	return writeHostShutdown(stdout, opts.output, report)
+}
+
+func waitNodeOffline(ctx context.Context, endpoint string) error {
+	for {
+		attemptCtx, cancelAttempt := context.WithTimeout(ctx, 2*time.Second)
+		conn, err := dialKatlcAgent(attemptCtx, endpoint)
+		if err == nil {
+			_, err = conn.Client.GetNodeStatus(attemptCtx, &agentapi.GetNodeStatusRequest{})
+			_ = conn.Close()
+		}
+		cancelAttempt()
+		if err != nil {
+			return nil
+		}
+
+		timer := time.NewTimer(hostShutdownPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func readHostState(ctx context.Context, client agentapi.KatlcAgentClient, node string) (*agentapi.NodeStatus, *agentapi.Generation, error) {
 	status, err := client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
 	if err != nil {
@@ -258,6 +372,18 @@ func writeHostReboot(stdout io.Writer, output string, report hostRebootReport) e
 		return err
 	}
 	_, err := fmt.Fprintf(stdout, "%s rebooted successfully; health %s\n", report.Node, report.Health)
+	return err
+}
+
+func writeHostShutdown(stdout io.Writer, output string, report hostShutdownReport) error {
+	if output == hostOutputJSON {
+		return writeJSON(stdout, report)
+	}
+	if report.Result == "scheduled" {
+		_, err := fmt.Fprintf(stdout, "%s shutdown scheduled\n", report.Node)
+		return err
+	}
+	_, err := fmt.Fprintf(stdout, "%s shut down; management API is offline\n", report.Node)
 	return err
 }
 

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -142,6 +142,52 @@ func TestHostRebootTimesOutWhenAgentDoesNotRestart(t *testing.T) {
 	}
 }
 
+func TestHostShutdownWaitsForManagementAPIToStop(t *testing.T) {
+	fake := healthyHostClient("machine-a", "agent-a", "generation-0")
+	fake.onShutdown = func(*agentapi.ShutdownRequest) {
+		fake.nodeStatusErr = context.Canceled
+	}
+	installKatlcDial(t, nil, fake)
+	oldInterval := hostShutdownPollInterval
+	hostShutdownPollInterval = time.Millisecond
+	t.Cleanup(func() { hostShutdownPollInterval = oldInterval })
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"node", "shutdown", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if len(fake.shutdownRequests) != 1 {
+		t.Fatalf("shutdown requests = %d, want 1", len(fake.shutdownRequests))
+	}
+	request := fake.shutdownRequests[0]
+	if request.GetActor() != "katlctl node shutdown" || request.GetExpectedMachineId() != "machine-a" {
+		t.Fatalf("shutdown request = %#v", request)
+	}
+	if got := stdout.String(); got != "node-a shut down; management API is offline\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "Shutdown scheduled for node-a") {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestHostShutdownNoWaitJSON(t *testing.T) {
+	fake := healthyHostClient("machine-a", "agent-a", "generation-0")
+	installKatlcDial(t, nil, fake)
+
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"node", "shutdown", "node-a", "--endpoint", "node-a.test:9443", "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	var report hostShutdownReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode shutdown: %v\n%s", err, stdout.String())
+	}
+	if report.Node != "node-a" || report.Result != "scheduled" {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
 func TestHostManagementRejectsDuplicateNodeSelection(t *testing.T) {
 	err := run(context.Background(), []string{"node", "status", "cp-1", "--node", "worker-1"}, &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "NODE cannot be combined with --node") {

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -146,6 +146,7 @@ Start with "katlctl install discover" for a waiting installer or
 	nodeCmd := &cobra.Command{Use: "node", Short: "Manage individual KatlOS nodes"}
 	nodeCmd.AddCommand(newHostStatusCommand(ctx, stdout, stderr))
 	nodeCmd.AddCommand(newHostRebootCommand(ctx, stdout, stderr))
+	nodeCmd.AddCommand(newHostShutdownCommand(ctx, stdout, stderr))
 	nodeCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))
 	nodeCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
 	nodeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl node wipe"))
@@ -219,6 +220,7 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 		"katlctl node":                "katlctl node status cp-1 --config cluster.yaml",
 		"katlctl node status":         "katlctl node status cp-1 --config cluster.yaml",
 		"katlctl node reboot":         "katlctl node reboot cp-1 --config cluster.yaml",
+		"katlctl node shutdown":       "katlctl node shutdown cp-1 --config cluster.yaml",
 		"katlctl node upgrade":        "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml",
 		"katlctl node apply":          "katlctl node apply cp-1 --config cluster.yaml",
 		"katlctl node apply validate": "katlctl node apply validate --config cluster.yaml --node cp-1",

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -141,7 +141,7 @@ func TestRoutineRemoteExamplesDeclareClusterConfig(t *testing.T) {
 	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
 	for _, path := range []string{
 		"cluster bootstrap", "cluster status", "cluster wipe", "kubernetes upgrade",
-		"node apply", "node reboot", "node status", "node upgrade", "node wipe",
+		"node apply", "node reboot", "node shutdown", "node status", "node upgrade", "node wipe",
 		"operations list", "operations status",
 	} {
 		command, _, err := root.Find(strings.Fields(path))
@@ -227,6 +227,7 @@ func TestConfigInputFlagsUseOneName(t *testing.T) {
 		"katlctl node apply":          true,
 		"katlctl node apply validate": true,
 		"katlctl node reboot":         true,
+		"katlctl node shutdown":       true,
 		"katlctl node status":         true,
 		"katlctl node upgrade":        true,
 		"katlctl node wipe":           true,
@@ -262,7 +263,7 @@ func TestCommandGroupsExposeOneSupportedPath(t *testing.T) {
 		required  []string
 		forbidden []string
 	}{
-		{group: "node", required: []string{"apply", "reboot", "status", "upgrade", "wipe"}},
+		{group: "node", required: []string{"apply", "reboot", "shutdown", "status", "upgrade", "wipe"}},
 		{group: "cluster", required: []string{"bootstrap", "status", "wipe"}, forbidden: []string{"enroll", "kubeadm-control-plane-config"}},
 		{group: "kubernetes", required: []string{"upgrade"}, forbidden: []string{"apply-config"}},
 		{group: "config", required: []string{"bundle", "init", "schema", "validate"}, forbidden: []string{"apply", "path", "topology"}},
@@ -2346,6 +2347,8 @@ type fakeKatlcAgentClient struct {
 	onSubmit          func(*agentapi.SubmitOperationRequest)
 	rebootRequests    []*agentapi.RebootRequest
 	onReboot          func(*agentapi.RebootRequest)
+	shutdownRequests  []*agentapi.ShutdownRequest
+	onShutdown        func(*agentapi.ShutdownRequest)
 }
 
 type fakeWipeClusterConnector struct {
@@ -2415,6 +2418,14 @@ func (c *fakeKatlcAgentClient) Reboot(_ context.Context, req *agentapi.RebootReq
 		c.onReboot(req)
 	}
 	return &agentapi.RebootAccepted{Scheduled: true, TargetGenerationId: req.TargetGenerationId}, nil
+}
+
+func (c *fakeKatlcAgentClient) Shutdown(_ context.Context, req *agentapi.ShutdownRequest, _ ...grpc.CallOption) (*agentapi.ShutdownAccepted, error) {
+	c.shutdownRequests = append(c.shutdownRequests, req)
+	if c.onShutdown != nil {
+		c.onShutdown(req)
+	}
+	return &agentapi.ShutdownAccepted{Scheduled: true}, nil
 }
 
 func (c *fakeKatlcAgentClient) ValidateConfig(_ context.Context, req *agentapi.ValidateConfigRequest, _ ...grpc.CallOption) (*agentapi.ConfigValidationResult, error) {

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -92,12 +92,20 @@ Reboot a node and wait for it to return healthy:
 katlctl node reboot cp-1
 ```
 
+Shut down a node and wait for its management API to stop:
+
+```sh
+katlctl node shutdown cp-1
+```
+
 The reboot command does not require a confirmation flag. It honors the node's
 selected boot target, including a generation already staged for next boot, and
 verifies that a new agent instance returns on that generation with good boot
 health.
-Use `--no-wait` only when intentionally detaching, and `--output json` when a
-script needs structured output.
+Neither command requires confirmation. Use `--no-wait` only when intentionally
+detaching, and `--output json` when a script needs structured output. Shutdown
+can prove that KatlOS management is offline; without an out-of-band power API,
+it cannot independently prove the machine's final hardware power state.
 
 Use SSH for an interactive shell and arbitrary system administration. The
 KatlOS management API intentionally exposes bounded lifecycle operations rather

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -34,6 +34,7 @@ const (
 
 	RequestKind                   = "SubmitOperationRequest"
 	RebootRequestKind             = "RebootRequest"
+	ShutdownRequestKind           = "ShutdownRequest"
 	WorkerJoinMaterialRequestKind = "CreateWorkerJoinMaterialRequest"
 
 	DefaultListen = "tcp://0.0.0.0:9443"
@@ -71,6 +72,7 @@ type Server struct {
 	Dispatcher              Dispatcher
 	RunJoinMaterial         ToolRunner
 	RunReboot               ToolRunner
+	RunShutdown             ToolRunner
 	Now                     func() time.Time
 	OperationID             func(string, time.Time) (string, error)
 	submitMu                sync.Mutex
@@ -87,6 +89,7 @@ func NewServer(root string, store operation.Store) *Server {
 		SupportedOperationKinds: append([]string(nil), bootstrapOperationKinds...),
 		RunJoinMaterial:         runChildProcess,
 		RunReboot:               runChildProcess,
+		RunShutdown:             runChildProcess,
 		Now:                     func() time.Time { return time.Now().UTC() },
 		OperationID:             defaultOperationID,
 	}
@@ -145,6 +148,43 @@ func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agen
 		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(toolFailure(result)))
 	}
 	return &agentapi.RebootAccepted{Scheduled: true, TargetGenerationId: target}, nil
+}
+
+func (s *Server) Shutdown(ctx context.Context, req *agentapi.ShutdownRequest) (*agentapi.ShutdownAccepted, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if req.ApiVersion != APIVersion {
+		return nil, status.Errorf(codes.InvalidArgument, "apiVersion must be %q", APIVersion)
+	}
+	if req.Kind != ShutdownRequestKind {
+		return nil, status.Errorf(codes.InvalidArgument, "kind must be %q", ShutdownRequestKind)
+	}
+	if strings.TrimSpace(req.Actor) == "" {
+		return nil, status.Error(codes.InvalidArgument, "actor is required")
+	}
+	machineID, err := s.machineID()
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
+	}
+	if strings.TrimSpace(req.ExpectedMachineId) == "" || req.ExpectedMachineId != machineID {
+		return nil, status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
+	}
+	active, err := s.activeOperationIDs()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "read operation locks: %v", err)
+	}
+	if len(active) > 0 {
+		return nil, status.Error(codes.FailedPrecondition, "cannot shut down while another operation is active")
+	}
+	if s.RunShutdown == nil {
+		return nil, status.Error(codes.FailedPrecondition, "node shutdown runner is not configured")
+	}
+	result := s.RunShutdown(ctx, []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return nil, status.Errorf(codes.Internal, "schedule shutdown: %s", inventory.Redact(toolFailure(result)))
+	}
+	return &agentapi.ShutdownAccepted{Scheduled: true}, nil
 }
 
 func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusRequest) (*agentapi.NodeStatus, error) {

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -122,6 +122,33 @@ func TestRebootSchedulesCommittedSelectedGeneration(t *testing.T) {
 	}
 }
 
+func TestShutdownSchedulesPoweroff(t *testing.T) {
+	server := newTestServer(t)
+	var argv []string
+	server.RunShutdown = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		argv = append([]string(nil), got...)
+		return ToolResult{ExitStatus: 0}
+	}
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := server.Shutdown(context.Background(), &agentapi.ShutdownRequest{
+		ApiVersion: generation.APIVersion, Kind: ShutdownRequestKind, Actor: "test",
+		ExpectedMachineId: machineID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accepted.Scheduled {
+		t.Fatalf("accepted = %#v", accepted)
+	}
+	want := []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("shutdown argv = %#v, want %#v", argv, want)
+	}
+}
+
 func TestNodeStatusReportsSelectedBootTarget(t *testing.T) {
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
@@ -159,6 +186,23 @@ func TestRebootRefusesActiveOperationWithoutExposingID(t *testing.T) {
 	})
 	if status.Code(err) != codes.FailedPrecondition || !strings.Contains(err.Error(), "another operation is active") || strings.Contains(err.Error(), "operation-secret") {
 		t.Fatalf("Reboot() error = %v", err)
+	}
+}
+
+func TestShutdownRefusesActiveOperationWithoutExposingID(t *testing.T) {
+	server := newTestServer(t)
+	createAgentOperation(t, server.Store, "operation-secret")
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.Shutdown(context.Background(), &agentapi.ShutdownRequest{
+		ApiVersion: generation.APIVersion, Kind: ShutdownRequestKind, Actor: "test",
+		ExpectedMachineId: machineID,
+	})
+	if status.Code(err) != codes.FailedPrecondition || !strings.Contains(err.Error(), "another operation is active") || strings.Contains(err.Error(), "operation-secret") {
+		t.Fatalf("Shutdown() error = %v", err)
 	}
 }
 

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -3193,6 +3193,118 @@ func (x *RebootAccepted) GetTargetGenerationId() string {
 	return ""
 }
 
+type ShutdownRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion        string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind              string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor             string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ShutdownRequest) Reset() {
+	*x = ShutdownRequest{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownRequest) ProtoMessage() {}
+
+func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
+func (*ShutdownRequest) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ShutdownRequest) GetApiVersion() string {
+	if x != nil {
+		return x.ApiVersion
+	}
+	return ""
+}
+
+func (x *ShutdownRequest) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *ShutdownRequest) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *ShutdownRequest) GetExpectedMachineId() string {
+	if x != nil {
+		return x.ExpectedMachineId
+	}
+	return ""
+}
+
+type ShutdownAccepted struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Scheduled     bool                   `protobuf:"varint,1,opt,name=scheduled,proto3" json:"scheduled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownAccepted) Reset() {
+	*x = ShutdownAccepted{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownAccepted) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownAccepted) ProtoMessage() {}
+
+func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShutdownAccepted.ProtoReflect.Descriptor instead.
+func (*ShutdownAccepted) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ShutdownAccepted) GetScheduled() bool {
+	if x != nil {
+		return x.Scheduled
+	}
+	return false
+}
+
 var File_internal_katlc_agentapi_agent_proto protoreflect.FileDescriptor
 
 const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
@@ -3531,11 +3643,20 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x14target_generation_id\x18\x05 \x01(\tR\x12targetGenerationId\"`\n" +
 	"\x0eRebootAccepted\x12\x1c\n" +
 	"\tscheduled\x18\x01 \x01(\bR\tscheduled\x120\n" +
-	"\x14target_generation_id\x18\x02 \x01(\tR\x12targetGenerationId2\xd3\b\n" +
+	"\x14target_generation_id\x18\x02 \x01(\tR\x12targetGenerationId\"\x8c\x01\n" +
+	"\x0fShutdownRequest\x12\x1f\n" +
+	"\vapi_version\x18\x01 \x01(\tR\n" +
+	"apiVersion\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x14\n" +
+	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
+	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\"0\n" +
+	"\x10ShutdownAccepted\x12\x1c\n" +
+	"\tscheduled\x18\x01 \x01(\bR\tscheduled2\xa0\t\n" +
 	"\n" +
 	"KatlcAgent\x12O\n" +
 	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12E\n" +
-	"\x06Reboot\x12\x1c.katl.agent.v1.RebootRequest\x1a\x1d.katl.agent.v1.RebootAccepted\x12]\n" +
+	"\x06Reboot\x12\x1c.katl.agent.v1.RebootRequest\x1a\x1d.katl.agent.v1.RebootAccepted\x12K\n" +
+	"\bShutdown\x12\x1e.katl.agent.v1.ShutdownRequest\x1a\x1f.katl.agent.v1.ShutdownAccepted\x12]\n" +
 	"\x0eValidateConfig\x12$.katl.agent.v1.ValidateConfigRequest\x1a%.katl.agent.v1.ConfigValidationResult\x12Z\n" +
 	"\x0fApplyGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
 	"\x0fStageGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
@@ -3559,7 +3680,7 @@ func file_internal_katlc_agentapi_agent_proto_rawDescGZIP() []byte {
 	return file_internal_katlc_agentapi_agent_proto_rawDescData
 }
 
-var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*GetNodeStatusRequest)(nil),                      // 0: katl.agent.v1.GetNodeStatusRequest
 	(*NodeStatus)(nil),                                // 1: katl.agent.v1.NodeStatus
@@ -3594,6 +3715,8 @@ var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*ConfigApplyStatus)(nil),                         // 30: katl.agent.v1.ConfigApplyStatus
 	(*RebootRequest)(nil),                             // 31: katl.agent.v1.RebootRequest
 	(*RebootAccepted)(nil),                            // 32: katl.agent.v1.RebootAccepted
+	(*ShutdownRequest)(nil),                           // 33: katl.agent.v1.ShutdownRequest
+	(*ShutdownAccepted)(nil),                          // 34: katl.agent.v1.ShutdownAccepted
 }
 var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	3,  // 0: katl.agent.v1.SubmitOperationRequest.bootstrap:type_name -> katl.agent.v1.BootstrapOperationRequest
@@ -3616,30 +3739,32 @@ var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	30, // 17: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
 	0,  // 18: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
 	31, // 19: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
-	5,  // 20: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
-	7,  // 21: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	7,  // 22: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	2,  // 23: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
-	13, // 24: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
-	16, // 25: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
-	17, // 26: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
-	22, // 27: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
-	24, // 28: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
-	26, // 29: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
-	1,  // 30: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
-	32, // 31: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
-	6,  // 32: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
-	15, // 33: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
-	15, // 34: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
-	15, // 35: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
-	14, // 36: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
-	19, // 37: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
-	18, // 38: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
-	23, // 39: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
-	25, // 40: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
-	27, // 41: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
-	30, // [30:42] is the sub-list for method output_type
-	18, // [18:30] is the sub-list for method input_type
+	33, // 20: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
+	5,  // 21: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
+	7,  // 22: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	7,  // 23: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	2,  // 24: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
+	13, // 25: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
+	16, // 26: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
+	17, // 27: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
+	22, // 28: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
+	24, // 29: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
+	26, // 30: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
+	1,  // 31: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
+	32, // 32: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
+	34, // 33: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
+	6,  // 34: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
+	15, // 35: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
+	15, // 36: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
+	15, // 37: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
+	14, // 38: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
+	19, // 39: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
+	18, // 40: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
+	23, // 41: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
+	25, // 42: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
+	27, // 43: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
+	31, // [31:44] is the sub-list for method output_type
+	18, // [18:31] is the sub-list for method input_type
 	18, // [18:18] is the sub-list for extension type_name
 	18, // [18:18] is the sub-list for extension extendee
 	0,  // [0:18] is the sub-list for field type_name
@@ -3656,7 +3781,7 @@ func file_internal_katlc_agentapi_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_katlc_agentapi_agent_proto_rawDesc), len(file_internal_katlc_agentapi_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/katl-dev/katl/internal/katlc/agentapi;agentapi";
 service KatlcAgent {
   rpc GetNodeStatus(GetNodeStatusRequest) returns (NodeStatus);
   rpc Reboot(RebootRequest) returns (RebootAccepted);
+  rpc Shutdown(ShutdownRequest) returns (ShutdownAccepted);
   rpc ValidateConfig(ValidateConfigRequest) returns (ConfigValidationResult);
   rpc ApplyGeneration(GenerationApplyRequest) returns (OperationAccepted);
   rpc StageGeneration(GenerationApplyRequest) returns (OperationAccepted);
@@ -363,4 +364,15 @@ message RebootRequest {
 message RebootAccepted {
   bool scheduled = 1;
   string target_generation_id = 2;
+}
+
+message ShutdownRequest {
+  string api_version = 1;
+  string kind = 2;
+  string actor = 3;
+  string expected_machine_id = 4;
+}
+
+message ShutdownAccepted {
+  bool scheduled = 1;
 }

--- a/internal/katlc/agentapi/agent_grpc.pb.go
+++ b/internal/katlc/agentapi/agent_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	KatlcAgent_GetNodeStatus_FullMethodName            = "/katl.agent.v1.KatlcAgent/GetNodeStatus"
 	KatlcAgent_Reboot_FullMethodName                   = "/katl.agent.v1.KatlcAgent/Reboot"
+	KatlcAgent_Shutdown_FullMethodName                 = "/katl.agent.v1.KatlcAgent/Shutdown"
 	KatlcAgent_ValidateConfig_FullMethodName           = "/katl.agent.v1.KatlcAgent/ValidateConfig"
 	KatlcAgent_ApplyGeneration_FullMethodName          = "/katl.agent.v1.KatlcAgent/ApplyGeneration"
 	KatlcAgent_StageGeneration_FullMethodName          = "/katl.agent.v1.KatlcAgent/StageGeneration"
@@ -39,6 +40,7 @@ const (
 type KatlcAgentClient interface {
 	GetNodeStatus(ctx context.Context, in *GetNodeStatusRequest, opts ...grpc.CallOption) (*NodeStatus, error)
 	Reboot(ctx context.Context, in *RebootRequest, opts ...grpc.CallOption) (*RebootAccepted, error)
+	Shutdown(ctx context.Context, in *ShutdownRequest, opts ...grpc.CallOption) (*ShutdownAccepted, error)
 	ValidateConfig(ctx context.Context, in *ValidateConfigRequest, opts ...grpc.CallOption) (*ConfigValidationResult, error)
 	ApplyGeneration(ctx context.Context, in *GenerationApplyRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
 	StageGeneration(ctx context.Context, in *GenerationApplyRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
@@ -73,6 +75,16 @@ func (c *katlcAgentClient) Reboot(ctx context.Context, in *RebootRequest, opts .
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RebootAccepted)
 	err := c.cc.Invoke(ctx, KatlcAgent_Reboot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *katlcAgentClient) Shutdown(ctx context.Context, in *ShutdownRequest, opts ...grpc.CallOption) (*ShutdownAccepted, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ShutdownAccepted)
+	err := c.cc.Invoke(ctx, KatlcAgent_Shutdown_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +206,7 @@ func (c *katlcAgentClient) GetGeneration(ctx context.Context, in *GetGenerationR
 type KatlcAgentServer interface {
 	GetNodeStatus(context.Context, *GetNodeStatusRequest) (*NodeStatus, error)
 	Reboot(context.Context, *RebootRequest) (*RebootAccepted, error)
+	Shutdown(context.Context, *ShutdownRequest) (*ShutdownAccepted, error)
 	ValidateConfig(context.Context, *ValidateConfigRequest) (*ConfigValidationResult, error)
 	ApplyGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error)
 	StageGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error)
@@ -219,6 +232,9 @@ func (UnimplementedKatlcAgentServer) GetNodeStatus(context.Context, *GetNodeStat
 }
 func (UnimplementedKatlcAgentServer) Reboot(context.Context, *RebootRequest) (*RebootAccepted, error) {
 	return nil, status.Error(codes.Unimplemented, "method Reboot not implemented")
+}
+func (UnimplementedKatlcAgentServer) Shutdown(context.Context, *ShutdownRequest) (*ShutdownAccepted, error) {
+	return nil, status.Error(codes.Unimplemented, "method Shutdown not implemented")
 }
 func (UnimplementedKatlcAgentServer) ValidateConfig(context.Context, *ValidateConfigRequest) (*ConfigValidationResult, error) {
 	return nil, status.Error(codes.Unimplemented, "method ValidateConfig not implemented")
@@ -303,6 +319,24 @@ func _KatlcAgent_Reboot_Handler(srv interface{}, ctx context.Context, dec func(i
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(KatlcAgentServer).Reboot(ctx, req.(*RebootRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _KatlcAgent_Shutdown_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ShutdownRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KatlcAgentServer).Shutdown(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KatlcAgent_Shutdown_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KatlcAgentServer).Shutdown(ctx, req.(*ShutdownRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -494,6 +528,10 @@ var KatlcAgent_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Reboot",
 			Handler:    _KatlcAgent_Reboot_Handler,
+		},
+		{
+			MethodName: "Shutdown",
+			Handler:    _KatlcAgent_Shutdown_Handler,
 		},
 		{
 			MethodName: "ValidateConfig",

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -335,7 +335,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 		t.Fatalf("booted networkd katlctl generation status = %+v, want next-boot config apply", bootedGenerationStatus.GetConfigApply())
 	}
 	assertBootstrappedKubernetesSysextChangeRejected(t, ctx, guest, endpoint)
-	powerOffGuestForCleanSuccess(t, ctx, node, guest, client)
+	shutdownGuestThroughKatlctl(t, ctx, result, katlctl, endpoint, node, client)
 	return guest, nil
 }
 
@@ -496,6 +496,24 @@ func powerOffGuestForCleanSuccess(t *testing.T, ctx context.Context, node *Runni
 	}
 	if err := waitGuestPoweredOff(node.handle, 45*time.Second); err != nil {
 		t.Fatalf("wait for guest poweroff after config apply smoke success: %v", err)
+	}
+}
+
+func shutdownGuestThroughKatlctl(t *testing.T, ctx context.Context, result Result, katlctl, endpoint string, node *RunningInstalledRuntimeNode, client *AgentClient) {
+	t.Helper()
+	if node == nil || node.handle == nil {
+		t.Fatal("running installed runtime node handle is required")
+	}
+	runKatlctl(t, ctx, result, katlctl, "host-shutdown",
+		"node", "shutdown", "cp-1",
+		"--endpoint", endpoint,
+		"--timeout", "2m",
+	)
+	if client != nil {
+		_ = client.Close()
+	}
+	if err := waitGuestPoweredOff(node.handle, 45*time.Second); err != nil {
+		t.Fatalf("wait for guest shutdown after config apply smoke success: %v", err)
 	}
 }
 


### PR DESCRIPTION
Adds `katlctl node shutdown` with the same ClusterConfig-first targeting as other node management commands. The typed agent endpoint refuses active mutations, schedules a systemd poweroff, and waits for the management API to go offline by default.

The installed-runtime VM journey now shuts down through the public command, covering the packaged CLI and agent path.
