### PR TITLE
endpoint: retain pre-bootstrap advertiser

### DIFF
--- a/docs/internal/katl-routed-control-plane-endpoint-design.md
+++ b/docs/internal/katl-routed-control-plane-endpoint-design.md
@@ -675,6 +675,13 @@ The extension is active only on control-plane nodes. Workers retain the stable
 endpoint in their kubeadm join configuration but do not receive the VIP,
 routing daemon or endpoint application.
 
+Control-plane installation retains the compatible endpoint-application payload
+in Katl's internal artifact cache even when the endpoint is externally owned.
+It is not selected or activated unless advertisement is enabled. This lets a
+pre-initialization generation adopt managed advertisement without requiring
+new installation media, while workers retain neither the payload nor the
+application.
+
 Native ordering must establish:
 
 ```text

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -52,6 +52,7 @@ type TrustedBundleRequest struct {
 	RuntimeKubernetesVersion        string
 	RuntimeKubernetesActivationPath string
 	KubernetesInitialized           bool
+	EndpointAdvertiserSysext        *generation.ExtensionRef
 	Executor                        *Executor
 	Chown                           func(path string, uid int, gid int) error
 	Now                             func() time.Time
@@ -215,7 +216,15 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
 		return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
 	}
-	sysexts, err := materializeSysexts(request.Root, request.GenerationID, request.CurrentRecord.Sysexts)
+	desiredSysexts, err := endpointAdvertiserSysexts(request, merged)
+	if err != nil {
+		audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
+		audit.CandidateGeneration = request.GenerationID
+		audit.AcceptedApplyMode = matrixDecision.AcceptedMode
+		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
+		return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
+	}
+	sysexts, err := materializeSysexts(request.Root, request.GenerationID, desiredSysexts)
 	if err != nil {
 		audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
 		audit.CandidateGeneration = request.GenerationID
@@ -310,6 +319,29 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 		StatusPath:   statusPath,
 		AuditPath:    auditPath,
 	}, nil
+}
+
+func endpointAdvertiserSysexts(request TrustedBundleRequest, desired manifest.Manifest) ([]generation.ExtensionRef, error) {
+	refs := make([]generation.ExtensionRef, 0, len(request.CurrentRecord.Sysexts)+1)
+	var current *generation.ExtensionRef
+	for _, ref := range request.CurrentRecord.Sysexts {
+		if ref.Name == "endpoint-advertiser" {
+			candidate := ref
+			current = &candidate
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	if desired.Node.ControlPlaneEndpoint == nil {
+		return refs, nil
+	}
+	if current != nil {
+		return append(refs, *current), nil
+	}
+	if request.EndpointAdvertiserSysext == nil {
+		return nil, fmt.Errorf("managed control-plane endpoint requires the endpoint advertiser artifact retained during installation; reinstall this pre-bootstrap node with current KatlOS media")
+	}
+	return append(refs, *request.EndpointAdvertiserSysext), nil
 }
 
 func confextReleaseFromCurrent(record generation.Record) (confext.ExtensionRelease, error) {
@@ -933,6 +965,7 @@ func requestDigest(request TrustedBundleRequest) string {
 		RuntimeVersion        string
 		RuntimeActivation     string
 		KubernetesInitialized bool
+		EndpointAdvertiser    *generation.ExtensionRef
 	}
 	data, _ := json.Marshal(digestInput{
 		SourceID:              request.SourceID,
@@ -950,6 +983,7 @@ func requestDigest(request TrustedBundleRequest) string {
 		RuntimeVersion:        request.RuntimeKubernetesVersion,
 		RuntimeActivation:     request.RuntimeKubernetesActivationPath,
 		KubernetesInitialized: request.KubernetesInitialized,
+		EndpointAdvertiser:    request.EndpointAdvertiserSysext,
 	})
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -2,6 +2,8 @@ package configapply
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,10 +128,13 @@ func TestApplyTrustedBundleReloadsEnabledEndpointRouting(t *testing.T) {
 	root := t.TempDir()
 	current := baseManifest()
 	current.Node.ControlPlaneEndpoint = managedEndpoint("192.0.2.1")
+	currentRecord := currentRecord()
+	selectEndpointAdvertiser(t, root, &currentRecord)
 	runner := &fakeCommandRunner{}
 	result, err := ApplyTrustedBundle(context.Background(), trustedBundleRequest(root, TrustedBundleRequest{
 		ApplyMode:       generation.ApplyModeLive,
 		CurrentManifest: current,
+		CurrentRecord:   currentRecord,
 		NodeOverrides: map[string]NodeOverlay{
 			"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: managedEndpoint("192.0.2.2")},
 		},
@@ -146,6 +151,78 @@ func TestApplyTrustedBundleReloadsEnabledEndpointRouting(t *testing.T) {
 	}
 	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
+	}
+}
+
+func TestApplyTrustedBundleRemovesEndpointAdvertiserBeforeBootstrap(t *testing.T) {
+	root := t.TempDir()
+	current := baseManifest()
+	current.Node.ControlPlaneEndpoint = managedEndpoint("192.0.2.1")
+	currentRecord := currentRecord()
+	selectEndpointAdvertiser(t, root, &currentRecord)
+	result, err := ApplyTrustedBundle(context.Background(), trustedBundleRequest(root, TrustedBundleRequest{
+		ApplyMode:       generation.ApplyModeAuto,
+		CurrentManifest: current,
+		CurrentRecord:   currentRecord,
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {ControlPlaneEndpointSet: true},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ApplyTrustedBundle() error = %v", err)
+	}
+	if result.Plan.Decision.AcceptedMode != generation.ApplyModeNextBoot || !containsDomain(result.Plan.Decision.ChangedDomains, DomainControlPlaneEndpointBootstrap) {
+		t.Fatalf("decision = %#v", result.Plan.Decision)
+	}
+	for _, ref := range result.Plan.GenerationRecord.Sysexts {
+		if ref.Name == "endpoint-advertiser" {
+			t.Fatalf("candidate retained disabled endpoint advertiser: %#v", ref)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(result.Tree.ConfextDir, "etc/katl/apps/bgp-api-vip/advertisement-enabled")); !os.IsNotExist(err) {
+		t.Fatalf("disabled endpoint advertisement marker = %v, want absent", err)
+	}
+}
+
+func TestApplyTrustedBundleStagesEndpointAdvertiserBeforeBootstrap(t *testing.T) {
+	root := t.TempDir()
+	result, err := ApplyTrustedBundle(context.Background(), trustedBundleRequest(root, TrustedBundleRequest{
+		ApplyMode:                generation.ApplyModeAuto,
+		EndpointAdvertiserSysext: testEndpointAdvertiserArtifact(t, root),
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: managedEndpoint("192.0.2.1")},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ApplyTrustedBundle() error = %v", err)
+	}
+	if result.Plan.Decision.AcceptedMode != generation.ApplyModeNextBoot || !containsDomain(result.Plan.Decision.ChangedDomains, DomainControlPlaneEndpointBootstrap) {
+		t.Fatalf("decision = %#v", result.Plan.Decision)
+	}
+	var endpoint *generation.ExtensionRef
+	for i := range result.Plan.GenerationRecord.Sysexts {
+		if result.Plan.GenerationRecord.Sysexts[i].Name == "endpoint-advertiser" {
+			endpoint = &result.Plan.GenerationRecord.Sysexts[i]
+		}
+	}
+	if endpoint == nil {
+		t.Fatalf("candidate sysexts = %#v, want endpoint advertiser", result.Plan.GenerationRecord.Sysexts)
+	}
+	if _, err := os.Stat(filepath.Join(root, strings.TrimPrefix(endpoint.Path, "/"))); err != nil {
+		t.Fatalf("candidate endpoint advertiser sysext: %v", err)
+	}
+}
+
+func TestApplyTrustedBundleExplainsMissingPreBootstrapEndpointArtifact(t *testing.T) {
+	root := t.TempDir()
+	_, err := ApplyTrustedBundle(context.Background(), trustedBundleRequest(root, TrustedBundleRequest{
+		ApplyMode: generation.ApplyModeAuto,
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: managedEndpoint("192.0.2.1")},
+		},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "artifact retained during installation") {
+		t.Fatalf("ApplyTrustedBundle() error = %v, want retained artifact recovery guidance", err)
 	}
 }
 
@@ -869,6 +946,7 @@ func trustedBundleRequest(root string, override TrustedBundleRequest) TrustedBun
 	request.KubernetesVersion = override.KubernetesVersion
 	request.KubernetesActivationPath = override.KubernetesActivationPath
 	request.KubernetesInitialized = override.KubernetesInitialized
+	request.EndpointAdvertiserSysext = override.EndpointAdvertiserSysext
 	request.Executor = override.Executor
 	if override.Chown != nil {
 		request.Chown = override.Chown
@@ -883,6 +961,9 @@ func trustedBundleRequest(root string, override TrustedBundleRequest) TrustedBun
 func ensureTestSysext(root string, record generation.Record) {
 	for _, ref := range record.Sysexts {
 		path := filepath.Join(filepath.Clean(root), strings.TrimPrefix(ref.Path, "/"))
+		if _, err := os.Stat(path); err == nil {
+			continue
+		}
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			panic(err)
 		}
@@ -890,6 +971,50 @@ func ensureTestSysext(root string, record generation.Record) {
 			panic(err)
 		}
 	}
+}
+
+func testEndpointAdvertiserArtifact(t *testing.T, root string) *generation.ExtensionRef {
+	t.Helper()
+	content := []byte("endpoint advertiser sysext\n")
+	sum := sha256.Sum256(content)
+	path := "/var/lib/katl/artifacts/katlos-image/katl-endpoint-advertiser.raw"
+	fullPath := filepath.Join(root, strings.TrimPrefix(path, "/"))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &generation.ExtensionRef{
+		Name:            "endpoint-advertiser",
+		Path:            path,
+		ActivationPath:  "/run/extensions/katl-endpoint-advertiser.raw",
+		SHA256:          hex.EncodeToString(sum[:]),
+		ArtifactVersion: "2026.7.0",
+		PayloadVersion:  "2026.7.0",
+		Architecture:    "x86_64",
+		Compatibility:   generation.ExtensionCompatibility{RuntimeInterfaces: []string{"katl-runtime-1"}},
+	}
+}
+
+func selectEndpointAdvertiser(t *testing.T, root string, record *generation.Record) {
+	t.Helper()
+	artifact := testEndpointAdvertiserArtifact(t, root)
+	source := filepath.Join(root, strings.TrimPrefix(artifact.Path, "/"))
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := *artifact
+	selected.Path = filepath.ToSlash(filepath.Join(generation.GenerationRecordsDir, record.GenerationID, "sysext", "endpoint-advertiser.raw"))
+	target := filepath.Join(root, strings.TrimPrefix(selected.Path, "/"))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	record.Sysexts = append(record.Sysexts, selected)
 }
 
 func baseManifest() manifest.Manifest {

--- a/internal/installer/endpoint_advertiser_artifact.go
+++ b/internal/installer/endpoint_advertiser_artifact.go
@@ -1,0 +1,120 @@
+package installer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
+	"github.com/katl-dev/katl/internal/installer/persistedrecord"
+)
+
+const (
+	EndpointAdvertiserArtifactPath     = "/var/lib/katl/artifacts/katlos-image/katl-endpoint-advertiser.raw"
+	EndpointAdvertiserArtifactMetadata = "/var/lib/katl/artifacts/katlos-image/katl-endpoint-advertiser.json"
+	endpointAdvertiserArtifactKind     = "EndpointAdvertiserArtifact"
+)
+
+type EndpointAdvertiserArtifact struct {
+	APIVersion string                  `json:"apiVersion"`
+	Kind       string                  `json:"kind"`
+	SizeBytes  int64                   `json:"sizeBytes"`
+	Extension  generation.ExtensionRef `json:"extension"`
+}
+
+func endpointAdvertiserArtifact(payload katlosimage.Payload) (EndpointAdvertiserArtifact, error) {
+	ref, err := payload.EndpointAdvertiserExtensionRef(EndpointAdvertiserArtifactPath)
+	if err != nil {
+		return EndpointAdvertiserArtifact{}, err
+	}
+	return EndpointAdvertiserArtifact{
+		APIVersion: generation.APIVersion,
+		Kind:       endpointAdvertiserArtifactKind,
+		SizeBytes:  payload.EndpointAdvertiser.SizeBytes,
+		Extension:  ref,
+	}, nil
+}
+
+func writeEndpointAdvertiserArtifact(root string, artifact EndpointAdvertiserArtifact) error {
+	if err := validateEndpointAdvertiserArtifact(artifact); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode endpoint advertiser artifact metadata: %w", err)
+	}
+	path := rootedInstallerPath(root, EndpointAdvertiserArtifactMetadata)
+	if err := persistedrecord.WriteFileAtomic(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write endpoint advertiser artifact metadata: %w", err)
+	}
+	return nil
+}
+
+func ReadEndpointAdvertiserArtifact(root string) (EndpointAdvertiserArtifact, error) {
+	path := rootedInstallerPath(root, EndpointAdvertiserArtifactMetadata)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("read endpoint advertiser artifact metadata: %w", err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	var artifact EndpointAdvertiserArtifact
+	if err := decoder.Decode(&artifact); err != nil {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("decode endpoint advertiser artifact metadata: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("decode endpoint advertiser artifact metadata: multiple JSON values")
+	}
+	if err := validateEndpointAdvertiserArtifact(artifact); err != nil {
+		return EndpointAdvertiserArtifact{}, err
+	}
+	artifactPath := rootedInstallerPath(root, artifact.Extension.Path)
+	info, err := os.Stat(artifactPath)
+	if err != nil {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("stat endpoint advertiser artifact: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != artifact.SizeBytes {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("endpoint advertiser artifact size or type does not match metadata")
+	}
+	file, err := os.Open(artifactPath)
+	if err != nil {
+		return EndpointAdvertiserArtifact{}, err
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("hash endpoint advertiser artifact: %w", copyErr)
+	}
+	if closeErr != nil {
+		return EndpointAdvertiserArtifact{}, closeErr
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); got != artifact.Extension.SHA256 {
+		return EndpointAdvertiserArtifact{}, fmt.Errorf("endpoint advertiser artifact SHA-256 mismatch")
+	}
+	return artifact, nil
+}
+
+func validateEndpointAdvertiserArtifact(artifact EndpointAdvertiserArtifact) error {
+	if artifact.APIVersion != generation.APIVersion || artifact.Kind != endpointAdvertiserArtifactKind {
+		return fmt.Errorf("endpoint advertiser artifact metadata has unsupported identity")
+	}
+	ref := artifact.Extension
+	if ref.Name != katlosimage.EndpointAdvertiserName || filepath.Clean(ref.Path) != EndpointAdvertiserArtifactPath || ref.ActivationPath != "/run/extensions/katl-endpoint-advertiser.raw" {
+		return fmt.Errorf("endpoint advertiser artifact metadata has invalid extension selection")
+	}
+	if artifact.SizeBytes <= 0 || len(ref.SHA256) != sha256.Size*2 || strings.TrimSpace(ref.PayloadVersion) == "" || strings.TrimSpace(ref.Architecture) == "" || len(ref.Compatibility.RuntimeInterfaces) == 0 {
+		return fmt.Errorf("endpoint advertiser artifact metadata is incomplete")
+	}
+	return nil
+}
+
+func rootedInstallerPath(root, absolute string) string {
+	return filepath.Join(filepath.Clean(root), strings.TrimPrefix(absolute, "/"))
+}

--- a/internal/installer/endpoint_advertiser_artifact_test.go
+++ b/internal/installer/endpoint_advertiser_artifact_test.go
@@ -1,0 +1,55 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
+)
+
+func TestEndpointAdvertiserArtifactRoundTrip(t *testing.T) {
+	payload, contents := writeInstallPayload(t)
+	root := t.TempDir()
+	artifact, err := endpointAdvertiserArtifact(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := rootedInstallerPath(root, EndpointAdvertiserArtifactPath)
+	if err := copyVerifiedComponent(payload.ComponentPath(payload.EndpointAdvertiser), target, payload.EndpointAdvertiser); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeEndpointAdvertiserArtifact(root, artifact); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadEndpointAdvertiserArtifact(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Extension.Name != katlosimage.EndpointAdvertiserName || got.Extension.SHA256 != payload.EndpointAdvertiser.SHA256 || got.SizeBytes != int64(len(contents.endpoint)) {
+		t.Fatalf("artifact = %#v", got)
+	}
+}
+
+func TestEndpointAdvertiserArtifactRejectsTamperedPayload(t *testing.T) {
+	payload, _ := writeInstallPayload(t)
+	root := t.TempDir()
+	artifact, err := endpointAdvertiserArtifact(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := rootedInstallerPath(root, EndpointAdvertiserArtifactPath)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(strings.Repeat("x", int(artifact.SizeBytes))), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeEndpointAdvertiserArtifact(root, artifact); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadEndpointAdvertiserArtifact(root); err == nil || !strings.Contains(err.Error(), "SHA-256 mismatch") {
+		t.Fatalf("ReadEndpointAdvertiserArtifact() error = %v, want digest mismatch", err)
+	}
+}

--- a/internal/installer/katlosimage/image.go
+++ b/internal/installer/katlosimage/image.go
@@ -384,21 +384,11 @@ func (p Payload) FirstInstallRequest(request FirstInstallRequest) (generation.Fi
 	}
 	var sysexts []generation.ExtensionRef
 	if request.EnableEndpointAdvertiser {
-		if p.EndpointAdvertiser.Role != ComponentEndpointAdvertiser {
-			return generation.FirstInstallRequest{}, fmt.Errorf("managed control-plane endpoint requires endpoint advertiser component")
+		ref, err := p.EndpointAdvertiserExtensionRef(filepath.Join("/var/lib/katl/generations", request.GenerationID, "sysext", EndpointAdvertiserName+".raw"))
+		if err != nil {
+			return generation.FirstInstallRequest{}, err
 		}
-		sysexts = append(sysexts, generation.ExtensionRef{
-			Name:            EndpointAdvertiserName,
-			Path:            filepath.Join("/var/lib/katl/generations", request.GenerationID, "sysext", EndpointAdvertiserName+".raw"),
-			ActivationPath:  "/run/extensions/katl-endpoint-advertiser.raw",
-			SHA256:          p.EndpointAdvertiser.SHA256,
-			ArtifactVersion: p.EndpointAdvertiser.Version,
-			PayloadVersion:  first(p.EndpointAdvertiser.PayloadVersion, p.EndpointAdvertiser.Version),
-			Architecture:    p.EndpointAdvertiser.Architecture,
-			Compatibility: generation.ExtensionCompatibility{
-				RuntimeInterfaces: []string{p.EndpointAdvertiser.Compatibility.RuntimeInterface},
-			},
-		})
+		sysexts = append(sysexts, ref)
 	}
 	return generation.FirstInstallRequest{
 		GenerationID:          request.GenerationID,
@@ -412,6 +402,27 @@ func (p Payload) FirstInstallRequest(request FirstInstallRequest) (generation.Fi
 		KernelCommandLine:     append([]string(nil), p.Boot.Compatibility.KernelCommandLine...),
 		Sysexts:               sysexts,
 		CreatedAt:             request.CreatedAt,
+	}, nil
+}
+
+func (p Payload) EndpointAdvertiserExtensionRef(artifactPath string) (generation.ExtensionRef, error) {
+	if p.EndpointAdvertiser.Role != ComponentEndpointAdvertiser {
+		return generation.ExtensionRef{}, fmt.Errorf("KatlOS image does not contain the endpoint advertiser component")
+	}
+	if strings.TrimSpace(artifactPath) == "" || !filepath.IsAbs(artifactPath) {
+		return generation.ExtensionRef{}, fmt.Errorf("endpoint advertiser artifact path must be absolute")
+	}
+	return generation.ExtensionRef{
+		Name:            EndpointAdvertiserName,
+		Path:            filepath.Clean(artifactPath),
+		ActivationPath:  "/run/extensions/katl-endpoint-advertiser.raw",
+		SHA256:          p.EndpointAdvertiser.SHA256,
+		ArtifactVersion: p.EndpointAdvertiser.Version,
+		PayloadVersion:  first(p.EndpointAdvertiser.PayloadVersion, p.EndpointAdvertiser.Version),
+		Architecture:    p.EndpointAdvertiser.Architecture,
+		Compatibility: generation.ExtensionCompatibility{
+			RuntimeInterfaces: []string{p.EndpointAdvertiser.Compatibility.RuntimeInterface},
+		},
 	}, nil
 }
 

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -597,13 +597,26 @@ func (installExtensionsStep) Run(ctx context.Context, install *Context) error {
 	if install.LoaderRecord == nil {
 		return fmt.Errorf("loader generation record is required to install extensions")
 	}
+	if install.Manifest.Node.SystemRole != "control-plane" {
+		return recordStep(ctx, install, InstallExtensions)
+	}
+	artifact, err := endpointAdvertiserArtifact(*install.KatlosImage)
+	if err != nil {
+		return err
+	}
+	cacheTarget, err := targetPathForAbsolute(install.TargetRoot, artifact.Extension.Path)
+	if err != nil {
+		return err
+	}
+	if err := copyVerifiedComponent(install.KatlosImage.ComponentPath(install.KatlosImage.EndpointAdvertiser), cacheTarget, install.KatlosImage.EndpointAdvertiser); err != nil {
+		return err
+	}
+	if err := writeEndpointAdvertiserArtifact(install.TargetRoot, artifact); err != nil {
+		return err
+	}
 	for _, extension := range install.LoaderRecord.Sysexts {
 		if extension.Name != katlosimage.EndpointAdvertiserName {
 			continue
-		}
-		component := install.KatlosImage.EndpointAdvertiser
-		if component.Role != katlosimage.ComponentEndpointAdvertiser {
-			return fmt.Errorf("endpoint advertiser component is required by selected generation")
 		}
 		target, err := targetPathForAbsolute(install.TargetRoot, extension.Path)
 		if err != nil {
@@ -612,11 +625,49 @@ func (installExtensionsStep) Run(ctx context.Context, install *Context) error {
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return fmt.Errorf("create endpoint advertiser sysext directory: %w", err)
 		}
-		if err := copyVerifiedComponent(install.KatlosImage.ComponentPath(component), target, component); err != nil {
+		if err := linkOrCopyInstalledArtifact(cacheTarget, target); err != nil {
 			return err
 		}
 	}
 	return recordStep(ctx, install, InstallExtensions)
+}
+
+func linkOrCopyInstalledArtifact(source, target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	if targetInfo, err := os.Stat(target); err == nil {
+		if os.SameFile(sourceInfo, targetInfo) {
+			return nil
+		}
+		if err := os.Remove(target); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Link(source, target); err == nil {
+		return nil
+	}
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+	targetFile, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(targetFile, sourceFile)
+	closeErr := targetFile.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }
 
 func targetPathForAbsolute(root string, path string) (string, error) {

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -803,6 +803,14 @@ func TestRunnerInstallsSingleKatlosImageThroughTargetVerification(t *testing.T) 
 	assertText(t, filepath.Join(targetRoot, "efi/EFI/Linux/katl-0.efi"), string(contents.boot))
 	assertMissing(t, filepath.Join(targetRoot, "var/lib/katl/generations/0/sysext/katl-kubernetes.raw"))
 	assertMissing(t, filepath.Join(targetRoot, "var/lib/katl/artifacts/katlos-image/katl-kubernetes.raw"))
+	assertText(t, filepath.Join(targetRoot, strings.TrimPrefix(EndpointAdvertiserArtifactPath, "/")), string(contents.endpoint))
+	artifact, err := ReadEndpointAdvertiserArtifact(targetRoot)
+	if err != nil {
+		t.Fatalf("read retained endpoint advertiser artifact: %v", err)
+	}
+	if artifact.Extension.Name != katlosimage.EndpointAdvertiserName || artifact.Extension.SHA256 != payload.EndpointAdvertiser.SHA256 {
+		t.Fatalf("retained endpoint advertiser artifact = %#v", artifact)
+	}
 	assertText(t, filepath.Join(targetRoot, "var/lib/katl/identity/machine-id"), "30313233343536373839616263646566\n")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var.mount"), "What=PARTUUID=11111111-2222-3333-4444-555555555555")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/efi.mount"), "What=/dev/disk/by-partlabel/KATL_ESP")
@@ -920,6 +928,7 @@ func TestRunnerInstallsKatlosImageComponents(t *testing.T) {
 		Commands:    &NoopCommandRunner{},
 		Store:       store,
 		KatlosImage: &payload,
+		Manifest:    manifest.Manifest{Node: manifest.NodeConfig{SystemRole: "control-plane"}},
 		RootSlotPlan: &disk.RootSlotWritePlan{
 			Slot:              disk.RootSlotA,
 			TargetPartition:   disk.RootSlotTarget{GPTLabel: disk.GPTLabelRootA},
@@ -951,9 +960,29 @@ func TestRunnerInstallsKatlosImageComponents(t *testing.T) {
 	}
 	assertText(t, filepath.Join(targetRoot, "efi/EFI/Linux/katl-2026.06.06-001.efi"), string(contents.boot))
 	assertMissing(t, filepath.Join(targetRoot, "var/lib/katl/generations/2026.06.06-001/sysext/kubernetes.raw"))
+	assertText(t, filepath.Join(targetRoot, strings.TrimPrefix(EndpointAdvertiserArtifactPath, "/")), string(contents.endpoint))
 	if got := install.Completed; !reflect.DeepEqual(got, []StepID{InstallRootSlot, InstallBootArtifacts, InstallExtensions}) {
 		t.Fatalf("completed steps = %#v", got)
 	}
+}
+
+func TestInstallExtensionsKeepsEndpointAdvertiserOffWorkers(t *testing.T) {
+	payload, _ := writeInstallPayload(t)
+	targetRoot := t.TempDir()
+	install := &Context{
+		TargetRoot:  targetRoot,
+		KatlosImage: &payload,
+		Store:       &MemoryStateStore{},
+		Manifest:    manifest.Manifest{Node: manifest.NodeConfig{SystemRole: "worker"}},
+		LoaderRecord: &generation.Record{
+			GenerationID: "0",
+		},
+	}
+	if err := (installExtensionsStep{}).Run(context.Background(), install); err != nil {
+		t.Fatal(err)
+	}
+	assertMissing(t, filepath.Join(targetRoot, strings.TrimPrefix(EndpointAdvertiserArtifactPath, "/")))
+	assertMissing(t, filepath.Join(targetRoot, strings.TrimPrefix(EndpointAdvertiserArtifactMetadata, "/")))
 }
 
 func TestRunnerOpensRootSlotTarget(t *testing.T) {
@@ -1553,19 +1582,22 @@ func (s *sequenceDiscoverySource) Discover(ctx context.Context) (discovery.Hardw
 }
 
 type installPayloadContents struct {
-	runtime []byte
-	boot    []byte
+	runtime  []byte
+	boot     []byte
+	endpoint []byte
 }
 
 func writeInstallPayload(t *testing.T) (katlosimage.Payload, installPayloadContents) {
 	t.Helper()
 	root := t.TempDir()
 	contents := installPayloadContents{
-		runtime: []byte("runtime-root-payload"),
-		boot:    []byte("runtime-uki-payload"),
+		runtime:  []byte("runtime-root-payload"),
+		boot:     []byte("runtime-uki-payload"),
+		endpoint: []byte("endpoint-advertiser-sysext"),
 	}
 	writePayloadComponent(t, root, "components/runtime/root.squashfs", contents.runtime)
 	writePayloadComponent(t, root, "components/boot/katl.efi", contents.boot)
+	writePayloadComponent(t, root, "components/sysext/endpoint-advertiser.raw", contents.endpoint)
 	payload := katlosimage.Payload{
 		Root: root,
 		Index: katlosimage.Index{
@@ -1573,8 +1605,9 @@ func writeInstallPayload(t *testing.T) (katlosimage.Payload, installPayloadConte
 			Architecture:     "x86_64",
 			RuntimeInterface: "katl-runtime-1",
 		},
-		Runtime: payloadComponent("runtime-root", katlosimage.ComponentRuntimeRoot, "components/runtime/root.squashfs", contents.runtime),
-		Boot:    payloadComponent("runtime-uki", katlosimage.ComponentRuntimeUKI, "components/boot/katl.efi", contents.boot),
+		Runtime:            payloadComponent("runtime-root", katlosimage.ComponentRuntimeRoot, "components/runtime/root.squashfs", contents.runtime),
+		Boot:               payloadComponent("runtime-uki", katlosimage.ComponentRuntimeUKI, "components/boot/katl.efi", contents.boot),
+		EndpointAdvertiser: payloadComponent(katlosimage.EndpointAdvertiserName, katlosimage.ComponentEndpointAdvertiser, "components/sysext/endpoint-advertiser.raw", contents.endpoint),
 	}
 	return payload, contents
 }

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -667,6 +667,15 @@ func configApplyBase(root string, nodeName string, generationID string, now func
 	}
 	kubernetesVersion := currentKubernetesPayloadVersion(current)
 	kubernetesActivationPath := currentKubernetesActivationPath(current)
+	var endpointAdvertiserSysext *generation.ExtensionRef
+	if currentManifest.Node.SystemRole == "control-plane" {
+		artifact, artifactErr := installer.ReadEndpointAdvertiserArtifact(root)
+		if artifactErr == nil {
+			endpointAdvertiserSysext = &artifact.Extension
+		} else if !errors.Is(artifactErr, os.ErrNotExist) {
+			return configapply.TrustedBundleRequest{}, artifactErr
+		}
+	}
 	if currentManifest.Node.Kubernetes.Kubeadm.ConfigRef != "" && (kubernetesVersion == "" || kubernetesActivationPath == "") {
 		intent, _, err := installer.ReadClusterIntent(root)
 		if err != nil {
@@ -689,6 +698,7 @@ func configApplyBase(root string, nodeName string, generationID string, now func
 		RuntimeKubernetesVersion:        kubernetesVersion,
 		RuntimeKubernetesActivationPath: kubernetesActivationPath,
 		KubernetesInitialized:           controlPlaneKubernetesInitialized(root),
+		EndpointAdvertiserSysext:        endpointAdvertiserSysext,
 		Chown:                           func(string, int, int) error { return nil },
 		Now:                             now,
 	}, nil

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -1245,6 +1245,19 @@ func TestApplyGenerationLiveMarksMutationAndActivationState(t *testing.T) {
 	}
 }
 
+func TestConfigApplyBaseLoadsRetainedEndpointAdvertiser(t *testing.T) {
+	server := newTestServer(t)
+	writeConfigApplyBaseState(t, server.Root)
+	writeRetainedEndpointAdvertiserArtifact(t, server.Root)
+	base, err := configApplyBase(server.Root, "node-a", "generation-next", time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base.EndpointAdvertiserSysext == nil || base.EndpointAdvertiserSysext.Name != "endpoint-advertiser" || base.EndpointAdvertiserSysext.Path != installer.EndpointAdvertiserArtifactPath {
+		t.Fatalf("retained endpoint advertiser = %#v", base.EndpointAdvertiserSysext)
+	}
+}
+
 func TestSubmitOperationAutoConfigApplyRejectsOperationKindMismatch(t *testing.T) {
 	for _, tt := range []struct {
 		name          string
@@ -2532,6 +2545,32 @@ func writeConfigApplyBaseState(t *testing.T, root string) {
 	if err := os.WriteFile(manifestPath, []byte(configApplyInstallManifestJSON), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeRetainedEndpointAdvertiserArtifact(t *testing.T, root string) {
+	t.Helper()
+	content := []byte("endpoint advertiser sysext\n")
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+	artifactPath := filepath.Join(root, strings.TrimPrefix(installer.EndpointAdvertiserArtifactPath, "/"))
+	writeTestFile(t, artifactPath, string(content))
+	metadata := fmt.Sprintf(`{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "EndpointAdvertiserArtifact",
+  "sizeBytes": %d,
+  "extension": {
+    "name": "endpoint-advertiser",
+    "path": %q,
+    "activationPath": "/run/extensions/katl-endpoint-advertiser.raw",
+    "sha256": %q,
+    "artifactVersion": "2026.7.0",
+    "payloadVersion": "2026.7.0",
+    "architecture": "x86_64",
+    "compatibility": {"runtimeInterfaces": ["katl-runtime-1"]}
+  }
+}
+`, len(content), installer.EndpointAdvertiserArtifactPath, digest)
+	writeTestFile(t, filepath.Join(root, strings.TrimPrefix(installer.EndpointAdvertiserArtifactMetadata, "/")), metadata)
 }
 
 func writeConfigApplyManifestWithKubeadmRef(t *testing.T, root string, ref string) {


### PR DESCRIPTION
Retains the compatible endpoint-advertiser payload on control-plane installs without selecting or activating it.

This makes pre-bootstrap managed-endpoint adoption generation-safe while keeping BIRD absent from workers and disabled configurations.