### PR TITLE
endpoint: retry while BIRD starts

### DIFF
--- a/cmd/katlctl/cluster_status.go
+++ b/cmd/katlctl/cluster_status.go
@@ -155,6 +155,9 @@ func runClusterStatus(ctx context.Context, opts clusterStatusOptions, stdout io.
 		if node.Error != "" {
 			fmt.Fprintf(w, "\t\t\t%s\n", node.Error)
 		}
+		if node.ControlPlaneEndpoint != nil && node.ControlPlaneEndpoint.FailureReason != "" {
+			fmt.Fprintf(w, "\t\t\tcontrol-plane endpoint: %s\n", node.ControlPlaneEndpoint.FailureReason)
+		}
 	}
 	return w.Flush()
 }

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -441,6 +441,11 @@ func writeHostStatus(stdout io.Writer, output string, report hostStatusReport) e
 	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d/%d\t%d\n", endpoint.Endpoint, endpoint.VIP, endpoint.State, yesNo(endpoint.LocalAPIReady), yesNo(endpoint.RouteOriginated), established, len(endpoint.Peers), len(endpoint.RouteExchange)); err != nil {
 		return err
 	}
+	if endpoint.FailureReason != "" {
+		if _, err := fmt.Fprintf(w, "\t%s\n", endpoint.FailureReason); err != nil {
+			return err
+		}
+	}
 	return w.Flush()
 }
 

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -29,7 +29,7 @@ clusters:
 	fake.nodeStatus.ActiveOperationIds = []string{"operation-secret"}
 	fake.nodeStatus.BootTargetGenerationId = "generation-staged"
 	fake.nodeStatus.ControlPlaneEndpoint = &agentapi.ControlPlaneEndpointStatus{
-		Endpoint: "api.home.example:6443", Vip: "10.40.0.10/32", State: "advertised", LocalApiReady: true, RouteOriginated: true,
+		Endpoint: "api.home.example:6443", Vip: "10.40.0.10/32", State: "failed", FailureReason: "endpoint routing control socket unavailable",
 		Peers: []*agentapi.ControlPlaneEndpointPeerStatus{{Address: "10.0.0.1", Asn: 64500, State: "established", RouteExported: true}},
 	}
 	fake.generation.RuntimeVersion = "2026.7.0-alpha.10"
@@ -44,7 +44,7 @@ clusters:
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	output := stdout.String()
-	for _, want := range []string{"NODE", "HEALTH", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy", "CONTROL PLANE ENDPOINT", "api.home.example:6443", "10.40.0.10/32", "advertised", "1/1"} {
+	for _, want := range []string{"NODE", "HEALTH", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy", "CONTROL PLANE ENDPOINT", "api.home.example:6443", "10.40.0.10/32", "failed", "1/1", "endpoint routing control socket unavailable"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}

--- a/internal/installer/bgpapivip/controller.go
+++ b/internal/installer/bgpapivip/controller.go
@@ -159,9 +159,10 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 	}
 	now := c.now()
 	var failure string
+	var startWithdrawFailure string
 	if !c.started {
 		if err := c.Bird.SetAdvertisement(ctx, false); err != nil {
-			failure = "start withdrawn: " + inventory.Redact(err.Error())
+			startWithdrawFailure = "start withdrawn: " + inventory.Redact(err.Error())
 		}
 		c.started = true
 		c.advertised = false
@@ -169,10 +170,18 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 	}
 
 	bird, err := c.Bird.Status(ctx)
-	if err != nil && failure == "" {
+	birdReady := bird.ProcessActive && bird.ControlSocketReady
+	// The generated BIRD configuration starts the API route disabled. While the
+	// controller has never advertised it, an unavailable startup socket is a
+	// safe dependency-wait state that can be retried. Once BIRD is ready, a
+	// failed explicit withdrawal is a real controller failure.
+	if startWithdrawFailure != "" && birdReady {
+		failure = startWithdrawFailure
+	}
+	if err != nil && (c.advertised || birdReady) && failure == "" {
 		failure = inventory.Redact(err.Error())
 	}
-	if bird.FailureReason != "" && failure == "" {
+	if bird.FailureReason != "" && (c.advertised || birdReady) && failure == "" {
 		failure = inventory.Redact(bird.FailureReason)
 	}
 	interfaceReady := true

--- a/internal/installer/bgpapivip/controller_test.go
+++ b/internal/installer/bgpapivip/controller_test.go
@@ -187,6 +187,73 @@ func TestControllerReturnsAdvertisementFailureAndKeepsWithdrawn(t *testing.T) {
 	}
 }
 
+func TestControllerRetriesWhileBirdControlSocketStarts(t *testing.T) {
+	bird := &fakeBird{
+		status: BirdRuntimeStatus{
+			ReadinessState: "not-ready",
+			FailureReason:  "dial /run/katl-bird/bird.ctl: no such file or directory",
+		},
+		statusErr: errors.New("query endpoint routing status: control socket unavailable"),
+		setErr:    errors.New("disable endpoint route: control socket unavailable"),
+	}
+	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
+	controller.Config.Health.SuccessThreshold = 1
+
+	status, err := controller.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("startup RunOnce() error = %v, want dependency wait", err)
+	}
+	if status.AdvertisementState != AdvertisementWithdrawn || status.WithdrawReason != "dependency-not-ready" {
+		t.Fatalf("startup status = %#v", status)
+	}
+	if status.RecoveryRequired || status.FailureReason != "" {
+		t.Fatalf("startup socket wait requires recovery: %#v", status)
+	}
+	if got, want := bird.advertisements, []bool{false}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("startup advertisements = %#v, want %#v", got, want)
+	}
+
+	bird.status = readyBirdStatus()
+	bird.statusErr = nil
+	bird.setErr = nil
+	status, err = controller.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("ready RunOnce() error = %v", err)
+	}
+	if status.AdvertisementState != AdvertisementAdvertised {
+		t.Fatalf("ready status = %#v", status)
+	}
+	if got, want := bird.advertisements, []bool{false, true}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovered advertisements = %#v, want %#v", got, want)
+	}
+}
+
+func TestControllerFailsWhenAdvertisedRouteCannotBeWithdrawn(t *testing.T) {
+	bird := &fakeBird{status: readyBirdStatus()}
+	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
+	controller.Config.Health.SuccessThreshold = 1
+	if _, err := controller.RunOnce(context.Background()); err != nil {
+		t.Fatalf("advertise RunOnce() error = %v", err)
+	}
+
+	bird.status = BirdRuntimeStatus{
+		ReadinessState: "not-ready",
+		FailureReason:  "dial /run/katl-bird/bird.ctl: connection refused",
+	}
+	bird.statusErr = errors.New("query endpoint routing status: control socket unavailable")
+	bird.setErr = errors.New("disable endpoint route: control socket unavailable")
+	status, err := controller.RunOnce(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "control socket unavailable") {
+		t.Fatalf("withdraw RunOnce() error = %v", err)
+	}
+	if !status.RecoveryRequired || status.FailureReason == "" {
+		t.Fatalf("withdraw status = %#v", status)
+	}
+	if got, want := bird.advertisements, []bool{false, true, false}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("withdraw advertisements = %#v, want %#v", got, want)
+	}
+}
+
 func TestControllerWithdrawsWhenDependencyNotReady(t *testing.T) {
 	bird := &fakeBird{status: readyBirdStatus()}
 	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})


### PR DESCRIPTION
Fixes the BIRD startup race observed during a clean three-control-plane KatlOS beta.3 install.

The endpoint advertiser now treats an unavailable BIRD control socket as a safe dependency-wait state before it has advertised a route. It remains withdrawn and retries instead of exiting and triggering fail-closed cleanup that stops BIRD. Failed withdrawal after advertisement remains fatal.

`katlctl node status` and `katlctl cluster status` also print bounded endpoint failure reasons so genuine controller failures are actionable.
