### PR TITLE
endpoint: decouple advertisement from DNS

### DIFF
--- a/docs/internal/katl-routed-control-plane-endpoint-design.md
+++ b/docs/internal/katl-routed-control-plane-endpoint-design.md
@@ -584,11 +584,12 @@ TLS server name: controlPlaneEndpoint.host
 trust root: /etc/kubernetes/pki/ca.crt
 ```
 
-When the endpoint host is a DNS name, the controller first requires local DNS
-to resolve it to the managed VIP. Probing the VIP then verifies local address
-delivery, API listening, TLS identity, etcd-dependent API readiness and the
-endpoint port. A `200` response is healthy. Probe timing and thresholds are
-Katl-owned constants and are not configuration fields.
+The endpoint host may be either an IP literal or a DNS name. Katl does not use
+DNS resolution as an advertisement health signal: a transient or deliberately
+external DNS view must not withdraw an otherwise healthy route. Probing the VIP
+verifies local address delivery, API listening, TLS identity, etcd-dependent
+API readiness and the endpoint port. A `200` response is healthy. Probe timing
+and thresholds are Katl-owned constants and are not configuration fields.
 
 State transitions are:
 

--- a/internal/installer/bgpapivip/controller.go
+++ b/internal/installer/bgpapivip/controller.go
@@ -9,9 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,10 +140,7 @@ type FileStatusWriter struct {
 }
 
 type HTTPHealthChecker struct {
-	Client   *http.Client
-	Resolver interface {
-		LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
-	}
+	Client *http.Client
 }
 
 type AlwaysReadyInterface struct{}
@@ -272,10 +267,6 @@ func (c *Controller) Stop(ctx context.Context) (Status, error) {
 }
 
 func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResult {
-	target := healthTarget(health)
-	if err := h.checkEndpointDNS(ctx, target, health.TLSServerName); err != nil {
-		return HealthResult{Healthy: false, Error: err.Error(), CheckedAt: time.Now().UTC()}
-	}
 	client := h.Client
 	if client == nil {
 		ca, err := os.ReadFile("/etc/kubernetes/pki/ca.crt")
@@ -299,6 +290,7 @@ func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResul
 			}},
 		}
 	}
+	target := healthTarget(health)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
 		return HealthResult{Healthy: false, Error: err.Error(), CheckedAt: time.Now().UTC()}
@@ -309,35 +301,6 @@ func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResul
 	}
 	defer resp.Body.Close()
 	return HealthResult{Healthy: resp.StatusCode >= 200 && resp.StatusCode < 300, StatusCode: resp.StatusCode, CheckedAt: time.Now().UTC()}
-}
-
-func (h HTTPHealthChecker) checkEndpointDNS(ctx context.Context, target, serverName string) error {
-	serverName = strings.TrimSpace(serverName)
-	if serverName == "" || net.ParseIP(serverName) != nil {
-		return nil
-	}
-	parsed, err := url.Parse(target)
-	if err != nil {
-		return fmt.Errorf("parse endpoint health target: %w", err)
-	}
-	vip := net.ParseIP(parsed.Hostname())
-	if vip == nil {
-		return fmt.Errorf("endpoint health target does not contain the managed VIP")
-	}
-	resolver := h.Resolver
-	if resolver == nil {
-		resolver = net.DefaultResolver
-	}
-	addresses, err := resolver.LookupIPAddr(ctx, serverName)
-	if err != nil {
-		return fmt.Errorf("resolve endpoint host %s: %w", serverName, err)
-	}
-	for _, address := range addresses {
-		if address.IP.Equal(vip) {
-			return nil
-		}
-	}
-	return fmt.Errorf("endpoint host %s does not resolve to managed VIP %s", serverName, vip)
 }
 
 func (AlwaysReadyInterface) Ready(context.Context, Config) (bool, error) {

--- a/internal/installer/bgpapivip/controller_test.go
+++ b/internal/installer/bgpapivip/controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -208,32 +207,19 @@ func TestControllerWithdrawsWhenDependencyNotReady(t *testing.T) {
 	}
 }
 
-func TestHTTPHealthCheckerRequiresDNSNameToResolveToManagedVIP(t *testing.T) {
-	config, err := Normalize(minimalConfig())
-	if err != nil {
-		t.Fatal(err)
-	}
-	health := config.Health
-	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+func TestHTTPHealthCheckerDoesNotUseDNSAsAdvertisementHealth(t *testing.T) {
+	checker := HTTPHealthChecker{Client: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
-	})}
-	tests := []struct {
-		name      string
-		addresses []net.IPAddr
-		healthy   bool
-		wantError string
-	}{
-		{name: "managed VIP present", addresses: []net.IPAddr{{IP: net.ParseIP("10.40.0.10")}}, healthy: true},
-		{name: "managed VIP absent", addresses: []net.IPAddr{{IP: net.ParseIP("10.40.0.11")}}, wantError: "does not resolve to managed VIP"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			checker := HTTPHealthChecker{Client: client, Resolver: fakeResolver{addresses: tt.addresses}}
-			result := checker.Check(context.Background(), health)
-			if result.Healthy != tt.healthy || !strings.Contains(result.Error, tt.wantError) {
-				t.Fatalf("Check() = %#v", result)
-			}
-		})
+	})}}
+	result := checker.Check(context.Background(), Health{
+		Scheme:        "https",
+		Host:          "10.40.0.10",
+		Port:          6443,
+		Path:          "/readyz",
+		TLSServerName: "intentionally-unresolved.invalid",
+	})
+	if !result.Healthy || result.StatusCode != http.StatusOK {
+		t.Fatalf("Check() = %#v", result)
 	}
 }
 
@@ -309,15 +295,6 @@ func (h *sequenceHealth) Check(context.Context, Health) HealthResult {
 type fakeInterface struct {
 	ready bool
 	err   error
-}
-
-type fakeResolver struct {
-	addresses []net.IPAddr
-	err       error
-}
-
-func (r fakeResolver) LookupIPAddr(context.Context, string) ([]net.IPAddr, error) {
-	return r.addresses, r.err
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/internal/installer/controlplaneendpoint/endpoint_test.go
+++ b/internal/installer/controlplaneendpoint/endpoint_test.go
@@ -16,6 +16,18 @@ func TestNormalizeExternalEndpoint(t *testing.T) {
 	}
 }
 
+func TestNormalizeAcceptsIPLiteralHost(t *testing.T) {
+	config := managedConfig()
+	config.Host = config.Advertisement.VIP
+	plan, err := Normalize(config)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if plan.Endpoint != "10.40.0.10:6443" || plan.Config.Host != "10.40.0.10" {
+		t.Fatalf("plan = %#v", plan)
+	}
+}
+
 func TestNormalizeManagedEndpoint(t *testing.T) {
 	length := 32
 	plan, err := Normalize(Config{


### PR DESCRIPTION
Allows the control-plane endpoint host to be either a DNS name or an IP literal. Removes DNS resolution from route-advertisement health so a healthy local API VIP remains advertised while retaining TLS identity and API readiness checks.