### PR TITLE
endpoint: fail closed around VIP lifecycle

### DIFF
--- a/cmd/katl-endpoint-advertiser/main.go
+++ b/cmd/katl-endpoint-advertiser/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -86,6 +87,9 @@ func run(args []string, stderr io.Writer) error {
 			}
 			lastState = state
 		}
+		if runErr != nil {
+			return failClosed(runErr, client, bgpapivip.ExecRunner{})
+		}
 		select {
 		case <-ctx.Done():
 			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -95,6 +99,13 @@ func run(args []string, stderr io.Writer) error {
 		case <-ticker.C:
 		}
 	}
+}
+
+func failClosed(runErr error, client bgpapivip.BirdClient, runner bgpapivip.CommandRunner) error {
+	if runErr == nil {
+		return nil
+	}
+	return errors.Join(runErr, withdrawWith(context.Background(), client, runner))
 }
 
 func withdraw(parent context.Context) error {

--- a/cmd/katl-endpoint-advertiser/main_test.go
+++ b/cmd/katl-endpoint-advertiser/main_test.go
@@ -45,6 +45,23 @@ func TestWithdrawFailsWhenNeitherRouteNorDaemonCanBeStopped(t *testing.T) {
 	}
 }
 
+func TestControllerErrorFailsClosedBeforeSystemdRestart(t *testing.T) {
+	bird := &fakeBirdClient{}
+	runner := &fakeCommandRunner{}
+	runErr := errors.New("routing status unavailable")
+
+	err := failClosed(runErr, bird, runner)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("failClosed() error = %v", err)
+	}
+	if !reflect.DeepEqual(bird.advertisements, []bool{false}) {
+		t.Fatalf("advertisements = %#v", bird.advertisements)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("fallback calls = %#v", runner.calls)
+	}
+}
+
 type fakeBirdClient struct {
 	setErr         error
 	advertisements []bool

--- a/docs/internal/bgp-api-vip-extension-contract.md
+++ b/docs/internal/bgp-api-vip-extension-contract.md
@@ -224,6 +224,9 @@ Generated confext owns:
 /etc/katl/apps/bgp-api-vip/config.yaml
   normalized app input and validation digest
 
+/etc/katl/apps/bgp-api-vip/advertisement-enabled
+  generated activation marker, present only when advertisement.enabled is true
+
 /etc/katl/apps/bird/bird.conf
   deterministic BIRD config generated from this bounded app schema
 
@@ -352,7 +355,8 @@ Advertisement is explicit and fail-closed:
 
 ```text
 advertisement.enabled
-  false keeps the route withdrawn even when BIRD and health are otherwise ready
+  false keeps the route withdrawn and prevents BIRD and the endpoint controller
+  from starting
 
 advertisement.startWithdrawn
   must be true

--- a/internal/installer/bgpapivip/bgpapivip.go
+++ b/internal/installer/bgpapivip/bgpapivip.go
@@ -22,16 +22,17 @@ const (
 	AppID        = "bgp-api-vip"
 	BirdConfigID = "bird"
 
-	ConfigPath        = "/etc/katl/apps/bgp-api-vip/config.yaml"
-	BirdConfigPath    = "/etc/katl/apps/bird/bird.conf"
-	LiveStatusPath    = "/run/katl/apps/bgp-api-vip/status.json"
-	OperationStatus   = "/var/lib/katl/operations/<operation-id>/apps/bgp-api-vip/status.json"
-	AppDropInPath     = "/etc/systemd/system/katl-app-bgp-api-vip.service.d/10-katl-config.conf"
-	BirdDropInPath    = "/etc/systemd/system/katl-app-bird.service.d/20-katl-bgp-api-vip.conf"
-	KubeletDropInPath = "/etc/systemd/system/kubelet.service.d/20-katl-control-plane-endpoint.conf"
-	NetworkPath       = "/etc/systemd/network/05-katl-bgp-api-vip.network"
-	DummyNetDevPath   = "/etc/systemd/network/05-katl-bgp-api-vip.netdev"
-	defaultHealthPath = "/readyz"
+	ConfigPath               = "/etc/katl/apps/bgp-api-vip/config.yaml"
+	AdvertisementEnabledPath = "/etc/katl/apps/bgp-api-vip/advertisement-enabled"
+	BirdConfigPath           = "/etc/katl/apps/bird/bird.conf"
+	LiveStatusPath           = "/run/katl/apps/bgp-api-vip/status.json"
+	OperationStatus          = "/var/lib/katl/operations/<operation-id>/apps/bgp-api-vip/status.json"
+	AppDropInPath            = "/etc/systemd/system/katl-app-bgp-api-vip.service.d/10-katl-config.conf"
+	BirdDropInPath           = "/etc/systemd/system/katl-app-bird.service.d/20-katl-bgp-api-vip.conf"
+	KubeletDropInPath        = "/etc/systemd/system/kubelet.service.d/20-katl-control-plane-endpoint.conf"
+	NetworkPath              = "/etc/systemd/network/05-katl-bgp-api-vip.network"
+	DummyNetDevPath          = "/etc/systemd/network/05-katl-bgp-api-vip.netdev"
+	defaultHealthPath        = "/readyz"
 )
 
 var (
@@ -361,6 +362,13 @@ func RenderNativeEtcFiles(request RenderRequest) (Plan, error) {
 			Content: renderKubeletDropIn(),
 			Mode:    0o644,
 		},
+	}
+	if *config.Advertisement.Enabled {
+		files = append(files, confext.NativeEtcFile{
+			Path:    AdvertisementEnabledPath,
+			Content: "enabled\n",
+			Mode:    0o644,
+		})
 	}
 	if config.VIPInterface.Kind == "dummy" {
 		files = append(files, confext.NativeEtcFile{

--- a/internal/installer/bgpapivip/bgpapivip_test.go
+++ b/internal/installer/bgpapivip/bgpapivip_test.go
@@ -116,6 +116,7 @@ func TestRenderNativeEtcFilesMinimalIPv4DummyVIP(t *testing.T) {
 		t.Fatalf("RenderNativeEtcFiles() error = %v", err)
 	}
 	assertFile(t, plan.Files, ConfigPath, "kind: BGPAPIEndpoint\n")
+	assertFile(t, plan.Files, AdvertisementEnabledPath, "enabled\n")
 	assertFile(t, plan.Files, DummyNetDevPath, "Name=katl-api0\nKind=dummy\n")
 	assertFile(t, plan.Files, NetworkPath, "Address=10.40.0.10/32\n")
 	if filepath.Base(NetworkPath) >= "10-lan.network" {
@@ -133,6 +134,23 @@ func TestRenderNativeEtcFilesMinimalIPv4DummyVIP(t *testing.T) {
 	if plan.Config.Health.Path != "/readyz" || plan.Config.Health.TLSServerName != "api.home.example" {
 		t.Fatalf("normalized health = %#v", plan.Config.Health)
 	}
+}
+
+func TestRenderDoesNotActivateRoutingWhenAdvertisementIsDisabled(t *testing.T) {
+	config := minimalConfig()
+	disabled := false
+	config.Advertisement.Enabled = &disabled
+
+	plan, err := RenderNativeEtcFiles(RenderRequest{
+		NodeRole: "control-plane",
+		Config:   config,
+	})
+	if err != nil {
+		t.Fatalf("RenderNativeEtcFiles() error = %v", err)
+	}
+
+	assertFile(t, plan.Files, ConfigPath, "enabled: false\n")
+	assertNoFile(t, plan.Files, AdvertisementEnabledPath)
 }
 
 func TestRenderMatchesMinimalIPv4Golden(t *testing.T) {

--- a/internal/installer/bgpapivip/testdata/minimal-ipv4-dummy.golden
+++ b/internal/installer/bgpapivip/testdata/minimal-ipv4-dummy.golden
@@ -1,3 +1,5 @@
+--- /etc/katl/apps/bgp-api-vip/advertisement-enabled
+enabled
 --- /etc/katl/apps/bgp-api-vip/config.yaml
 apiVersion: apps.katl.dev/v1alpha1
 kind: BGPAPIEndpoint

--- a/internal/katlc/agent/endpoint_lifecycle.go
+++ b/internal/katlc/agent/endpoint_lifecycle.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
+)
+
+const (
+	endpointAdvertiserUnit    = "katl-app-bgp-api-vip.service"
+	endpointAdvertiserCommand = "/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser"
+)
+
+func pauseManagedEndpoint(ctx context.Context, root string, run ToolRunner) (bool, error) {
+	configured, err := managedEndpointConfigured(root)
+	if err != nil || !configured {
+		return false, err
+	}
+	if run == nil {
+		return false, fmt.Errorf("endpoint lifecycle runner is not configured")
+	}
+	result := run(ctx, []string{"systemctl", "stop", endpointAdvertiserUnit}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return false, fmt.Errorf("stop managed control-plane endpoint: %s", toolFailure(result))
+	}
+	result = run(ctx, []string{endpointAdvertiserCommand, "withdraw"}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return false, fmt.Errorf("confirm managed control-plane endpoint withdrawal: %s", toolFailure(result))
+	}
+	return true, nil
+}
+
+func resumeManagedEndpoint(ctx context.Context, root string, run ToolRunner) error {
+	configured, err := managedEndpointConfigured(root)
+	if err != nil || !configured {
+		return err
+	}
+	if run == nil {
+		return fmt.Errorf("endpoint lifecycle runner is not configured")
+	}
+	result := run(ctx, []string{"systemctl", "start", endpointAdvertiserUnit}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return fmt.Errorf("resume managed control-plane endpoint: %s", toolFailure(result))
+	}
+	return nil
+}
+
+func managedEndpointConfigured(root string) (bool, error) {
+	_, err := os.Stat(rootedRuntimePath(root, bgpapivip.AdvertisementEnabledPath))
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+	default:
+		return false, fmt.Errorf("inspect managed control-plane endpoint: %w", err)
+	}
+}

--- a/internal/katlc/agent/endpoint_lifecycle_test.go
+++ b/internal/katlc/agent/endpoint_lifecycle_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
+)
+
+func TestManagedEndpointLifecycleFollowsGeneratedEnablement(t *testing.T) {
+	root := t.TempDir()
+	var calls [][]string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		calls = append(calls, append([]string(nil), argv...))
+		return ToolResult{}
+	}
+
+	paused, err := pauseManagedEndpoint(context.Background(), root, run)
+	if err != nil || paused {
+		t.Fatalf("pause without managed endpoint = %v, %v", paused, err)
+	}
+	if err := resumeManagedEndpoint(context.Background(), root, run); err != nil {
+		t.Fatalf("resume without managed endpoint: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("commands without managed endpoint = %#v", calls)
+	}
+
+	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	paused, err = pauseManagedEndpoint(context.Background(), root, run)
+	if err != nil || !paused {
+		t.Fatalf("pause managed endpoint = %v, %v", paused, err)
+	}
+	if err := resumeManagedEndpoint(context.Background(), root, run); err != nil {
+		t.Fatalf("resume managed endpoint: %v", err)
+	}
+	want := [][]string{
+		{"systemctl", "stop", endpointAdvertiserUnit},
+		{endpointAdvertiserCommand, "withdraw"},
+		{"systemctl", "start", endpointAdvertiserUnit},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("endpoint lifecycle commands = %#v, want %#v", calls, want)
+	}
+}
+
+func TestManagedEndpointPauseFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	run := func(_ context.Context, _ []string, _ func(int)) ToolResult {
+		return ToolResult{Err: errors.New("service failed"), ExitStatus: 1}
+	}
+
+	paused, err := pauseManagedEndpoint(context.Background(), root, run)
+	if err == nil || paused {
+		t.Fatalf("pauseManagedEndpoint() = %v, %v", paused, err)
+	}
+}

--- a/internal/katlc/agent/kubeadm_upgrade_executor.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor.go
@@ -124,15 +124,30 @@ func (e *Executor) executeKubeadmUpgrade(ctx context.Context, record operation.O
 		}); err != nil {
 			return err
 		}
-		retainToolView = true
+	}
+
+	endpointPaused := false
+	if request.UpgradeRole != "worker" {
+		endpointPaused, err = pauseManagedEndpoint(ctx, e.Root, e.toolRunner())
+		if err != nil {
+			return e.failKubeadmUpgrade(record, "endpoint-withdraw-running", err, false)
+		}
+		if endpointPaused {
+			defer func() {
+				if endpointPaused {
+					_ = resumeManagedEndpoint(context.Background(), e.Root, e.toolRunner())
+				}
+			}()
+		}
+	}
+
+	retainToolView = true
+	if request.UpgradeRole == "apply" {
 		if err := e.runKubeadmUpgradeCommand(ctx, record, "kubeadm-apply-running", []string{targetKubeadm, "upgrade", "apply", "--yes", request.TargetPayloadVersion}, true); err != nil {
 			return err
 		}
-	} else {
-		retainToolView = true
-		if err := e.runKubeadmUpgradeCommand(ctx, record, "kubeadm-node-running", []string{targetKubeadm, "upgrade", "node"}, true); err != nil {
-			return err
-		}
+	} else if err := e.runKubeadmUpgradeCommand(ctx, record, "kubeadm-node-running", []string{targetKubeadm, "upgrade", "node"}, true); err != nil {
+		return err
 	}
 
 	if _, err := e.Store.Update(record.OperationID, "stop-source-kubelet", "kubelet-stop-running", func(current operation.OperationRecord) (operation.OperationRecord, error) {
@@ -179,6 +194,12 @@ func (e *Executor) executeKubeadmUpgrade(ctx context.Context, record operation.O
 	}
 	if err := e.checkKubeadmUpgradeHealth(ctx, *request); err != nil {
 		return e.failKubeadmUpgrade(record, "health-check-running", err, true)
+	}
+	if endpointPaused {
+		if err := resumeManagedEndpoint(ctx, e.Root, e.toolRunner()); err != nil {
+			return e.failKubeadmUpgrade(record, "endpoint-resume-running", err, true)
+		}
+		endpointPaused = false
 	}
 	if err := e.completeKubeadmUpgrade(ctx, record); err != nil {
 		return err

--- a/internal/katlc/agent/kubeadm_upgrade_executor_test.go
+++ b/internal/katlc/agent/kubeadm_upgrade_executor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -18,6 +19,7 @@ import (
 
 func TestExecutorRunsApplyUpgradeWithPrivateKubeadmAndGate(t *testing.T) {
 	root, store, record, now := kubeadmUpgradeFixture(t, "apply")
+	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
 	var commands [][]string
 	executor := NewExecutor(root, store, "agent-test")
 	executor.Async = false
@@ -56,7 +58,16 @@ func TestExecutorRunsApplyUpgradeWithPrivateKubeadmAndGate(t *testing.T) {
 	if completed.KubeadmUpgradeEvidence.TargetKubeadmAccessMode != kubeadmAccessOperationPrivate || completed.KubeadmUpgradeEvidence.KubeletGateState != "target-observed" || completed.KubeadmUpgradeEvidence.GlobalTargetActiveBeforeKubeadm {
 		t.Fatalf("upgrade evidence = %+v", completed.KubeadmUpgradeEvidence)
 	}
-	assertCommandOrder(t, commands, "kubeadm upgrade plan v1.36.2", "kubeadm upgrade apply --yes v1.36.2", "systemctl stop kubelet.service", "systemd-sysext refresh", "systemctl restart kubelet.service")
+	assertCommandOrder(t, commands,
+		"kubeadm upgrade plan v1.36.2",
+		"systemctl stop "+endpointAdvertiserUnit,
+		endpointAdvertiserCommand+" withdraw",
+		"kubeadm upgrade apply --yes v1.36.2",
+		"systemctl stop kubelet.service",
+		"systemd-sysext refresh",
+		"systemctl restart kubelet.service",
+		"systemctl start "+endpointAdvertiserUnit,
+	)
 	spec, status, err := generation.ReadGeneration(root, "gen1")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -71,6 +71,7 @@ type Server struct {
 	SupportedOperationKinds []string
 	Dispatcher              Dispatcher
 	RunJoinMaterial         ToolRunner
+	RunEndpointLifecycle    ToolRunner
 	RunReboot               ToolRunner
 	RunShutdown             ToolRunner
 	Now                     func() time.Time
@@ -88,6 +89,7 @@ func NewServer(root string, store operation.Store) *Server {
 		StartedAt:               now,
 		SupportedOperationKinds: append([]string(nil), bootstrapOperationKinds...),
 		RunJoinMaterial:         runChildProcess,
+		RunEndpointLifecycle:    runChildProcess,
 		RunReboot:               runChildProcess,
 		RunShutdown:             runChildProcess,
 		Now:                     func() time.Time { return time.Now().UTC() },
@@ -143,9 +145,17 @@ func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agen
 	if s.RunReboot == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node reboot runner is not configured")
 	}
+	endpointPaused, err := pauseManagedEndpoint(ctx, s.Root, s.RunEndpointLifecycle)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "prepare control-plane endpoint for reboot: %s", inventory.Redact(err.Error()))
+	}
 	result := s.RunReboot(ctx, []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(toolFailure(result)))
+		var resumeErr error
+		if endpointPaused {
+			resumeErr = resumeManagedEndpoint(context.Background(), s.Root, s.RunEndpointLifecycle)
+		}
+		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(errors.Join(errors.New(toolFailure(result)), resumeErr).Error()))
 	}
 	return &agentapi.RebootAccepted{Scheduled: true, TargetGenerationId: target}, nil
 }
@@ -180,9 +190,17 @@ func (s *Server) Shutdown(ctx context.Context, req *agentapi.ShutdownRequest) (*
 	if s.RunShutdown == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node shutdown runner is not configured")
 	}
+	endpointPaused, err := pauseManagedEndpoint(ctx, s.Root, s.RunEndpointLifecycle)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "prepare control-plane endpoint for shutdown: %s", inventory.Redact(err.Error()))
+	}
 	result := s.RunShutdown(ctx, []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		return nil, status.Errorf(codes.Internal, "schedule shutdown: %s", inventory.Redact(toolFailure(result)))
+		var resumeErr error
+		if endpointPaused {
+			resumeErr = resumeManagedEndpoint(context.Background(), s.Root, s.RunEndpointLifecycle)
+		}
+		return nil, status.Errorf(codes.Internal, "schedule shutdown: %s", inventory.Redact(errors.Join(errors.New(toolFailure(result)), resumeErr).Error()))
 	}
 	return &agentapi.ShutdownAccepted{Scheduled: true}, nil
 }

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer"
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
@@ -122,6 +123,68 @@ func TestRebootSchedulesCommittedSelectedGeneration(t *testing.T) {
 	}
 }
 
+func TestRebootWithdrawsManagedEndpointBeforeScheduling(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	var actions []string
+	server.RunEndpointLifecycle = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		actions = append(actions, strings.Join(got, " "))
+		return ToolResult{}
+	}
+	server.RunReboot = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		actions = append(actions, strings.Join(got, " "))
+		return ToolResult{}
+	}
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.Reboot(context.Background(), &agentapi.RebootRequest{
+		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
+		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"systemctl stop " + endpointAdvertiserUnit,
+		endpointAdvertiserCommand + " withdraw",
+		"systemd-run --unit=katl-reboot --collect --on-active=2s systemctl reboot",
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("reboot actions = %#v, want %#v", actions, want)
+	}
+}
+
+func TestRebootRefusesWhenManagedEndpointCannotWithdraw(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	server.RunEndpointLifecycle = func(_ context.Context, _ []string, _ func(int)) ToolResult {
+		return ToolResult{Err: errors.New("withdraw failed"), ExitStatus: 1}
+	}
+	rebootCalled := false
+	server.RunReboot = func(_ context.Context, _ []string, _ func(int)) ToolResult {
+		rebootCalled = true
+		return ToolResult{}
+	}
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.Reboot(context.Background(), &agentapi.RebootRequest{
+		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
+		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
+	})
+	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "prepare control-plane endpoint for reboot") {
+		t.Fatalf("Reboot() error = %v", err)
+	}
+	if rebootCalled {
+		t.Fatal("reboot was scheduled without withdrawing the managed endpoint")
+	}
+}
+
 func TestShutdownSchedulesPoweroff(t *testing.T) {
 	server := newTestServer(t)
 	var argv []string
@@ -146,6 +209,39 @@ func TestShutdownSchedulesPoweroff(t *testing.T) {
 	want := []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("shutdown argv = %#v, want %#v", argv, want)
+	}
+}
+
+func TestShutdownWithdrawsManagedEndpointBeforeScheduling(t *testing.T) {
+	server := newTestServer(t)
+	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	var actions []string
+	server.RunEndpointLifecycle = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		actions = append(actions, strings.Join(got, " "))
+		return ToolResult{}
+	}
+	server.RunShutdown = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		actions = append(actions, strings.Join(got, " "))
+		return ToolResult{}
+	}
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.Shutdown(context.Background(), &agentapi.ShutdownRequest{
+		ApiVersion: generation.APIVersion, Kind: ShutdownRequestKind, Actor: "test",
+		ExpectedMachineId: machineID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"systemctl stop " + endpointAdvertiserUnit,
+		endpointAdvertiserCommand + " withdraw",
+		"systemd-run --unit=katl-shutdown --collect --on-active=2s systemctl poweroff",
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("shutdown actions = %#v, want %#v", actions, want)
 	}
 }
 

--- a/internal/scriptstest/endpoint_advertiser_sysext_test.go
+++ b/internal/scriptstest/endpoint_advertiser_sysext_test.go
@@ -21,6 +21,7 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	birdUnit := read("mkosi.profiles/endpoint-advertiser-sysext/katl-app-bird.service")
 	for _, want := range []string{
 		"ConditionPathExists=/etc/katl/apps/bird/bird.conf",
+		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
 		"ExecStart=/usr/bin/bird ",
 		"RestrictAddressFamilies=AF_INET AF_NETLINK AF_UNIX",
 	} {
@@ -36,6 +37,7 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	for _, want := range []string{
 		"Requires=katl-app-bird.service",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml",
+		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
 		"RestrictAddressFamilies=AF_INET AF_NETLINK AF_UNIX",
 	} {
 		if !strings.Contains(appUnit, want) {
@@ -49,6 +51,7 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	activationUnit := read("mkosi.profiles/runtime/katl-endpoint-activate.service")
 	for _, want := range []string{
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml",
+		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
 		"ExecStart=/usr/bin/systemctl daemon-reload",
 		"start katl-app-bgp-api-vip.service",
 	} {

--- a/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service
+++ b/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service
@@ -4,6 +4,7 @@ Documentation=https://katl.dev
 Requires=katl-app-bird.service
 After=katl-app-bird.service
 ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml
+ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
 
 [Service]
 Type=simple

--- a/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bird.service
+++ b/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bird.service
@@ -4,6 +4,7 @@ Documentation=https://katl.dev
 Wants=network-online.target
 After=network-online.target
 ConditionPathExists=/etc/katl/apps/bird/bird.conf
+ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
 
 [Service]
 Type=simple

--- a/mkosi.profiles/runtime/katl-endpoint-activate.service
+++ b/mkosi.profiles/runtime/katl-endpoint-activate.service
@@ -4,6 +4,7 @@ Documentation=https://katl.dev
 Wants=systemd-sysext.service systemd-confext.service
 After=systemd-sysext.service systemd-confext.service
 ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml
+ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Gate BIRD and the endpoint controller on explicit VIP-advertisement enablement. Withdraw and confirm the managed route before reboot, shutdown, and kubeadm mutation, then resume only after upgrade health; controller routing errors now exit fail-closed instead of leaving stale advertisement state.