### PR TITLE
runtime: include NFS client support

### DIFF
--- a/mkosi.profiles/runtime/mkosi.conf
+++ b/mkosi.profiles/runtime/mkosi.conf
@@ -28,6 +28,8 @@ Packages=
         iptables-nft
         ipset
         ipvsadm
+        # Node-level network filesystem support used by Kubernetes volumes.
+        nfs-common-utils
         # Container host plumbing; Kubernetes packages live in the sysext.
         containerd
         crun

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -162,6 +162,7 @@ for path in \
     /usr/lib/os-release \
     /usr/bin/katlc \
     /usr/bin/katl-console \
+    /usr/bin/mount.nfs \
     /usr/lib/katl/runtime/katl-boot-health \
     /usr/lib/katl/runtime/katl-runtime-status \
     /usr/lib/katl/runtime/katl-generation-activate \


### PR DESCRIPTION
Include Fedora's minimal NFS client utilities in the immutable base runtime so Kubernetes NFS PersistentVolumes work independently of the selected Kubernetes bundle. The release artifact contract now requires the NFS mount helper.