### PR TITLE
endpoint: complete routed VIP acceptance

### DIFF
--- a/docs/internal/katl-routed-control-plane-endpoint-design.md
+++ b/docs/internal/katl-routed-control-plane-endpoint-design.md
@@ -584,10 +584,11 @@ TLS server name: controlPlaneEndpoint.host
 trust root: /etc/kubernetes/pki/ca.crt
 ```
 
-Probing the VIP verifies local address delivery, API listening, TLS identity,
-etcd-dependent API readiness and the endpoint port. A `200` response is
-healthy. Probe timing and thresholds are Katl-owned constants and are not
-configuration fields.
+When the endpoint host is a DNS name, the controller first requires local DNS
+to resolve it to the managed VIP. Probing the VIP then verifies local address
+delivery, API listening, TLS identity, etcd-dependent API readiness and the
+endpoint port. A `200` response is healthy. Probe timing and thresholds are
+Katl-owned constants and are not configuration fields.
 
 State transitions are:
 

--- a/internal/installer/bgpapivip/controller.go
+++ b/internal/installer/bgpapivip/controller.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,7 +142,10 @@ type FileStatusWriter struct {
 }
 
 type HTTPHealthChecker struct {
-	Client *http.Client
+	Client   *http.Client
+	Resolver interface {
+		LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
+	}
 }
 
 type AlwaysReadyInterface struct{}
@@ -267,6 +272,10 @@ func (c *Controller) Stop(ctx context.Context) (Status, error) {
 }
 
 func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResult {
+	target := healthTarget(health)
+	if err := h.checkEndpointDNS(ctx, target, health.TLSServerName); err != nil {
+		return HealthResult{Healthy: false, Error: err.Error(), CheckedAt: time.Now().UTC()}
+	}
 	client := h.Client
 	if client == nil {
 		ca, err := os.ReadFile("/etc/kubernetes/pki/ca.crt")
@@ -290,7 +299,6 @@ func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResul
 			}},
 		}
 	}
-	target := healthTarget(health)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
 		return HealthResult{Healthy: false, Error: err.Error(), CheckedAt: time.Now().UTC()}
@@ -301,6 +309,35 @@ func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResul
 	}
 	defer resp.Body.Close()
 	return HealthResult{Healthy: resp.StatusCode >= 200 && resp.StatusCode < 300, StatusCode: resp.StatusCode, CheckedAt: time.Now().UTC()}
+}
+
+func (h HTTPHealthChecker) checkEndpointDNS(ctx context.Context, target, serverName string) error {
+	serverName = strings.TrimSpace(serverName)
+	if serverName == "" || net.ParseIP(serverName) != nil {
+		return nil
+	}
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return fmt.Errorf("parse endpoint health target: %w", err)
+	}
+	vip := net.ParseIP(parsed.Hostname())
+	if vip == nil {
+		return fmt.Errorf("endpoint health target does not contain the managed VIP")
+	}
+	resolver := h.Resolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	addresses, err := resolver.LookupIPAddr(ctx, serverName)
+	if err != nil {
+		return fmt.Errorf("resolve endpoint host %s: %w", serverName, err)
+	}
+	for _, address := range addresses {
+		if address.IP.Equal(vip) {
+			return nil
+		}
+	}
+	return fmt.Errorf("endpoint host %s does not resolve to managed VIP %s", serverName, vip)
 }
 
 func (AlwaysReadyInterface) Ready(context.Context, Config) (bool, error) {

--- a/internal/installer/bgpapivip/controller_test.go
+++ b/internal/installer/bgpapivip/controller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -206,6 +208,35 @@ func TestControllerWithdrawsWhenDependencyNotReady(t *testing.T) {
 	}
 }
 
+func TestHTTPHealthCheckerRequiresDNSNameToResolveToManagedVIP(t *testing.T) {
+	config, err := Normalize(minimalConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	health := config.Health
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})}
+	tests := []struct {
+		name      string
+		addresses []net.IPAddr
+		healthy   bool
+		wantError string
+	}{
+		{name: "managed VIP present", addresses: []net.IPAddr{{IP: net.ParseIP("10.40.0.10")}}, healthy: true},
+		{name: "managed VIP absent", addresses: []net.IPAddr{{IP: net.ParseIP("10.40.0.11")}}, wantError: "does not resolve to managed VIP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := HTTPHealthChecker{Client: client, Resolver: fakeResolver{addresses: tt.addresses}}
+			result := checker.Check(context.Background(), health)
+			if result.Healthy != tt.healthy || !strings.Contains(result.Error, tt.wantError) {
+				t.Fatalf("Check() = %#v", result)
+			}
+		})
+	}
+}
+
 func testController(bird *fakeBird, health HealthChecker) *Controller {
 	return &Controller{
 		Config:            minimalConfig(),
@@ -278,6 +309,21 @@ func (h *sequenceHealth) Check(context.Context, Health) HealthResult {
 type fakeInterface struct {
 	ready bool
 	err   error
+}
+
+type fakeResolver struct {
+	addresses []net.IPAddr
+	err       error
+}
+
+func (r fakeResolver) LookupIPAddr(context.Context, string) ([]net.IPAddr, error) {
+	return r.addresses, r.err
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
 }
 
 func (i fakeInterface) Ready(context.Context, Config) (bool, error) {

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -66,6 +66,13 @@ func Compile(request CompileRequest) (Plan, error) {
 	if endpointPlan != nil {
 		controlPlaneEndpoint = endpointPlan.Endpoint
 	}
+	if endpointPlan != nil && endpointPlan.Config.Advertisement != nil {
+		for _, plan := range request.KubeadmConfigs {
+			if err := kubeadmconfig.ValidateManagedEndpoint(plan, endpointPlan.Config.Advertisement.VIP, endpointPlan.Config.Port); err != nil {
+				return Plan{}, err
+			}
+		}
+	}
 
 	nodes := append([]Node(nil), config.Spec.Nodes...)
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -120,6 +120,29 @@ func TestCompileSelectsManagedEndpointOnlyForControlPlanes(t *testing.T) {
 	}
 }
 
+func TestCompileRejectsNativeKubeadmConflictWithManagedEndpoint(t *testing.T) {
+	config := validConfig()
+	config.Spec.ControlPlaneEndpoint = &controlplaneendpoint.Config{
+		Host: "api.katl.test",
+		Advertisement: &controlplaneendpoint.Advertisement{
+			VIP: "10.40.0.10",
+			BGP: &controlplaneendpoint.BGP{
+				LocalASN: 64512,
+				Peers:    []controlplaneendpoint.Peer{{Address: "10.0.0.1", ASN: 64500}},
+			},
+		},
+	}
+	configs := validKubeadmConfigs("v1.36.1")
+	controlPlane := configs["control-plane"]
+	controlPlane.Config.Content = []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\napiServer:\n  extraArgs:\n    - name: bind-address\n      value: 10.0.0.11\n")
+	configs["control-plane"] = controlPlane
+
+	_, err := Compile(CompileRequest{Config: config, KubeadmConfigs: configs})
+	if err == nil || !strings.Contains(err.Error(), "does not accept the managed VIP") {
+		t.Fatalf("Compile() error = %v, want managed endpoint conflict", err)
+	}
+}
+
 func nativeFile(files []confext.NativeEtcFile, path string) *confext.NativeEtcFile {
 	for index := range files {
 		if files[index].Path == path {

--- a/internal/installer/configapply/matrix.go
+++ b/internal/installer/configapply/matrix.go
@@ -48,8 +48,20 @@ const (
 )
 
 type Change struct {
-	Domain          string
-	LivePreflightOK bool
+	Domain                string
+	LivePreflightOK       bool
+	EndpointRoutingImpact *EndpointRoutingImpact
+}
+
+// EndpointRoutingImpact is the bounded operator-facing effect of changing the
+// managed control-plane endpoint's routing attachment. It deliberately names
+// sessions and exported route unions rather than exposing generated BIRD
+// protocol identifiers or configuration paths.
+type EndpointRoutingImpact struct {
+	FabricSessionsReset        []string `json:"fabricSessionsReset,omitempty"`
+	RouteExchangeSessionsReset []string `json:"routeExchangeSessionsReset,omitempty"`
+	ChangedExportUnions        []string `json:"changedExportUnions,omitempty"`
+	MayLoseAllFabricPaths      bool     `json:"mayLoseAllFabricPaths"`
 }
 
 type Decision struct {
@@ -60,11 +72,12 @@ type Decision struct {
 }
 
 type Diagnostic struct {
-	Domain            string
-	Classification    string
-	Decision          string
-	RequiredOperation string
-	Message           string
+	Domain            string                 `json:"domain"`
+	Classification    string                 `json:"classification"`
+	Decision          string                 `json:"decision"`
+	RequiredOperation string                 `json:"requiredOperation,omitempty"`
+	Message           string                 `json:"message,omitempty"`
+	EndpointRouting   *EndpointRoutingImpact `json:"endpointRouting,omitempty"`
 }
 
 type domainPolicy struct {
@@ -110,6 +123,11 @@ func Plan(requestedMode string, changes []Change) (Decision, error) {
 		diagnostic := diagnosticForChange(requestedMode, change, policy)
 		switch diagnostic.Decision {
 		case DecisionAccepted:
+			if change.EndpointRoutingImpact != nil {
+				diagnostic.EndpointRouting = change.EndpointRoutingImpact
+				diagnostic.Message = endpointRoutingImpactMessage(*change.EndpointRoutingImpact)
+				decision.Diagnostics = append(decision.Diagnostics, diagnostic)
+			}
 		case DecisionActionRequired:
 			needsNextBoot = true
 			decision.Diagnostics = append(decision.Diagnostics, diagnostic)
@@ -134,6 +152,23 @@ func Plan(requestedMode string, changes []Change) (Decision, error) {
 		decision.AcceptedMode = generation.ApplyModeLive
 	}
 	return decision, nil
+}
+
+func endpointRoutingImpactMessage(impact EndpointRoutingImpact) string {
+	parts := make([]string, 0, 4)
+	if len(impact.FabricSessionsReset) > 0 {
+		parts = append(parts, "fabric sessions reset: "+strings.Join(impact.FabricSessionsReset, ", "))
+	}
+	if len(impact.RouteExchangeSessionsReset) > 0 {
+		parts = append(parts, "local route-exchange sessions reset: "+strings.Join(impact.RouteExchangeSessionsReset, ", "))
+	}
+	if len(impact.ChangedExportUnions) > 0 {
+		parts = append(parts, "exported route unions change: "+strings.Join(impact.ChangedExportUnions, ", "))
+	}
+	if impact.MayLoseAllFabricPaths {
+		parts = append(parts, "this node temporarily withdraws its API route while routing configuration activates; cluster reachability requires another healthy advertiser")
+	}
+	return strings.Join(parts, "; ")
 }
 
 func DomainClassification(domain string) string {

--- a/internal/installer/configapply/matrix_test.go
+++ b/internal/installer/configapply/matrix_test.go
@@ -59,6 +59,34 @@ func TestPlanDefaultsOmittedModeToAutoAndAcceptsSysctlLive(t *testing.T) {
 	}
 }
 
+func TestPlanExplainsLiveEndpointRoutingImpact(t *testing.T) {
+	impact := &EndpointRoutingImpact{
+		FabricSessionsReset:        []string{"10.0.0.1", "10.0.0.2"},
+		RouteExchangeSessionsReset: []string{"cilium"},
+		ChangedExportUnions:        []string{"cilium"},
+		MayLoseAllFabricPaths:      true,
+	}
+	decision, err := Plan(generation.ApplyModeLive, []Change{{
+		Domain:                DomainControlPlaneEndpointRouting,
+		EndpointRoutingImpact: impact,
+	}})
+	if err != nil {
+		t.Fatalf("Plan() error = %v, diagnostics = %#v", err, decision.Diagnostics)
+	}
+	if decision.AcceptedMode != generation.ApplyModeLive || len(decision.Diagnostics) != 1 {
+		t.Fatalf("decision = %#v", decision)
+	}
+	diagnostic := decision.Diagnostics[0]
+	if diagnostic.Decision != DecisionAccepted || diagnostic.EndpointRouting != impact {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+	for _, want := range []string{"fabric sessions reset: 10.0.0.1, 10.0.0.2", "local route-exchange sessions reset: cilium", "exported route unions change: cilium", "requires another healthy advertiser"} {
+		if !strings.Contains(diagnostic.Message, want) {
+			t.Fatalf("diagnostic message = %q, want %q", diagnostic.Message, want)
+		}
+	}
+}
+
 func TestPlanAutoFallsBackToNextBootForStagedDomains(t *testing.T) {
 	decision, err := Plan(generation.ApplyModeAuto, []Change{
 		{Domain: DomainSysctl},

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -560,13 +560,14 @@ func classifyControlPlaneEndpointChange(current, desired *controlplaneendpoint.C
 		return
 	}
 	if !reflect.DeepEqual(currentPlan.Config, desiredPlan.Config) {
-		domains.add(DomainControlPlaneEndpointRouting)
+		domains.addEndpointRouting(endpointRoutingImpact(currentPlan.Config, desiredPlan.Config))
 	}
 }
 
 type domainAccumulator struct {
-	domains []string
-	seen    map[string]struct{}
+	domains               []string
+	seen                  map[string]struct{}
+	endpointRoutingImpact *EndpointRoutingImpact
 }
 
 func (a *domainAccumulator) add(domain string) {
@@ -580,6 +581,11 @@ func (a *domainAccumulator) add(domain string) {
 	a.domains = append(a.domains, domain)
 }
 
+func (a *domainAccumulator) addEndpointRouting(impact EndpointRoutingImpact) {
+	a.add(DomainControlPlaneEndpointRouting)
+	a.endpointRoutingImpact = &impact
+}
+
 func (a *domainAccumulator) changes(overlays ...NodeOverlay) []Change {
 	preflight := map[string]bool{}
 	for _, overlay := range overlays {
@@ -591,9 +597,75 @@ func (a *domainAccumulator) changes(overlays ...NodeOverlay) []Change {
 	}
 	changes := make([]Change, 0, len(a.domains))
 	for _, domain := range a.domains {
-		changes = append(changes, Change{Domain: domain, LivePreflightOK: preflight[domain]})
+		change := Change{Domain: domain, LivePreflightOK: preflight[domain]}
+		if domain == DomainControlPlaneEndpointRouting {
+			change.EndpointRoutingImpact = a.endpointRoutingImpact
+		}
+		changes = append(changes, change)
 	}
 	return changes
+}
+
+func endpointRoutingImpact(current, desired controlplaneendpoint.Config) EndpointRoutingImpact {
+	impact := EndpointRoutingImpact{MayLoseAllFabricPaths: true}
+	currentBGP := current.Advertisement.BGP
+	desiredBGP := desired.Advertisement.BGP
+
+	currentPeers := peerASNs(currentBGP.Peers)
+	desiredPeers := peerASNs(desiredBGP.Peers)
+	for _, address := range sortedStringUnion(currentPeers, desiredPeers) {
+		currentASN, currentOK := currentPeers[address]
+		desiredASN, desiredOK := desiredPeers[address]
+		if currentBGP.LocalASN != desiredBGP.LocalASN || currentOK != desiredOK || currentASN != desiredASN {
+			impact.FabricSessionsReset = append(impact.FabricSessionsReset, address)
+		}
+	}
+
+	currentExchanges := routeExchangesByName(currentBGP.RouteExchange)
+	desiredExchanges := routeExchangesByName(desiredBGP.RouteExchange)
+	for _, name := range sortedStringUnion(currentExchanges, desiredExchanges) {
+		before, beforeOK := currentExchanges[name]
+		after, afterOK := desiredExchanges[name]
+		if currentBGP.LocalASN != desiredBGP.LocalASN || beforeOK != afterOK || before.ListenPort != after.ListenPort || before.PeerASN != after.PeerASN {
+			impact.RouteExchangeSessionsReset = append(impact.RouteExchangeSessionsReset, name)
+		}
+		if beforeOK != afterOK || !reflect.DeepEqual(before.ExportToFabric, after.ExportToFabric) {
+			impact.ChangedExportUnions = append(impact.ChangedExportUnions, name)
+		}
+	}
+	return impact
+}
+
+func peerASNs(peers []controlplaneendpoint.Peer) map[string]uint32 {
+	out := make(map[string]uint32, len(peers))
+	for _, peer := range peers {
+		out[peer.Address] = peer.ASN
+	}
+	return out
+}
+
+func routeExchangesByName(exchanges []controlplaneendpoint.RouteExchange) map[string]controlplaneendpoint.RouteExchange {
+	out := make(map[string]controlplaneendpoint.RouteExchange, len(exchanges))
+	for _, exchange := range exchanges {
+		out[exchange.Name] = exchange
+	}
+	return out
+}
+
+func sortedStringUnion[A any](left, right map[string]A) []string {
+	set := make(map[string]struct{}, len(left)+len(right))
+	for value := range left {
+		set[value] = struct{}{}
+	}
+	for value := range right {
+		set[value] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	slices.Sort(out)
+	return out
 }
 
 func (request TrustedBundleRequest) kubeadmActionRequired(changes []Change) generation.KubeadmActionRequired {

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -120,7 +120,50 @@ func TestControlPlaneEndpointApplyClassification(t *testing.T) {
 			if err != nil || decision.AcceptedMode != tt.wantMode {
 				t.Fatalf("Plan() error = %v, decision = %#v, want mode %q", err, decision, tt.wantMode)
 			}
+			if tt.wantDomain == DomainControlPlaneEndpointRouting {
+				if len(decision.Diagnostics) != 1 || decision.Diagnostics[0].EndpointRouting == nil {
+					t.Fatalf("routing decision = %#v, want bounded impact", decision)
+				}
+				impact := decision.Diagnostics[0].EndpointRouting
+				if got, want := strings.Join(impact.FabricSessionsReset, ","), "192.0.2.1,192.0.2.2"; got != want {
+					t.Fatalf("fabric session resets = %q, want %q", got, want)
+				}
+				if !impact.MayLoseAllFabricPaths {
+					t.Fatal("routing plan did not disclose temporary local API route withdrawal")
+				}
+			}
 		})
+	}
+}
+
+func TestEndpointRoutingImpactNamesExchangeAndExportChanges(t *testing.T) {
+	before := managedEndpoint("192.0.2.1")
+	before.Advertisement.BGP.RouteExchange = []controlplaneendpoint.RouteExchange{{
+		Name: "cilium", ListenPort: 179, PeerASN: 64512,
+		ExportToFabric: []controlplaneendpoint.PrefixEnvelope{{CIDR: "10.50.0.0/16"}},
+	}}
+	after := managedEndpoint("192.0.2.1")
+	after.Advertisement.BGP.RouteExchange = []controlplaneendpoint.RouteExchange{{
+		Name: "cilium", ListenPort: 1179, PeerASN: 64513,
+		ExportToFabric: []controlplaneendpoint.PrefixEnvelope{{CIDR: "10.60.0.0/16"}},
+	}}
+	current, err := controlplaneendpoint.Normalize(*before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired, err := controlplaneendpoint.Normalize(*after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	impact := endpointRoutingImpact(current.Config, desired.Config)
+	if got, want := strings.Join(impact.RouteExchangeSessionsReset, ","), "cilium"; got != want {
+		t.Fatalf("route exchange resets = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(impact.ChangedExportUnions, ","), "cilium"; got != want {
+		t.Fatalf("changed export unions = %q, want %q", got, want)
+	}
+	if len(impact.FabricSessionsReset) != 0 {
+		t.Fatalf("unchanged fabric sessions reset = %#v", impact.FabricSessionsReset)
 	}
 }
 

--- a/internal/installer/kubeadmconfig/managed_endpoint.go
+++ b/internal/installer/kubeadmconfig/managed_endpoint.go
@@ -1,0 +1,132 @@
+package kubeadmconfig
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/netip"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ValidateManagedEndpoint rejects native kubeadm settings that would prevent
+// the API server from accepting traffic for the endpoint Katl advertises.
+func ValidateManagedEndpoint(plan Plan, vip string, port int) error {
+	address, err := netip.ParseAddr(strings.TrimSpace(vip))
+	if err != nil || !address.Is4() {
+		return fmt.Errorf("managed endpoint VIP must be an IPv4 address")
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("managed endpoint port must be between 1 and 65535")
+	}
+	if err := validateEndpointDocuments(plan.Config.Content, address.String(), port); err != nil {
+		return fmt.Errorf("KubeadmConfig %q: %w", plan.Name, err)
+	}
+	for _, patch := range plan.Patches {
+		if !strings.HasPrefix(filepath.Base(patch.RenderPath), "kube-apiserver") {
+			continue
+		}
+		if err := validateEndpointPatch(patch.Content, address.String(), port); err != nil {
+			return fmt.Errorf("KubeadmConfig %q patch %q: %w", plan.Name, filepath.Base(patch.RenderPath), err)
+		}
+	}
+	return nil
+}
+
+func validateEndpointDocuments(data []byte, vip string, port int) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var document map[string]any
+		if err := decoder.Decode(&document); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("decode native kubeadm input: %w", err)
+		}
+		if fmt.Sprint(document["kind"]) != "ClusterConfiguration" {
+			continue
+		}
+		apiServer, _ := document["apiServer"].(map[string]any)
+		if err := validateEndpointExtraArgs(apiServer["extraArgs"], vip, port); err != nil {
+			return err
+		}
+	}
+}
+
+func validateEndpointExtraArgs(value any, vip string, port int) error {
+	switch args := value.(type) {
+	case []any:
+		for _, item := range args {
+			arg, _ := item.(map[string]any)
+			if err := validateEndpointFlag(fmt.Sprint(arg["name"]), fmt.Sprint(arg["value"]), vip, port); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		for name, value := range args {
+			if err := validateEndpointFlag(name, fmt.Sprint(value), vip, port); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateEndpointPatch(data []byte, vip string, port int) error {
+	var document any
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return fmt.Errorf("decode patch: %w", err)
+	}
+	var scalars []string
+	collectStrings(document, &scalars)
+	for index, scalar := range scalars {
+		name, value, found := strings.Cut(strings.TrimSpace(scalar), "=")
+		if !found {
+			if name != "--bind-address" && name != "--secure-port" {
+				continue
+			}
+			if index+1 >= len(scalars) {
+				return fmt.Errorf("%s requires an explicit value which Katl can validate", name)
+			}
+			value = scalars[index+1]
+		}
+		if err := validateEndpointFlag(strings.TrimPrefix(name, "--"), value, vip, port); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectStrings(value any, out *[]string) {
+	switch value := value.(type) {
+	case string:
+		*out = append(*out, value)
+	case []any:
+		for _, item := range value {
+			collectStrings(item, out)
+		}
+	case map[string]any:
+		for _, item := range value {
+			collectStrings(item, out)
+		}
+	}
+}
+
+func validateEndpointFlag(name, value, vip string, port int) error {
+	switch strings.TrimPrefix(strings.TrimSpace(name), "--") {
+	case "bind-address":
+		value = strings.TrimSpace(value)
+		if value != "0.0.0.0" && value != vip {
+			return fmt.Errorf("apiServer bind-address %q does not accept the managed VIP %s; remove it or use 0.0.0.0", value, vip)
+		}
+	case "secure-port":
+		value = strings.TrimSpace(value)
+		configured, err := strconv.Atoi(value)
+		if err != nil || configured != port {
+			return fmt.Errorf("apiServer secure-port %q conflicts with the managed endpoint port %d", value, port)
+		}
+	}
+	return nil
+}

--- a/internal/installer/kubeadmconfig/managed_endpoint_test.go
+++ b/internal/installer/kubeadmconfig/managed_endpoint_test.go
@@ -1,0 +1,62 @@
+package kubeadmconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateManagedEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		patches []File
+		wantErr string
+	}{
+		{
+			name:   "defaults",
+			config: "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\napiServer: {}\n",
+		},
+		{
+			name:   "explicit compatible arguments",
+			config: "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\napiServer:\n  extraArgs:\n    - name: bind-address\n      value: 0.0.0.0\n    - name: secure-port\n      value: \"6443\"\n",
+		},
+		{
+			name:    "conflicting bind address",
+			config:  "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\napiServer:\n  extraArgs:\n    - name: bind-address\n      value: 192.0.2.11\n",
+			wantErr: "does not accept the managed VIP",
+		},
+		{
+			name:    "conflicting secure port",
+			config:  "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\napiServer:\n  extraArgs:\n    - name: secure-port\n      value: \"7443\"\n",
+			wantErr: "conflicts with the managed endpoint port 6443",
+		},
+		{
+			name:    "compatible apiserver patch",
+			config:  "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n",
+			patches: []File{{RenderPath: "/etc/katl/kubeadm/cp/patches/kube-apiserver0+merge.yaml", Content: []byte("spec:\n  containers:\n    - name: kube-apiserver\n      command: [kube-apiserver, --bind-address=10.40.0.10]\n")}},
+		},
+		{
+			name:    "conflicting apiserver patch",
+			config:  "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n",
+			patches: []File{{RenderPath: "/etc/katl/kubeadm/cp/patches/kube-apiserver0+merge.yaml", Content: []byte("spec:\n  containers:\n    - name: kube-apiserver\n      command: [kube-apiserver, --secure-port=7443]\n")}},
+			wantErr: "conflicts with the managed endpoint port 6443",
+		},
+		{
+			name:    "other component patch ignored",
+			config:  "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n",
+			patches: []File{{RenderPath: "/etc/katl/kubeadm/cp/patches/kube-controller-manager0+merge.yaml", Content: []byte("spec:\n  containers:\n    - command: [controller, --secure-port=7443]\n")}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := Plan{Name: "cp", Config: File{Content: []byte(tt.config)}, Patches: tt.patches}
+			err := ValidateManagedEndpoint(plan, "10.40.0.10", 6443)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("ValidateManagedEndpoint() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("ValidateManagedEndpoint() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/vmtest/scenarios/bgp_api_vip_vmtest_test.go
+++ b/internal/vmtest/scenarios/bgp_api_vip_vmtest_test.go
@@ -2,8 +2,15 @@ package scenarios
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,10 +21,13 @@ import (
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/nodeextensionbundle"
 	"github.com/katl-dev/katl/internal/vmtest"
 	vmtestpb "github.com/katl-dev/katl/internal/vmtest/proto"
 )
+
+const routedEndpointProofVIP = "198.51.100.10"
 
 func TestBIRDAndBGPAPIVIPExtensionsVMProof(t *testing.T) {
 	if run, ok := bgpAPIVIPWorldRun(t); ok {
@@ -55,6 +65,10 @@ type bgpAPIVIPInputs struct {
 	WorkerMetadata         string                        `json:"workerMetadata"`
 	WorkerAddress          string                        `json:"workerAddress"`
 	WorkerMAC              string                        `json:"workerMAC"`
+	RouterAddress          string                        `json:"routerAddress"`
+	RouterMAC              string                        `json:"routerMAC"`
+	ClientAddress          string                        `json:"clientAddress"`
+	ClientMAC              string                        `json:"clientMAC"`
 	WorldProvenance        multiNodeWorldProvenancePaths `json:"worldProvenance"`
 }
 
@@ -136,6 +150,16 @@ func planBGPAPIVIPWorldRun(world vmtest.World, repo string, kvm vmtest.KVMPolicy
 		_ = scenario.WriteSetupFailure(err)
 		return run, err
 	}
+	router, err := scenario.AddNode(vmtest.NodeSpec{Name: "fabric-router", Role: vmtest.ControlPlane})
+	if err != nil {
+		_ = scenario.WriteSetupFailure(err)
+		return run, err
+	}
+	client, err := scenario.AddNode(vmtest.NodeSpec{Name: "external-client", Role: vmtest.Worker})
+	if err != nil {
+		_ = scenario.WriteSetupFailure(err)
+		return run, err
+	}
 	options := vmtest.Options{
 		Enabled:   true,
 		StateRoot: filepath.Join(scenario.Dir, "vm-runs"),
@@ -172,6 +196,10 @@ func planBGPAPIVIPWorldRun(world vmtest.World, repo string, kvm vmtest.KVMPolicy
 			WorkerMetadata:         worker.Config.NodeMetadata,
 			WorkerAddress:          worker.Node.Address,
 			WorkerMAC:              worker.Node.MACAddress,
+			RouterAddress:          router.Address,
+			RouterMAC:              router.MACAddress,
+			ClientAddress:          client.Address,
+			ClientMAC:              client.MACAddress,
 			WorldProvenance:        multiNodeWorldProvenanceForSpecs(world, repo, []vmtest.NodeSpec{{Name: "cp-1", Role: vmtest.ControlPlane}, {Name: "worker-1", Role: vmtest.Worker}}),
 		},
 	}, nil
@@ -227,6 +255,22 @@ func runBGPAPIVIPProof(t *testing.T, run bgpAPIVIPRun) {
 	}
 	defer stopNode(t, workerNode)
 
+	routerNode, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "fabric-router", run.Inputs.ControlPlaneDisk, run.Inputs.ControlPlaneESP, run.Inputs.ControlPlaneFixture, run.Inputs.ControlPlaneMetadata, vmtest.DiskFormat(run.Inputs.ControlPlaneDiskFormat), run.Inputs.RouterMAC), vmtest.VMRunner{})
+	if err != nil {
+		collectTwoNodeDiagnostics("", cpNode, workerNode)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("start fabric-router VM: %v", err)
+	}
+	defer stopNode(t, routerNode)
+
+	clientNode, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "external-client", run.Inputs.WorkerDisk, run.Inputs.WorkerESP, run.Inputs.WorkerFixture, run.Inputs.WorkerMetadata, vmtest.DiskFormat(run.Inputs.WorkerDiskFormat), run.Inputs.ClientMAC), vmtest.VMRunner{})
+	if err != nil {
+		collectTwoNodeDiagnostics("", cpNode, workerNode, routerNode)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("start external-client VM: %v", err)
+	}
+	defer stopNode(t, clientNode)
+
 	config := bgpAPIVIPConfigYAML(firstString(cpNode.Result.IPAddress, run.Inputs.ControlPlaneAddress))
 	configPath := filepath.Join(result.ManifestDir, "bgp-api-vip.yaml")
 	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
@@ -248,6 +292,11 @@ func runBGPAPIVIPProof(t *testing.T, run bgpAPIVIPRun) {
 		collectTwoNodeDiagnostics("", cpNode, workerNode)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatal(err)
+	}
+	if err := runRealRoutedEndpointProof(ctx, result, cpNode, workerNode, routerNode, clientNode, helper); err != nil {
+		collectTwoNodeDiagnostics("", cpNode, workerNode, routerNode, clientNode)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("real routed endpoint proof: %v", err)
 	}
 	if err := writeBGPAPIVIPProofManifest(result, run.Inputs, staged, helper, cpNode, workerNode, cpProof, workerProof); err != nil {
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
@@ -449,6 +498,438 @@ func assertBGPAPIVIPGuestProofs(cpProofPath, workerProofPath string) error {
 		return fmt.Errorf("worker proof = %#v", worker)
 	}
 	return nil
+}
+
+type routedEndpointVMProof struct {
+	APIVersion               string   `json:"apiVersion"`
+	Kind                     string   `json:"kind"`
+	VIP                      string   `json:"vip"`
+	ControlPlane             string   `json:"controlPlane"`
+	FabricRouter             string   `json:"fabricRouter"`
+	ExternalClient           string   `json:"externalClient"`
+	Worker                   string   `json:"worker"`
+	InitialBirdInactive      bool     `json:"initialBirdInactive"`
+	WorkerArtifactAbsent     bool     `json:"workerArtifactAbsent"`
+	RouteAdvertised          bool     `json:"routeAdvertised"`
+	ExternalReadyzReachable  bool     `json:"externalReadyzReachable"`
+	APIFailureWithdrawn      bool     `json:"apiFailureWithdrawn"`
+	APIRecoveryReadvertised  bool     `json:"apiRecoveryReadvertised"`
+	ControllerKillWithdrawn  bool     `json:"controllerKillWithdrawn"`
+	RoutingDaemonKillRemoved bool     `json:"routingDaemonKillRemoved"`
+	Checks                   []string `json:"checks"`
+}
+
+func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, worker, router, client vmtest.RunningInstalledRuntimeNode, helper string) error {
+	proof := routedEndpointVMProof{
+		APIVersion:     "katl.dev/v1alpha1",
+		Kind:           "RoutedControlPlaneEndpointVMProof",
+		VIP:            routedEndpointProofVIP + "/32",
+		ControlPlane:   cp.Result.IPAddress,
+		FabricRouter:   router.Result.IPAddress,
+		ExternalClient: client.Result.IPAddress,
+		Worker:         worker.Result.IPAddress,
+	}
+	writeProof := func() {
+		data, _ := json.MarshalIndent(proof, "", "  ")
+		_ = os.WriteFile(filepath.Join(result.ManifestDir, "routed-control-plane-endpoint-proof.json"), append(data, '\n'), 0o644)
+	}
+	defer writeProof()
+
+	if err := assertGuestCommand(ctx, worker, []string{"test", "!", "-e", "/var/lib/katl/artifacts/katlos-image/katl-endpoint-advertiser.raw"}); err != nil {
+		return fmt.Errorf("worker retained endpoint advertiser artifact: %w", err)
+	}
+	proof.WorkerArtifactAbsent = true
+	proof.Checks = append(proof.Checks, "worker has no endpoint advertiser payload")
+
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, router} {
+		if err := activateRetainedEndpointSysext(ctx, node); err != nil {
+			return fmt.Errorf("activate endpoint sysext on %s: %w", node.Name, err)
+		}
+	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "start", "katl-app-bird.service"}); err != nil {
+		return fmt.Errorf("ask conditioned BIRD unit to start without config: %w", err)
+	}
+	if active, err := guestUnitActive(ctx, cp, "katl-app-bird.service"); err != nil {
+		return err
+	} else if active {
+		return fmt.Errorf("BIRD became active without managed VIP configuration")
+	}
+	proof.InitialBirdInactive = true
+	proof.Checks = append(proof.Checks, "BIRD remains inactive without the managed-advertisement marker")
+
+	if err := configureFabricRouter(ctx, router, []string{cp.Result.IPAddress}); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, router, []string{"sysctl", "-w", "net.ipv4.ip_forward=1"}); err != nil {
+		return fmt.Errorf("enable fabric router forwarding: %w", err)
+	}
+	if err := assertGuestCommand(ctx, client, []string{"ip", "route", "replace", routedEndpointProofVIP + "/32", "via", router.Result.IPAddress}); err != nil {
+		return fmt.Errorf("install external client VIP route: %w", err)
+	}
+
+	caPEM, certPEM, keyPEM, err := routedEndpointTLSFixture(net.ParseIP(routedEndpointProofVIP))
+	if err != nil {
+		return err
+	}
+	const fixtureRoot = "/var/lib/katl/test-artifacts/routed-endpoint"
+	for _, target := range []struct {
+		node vmtest.RunningInstalledRuntimeNode
+		path string
+		data []byte
+		mode uint32
+	}{
+		{cp, fixtureRoot + "/ca.crt", caPEM, 0o644},
+		{cp, fixtureRoot + "/server.crt", certPEM, 0o644},
+		{cp, fixtureRoot + "/server.key", keyPEM, 0o600},
+		{client, fixtureRoot + "/ca.crt", caPEM, 0o644},
+	} {
+		if err := writeNodeFile(ctx, target.node, target.path, target.data, target.mode, target.mode == 0o600); err != nil {
+			return err
+		}
+	}
+	if err := assertGuestCommand(ctx, cp, []string{
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		"/usr/bin/install", "-D", "-m", "0644", fixtureRoot + "/ca.crt", "/etc/kubernetes/pki/ca.crt",
+	}); err != nil {
+		return fmt.Errorf("install kubeadm-compatible API CA: %w", err)
+	}
+	helperData, err := os.ReadFile(helper)
+	if err != nil {
+		return err
+	}
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, client} {
+		if err := writeNodeFileChunked(ctx, node, fixtureRoot+"/bgp-api-vip-smoke", helperData, 0o755); err != nil {
+			return err
+		}
+	}
+
+	endpointPlan, err := controlPlaneEndpointVMFiles(router.Result.IPAddress)
+	if err != nil {
+		return err
+	}
+	if err := activateEndpointConfext(ctx, cp, fixtureRoot, endpointPlan); err != nil {
+		return err
+	}
+	if err := createGuestDummyVIP(ctx, cp); err != nil {
+		return err
+	}
+	if err := startReadyzFixture(ctx, cp, fixtureRoot); err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = runNodeCommand(context.Background(), cp, []string{"systemctl", "stop", "katl-vmtest-readyz.service"}, 8<<10)
+	}()
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "daemon-reload"}); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}); err != nil {
+		return fmt.Errorf("start production endpoint controller: %w", err)
+	}
+
+	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, true, 30*time.Second); err != nil {
+		return err
+	}
+	proof.RouteAdvertised = true
+	proof.Checks = append(proof.Checks, "fabric router learned the healthy API /32 from production BIRD")
+	if err := probeReadyzFromClient(ctx, client, fixtureRoot); err != nil {
+		return err
+	}
+	proof.ExternalReadyzReachable = true
+	proof.Checks = append(proof.Checks, "external client reached TLS /readyz through the fabric router")
+
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "stop", "katl-vmtest-readyz.service"}); err != nil {
+		return fmt.Errorf("stop API readiness fixture: %w", err)
+	}
+	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, false, 20*time.Second); err != nil {
+		return fmt.Errorf("API failure did not withdraw route: %w", err)
+	}
+	proof.APIFailureWithdrawn = true
+	proof.Checks = append(proof.Checks, "local API failure withdrew only the API route")
+	if err := startReadyzFixture(ctx, cp, fixtureRoot); err != nil {
+		return err
+	}
+	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, true, 30*time.Second); err != nil {
+		return fmt.Errorf("API recovery did not readvertise route: %w", err)
+	}
+	proof.APIRecoveryReadvertised = true
+
+	if err := setVMTestRestartPolicy(ctx, cp, "katl-app-bgp-api-vip.service", "no"); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "kill", "--kill-whom=main", "--signal=SIGKILL", "katl-app-bgp-api-vip.service"}); err != nil {
+		return fmt.Errorf("kill endpoint controller: %w", err)
+	}
+	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, false, 20*time.Second); err != nil {
+		return fmt.Errorf("ungraceful controller death did not withdraw route: %w", err)
+	}
+	proof.ControllerKillWithdrawn = true
+	proof.Checks = append(proof.Checks, "ungraceful controller death failed closed")
+	if err := setVMTestRestartPolicy(ctx, cp, "katl-app-bgp-api-vip.service", "always"); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "reset-failed", "katl-app-bgp-api-vip.service"}); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}); err != nil {
+		return err
+	}
+	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, true, 30*time.Second); err != nil {
+		return err
+	}
+
+	if err := setVMTestRestartPolicy(ctx, cp, "katl-app-bird.service", "no"); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "kill", "--kill-whom=main", "--signal=SIGKILL", "katl-app-bird.service"}); err != nil {
+		return fmt.Errorf("kill routing daemon: %w", err)
+	}
+	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, false, 20*time.Second); err != nil {
+		return fmt.Errorf("routing daemon death did not remove route: %w", err)
+	}
+	proof.RoutingDaemonKillRemoved = true
+	proof.Checks = append(proof.Checks, "routing-daemon death removed the fabric route")
+	return nil
+}
+
+func activateRetainedEndpointSysext(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) error {
+	const artifact = "/var/lib/katl/artifacts/katlos-image/katl-endpoint-advertiser.raw"
+	if err := assertGuestCommand(ctx, node, []string{"test", "-f", artifact}); err != nil {
+		return fmt.Errorf("retained endpoint artifact is missing: %w", err)
+	}
+	for _, argv := range [][]string{
+		{"install", "-d", "/run/extensions"},
+		{"systemd-run", "--quiet", "--wait", "--collect", "--pipe", "/usr/bin/ln", "-sf", artifact, "/run/extensions/katl-endpoint-advertiser.raw"},
+		{"systemd-run", "--quiet", "--wait", "--collect", "--pipe", "/usr/bin/systemd-sysext", "refresh"},
+		{"systemctl", "daemon-reload"},
+	} {
+		if err := assertGuestCommand(ctx, node, argv); err != nil {
+			return fmt.Errorf("%s: %w", strings.Join(argv, " "), err)
+		}
+	}
+	return nil
+}
+
+func controlPlaneEndpointVMFiles(routerAddress string) (bgpapivip.Plan, error) {
+	intent, err := controlplaneendpoint.Normalize(controlplaneendpoint.Config{
+		Host: routedEndpointProofVIP,
+		Advertisement: &controlplaneendpoint.Advertisement{
+			VIP: routedEndpointProofVIP,
+			BGP: &controlplaneendpoint.BGP{
+				LocalASN: 64512,
+				Peers:    []controlplaneendpoint.Peer{{Address: routerAddress, ASN: 64500}},
+			},
+		},
+	})
+	if err != nil {
+		return bgpapivip.Plan{}, err
+	}
+	config, err := bgpapivip.FromControlPlaneEndpoint(intent)
+	if err != nil {
+		return bgpapivip.Plan{}, err
+	}
+	return bgpapivip.RenderNativeEtcFiles(bgpapivip.RenderRequest{NodeRole: "control-plane", Config: config})
+}
+
+func configureFabricRouter(ctx context.Context, router vmtest.RunningInstalledRuntimeNode, peers []string) error {
+	var config strings.Builder
+	fmt.Fprintf(&config, "router id %s;\n\nprotocol device {}\n\n", router.Result.IPAddress)
+	config.WriteString("protocol kernel katl_kernel {\n  ipv4 { import none; export all; };\n  merge paths on limit 16;\n}\n\n")
+	for index, peer := range peers {
+		fmt.Fprintf(&config, "protocol bgp katl_cp_%d {\n  local as 64500;\n  neighbor %s as 64512;\n  ipv4 { import all; export none; };\n}\n\n", index+1, peer)
+	}
+	const path = "/var/lib/katl/test-artifacts/routed-endpoint/fabric-router.conf"
+	if err := writeNodeFile(ctx, router, path, []byte(config.String()), 0o644, false); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, router, []string{"install", "-d", "/run/katl-fabric-router"}); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, router, []string{
+		"systemd-run", "--quiet", "--collect", "--unit=katl-vmtest-fabric-router.service", "--property=Restart=on-failure",
+		"/usr/bin/bird", "-f", "-c", path, "-s", "/run/katl-fabric-router/bird.ctl",
+	}); err != nil {
+		return fmt.Errorf("start fabric BIRD: %w", err)
+	}
+	return nil
+}
+
+func installStagedNodeFile(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, stagingRoot, target string, data []byte, mode uint32, sensitive bool) error {
+	staged := stagingRoot + "/privileged" + filepath.Clean(target)
+	if err := writeNodeFile(ctx, node, staged, data, mode, sensitive); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, node, []string{
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		"/usr/bin/install", "-D", "-m", fmt.Sprintf("%04o", mode), staged, target,
+	}); err != nil {
+		return fmt.Errorf("install %s: %w", target, err)
+	}
+	return nil
+}
+
+func activateEndpointConfext(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, stagingRoot string, plan bgpapivip.Plan) error {
+	const (
+		name = "katl-endpoint-vmtest"
+		root = "/run/confexts/" + name
+	)
+	for _, file := range plan.Files {
+		switch file.Path {
+		case bgpapivip.ConfigPath, bgpapivip.BirdConfigPath, bgpapivip.AdvertisementEnabledPath:
+			target := root + file.Path
+			if err := installStagedNodeFile(ctx, node, stagingRoot, target, []byte(file.Content), uint32(file.Mode.Perm()), false); err != nil {
+				return err
+			}
+		}
+	}
+	releasePath := root + "/etc/extension-release.d/extension-release." + name
+	if err := installStagedNodeFile(ctx, node, stagingRoot, releasePath, []byte("ID=katlos\nCONFEXT_LEVEL=1\n"), 0o644, false); err != nil {
+		return err
+	}
+	if err := assertGuestCommand(ctx, node, []string{
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe", "/usr/bin/systemd-confext", "refresh",
+	}); err != nil {
+		return fmt.Errorf("activate endpoint confext: %w", err)
+	}
+	return nil
+}
+
+func createGuestDummyVIP(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) error {
+	for _, argv := range [][]string{
+		{"ip", "link", "add", "katl-api", "type", "dummy"},
+		{"ip", "address", "add", routedEndpointProofVIP + "/32", "dev", "katl-api"},
+		{"ip", "link", "set", "katl-api", "up"},
+	} {
+		if err := assertGuestCommand(ctx, node, argv); err != nil {
+			return fmt.Errorf("%s: %w", strings.Join(argv, " "), err)
+		}
+	}
+	return nil
+}
+
+func startReadyzFixture(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, root string) error {
+	_, _ = runNodeCommand(ctx, node, []string{"systemctl", "stop", "katl-vmtest-readyz.service"}, 8<<10)
+	return assertGuestCommand(ctx, node, []string{
+		"systemd-run", "--quiet", "--collect", "--unit=katl-vmtest-readyz.service",
+		root + "/bgp-api-vip-smoke", "serve-readyz",
+		"--listen", routedEndpointProofVIP + ":6443", "--cert", root + "/server.crt", "--key", root + "/server.key",
+	})
+}
+
+func probeReadyzFromClient(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, root string) error {
+	result, err := runNodeCommand(ctx, node, []string{
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		root + "/bgp-api-vip-smoke", "probe-readyz",
+		"--url", "https://" + routedEndpointProofVIP + ":6443/readyz", "--ca", root + "/ca.crt", "--server-name", routedEndpointProofVIP,
+	}, 16<<10)
+	if err != nil {
+		return err
+	}
+	if result.ExitStatus != 0 || strings.TrimSpace(string(result.Stdout)) != "ok" {
+		return fmt.Errorf("external readyz probe: %w", commandErrorDetail(result))
+	}
+	return nil
+}
+
+func waitForRouterRoute(ctx context.Context, router vmtest.RunningInstalledRuntimeNode, prefix string, present bool, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		result, err := runNodeCommand(ctx, router, []string{
+			"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+			"/usr/bin/birdc", "-s", "/run/katl-fabric-router/bird.ctl", "show", "route", "for", prefix, "all",
+		}, 32<<10)
+		if err == nil {
+			last = string(result.Stdout) + string(result.Stderr)
+			hasRoute := result.ExitStatus == 0 && strings.Contains(last, prefix)
+			if hasRoute == present {
+				return last, nil
+			}
+		} else {
+			last = err.Error()
+		}
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return last, fmt.Errorf("fabric route %s presence=%t not observed: %s", prefix, present, strings.TrimSpace(last))
+}
+
+func guestUnitActive(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, unit string) (bool, error) {
+	result, err := runNodeCommand(ctx, node, []string{"systemctl", "is-active", "--quiet", unit}, 8<<10)
+	if err != nil {
+		return false, err
+	}
+	return result.ExitStatus == 0, nil
+}
+
+func assertGuestCommand(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, argv []string) error {
+	result, err := runNodeCommand(ctx, node, argv, 32<<10)
+	if err != nil {
+		return err
+	}
+	if result.ExitStatus != 0 {
+		return commandErrorDetail(result)
+	}
+	return nil
+}
+
+func setVMTestRestartPolicy(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, unit, restart string) error {
+	root := "/var/lib/katl/test-artifacts/routed-endpoint"
+	dropIn := root + "/" + strings.ReplaceAll(unit, ".", "-") + "-restart.conf"
+	if err := writeNodeFile(ctx, node, dropIn, []byte("[Service]\nRestart="+restart+"\n"), 0o644, false); err != nil {
+		return err
+	}
+	target := "/run/systemd/system/" + unit + ".d/90-vmtest-restart.conf"
+	if err := assertGuestCommand(ctx, node, []string{
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe", "/usr/bin/install", "-D", "-m", "0644", dropIn, target,
+	}); err != nil {
+		return err
+	}
+	return assertGuestCommand(ctx, node, []string{"systemctl", "daemon-reload"})
+}
+
+func routedEndpointTLSFixture(vip net.IP) ([]byte, []byte, []byte, error) {
+	now := time.Now().UTC()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "katl routed endpoint VM CA"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	serverTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: routedEndpointProofVIP},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{vip},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, &serverTemplate, &caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	return caPEM, certPEM, keyPEM, nil
 }
 
 func readProofJSON(path string, out any) error {

--- a/internal/vmtest/testcmd/bgp-api-vip-smoke/main.go
+++ b/internal/vmtest/testcmd/bgp-api-vip-smoke/main.go
@@ -2,14 +2,21 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
@@ -44,9 +51,102 @@ type fakeBird struct {
 }
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "serve-readyz":
+			if err := serveReadyz(os.Args[2:]); err != nil {
+				log.Fatal(err)
+			}
+			return
+		case "probe-readyz":
+			if err := probeReadyz(os.Args[2:], os.Stdout); err != nil {
+				log.Fatal(err)
+			}
+			return
+		}
+	}
 	if err := run(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func serveReadyz(args []string) error {
+	flags := flag.NewFlagSet("serve-readyz", flag.ContinueOnError)
+	listen := flags.String("listen", "", "listen address")
+	cert := flags.String("cert", "", "TLS certificate")
+	key := flags.String("key", "", "TLS private key")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *listen == "" || *cert == "" || *key == "" {
+		return errors.New("--listen, --cert, and --key are required")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "ok\n")
+	})
+	server := &http.Server{
+		Addr:              *listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 2 * time.Second,
+		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	done := make(chan error, 1)
+	go func() { done <- server.ListenAndServeTLS(*cert, *key) }()
+	select {
+	case err := <-done:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	}
+}
+
+func probeReadyz(args []string, stdout io.Writer) error {
+	flags := flag.NewFlagSet("probe-readyz", flag.ContinueOnError)
+	target := flags.String("url", "", "readyz URL")
+	caPath := flags.String("ca", "", "CA certificate")
+	serverName := flags.String("server-name", "", "TLS server name")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	ca, err := os.ReadFile(*caPath)
+	if err != nil {
+		return err
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(ca) {
+		return errors.New("CA certificate is invalid")
+	}
+	client := http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    roots,
+			ServerName: *serverName,
+		}},
+	}
+	response, err := client.Get(*target)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 4096))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK || strings.TrimSpace(string(body)) != "ok" {
+		return fmt.Errorf("readyz returned %s: %s", response.Status, strings.TrimSpace(string(body)))
+	}
+	_, err = stdout.Write(body)
+	return err
 }
 
 func run() error {


### PR DESCRIPTION
Completes the routed endpoint acceptance boundary by exposing live-routing impact, rejecting native kubeadm listener conflicts, and gating DNS-named advertisement on resolution to the managed VIP. Adds a real four-VM fabric journey proving BIRD stays stopped until advertisement is enabled, external TLS reachability, worker exclusion, and fail-closed withdrawal.