### PR TITLE
release: define the beta evaluation boundary

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: CalVer embedded in artifacts (for example 2026.7.0-alpha.1)
+        description: CalVer embedded in artifacts (for example 2026.7.0-beta.1)
         required: true
         type: string
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ uses standard Linux interfaces—systemd-boot, UKIs, `systemd-sysext`,
 them behind a new cluster API.
 
 > [!WARNING]
-> KatlOS is experimental alpha software. Do not use it for production,
-> security-sensitive, regulated, or availability-critical clusters. Alpha
-> formats and workflows may change incompatibly and reinstall may be required.
+> KatlOS is experimental beta software for home-lab evaluation. Do not use it
+> for production, security-sensitive, regulated, or availability-critical
+> clusters. Beta formats and workflows may change incompatibly and reinstall
+> may be required.
 > Read the [support boundary](docs/support.md) before evaluating a release.
 
 ## What Katl provides
@@ -84,7 +85,7 @@ trusted-home-network path; see [Verify release artifacts](docs/operations/verify
 Install the matching operator CLI and confirm its embedded identity:
 
 ```sh
-VERSION=2026.7.0-alpha.2
+VERSION=2026.7.0-beta.1
 install -m 0755 "katlctl-$VERSION-linux-amd64" ~/.local/bin/katlctl
 katlctl version
 ```
@@ -252,7 +253,7 @@ Host upgrades take a release version and select the node from `ClusterConfig`.
 for the new generation to pass boot health:
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 cp-1 --config ./cluster.yaml
+katlctl node upgrade v2026.7.0-beta.1 cp-1 --config ./cluster.yaml
 ```
 
 Add `--plan` to check the upgrade without changing or rebooting the node. The

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,6 +1,6 @@
 # Installing KatlOS
 
-Status: early user-facing guide. KatlOS is experimental alpha software; read
+Status: early user-facing guide. KatlOS is experimental beta software; read
 the [support boundary](support.md) before installing it.
 
 This document is the installation reference for ISO and PXE paths. After
@@ -50,7 +50,7 @@ Install it under the stable command name and confirm that its embedded release
 identity matches the KatlOS release:
 
 ```sh
-VERSION=2026.7.0-alpha.2
+VERSION=2026.7.0-beta.1
 install -m 0755 "katlctl-$VERSION-linux-amd64" ~/.local/bin/katlctl
 katlctl version
 ```
@@ -117,7 +117,7 @@ Then authenticate each asset against the keyless GitHub attestation issued to
 the Katl release workflow. Pin the expected tag in the verification policy:
 
 ```sh
-TAG=v2026.7.0-alpha.2
+TAG=v2026.7.0-beta.1
 gh attestation verify katl-installer.iso \
   --repo katl-dev/katl \
   --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \

--- a/docs/internal/alpha-release-readiness.md
+++ b/docs/internal/alpha-release-readiness.md
@@ -1,10 +1,16 @@
 # KatlOS Alpha Release Readiness
 
-Status: active release checklist for the first public alpha.
+Status: historical alpha checklist, superseded by the `2026.7.0-beta.1`
+home-lab evaluation boundary after `2026.7.0-alpha.17`.
 
 ## Release Decision
 
-The next non-development release should be `2026.7.0-alpha.1`, not a beta.
+The next release is `2026.7.0-beta.1`. In this project, beta means the normal
+home-lab install, bootstrap, upgrade, and management journeys are coherent
+enough for broader evaluation. It does not mean production support, a stable
+API or persisted-state contract, authenticated management, or a general
+hardware compatibility promise. Those limits remain explicit in
+[`../support.md`](../support.md).
 
 The v0.1 implementation has proved the intended lifecycle: reusable release
 artifacts, installation to generation 0, multi-node Kubernetes bootstrap,
@@ -15,10 +21,9 @@ configuration must drive the documented journey, the release must carry honest
 maturity metadata, and the release-built path must be repeated with retained
 evidence.
 
-Beta would imply that users can depend on stable authoring and persisted-state
-contracts, routine upgrade and recovery policy, enforced artifact trust, and a
-continuously exercised capable-host matrix. Katl does not make those promises
-yet.
+Stable authoring and persisted-state contracts, production recovery policy,
+enforced artifact trust, and a continuously exercised capable-host matrix are
+post-beta maturity work. Katl does not make those promises yet.
 
 ## Intended Alpha User Journey
 
@@ -99,10 +104,10 @@ summary, the alpha may ship with these explicit boundaries:
 - readable Kubernetes bundle tags on the normal path, with immutable digest
   pins available as an optional reproducibility control.
 
-## Beta Blockers
+## Post-Beta Maturity Work
 
-The following work is deliberately not required to publish an alpha, but blocks
-a beta:
+The following work is not required for the home-lab beta boundary, but blocks a
+production-support or stable-contract claim:
 
 - stable source, runtime-change, config-bundle, operation, and persisted-state
   compatibility policy beyond `v1alpha1`;
@@ -119,10 +124,10 @@ a beta:
 - an explicit hardware support and compatibility matrix rather than
   evidence-only experimental coverage.
 
-## Ship Rule
+## Historical Alpha Ship Rule
 
-Publish `v2026.7.0-alpha.1` only when every alpha blocker above is closed or its
-external capability gap is named in the release notes, the public user-journey
-gate has passed against the exact release commit and artifacts, and the release
-is still marked as a GitHub prerelease. Do not rename incomplete alpha evidence
-as beta readiness.
+The first alpha required every alpha blocker above to be closed or its external
+capability gap named in the release notes, a public user-journey gate against
+the exact release commit and artifacts, and GitHub prerelease metadata. Beta
+releases remain GitHub prereleases and continue to ship the explicit support
+boundary with every release.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,6 +1,6 @@
 # KatlOS Operator Guide
 
-These runbooks describe the implemented KatlOS alpha operating surface. Start
+These runbooks describe the implemented KatlOS beta operating surface. Start
 with the task that matches the current node state; do not skip directly to a
 mutating command.
 
@@ -79,6 +79,6 @@ the planner so they produce an explicit lifecycle action instead of being
 silently ignored. Disk policy and Kubernetes version selection use their named
 install or upgrade workflows.
 
-There is no supported alpha workflow for automatic host fleet rollout, etcd
+There is no supported beta workflow for automatic host fleet rollout, etcd
 disaster recovery, failed control-plane replacement, agent-token rotation, or
 general cluster reconciliation.

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -5,7 +5,7 @@ configuration, node upgrade, or wipe operations.
 
 ## Security Boundary
 
-The alpha `katlc` agent listens on TCP port `9443` without authentication or
+The beta `katlc` agent listens on TCP port `9443` without authentication or
 transport encryption. This is deliberate for Katl's trusted home-lab network:
 routine management must not require credential enrollment. Do not expose it to
 the public Internet, an untrusted LAN, or a shared production network. Restrict
@@ -111,6 +111,6 @@ Use SSH for an interactive shell and arbitrary system administration. The
 KatlOS management API intentionally exposes bounded lifecycle operations rather
 than remote command execution.
 
-There is no node credential to rotate in the alpha management path. If the
+There is no node credential to rotate in the beta management path. If the
 trusted management network is exposed, isolate the node and restore the network
 boundary before resuming lifecycle operations.

--- a/docs/operations/bootstrap-kubernetes.md
+++ b/docs/operations/bootstrap-kubernetes.md
@@ -119,4 +119,4 @@ operation: if kubeadm or API mutation began, host generation rollback does not
 erase it. Preserve the command result and follow [Troubleshoot
 KatlOS](troubleshoot.md). Kubernetes upgrades use the separate
 [Upgrade Kubernetes](upgrade-kubernetes.md) workflow. Additional-control-plane
-repair and general reconciliation remain unsupported alpha operations.
+repair and general reconciliation remain unsupported beta operations.

--- a/docs/operations/troubleshoot.md
+++ b/docs/operations/troubleshoot.md
@@ -96,7 +96,7 @@ systemctl status katlc-agent.service --no-pager
 ss -lntp | grep ':9443'
 ```
 
-The alpha agent transport is unauthenticated and unencrypted; do not solve
+The beta agent transport is unauthenticated and unencrypted; do not solve
 reachability by exposing port `9443` to an untrusted network.
 
 ## Reporting

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -20,7 +20,7 @@ orchestrate availability across several hosts.
 ## Plan
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 cp-1 --config ./cluster.yaml --plan
+katlctl node upgrade v2026.7.0-beta.1 cp-1 --config ./cluster.yaml --plan
 ```
 
 A plan response has no durable mutation and does not reboot the node.
@@ -34,7 +34,7 @@ component metadata before changing the inactive slot.
 Run the command without `--plan`:
 
 ```sh
-katlctl node upgrade v2026.7.0-alpha.9 cp-1 --config ./cluster.yaml
+katlctl node upgrade v2026.7.0-beta.1 cp-1 --config ./cluster.yaml
 ```
 
 For repeated day-two commands, `katlctl context save --config ./cluster.yaml`

--- a/docs/operations/verify-release.md
+++ b/docs/operations/verify-release.md
@@ -9,7 +9,7 @@ release; never mix files from different tags.
 
 ## Inputs
 
-- exact KatlOS tag, such as `v2026.7.0-alpha.2`;
+- exact KatlOS tag, such as `v2026.7.0-beta.1`;
 - assets required for the chosen operation;
 - `SHA256SUMS`; and
 - `PROVENANCE.md`.
@@ -53,7 +53,7 @@ Authenticate each executable or image asset against the exact tag and Katl
 release workflow:
 
 ```sh
-TAG=v2026.7.0-alpha.2
+TAG=v2026.7.0-beta.1
 gh attestation verify katl-installer.iso \
   --repo katl-dev/katl \
   --signer-workflow katl-dev/katl/.github/workflows/release-artifacts.yml \
@@ -69,7 +69,7 @@ attestation verification passed.
 Install the matching CLI under its stable name and inspect its identity:
 
 ```sh
-VERSION=2026.7.0-alpha.2
+VERSION=2026.7.0-beta.1
 install -m 0755 "katlctl-$VERSION-linux-amd64" ~/.local/bin/katlctl
 katlctl version
 ```

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,13 +1,13 @@
 # KatlOS Support Boundary
 
-KatlOS is experimental alpha software for evaluation and development. It is not
-supported for production clusters, security-sensitive workloads, compliance
-environments, or systems whose availability depends on KatlOS. There is no
-support SLA, security-response SLA, or compatibility guarantee.
+KatlOS is experimental beta software for home-lab evaluation and development.
+It is not supported for production clusters, security-sensitive workloads,
+compliance environments, or systems whose availability depends on KatlOS.
+There is no support SLA, security-response SLA, or compatibility guarantee.
 
 ## Supported Evaluation Surface
 
-The first alpha release surface is deliberately narrow:
+The beta release surface is deliberately narrow:
 
 - x86-64 machines booted with UEFI;
 - the self-contained installer ISO, or the matching loose UEFI/PXE artifacts;
@@ -60,8 +60,8 @@ This proves which repository workflow produced the bytes. It does not provide:
 ## Compatibility Promise
 
 All `v1alpha1` source, bundle, operation, API, and persisted-state formats are
-experimental. They may change incompatibly between alpha releases. Katl does
-not promise forward or backward compatibility with another alpha, automatic
+experimental. They may change incompatibly between beta releases. Katl does
+not promise forward or backward compatibility with another beta, automatic
 state migration, or an upgrade path from every development build. Preserve the
 source `ClusterConfig`, exact release assets, checksums, OCI digests, and
 recovery data. Reinstall may be required after an incompatible change.
@@ -88,7 +88,7 @@ rollback as a cluster backup.
 
 ## Explicitly Unsupported
 
-Do not use the alpha as the basis for:
+Do not use the beta as the basis for:
 
 - production, regulated, multi-tenant, or security-critical clusters;
 - an availability or disaster-recovery commitment;

--- a/internal/scriptstest/katl_release_artifacts_test.go
+++ b/internal/scriptstest/katl_release_artifacts_test.go
@@ -96,6 +96,7 @@ func TestKatlReleaseArtifactNotesFollowReleaseHistory(t *testing.T) {
 	}
 	notes := string(output)
 	for _, value := range []string{
+		"experimental beta release for home-lab evaluation",
 		"publish first beta",
 		"v2026.7.0-alpha.1...v2026.7.0-beta.1",
 	} {

--- a/scripts/katl-release-artifacts
+++ b/scripts/katl-release-artifacts
@@ -65,6 +65,8 @@ generate_release_notes() {
     printf '## Support boundary\n\n'
     if [[ "$version" == *-alpha.* ]]; then
         printf 'This is an experimental alpha release, not a production-supported release. '
+    elif [[ "$version" == *-beta.* ]]; then
+        printf 'This is an experimental beta release for home-lab evaluation, not a production-supported release. '
     fi
     printf 'Read SUPPORT.md before installation for the tested surface, trust and compatibility limits, recovery scope, and required issue evidence.\n\n'
 


### PR DESCRIPTION
Promotes the release train from alpha to beta for broader home-lab evaluation. Keeps the non-production, unstable-format, unauthenticated-management, and hardware-support boundaries explicit, and adds the same warning to generated beta release notes.