### PR TITLE
config: validate multi-control-plane sources

### DIFF
--- a/internal/bootstrap/inventory/inventory.go
+++ b/internal/bootstrap/inventory/inventory.go
@@ -118,6 +118,22 @@ type AddressOverride struct {
 	Address string `json:"address"`
 }
 
+// ValidateInventory validates durable cluster inventory without requiring an
+// operator-scoped kubeadm init choice. The first declared control-plane node is
+// used only to exercise the planner's complete validation path; the resulting
+// action ordering is discarded.
+func ValidateInventory(inv Inventory) error {
+	initNode := ""
+	for _, node := range inv.Nodes {
+		if SystemRole(strings.TrimSpace(string(node.SystemRole))) == RoleControlPlane {
+			initNode = strings.TrimSpace(node.Name)
+			break
+		}
+	}
+	_, err := PlanInventory(PlanRequest{Inventory: inv, InitNode: initNode})
+	return err
+}
+
 func PlanInventory(request PlanRequest) (Plan, error) {
 	if len(request.Inventory.Nodes) == 0 {
 		return Plan{}, fmt.Errorf("inventory must contain at least one node")

--- a/internal/bootstrap/inventory/inventory_test.go
+++ b/internal/bootstrap/inventory/inventory_test.go
@@ -42,6 +42,21 @@ func TestPlanInventoryDefaultsSingleControlPlaneInit(t *testing.T) {
 	}
 }
 
+func TestValidateInventoryAcceptsMultipleControlPlanesWithoutInitNode(t *testing.T) {
+	inv := validInventory()
+	inv.Nodes = append(inv.Nodes, Node{
+		Name:              "cp-2",
+		Address:           "10.0.0.12",
+		SystemRole:        RoleControlPlane,
+		Access:            Access{Method: "ssh", User: "core", CredentialRef: "ssh/cp-2"},
+		KubeadmConfig:     KubeadmConfig{Ref: "control-plane", Intent: IntentControlPlane},
+		KubernetesVersion: "v1.36.1",
+	})
+	if err := ValidateInventory(inv); err != nil {
+		t.Fatalf("ValidateInventory() error = %v", err)
+	}
+}
+
 func TestPlanInventoryClassifiesAdditionalControlPlaneJoin(t *testing.T) {
 	inv := validInventory()
 	inv.Nodes = append(inv.Nodes, Node{

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -493,7 +493,7 @@ func validateBootstrapInventory(bootstrapInventory inventory.Inventory) error {
 			validationInventory.Nodes[i].Address = "127.0.0.1"
 		}
 	}
-	if _, err := inventory.PlanInventory(inventory.PlanRequest{Inventory: validationInventory}); err != nil {
+	if err := inventory.ValidateInventory(validationInventory); err != nil {
 		return err
 	}
 	return nil

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -353,6 +353,24 @@ spec:
 	}
 }
 
+func TestCompileAcceptsMultipleControlPlanesWithoutBootstrapOrdering(t *testing.T) {
+	config := validConfig()
+	config.Spec.Nodes[1].SystemRole = inventory.RoleControlPlane
+	config.Spec.Nodes[1].Overrides.Kubernetes.KubeadmConfigRef = "control-plane"
+
+	plan, err := Compile(CompileRequest{
+		Config:                     config,
+		KubeadmConfigs:             validKubeadmConfigs("v1.36.1"),
+		KubernetesArtifactBasePath: "/var/lib/katl/artifacts",
+	})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if got := plan.BootstrapInventory.Nodes[1].SystemRole; got != inventory.RoleControlPlane {
+		t.Fatalf("second node role = %q", got)
+	}
+}
+
 func TestCompileRejectsInvalidInput(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Multi-control-plane `ClusterConfig` compilation now validates durable inventory without requiring an operation-scoped kubeadm init choice.

The compiler previously reused bootstrap planning for validation without supplying an init node, so every valid multi-control-plane source failed before install. The new validation entry point discards its placeholder action ordering, while real bootstrap planning continues to require an explicit init node.

Regression coverage exercises both inventory validation and cluster-plan compilation.
