### PR TITLE
endpoint: apply routed configuration safely

### DIFF
--- a/internal/installer/configapply/executor.go
+++ b/internal/installer/configapply/executor.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/generation"
 )
 
@@ -33,6 +35,7 @@ type ConfextActivator interface {
 }
 
 type Executor struct {
+	Root           string
 	Runner         CommandRunner
 	Activator      ConfextActivator
 	StatusPath     string
@@ -66,6 +69,15 @@ func (e Executor) ExecuteLive(ctx context.Context, plan Result) (generation.Conf
 		_ = e.writeStatus(status)
 		return status, err
 	}
+	if containsDomainAction(status.DomainActions, DomainControlPlaneEndpointRouting) {
+		enabled, err := e.endpointAdvertisementEnabled(plan.GenerationRecord)
+		if err != nil {
+			return e.failBeforeActivation(status, err)
+		}
+		if !enabled {
+			return e.failBeforeActivation(status, errors.New("control-plane endpoint routing cannot be applied because VIP advertisement is not enabled"))
+		}
+	}
 
 	var err error
 	status, err = generation.MarkConfigApplyPhase(status, generation.ConfigApplyPhaseActivating, e.now())
@@ -92,6 +104,49 @@ func (e Executor) ExecuteLive(ctx context.Context, plan Result) (generation.Conf
 		return status, err
 	}
 	return status, nil
+}
+
+func (e Executor) failBeforeActivation(status generation.ConfigApplyStatus, cause error) (generation.ConfigApplyStatus, error) {
+	status, err := generation.MarkConfigApplyFailed(status, cause, e.now())
+	if err != nil {
+		return status, err
+	}
+	if err := e.writeStatus(status); err != nil {
+		return status, err
+	}
+	return status, cause
+}
+
+func containsDomainAction(actions []generation.ConfigApplyDomainAction, domain string) bool {
+	for _, action := range actions {
+		if action.Domain == domain {
+			return true
+		}
+	}
+	return false
+}
+
+func (e Executor) endpointAdvertisementEnabled(record generation.Record) (bool, error) {
+	for _, candidate := range record.Confexts {
+		if candidate.Name != "katl-node" {
+			continue
+		}
+		root := filepath.Clean(e.Root)
+		if strings.TrimSpace(e.Root) == "" {
+			root = string(filepath.Separator)
+		}
+		path := filepath.Join(root, strings.TrimPrefix(candidate.Path, "/"), strings.TrimPrefix(bgpapivip.AdvertisementEnabledPath, "/"))
+		info, err := os.Stat(path)
+		switch {
+		case err == nil:
+			return info.Mode().IsRegular(), nil
+		case errors.Is(err, os.ErrNotExist):
+			return false, nil
+		default:
+			return false, fmt.Errorf("inspect VIP advertisement configuration: %w", err)
+		}
+	}
+	return false, nil
 }
 
 func (e Executor) runActions(ctx context.Context, status *generation.ConfigApplyStatus) error {
@@ -163,6 +218,13 @@ func (e Executor) commandsForDomain(domain string) ([]Command, error) {
 		commands = append(commands, Command{Name: "networkctl-reload", Argv: []string{"networkctl", "reload"}})
 	case DomainBootstrapNodeMetadata:
 		commands = append(commands, Command{Name: "node-metadata-refresh", Argv: []string{"systemctl", "try-reload-or-restart", "katl-runtime-handoff-status.service"}})
+	case DomainControlPlaneEndpointRouting:
+		commands = append(commands,
+			Command{Name: "endpoint-routing-validate", Argv: []string{"/usr/bin/bird", "-p", "-c", bgpapivip.BirdConfigPath}},
+			Command{Name: "endpoint-withdraw", Argv: []string{"systemctl", "stop", "katl-app-bgp-api-vip.service"}},
+			Command{Name: "endpoint-routing-reload", Argv: []string{"/usr/bin/birdc", "-s", bgpapivip.BirdControlSocketPath, "configure"}},
+			Command{Name: "endpoint-resume", Argv: []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}},
+		)
 	default:
 		return nil, fmt.Errorf("domain %q has no bounded live executor action", domain)
 	}

--- a/internal/installer/configapply/executor_test.go
+++ b/internal/installer/configapply/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -225,6 +226,55 @@ func TestExecutorRejectsNonLivePlans(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "accepted live plan") {
 		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestExecutorDoesNotRunBirdWithoutVIPAdvertisement(t *testing.T) {
+	root := t.TempDir()
+	plan := liveExecutorPlan(t, []Change{{Domain: DomainControlPlaneEndpointRouting}})
+	activator := &fakeActivator{}
+	runner := &fakeCommandRunner{}
+
+	status, err := Executor{
+		Root:      root,
+		Runner:    runner,
+		Activator: activator,
+		Now:       fixedNow,
+	}.ExecuteLive(context.Background(), plan)
+	if err == nil || !strings.Contains(err.Error(), "VIP advertisement is not enabled") {
+		t.Fatalf("ExecuteLive() error = %v, want disabled advertisement diagnostic", err)
+	}
+	if status.Phase != generation.ConfigApplyPhaseFailed {
+		t.Fatalf("status phase = %q, want failed", status.Phase)
+	}
+	if activator.activated != "" || len(runner.commands) != 0 {
+		t.Fatalf("disabled advertisement reached activation or BIRD: activator=%#v commands=%#v", activator, runner.commands)
+	}
+}
+
+func TestExecutorRunsBirdWhenVIPAdvertisementIsEnabled(t *testing.T) {
+	root := t.TempDir()
+	plan := liveExecutorPlan(t, []Change{{Domain: DomainControlPlaneEndpointRouting}})
+	marker := filepath.Join(root, strings.TrimPrefix(plan.GenerationRecord.Confexts[0].Path, "/"), "etc/katl/apps/bgp-api-vip/advertisement-enabled")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte("enabled\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeCommandRunner{}
+
+	_, err := Executor{
+		Root:      root,
+		Runner:    runner,
+		Activator: &fakeActivator{},
+		Now:       fixedNow,
+	}.ExecuteLive(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ExecuteLive() error = %v", err)
+	}
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
+		t.Fatalf("commands = %q, want %q", got, want)
 	}
 }
 

--- a/internal/installer/configapply/manifest_state.go
+++ b/internal/installer/configapply/manifest_state.go
@@ -1,0 +1,57 @@
+package configapply
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/manifest"
+	"github.com/katl-dev/katl/internal/installer/persistedrecord"
+)
+
+const generationManifestName = "manifest.json"
+
+func GenerationManifestPath(root, generationID string) (string, error) {
+	metadataPath, err := generation.MetadataPath(root, generationID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(metadataPath), generationManifestName), nil
+}
+
+func WriteGenerationManifest(root, generationID string, value manifest.Manifest) error {
+	if err := manifest.Validate(value); err != nil {
+		return fmt.Errorf("validate generation manifest: %w", err)
+	}
+	path, err := GenerationManifestPath(root, generationID)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode generation manifest: %w", err)
+	}
+	if err := persistedrecord.WriteFileAtomic(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write generation manifest: %w", err)
+	}
+	return nil
+}
+
+func ReadGenerationManifest(root, generationID string) (manifest.Manifest, error) {
+	path, err := GenerationManifestPath(root, generationID)
+	if err != nil {
+		return manifest.Manifest{}, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return manifest.Manifest{}, fmt.Errorf("open generation manifest: %w", err)
+	}
+	defer file.Close()
+	value, err := manifest.Decode(file)
+	if err != nil {
+		return manifest.Manifest{}, fmt.Errorf("decode generation manifest: %w", err)
+	}
+	return value, nil
+}

--- a/internal/installer/configapply/manifest_state_test.go
+++ b/internal/installer/configapply/manifest_state_test.go
@@ -1,0 +1,30 @@
+package configapply
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestGenerationManifestRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	want := baseManifest()
+	want.Node.ControlPlaneEndpoint = managedEndpoint("192.0.2.1")
+	if err := WriteGenerationManifest(root, "generation-1", want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadGenerationManifest(root, "generation-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Node.ControlPlaneEndpoint == nil || got.Node.ControlPlaneEndpoint.Advertisement == nil || got.Node.ControlPlaneEndpoint.Advertisement.BGP.Peers[0].Address != "192.0.2.1" {
+		t.Fatalf("generation manifest endpoint = %#v", got.Node.ControlPlaneEndpoint)
+	}
+}
+
+func TestReadGenerationManifestPreservesNotExist(t *testing.T) {
+	_, err := ReadGenerationManifest(t.TempDir(), "generation-0")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ReadGenerationManifest() error = %v, want os.ErrNotExist", err)
+	}
+}

--- a/internal/installer/configapply/matrix.go
+++ b/internal/installer/configapply/matrix.go
@@ -8,26 +8,29 @@ import (
 )
 
 const (
-	DomainNodeIdentity             = "node-identity"
-	DomainNetworkd                 = "networkd"
-	DomainResolved                 = "resolved"
-	DomainSysctl                   = "sysctl"
-	DomainModulesLoad              = "modules-load"
-	DomainTmpfiles                 = "tmpfiles"
-	DomainMountUnits               = "mount-units"
-	DomainExtraDisks               = "extra-disks"
-	DomainKubeadmConfig            = "kubeadm-config"
-	DomainBootstrapNodeMetadata    = "bootstrap-node-metadata"
-	DomainSSHOperatorAccess        = "ssh-operator-access"
-	DomainSystemRole               = "system-role"
-	DomainSelectedKubeadmConfig    = "selected-kubeadm-config"
-	DomainSelectedKubernetesSysext = "selected-kubernetes-sysext"
-	DomainKubeletNodeIdentity      = "kubelet-node-identity"
-	DomainHostAccountPolicy        = "host-account-policy"
-	DomainEtcKubernetes            = "etc-kubernetes"
-	DomainArbitraryEtc             = "arbitrary-etc"
-	DomainRootSelection            = "root-selection"
-	DomainSysextSelection          = "sysext-selection"
+	DomainNodeIdentity                  = "node-identity"
+	DomainNetworkd                      = "networkd"
+	DomainResolved                      = "resolved"
+	DomainSysctl                        = "sysctl"
+	DomainModulesLoad                   = "modules-load"
+	DomainTmpfiles                      = "tmpfiles"
+	DomainMountUnits                    = "mount-units"
+	DomainExtraDisks                    = "extra-disks"
+	DomainKubeadmConfig                 = "kubeadm-config"
+	DomainBootstrapNodeMetadata         = "bootstrap-node-metadata"
+	DomainSSHOperatorAccess             = "ssh-operator-access"
+	DomainSystemRole                    = "system-role"
+	DomainSelectedKubeadmConfig         = "selected-kubeadm-config"
+	DomainSelectedKubernetesSysext      = "selected-kubernetes-sysext"
+	DomainKubeletNodeIdentity           = "kubelet-node-identity"
+	DomainHostAccountPolicy             = "host-account-policy"
+	DomainEtcKubernetes                 = "etc-kubernetes"
+	DomainArbitraryEtc                  = "arbitrary-etc"
+	DomainRootSelection                 = "root-selection"
+	DomainSysextSelection               = "sysext-selection"
+	DomainControlPlaneEndpointBootstrap = "control-plane-endpoint-bootstrap"
+	DomainControlPlaneEndpointIdentity  = "control-plane-endpoint-identity"
+	DomainControlPlaneEndpointRouting   = "control-plane-endpoint-routing"
 )
 
 const (
@@ -326,5 +329,18 @@ var domainPolicies = map[string]domainPolicy{
 		Classification:      ClassificationOperationOnly,
 		LiveRejectionReason: "sysext selection changes require an explicit update action",
 		RequiredOperation:   "host-upgrade",
+	},
+	DomainControlPlaneEndpointBootstrap: {
+		Classification:  ClassificationStagedOnly,
+		NextBootAllowed: true,
+	},
+	DomainControlPlaneEndpointIdentity: {
+		Classification:      ClassificationOperationOnly,
+		LiveRejectionReason: "initialized control-plane endpoint host, port, VIP, and ownership cannot change without a dedicated endpoint migration",
+		RequiredOperation:   "control-plane-endpoint-migration (not yet supported)",
+	},
+	DomainControlPlaneEndpointRouting: {
+		Classification:  ClassificationOnlineApplicable,
+		NextBootAllowed: true,
 	},
 }

--- a/internal/installer/configapply/matrix_test.go
+++ b/internal/installer/configapply/matrix_test.go
@@ -32,6 +32,9 @@ func TestDomainClassificationMatrix(t *testing.T) {
 		{DomainArbitraryEtc, ClassificationRejected},
 		{DomainRootSelection, ClassificationOperationOnly},
 		{DomainSysextSelection, ClassificationOperationOnly},
+		{DomainControlPlaneEndpointBootstrap, ClassificationStagedOnly},
+		{DomainControlPlaneEndpointIdentity, ClassificationOperationOnly},
+		{DomainControlPlaneEndpointRouting, ClassificationOnlineApplicable},
 		{"unknown-domain", ClassificationRejected},
 	}
 	for _, tt := range tests {
@@ -100,6 +103,7 @@ func TestPlanTreatsStagedOnlyDomainsAsNextBoot(t *testing.T) {
 		DomainTmpfiles,
 		DomainNetworkd,
 		DomainBootstrapNodeMetadata,
+		DomainControlPlaneEndpointBootstrap,
 	} {
 		t.Run(domain, func(t *testing.T) {
 			live, err := Plan(generation.ApplyModeLive, []Change{{Domain: domain}})
@@ -123,11 +127,12 @@ func TestPlanTreatsStagedOnlyDomainsAsNextBoot(t *testing.T) {
 
 func TestPlanRejectsOperationOnlyAndUnsupportedMutations(t *testing.T) {
 	operationOnly := map[string]string{
-		DomainSystemRole:               "wipe-reinstall",
-		DomainSelectedKubernetesSysext: "kubernetes-upgrade",
-		DomainKubeletNodeIdentity:      "kubeadm-aware operation",
-		DomainRootSelection:            "host-upgrade",
-		DomainSysextSelection:          "host-upgrade",
+		DomainSystemRole:                   "wipe-reinstall",
+		DomainSelectedKubernetesSysext:     "kubernetes-upgrade",
+		DomainKubeletNodeIdentity:          "kubeadm-aware operation",
+		DomainRootSelection:                "host-upgrade",
+		DomainSysextSelection:              "host-upgrade",
+		DomainControlPlaneEndpointIdentity: "control-plane-endpoint-migration (not yet supported)",
 	}
 	for domain, required := range operationOnly {
 		t.Run(domain, func(t *testing.T) {
@@ -203,6 +208,8 @@ func TestPlanNextBootAllowsOnlyStagedAndOnlineDomains(t *testing.T) {
 		DomainModulesLoad,
 		DomainKubeadmConfig,
 		DomainSelectedKubeadmConfig,
+		DomainControlPlaneEndpointBootstrap,
+		DomainControlPlaneEndpointRouting,
 	}
 	for _, domain := range allowed {
 		t.Run("allowed-"+domain, func(t *testing.T) {
@@ -222,6 +229,7 @@ func TestPlanNextBootAllowsOnlyStagedAndOnlineDomains(t *testing.T) {
 		DomainArbitraryEtc,
 		DomainRootSelection,
 		DomainSysextSelection,
+		DomainControlPlaneEndpointIdentity,
 		"unknown-domain",
 	}
 	for _, domain := range rejected {

--- a/internal/installer/configapply/render.go
+++ b/internal/installer/configapply/render.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
@@ -38,10 +39,11 @@ type renderedNodeConfigurationChangeSpec struct {
 }
 
 type renderedNodeConfigurationOverlay struct {
-	Identity   renderedNodeIdentity       `yaml:"identity"`
-	SystemRole string                     `yaml:"systemRole,omitempty"`
-	Networkd   manifest.NetworkdConfig    `yaml:"networkd"`
-	Kubernetes *manifest.KubernetesConfig `yaml:"kubernetes,omitempty"`
+	Identity             renderedNodeIdentity        `yaml:"identity"`
+	SystemRole           string                      `yaml:"systemRole,omitempty"`
+	Networkd             manifest.NetworkdConfig     `yaml:"networkd"`
+	Kubernetes           *manifest.KubernetesConfig  `yaml:"kubernetes,omitempty"`
+	ControlPlaneEndpoint controlPlaneEndpointOverlay `yaml:"controlPlaneEndpoint"`
 }
 
 type renderedNodeIdentity struct {
@@ -88,9 +90,10 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 						Hostname:       node.Identity.Hostname,
 						AuthorizedKeys: append([]string{}, node.Identity.SSH.AuthorizedKeys...),
 					},
-					SystemRole: node.SystemRole,
-					Networkd:   node.Networkd,
-					Kubernetes: &node.Kubernetes,
+					SystemRole:           node.SystemRole,
+					Networkd:             node.Networkd,
+					Kubernetes:           &node.Kubernetes,
+					ControlPlaneEndpoint: renderedControlPlaneEndpoint(node.ControlPlaneEndpoint),
 				},
 			},
 		},
@@ -100,6 +103,10 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 		return nil, fmt.Errorf("marshal node configuration change: %w", err)
 	}
 	return data, nil
+}
+
+func renderedControlPlaneEndpoint(config *controlplaneendpoint.Config) controlPlaneEndpointOverlay {
+	return controlPlaneEndpointOverlay{Managed: config != nil, Config: config}
 }
 
 func renderKubeadmConfigs(ref string, configs map[string]kubeadmconfig.Plan) (map[string]inlineKubeadmConfig, error) {

--- a/internal/installer/configapply/render_test.go
+++ b/internal/installer/configapply/render_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
@@ -25,7 +26,8 @@ func TestRenderNodeConfigurationChange(t *testing.T) {
 					Name:    "10-lan.network",
 					Content: "[Network]\nDHCP=yes\n",
 				}}},
-				Kubernetes: manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: "control-plane"}},
+				Kubernetes:           manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: "control-plane"}},
+				ControlPlaneEndpoint: managedEndpoint("192.0.2.1"),
 			},
 		},
 		SourceID:       "lab",
@@ -52,8 +54,50 @@ func TestRenderNodeConfigurationChange(t *testing.T) {
 	if overlay.SystemRole != "control-plane" || overlay.Kubernetes == nil || overlay.Kubernetes.Kubeadm.ConfigRef != "control-plane" {
 		t.Fatalf("rendered operation fields = role %q kubernetes %#v", overlay.SystemRole, overlay.Kubernetes)
 	}
+	if !overlay.ControlPlaneEndpointSet || overlay.ControlPlaneEndpoint == nil || overlay.ControlPlaneEndpoint.Advertisement == nil {
+		t.Fatalf("rendered control-plane endpoint = %#v, set=%t", overlay.ControlPlaneEndpoint, overlay.ControlPlaneEndpointSet)
+	}
 	if strings.Contains(string(data), "install:") {
 		t.Fatalf("rendered change contains install fields:\n%s", data)
+	}
+}
+
+func TestRenderNodeConfigurationChangeCarriesExternalEndpointOwnership(t *testing.T) {
+	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
+		NodeName: "cp-1",
+		Manifest: manifest.Manifest{Node: manifest.NodeConfig{
+			Identity:             manifest.NodeIdentity{Hostname: "cp-1"},
+			ControlPlaneEndpoint: nil,
+		}},
+		SourceID:       "lab",
+		DesiredVersion: "2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(string(data)), TrustedBundleRequest{})
+	if err != nil {
+		t.Fatalf("DecodeNodeConfigurationChange() error = %v\n%s", err, data)
+	}
+	overlay := request.NodeOverrides["cp-1"]
+	if !overlay.ControlPlaneEndpointSet || overlay.ControlPlaneEndpoint != nil {
+		t.Fatalf("external endpoint overlay = %#v, set=%t", overlay.ControlPlaneEndpoint, overlay.ControlPlaneEndpointSet)
+	}
+	if !strings.Contains(string(data), "controlPlaneEndpoint:\n                managed: false") {
+		t.Fatalf("rendered change omitted external endpoint ownership:\n%s", data)
+	}
+}
+
+func managedEndpoint(peer string) *controlplaneendpoint.Config {
+	return &controlplaneendpoint.Config{
+		Host: "192.0.2.10",
+		Advertisement: &controlplaneendpoint.Advertisement{
+			VIP: "192.0.2.10",
+			BGP: &controlplaneendpoint.BGP{
+				LocalASN: 64512,
+				Peers:    []controlplaneendpoint.Peer{{Address: peer, ASN: 64500}},
+			},
+		},
 	}
 }
 

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -11,12 +11,14 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer/confext"
 	"github.com/katl-dev/katl/internal/installer/configdomain"
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
@@ -49,20 +51,23 @@ type TrustedBundleRequest struct {
 	KubernetesActivationPath        string
 	RuntimeKubernetesVersion        string
 	RuntimeKubernetesActivationPath string
+	KubernetesInitialized           bool
 	Executor                        *Executor
 	Chown                           func(path string, uid int, gid int) error
 	Now                             func() time.Time
 }
 
 type NodeOverlay struct {
-	Identity       *IdentityOverlay
-	SystemRole     string
-	Networkd       *manifest.NetworkdConfig
-	Sysctl         *manifest.SysctlConfig
-	Kubernetes     *manifest.KubernetesConfig
-	UnsafeEtcFiles []confext.NativeEtcFile
-	KubeadmChanged bool
-	LivePreflight  map[string]bool
+	Identity                *IdentityOverlay
+	SystemRole              string
+	Networkd                *manifest.NetworkdConfig
+	Sysctl                  *manifest.SysctlConfig
+	Kubernetes              *manifest.KubernetesConfig
+	ControlPlaneEndpoint    *controlplaneendpoint.Config
+	ControlPlaneEndpointSet bool
+	UnsafeEtcFiles          []confext.NativeEtcFile
+	KubeadmChanged          bool
+	LivePreflight           map[string]bool
 }
 
 type IdentityOverlay struct {
@@ -203,6 +208,13 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
 		return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
 	}
+	if err := WriteGenerationManifest(request.Root, request.GenerationID, merged); err != nil {
+		audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
+		audit.CandidateGeneration = request.GenerationID
+		audit.AcceptedApplyMode = matrixDecision.AcceptedMode
+		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
+		return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
+	}
 	sysexts, err := materializeSysexts(request.Root, request.GenerationID, request.CurrentRecord.Sysexts)
 	if err != nil {
 		audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
@@ -264,6 +276,9 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 			return TrustedBundleResult{}, fmt.Errorf("live apply executor is required")
 		}
 		executor := *request.Executor
+		if strings.TrimSpace(executor.Root) == "" {
+			executor.Root = request.Root
+		}
 		executor.StatusPath = statusPath
 		status, err = executor.ExecuteLive(ctx, plan)
 		if err != nil {
@@ -401,18 +416,18 @@ func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Chan
 	if err := validateOverlay("clusterDefaults", request.ClusterDefaults); err != nil {
 		return manifest.Manifest{}, nil, nil, err
 	}
-	applyOverlay(&merged.Node, request.ClusterDefaults, &domains, &unsafeFiles)
+	applyOverlay(&merged.Node, request.ClusterDefaults, request.KubernetesInitialized, &domains, &unsafeFiles)
 	roleOverlay := request.SystemRoleOverrides[merged.Node.SystemRole]
 	if err := validateOverlay("systemRoleOverrides."+merged.Node.SystemRole, roleOverlay); err != nil {
 		return manifest.Manifest{}, nil, nil, err
 	}
-	applyOverlay(&merged.Node, roleOverlay, &domains, &unsafeFiles)
+	applyOverlay(&merged.Node, roleOverlay, request.KubernetesInitialized, &domains, &unsafeFiles)
 	nodeOverlay := request.NodeOverrides[request.NodeName]
 	if request.NodeName != "" {
 		if err := validateOverlay("nodeOverrides."+request.NodeName, nodeOverlay); err != nil {
 			return manifest.Manifest{}, nil, nil, err
 		}
-		applyOverlay(&merged.Node, nodeOverlay, &domains, &unsafeFiles)
+		applyOverlay(&merged.Node, nodeOverlay, request.KubernetesInitialized, &domains, &unsafeFiles)
 	}
 	if len(domains.domains) == 0 {
 		return merged, nil, nil, ErrNoChanges
@@ -427,7 +442,7 @@ func validateOverlay(path string, overlay NodeOverlay) error {
 	return nil
 }
 
-func applyOverlay(node *manifest.NodeConfig, overlay NodeOverlay, domains *domainAccumulator, unsafeFiles *[]confext.NativeEtcFile) {
+func applyOverlay(node *manifest.NodeConfig, overlay NodeOverlay, kubernetesInitialized bool, domains *domainAccumulator, unsafeFiles *[]confext.NativeEtcFile) {
 	if overlay.Identity != nil {
 		if overlay.Identity.Hostname != "" {
 			changed := node.Identity.Hostname != overlay.Identity.Hostname
@@ -475,12 +490,45 @@ func applyOverlay(node *manifest.NodeConfig, overlay NodeOverlay, domains *domai
 			domains.add(DomainBootstrapNodeMetadata)
 		}
 	}
+	if overlay.ControlPlaneEndpointSet && !reflect.DeepEqual(node.ControlPlaneEndpoint, overlay.ControlPlaneEndpoint) {
+		classifyControlPlaneEndpointChange(node.ControlPlaneEndpoint, overlay.ControlPlaneEndpoint, kubernetesInitialized, domains)
+		node.ControlPlaneEndpoint = overlay.ControlPlaneEndpoint
+	}
 	if overlay.KubeadmChanged {
 		domains.add(DomainKubeadmConfig)
 	}
 	if len(overlay.UnsafeEtcFiles) > 0 {
 		*unsafeFiles = append(*unsafeFiles, overlay.UnsafeEtcFiles...)
 		domains.add(DomainArbitraryEtc)
+	}
+}
+
+func classifyControlPlaneEndpointChange(current, desired *controlplaneendpoint.Config, kubernetesInitialized bool, domains *domainAccumulator) {
+	if current == nil || desired == nil {
+		if kubernetesInitialized {
+			domains.add(DomainControlPlaneEndpointIdentity)
+		} else {
+			domains.add(DomainControlPlaneEndpointBootstrap)
+		}
+		return
+	}
+	currentPlan, currentErr := controlplaneendpoint.Normalize(*current)
+	desiredPlan, desiredErr := controlplaneendpoint.Normalize(*desired)
+	if currentErr != nil || desiredErr != nil {
+		domains.add(DomainControlPlaneEndpointIdentity)
+		return
+	}
+	identityChanged := currentPlan.Config.Host != desiredPlan.Config.Host || currentPlan.Config.Port != desiredPlan.Config.Port || currentPlan.VIPPrefix != desiredPlan.VIPPrefix
+	if identityChanged {
+		if kubernetesInitialized {
+			domains.add(DomainControlPlaneEndpointIdentity)
+		} else {
+			domains.add(DomainControlPlaneEndpointBootstrap)
+		}
+		return
+	}
+	if !reflect.DeepEqual(currentPlan.Config, desiredPlan.Config) {
+		domains.add(DomainControlPlaneEndpointRouting)
 	}
 }
 
@@ -870,36 +918,38 @@ func cleanDesiredVersion(value string) (string, error) {
 
 func requestDigest(request TrustedBundleRequest) string {
 	type digestInput struct {
-		SourceID             string
-		DesiredVersion       string
-		NodeName             string
-		ApplyMode            string
-		GenerationID         string
-		CurrentManifest      manifest.Manifest
-		ClusterDefaults      NodeOverlay
-		SystemRoleOverrides  map[string]NodeOverlay
-		NodeOverrides        map[string]NodeOverlay
-		KubeadmConfigs       map[string]kubeadmconfig.Plan
-		KubernetesVersion    string
-		KubernetesActivation string
-		RuntimeVersion       string
-		RuntimeActivation    string
+		SourceID              string
+		DesiredVersion        string
+		NodeName              string
+		ApplyMode             string
+		GenerationID          string
+		CurrentManifest       manifest.Manifest
+		ClusterDefaults       NodeOverlay
+		SystemRoleOverrides   map[string]NodeOverlay
+		NodeOverrides         map[string]NodeOverlay
+		KubeadmConfigs        map[string]kubeadmconfig.Plan
+		KubernetesVersion     string
+		KubernetesActivation  string
+		RuntimeVersion        string
+		RuntimeActivation     string
+		KubernetesInitialized bool
 	}
 	data, _ := json.Marshal(digestInput{
-		SourceID:             request.SourceID,
-		DesiredVersion:       request.DesiredVersion,
-		NodeName:             request.NodeName,
-		ApplyMode:            request.ApplyMode,
-		GenerationID:         request.GenerationID,
-		CurrentManifest:      request.CurrentManifest,
-		ClusterDefaults:      request.ClusterDefaults,
-		SystemRoleOverrides:  request.SystemRoleOverrides,
-		NodeOverrides:        request.NodeOverrides,
-		KubeadmConfigs:       request.KubeadmConfigs,
-		KubernetesVersion:    request.KubernetesVersion,
-		KubernetesActivation: request.KubernetesActivationPath,
-		RuntimeVersion:       request.RuntimeKubernetesVersion,
-		RuntimeActivation:    request.RuntimeKubernetesActivationPath,
+		SourceID:              request.SourceID,
+		DesiredVersion:        request.DesiredVersion,
+		NodeName:              request.NodeName,
+		ApplyMode:             request.ApplyMode,
+		GenerationID:          request.GenerationID,
+		CurrentManifest:       request.CurrentManifest,
+		ClusterDefaults:       request.ClusterDefaults,
+		SystemRoleOverrides:   request.SystemRoleOverrides,
+		NodeOverrides:         request.NodeOverrides,
+		KubeadmConfigs:        request.KubeadmConfigs,
+		KubernetesVersion:     request.KubernetesVersion,
+		KubernetesActivation:  request.KubernetesActivationPath,
+		RuntimeVersion:        request.RuntimeKubernetesVersion,
+		RuntimeActivation:     request.RuntimeKubernetesActivationPath,
+		KubernetesInitialized: request.KubernetesInitialized,
 	})
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/confext"
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
@@ -34,6 +35,118 @@ func TestApplyTrustedBundleRejectsLiveNetworkdBeforeRender(t *testing.T) {
 		t.Fatalf("audit = %#v", result.Audit)
 	}
 	assertGenerationMissing(t, root, "2026.06.05-002")
+}
+
+func TestControlPlaneEndpointApplyClassification(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialized bool
+		current     *controlplaneendpoint.Config
+		desired     *controlplaneendpoint.Config
+		wantDomain  string
+		wantMode    string
+		wantError   string
+	}{
+		{
+			name:       "routing changes apply live",
+			current:    managedEndpoint("192.0.2.1"),
+			desired:    managedEndpoint("192.0.2.2"),
+			wantDomain: DomainControlPlaneEndpointRouting,
+			wantMode:   generation.ApplyModeLive,
+		},
+		{
+			name:        "initialized host is immutable",
+			initialized: true,
+			current:     managedEndpoint("192.0.2.1"),
+			desired: func() *controlplaneendpoint.Config {
+				endpoint := managedEndpoint("192.0.2.1")
+				endpoint.Host = "192.0.2.11"
+				endpoint.Advertisement.VIP = "192.0.2.11"
+				return endpoint
+			}(),
+			wantDomain: DomainControlPlaneEndpointIdentity,
+			wantError:  "control-plane-endpoint-migration",
+		},
+		{
+			name:        "initialized ownership is immutable",
+			initialized: true,
+			current:     managedEndpoint("192.0.2.1"),
+			desired:     nil,
+			wantDomain:  DomainControlPlaneEndpointIdentity,
+			wantError:   "control-plane-endpoint-migration",
+		},
+		{
+			name:    "pre-bootstrap identity stages for next boot",
+			current: managedEndpoint("192.0.2.1"),
+			desired: func() *controlplaneendpoint.Config {
+				endpoint := managedEndpoint("192.0.2.1")
+				endpoint.Host = "192.0.2.11"
+				endpoint.Advertisement.VIP = "192.0.2.11"
+				return endpoint
+			}(),
+			wantDomain: DomainControlPlaneEndpointBootstrap,
+			wantMode:   generation.ApplyModeNextBoot,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := baseManifest()
+			current.Node.ControlPlaneEndpoint = tt.current
+			request := trustedBundleRequest(t.TempDir(), TrustedBundleRequest{
+				ApplyMode:             generation.ApplyModeAuto,
+				CurrentManifest:       current,
+				KubernetesInitialized: tt.initialized,
+				NodeOverrides: map[string]NodeOverlay{
+					"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: tt.desired},
+				},
+			})
+			_, changes, _, err := mergeRuntimeConfig(request)
+			if err != nil {
+				t.Fatalf("mergeRuntimeConfig() error = %v", err)
+			}
+			if len(changes) != 1 || changes[0].Domain != tt.wantDomain {
+				t.Fatalf("changes = %#v, want %q", changes, tt.wantDomain)
+			}
+			decision, err := Plan(request.ApplyMode, changes)
+			if tt.wantError != "" {
+				if err == nil || len(decision.Diagnostics) != 1 || !strings.Contains(decision.Diagnostics[0].RequiredOperation, tt.wantError) {
+					t.Fatalf("Plan() error = %v, decision = %#v", err, decision)
+				}
+				return
+			}
+			if err != nil || decision.AcceptedMode != tt.wantMode {
+				t.Fatalf("Plan() error = %v, decision = %#v, want mode %q", err, decision, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestApplyTrustedBundleReloadsEnabledEndpointRouting(t *testing.T) {
+	root := t.TempDir()
+	current := baseManifest()
+	current.Node.ControlPlaneEndpoint = managedEndpoint("192.0.2.1")
+	runner := &fakeCommandRunner{}
+	result, err := ApplyTrustedBundle(context.Background(), trustedBundleRequest(root, TrustedBundleRequest{
+		ApplyMode:       generation.ApplyModeLive,
+		CurrentManifest: current,
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: managedEndpoint("192.0.2.2")},
+		},
+		Executor: &Executor{Runner: runner, Activator: &fakeActivator{}, Now: fixedNow},
+	}))
+	if err != nil {
+		t.Fatalf("ApplyTrustedBundle() error = %v", err)
+	}
+	if result.Plan.Decision.AcceptedMode != generation.ApplyModeLive || !containsDomain(result.Plan.Decision.ChangedDomains, DomainControlPlaneEndpointRouting) {
+		t.Fatalf("decision = %#v", result.Plan.Decision)
+	}
+	if _, err := os.Stat(filepath.Join(result.Tree.ConfextDir, "etc/katl/apps/bgp-api-vip/advertisement-enabled")); err != nil {
+		t.Fatalf("candidate advertisement marker: %v", err)
+	}
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
+		t.Fatalf("commands = %q, want %q", got, want)
+	}
 }
 
 func TestApplyTrustedBundleRendersAndExecutesLiveSysctl(t *testing.T) {
@@ -755,6 +868,7 @@ func trustedBundleRequest(root string, override TrustedBundleRequest) TrustedBun
 	request.KubeadmConfigs = override.KubeadmConfigs
 	request.KubernetesVersion = override.KubernetesVersion
 	request.KubernetesActivationPath = override.KubernetesActivationPath
+	request.KubernetesInitialized = override.KubernetesInitialized
 	request.Executor = override.Executor
 	if override.Chown != nil {
 		request.Chown = override.Chown

--- a/internal/installer/configapply/runtime_request.go
+++ b/internal/installer/configapply/runtime_request.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
@@ -40,12 +41,18 @@ type inlineKubeadmConfig struct {
 }
 
 type nodeConfigurationOverlay struct {
-	Identity      *IdentityOverlay           `json:"identity,omitempty" yaml:"identity,omitempty"`
-	SystemRole    string                     `json:"systemRole,omitempty" yaml:"systemRole,omitempty"`
-	Networkd      *manifest.NetworkdConfig   `json:"networkd,omitempty" yaml:"networkd,omitempty"`
-	Sysctl        *manifest.SysctlConfig     `json:"sysctl,omitempty" yaml:"sysctl,omitempty"`
-	Kubernetes    *manifest.KubernetesConfig `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
-	LivePreflight map[string]bool            `json:"livePreflight,omitempty" yaml:"livePreflight,omitempty"`
+	Identity             *IdentityOverlay             `json:"identity,omitempty" yaml:"identity,omitempty"`
+	SystemRole           string                       `json:"systemRole,omitempty" yaml:"systemRole,omitempty"`
+	Networkd             *manifest.NetworkdConfig     `json:"networkd,omitempty" yaml:"networkd,omitempty"`
+	Sysctl               *manifest.SysctlConfig       `json:"sysctl,omitempty" yaml:"sysctl,omitempty"`
+	Kubernetes           *manifest.KubernetesConfig   `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
+	ControlPlaneEndpoint *controlPlaneEndpointOverlay `json:"controlPlaneEndpoint,omitempty" yaml:"controlPlaneEndpoint,omitempty"`
+	LivePreflight        map[string]bool              `json:"livePreflight,omitempty" yaml:"livePreflight,omitempty"`
+}
+
+type controlPlaneEndpointOverlay struct {
+	Managed bool                         `json:"managed" yaml:"managed"`
+	Config  *controlplaneendpoint.Config `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
 func DecodeNodeConfigurationChange(reader io.Reader, base TrustedBundleRequest) (TrustedBundleRequest, error) {
@@ -65,6 +72,9 @@ func DecodeNodeConfigurationChange(reader io.Reader, base TrustedBundleRequest) 
 	if document.Kind != NodeConfigurationChangeKind {
 		return TrustedBundleRequest{}, fmt.Errorf("kind must be %s", NodeConfigurationChangeKind)
 	}
+	if err := validateEndpointOverlays(document.Spec); err != nil {
+		return TrustedBundleRequest{}, err
+	}
 
 	request := base
 	request.SourceID = document.Metadata.SourceID
@@ -79,6 +89,36 @@ func DecodeNodeConfigurationChange(reader io.Reader, base TrustedBundleRequest) 
 	request.SystemRoleOverrides = nodeOverlayMap(document.Spec.SystemRoleOverrides, changedKubeadmConfigs)
 	request.NodeOverrides = nodeOverlayMap(document.Spec.NodeOverrides, changedKubeadmConfigs)
 	return request, nil
+}
+
+func validateEndpointOverlays(spec nodeConfigurationChangeSpec) error {
+	validate := func(path string, overlay nodeConfigurationOverlay) error {
+		endpoint := overlay.ControlPlaneEndpoint
+		if endpoint == nil {
+			return nil
+		}
+		if endpoint.Managed && endpoint.Config == nil {
+			return fmt.Errorf("%s.controlPlaneEndpoint.config is required when managed is true", path)
+		}
+		if !endpoint.Managed && endpoint.Config != nil {
+			return fmt.Errorf("%s.controlPlaneEndpoint.config must be omitted when managed is false", path)
+		}
+		return nil
+	}
+	if err := validate("spec.clusterDefaults", spec.ClusterDefaults); err != nil {
+		return err
+	}
+	for name, overlay := range spec.SystemRoleOverrides {
+		if err := validate("spec.systemRoleOverrides."+name, overlay); err != nil {
+			return err
+		}
+	}
+	for name, overlay := range spec.NodeOverrides {
+		if err := validate("spec.nodeOverrides."+name, overlay); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ApplyNodeConfigurationChange(ctx context.Context, reader io.Reader, base TrustedBundleRequest) (TrustedBundleResult, error) {
@@ -105,7 +145,7 @@ func (overlay nodeConfigurationOverlay) nodeOverlay(changedConfigs map[string]st
 	if overlay.Kubernetes != nil {
 		_, kubeadmChanged = changedConfigs[strings.TrimSpace(overlay.Kubernetes.Kubeadm.ConfigRef)]
 	}
-	return NodeOverlay{
+	nodeOverlay := NodeOverlay{
 		Identity:       overlay.Identity,
 		SystemRole:     overlay.SystemRole,
 		Networkd:       overlay.Networkd,
@@ -114,6 +154,11 @@ func (overlay nodeConfigurationOverlay) nodeOverlay(changedConfigs map[string]st
 		KubeadmChanged: kubeadmChanged,
 		LivePreflight:  overlay.LivePreflight,
 	}
+	if overlay.ControlPlaneEndpoint != nil {
+		nodeOverlay.ControlPlaneEndpointSet = true
+		nodeOverlay.ControlPlaneEndpoint = overlay.ControlPlaneEndpoint.Config
+	}
+	return nodeOverlay
 }
 
 func mergeInlineKubeadmConfigs(installed map[string]kubeadmconfig.Plan, inline map[string]inlineKubeadmConfig) (map[string]kubeadmconfig.Plan, map[string]struct{}, error) {

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -449,6 +449,7 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 			activator = generationActivator{root: e.Root}
 		}
 		decoded.Executor = &configapply.Executor{
+			Root:      e.Root,
 			Runner:    runner,
 			Activator: activator,
 			Now:       e.clock,
@@ -462,9 +463,16 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 			err = errorsJoin(err, splitErr)
 		}
 	}
-	if err == nil && result.Plan.Decision.AcceptedMode == generation.ApplyModeNextBoot {
-		if commitErr := e.commitCandidateGeneration(ctx, record, completedAt, "next-boot runtime configuration apply staged by katlc agent executor"); commitErr != nil {
-			err = commitErr
+	if err == nil {
+		switch result.Plan.Decision.AcceptedMode {
+		case generation.ApplyModeLive:
+			if promoteErr := e.promoteCandidateGenerationLive(ctx, record, completedAt, "live runtime configuration apply completed successfully"); promoteErr != nil {
+				err = promoteErr
+			}
+		case generation.ApplyModeNextBoot:
+			if commitErr := e.commitCandidateGeneration(ctx, record, completedAt, "next-boot runtime configuration apply staged by katlc agent executor"); commitErr != nil {
+				err = commitErr
+			}
 		}
 	}
 	if err != nil {
@@ -480,9 +488,8 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 		record.CandidateGenerationID = result.Plan.GenerationRecord.GenerationID
 		record.ConfigApplyPhase = result.Status.Phase
 		record.ChangedDomains = append([]string(nil), result.Status.ChangedDomains...)
-		record.GenerationCommitState = operation.GenerationCommitCandidate
+		record.GenerationCommitState = operation.GenerationCommitCommitted
 		if result.Plan.Decision.AcceptedMode == generation.ApplyModeNextBoot {
-			record.GenerationCommitState = operation.GenerationCommitCommitted
 			record.BootHealthPending = true
 		}
 		record.ActivationState = configApplyActivationState(result.Status, false)
@@ -638,13 +645,16 @@ func configApplyBase(root string, nodeName string, generationID string, now func
 		return configapply.TrustedBundleRequest{}, fmt.Errorf("read current generation: %w", err)
 	}
 	current := generation.RecordFromSplit(spec, status)
-	manifestPath := filepath.Join(filepath.Clean(root), "var/lib/katl/install/manifest.json")
-	manifestFile, err := os.Open(manifestPath)
-	if err != nil {
-		return configapply.TrustedBundleRequest{}, fmt.Errorf("open current install manifest: %w", err)
+	currentManifest, err := configapply.ReadGenerationManifest(root, currentID)
+	if errors.Is(err, os.ErrNotExist) {
+		manifestPath := filepath.Join(filepath.Clean(root), "var/lib/katl/install/manifest.json")
+		manifestFile, openErr := os.Open(manifestPath)
+		if openErr != nil {
+			return configapply.TrustedBundleRequest{}, fmt.Errorf("open current install manifest: %w", openErr)
+		}
+		defer manifestFile.Close()
+		currentManifest, err = manifest.Decode(manifestFile)
 	}
-	defer manifestFile.Close()
-	currentManifest, err := manifest.Decode(manifestFile)
 	if err != nil {
 		return configapply.TrustedBundleRequest{}, err
 	}
@@ -678,9 +688,19 @@ func configApplyBase(root string, nodeName string, generationID string, now func
 		KubeadmConfigs:                  kubeadmConfigs,
 		RuntimeKubernetesVersion:        kubernetesVersion,
 		RuntimeKubernetesActivationPath: kubernetesActivationPath,
+		KubernetesInitialized:           controlPlaneKubernetesInitialized(root),
 		Chown:                           func(string, int, int) error { return nil },
 		Now:                             now,
 	}, nil
+}
+
+func controlPlaneKubernetesInitialized(root string) bool {
+	for _, path := range []string{"/etc/kubernetes/admin.conf", "/etc/kubernetes/manifests/kube-apiserver.yaml"} {
+		if info, err := os.Stat(rootedRuntimePath(root, path)); err == nil && info.Mode().IsRegular() {
+			return true
+		}
+	}
+	return false
 }
 
 func clusterIntentKubernetesActivationPath(intent installer.ClusterIntent) string {

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -1186,6 +1186,7 @@ func TestApplyGenerationLiveMarksMutationAndActivationState(t *testing.T) {
 	executor.Async = false
 	executor.ConfigApplyRunner = runner
 	executor.ConfigApplyActivator = activator
+	executor.SetBootDefault = func(context.Context, string, string) error { return nil }
 	server.Dispatcher = executor
 
 	accepted, err := server.ApplyGeneration(context.Background(), &agentapi.GenerationApplyRequest{
@@ -1209,6 +1210,9 @@ func TestApplyGenerationLiveMarksMutationAndActivationState(t *testing.T) {
 	if record.ActivationState != operation.ActivationStateActiveLive || record.ConfigApplyPhase != generation.ConfigApplyPhaseActive {
 		t.Fatalf("activation/config phase = %q/%q, want active-live/active", record.ActivationState, record.ConfigApplyPhase)
 	}
+	if record.GenerationCommitState != operation.GenerationCommitCommitted {
+		t.Fatalf("generation commit state = %q, want committed", record.GenerationCommitState)
+	}
 	if !contains(record.MutationScopes, "confext-activation") || !contains(record.MutationScopes, "config-domain:sysctl") {
 		t.Fatalf("mutation scopes = %v, want confext activation and sysctl domain", record.MutationScopes)
 	}
@@ -1217,6 +1221,27 @@ func TestApplyGenerationLiveMarksMutationAndActivationState(t *testing.T) {
 	}
 	if activator.activated == "" || runner.calls == 0 {
 		t.Fatalf("live dependencies activated=%q runner calls=%d, want both used", activator.activated, runner.calls)
+	}
+	selection, err := generation.ReadBootSelection(server.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.DefaultGenerationID != "generation-live" || selection.PendingHealthValidation {
+		t.Fatalf("boot selection = %#v, want live generation as durable default", selection)
+	}
+	candidateManifest, err := configapply.ReadGenerationManifest(server.Root, "generation-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidateManifest.Node.Sysctl.Settings["net.ipv4.ip_forward"] != "1" {
+		t.Fatalf("candidate manifest sysctl = %#v", candidateManifest.Node.Sysctl.Settings)
+	}
+	nextBase, err := configApplyBase(server.Root, "node-a", "generation-next", time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextBase.CurrentRecord.GenerationID != "generation-live" || nextBase.CurrentManifest.Node.Sysctl.Settings["net.ipv4.ip_forward"] != "1" {
+		t.Fatalf("next config apply base = generation %q manifest %#v", nextBase.CurrentRecord.GenerationID, nextBase.CurrentManifest.Node.Sysctl.Settings)
 	}
 }
 
@@ -1281,6 +1306,7 @@ func TestSubmitOperationAutoConfigApplyRunsAcceptedLivePath(t *testing.T) {
 	executor.Async = false
 	executor.ConfigApplyRunner = runner
 	executor.ConfigApplyActivator = activator
+	executor.SetBootDefault = func(context.Context, string, string) error { return nil }
 	server.Dispatcher = executor
 
 	accepted, err := server.SubmitOperation(context.Background(), &agentapi.SubmitOperationRequest{
@@ -1332,6 +1358,7 @@ func TestApplyGenerationLiveLoadsInstalledKubeadmInputs(t *testing.T) {
 	executor.Async = false
 	executor.ConfigApplyRunner = runner
 	executor.ConfigApplyActivator = activator
+	executor.SetBootDefault = func(context.Context, string, string) error { return nil }
 	server.Dispatcher = executor
 
 	accepted, err := server.ApplyGeneration(context.Background(), &agentapi.GenerationApplyRequest{


### PR DESCRIPTION
Carries routed endpoint intent through generation apply and separates immutable endpoint identity from live routing changes.

BIRD reloads now require explicit VIP-advertisement enablement, while successful live applies persist and promote their desired generation so later operations use current state.