### PR TITLE
bootstrap: discover joins through the init node

### DIFF
--- a/docs/internal/cluster-bootstrap-cli.md
+++ b/docs/internal/cluster-bootstrap-cli.md
@@ -322,8 +322,8 @@ The bootstrap command runs phases in this order:
 
 These are control-client phases. Phases that run `kubeadm init` or
 `kubeadm join` are executed by node-local `katlc` and must update the
-corresponding `bootstrap-init` or `bootstrap-join-worker` `OperationRecord`.
-Additional control-plane joins are not part of the day-one operation set.
+corresponding `bootstrap-init`, `bootstrap-join-control-plane`, or
+`bootstrap-join-worker` `OperationRecord`.
 
 ```text
 1. load and validate inventory or compiled plan
@@ -336,8 +336,8 @@ Additional control-plane joins are not part of the day-one operation set.
    katl-kubeadm-ready.target on nodes before their kubeadm phase
 7. ask katlc to run kubeadm init only on the selected init node
 8. collect or create join material
-9. ask katlc to join remaining worker nodes
-10. join additional control-plane nodes later, when that path is implemented
+9. ask katlc to join remaining control-plane nodes serially
+10. ask katlc to join remaining worker nodes
 11. wait for API readiness using the init or declared endpoint
 12. katlc runs post-kubeadm health checks and commits each successful candidate
     generation
@@ -347,12 +347,9 @@ Additional control-plane joins are not part of the day-one operation set.
 15. print next steps and exit
 ```
 
-Worker joins must not start until init succeeds and join material exists.
-Additional control-plane joins require certificate-key handling and may be
-implemented after worker joins. The durable contract is that every non-init
-control-plane node is classified for a later control-plane join from
-`systemRole`; until that implementation exists, multi-control-plane plans fail
-with a clear unsupported message after init-node selection validation.
+Joins must not start until init succeeds and join material exists. Additional
+control-plane joins use short-lived uploaded certificate material and complete
+before worker joins.
 
 The greenfield multi-control-plane target is kubeadm stacked etcd. Its data
 ownership, quorum, join ordering, and rollback limits are defined in
@@ -406,14 +403,21 @@ The command supports two endpoint shapes:
 
 ```text
 initial kubeadm endpoint
-  single-node bootstrap may use the selected init node address
+  join discovery uses the selected init node address
   multi-node bootstrap requires an explicit --control-plane-endpoint or an
-  equivalent endpoint from the compiled plan
+  equivalent endpoint from the compiled plan for ClusterConfiguration
 
 stable endpoint verification
   use a user-declared VIP, DNS name, routed endpoint, or load balancer as the
   stable operator-facing API endpoint
 ```
+
+The discovery endpoint and the cluster control-plane endpoint deliberately have
+different jobs. Katl rewrites the short-lived join material to discover through
+the already initialized node. The uploaded kubeadm `ClusterConfiguration` and
+the final operator kubeconfig retain the declared stable endpoint. This avoids
+capturing discovery traffic on a joining control-plane node which has already
+configured the managed VIP but does not yet run a local API server.
 
 Katl does not own BIRD, VIP, kube-vip, ingress, load balancer, or DNS lifecycle
 as part of this command. The command may verify a declared stable endpoint before

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -470,11 +470,31 @@ func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.Planne
 	if strings.TrimSpace(material.GetExpiresAt()) == "" {
 		return workerJoinMaterial{}, fmt.Errorf("agent returned %s join material without expiry", role)
 	}
+	material, err = joinMaterialWithDiscoveryEndpoint(material, endpointForNode(initNode))
+	if err != nil {
+		return workerJoinMaterial{}, fmt.Errorf("prepare %s join material: %w", role, err)
+	}
 	ref := strings.TrimSpace(response.GetMaterialRef())
 	if ref == "" {
 		ref = requestRef
 	}
 	return workerJoinMaterial{Ref: ref, Material: material}, nil
+}
+
+func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, endpoint string) (*agentapi.WorkerJoinMaterial, error) {
+	argv := append([]string(nil), material.GetJoinArgv()...)
+	if len(argv) < 3 || argv[0] != "kubeadm" || argv[1] != "join" {
+		return nil, errors.New("join material must start with kubeadm join and an API endpoint")
+	}
+	endpoint = strings.TrimSpace(endpoint)
+	if err := validateEndpointLike(endpoint); err != nil {
+		return nil, fmt.Errorf("init-node discovery endpoint: %w", err)
+	}
+	argv[2] = endpoint
+	return &agentapi.WorkerJoinMaterial{
+		JoinArgv:  argv,
+		ExpiresAt: material.GetExpiresAt(),
+	}, nil
 }
 
 func submitAndWaitControlPlaneJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) (operationReference, error) {

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -131,6 +131,15 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	if cp2Req.Bootstrap.JoinMaterialRef != "operation:bootstrap-init-1/control-plane:cp-2" {
 		t.Fatalf("join material ref = %q", cp2Req.Bootstrap.JoinMaterialRef)
 	}
+	if got := cp2Req.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
+		t.Fatalf("control-plane join discovery endpoint = %q, want init-node endpoint", got)
+	}
+	if got := cp2Req.Bootstrap.ControlPlaneEndpoint; got != "api.katl.test:6443" {
+		t.Fatalf("control-plane endpoint = %q, want stable cluster endpoint", got)
+	}
+	if got := cpClient.createMaterial.GetWorkerJoinMaterial().GetJoinArgv()[2]; got != "api.katl.test:6443" {
+		t.Fatalf("source join material endpoint = %q, want unmodified agent response", got)
+	}
 }
 
 func TestRunAgentBootstrapPreservesFailedOperationReference(t *testing.T) {
@@ -525,6 +534,9 @@ func TestRunAgentBootstrapMintsWorkerJoinMaterialAndSubmitsWorkerJoin(t *testing
 	}
 	if workerReq.Bootstrap.WorkerJoinMaterial == nil || workerReq.Bootstrap.WorkerJoinMaterial.ExpiresAt != "2026-06-16T13:00:00Z" {
 		t.Fatalf("worker join material = %#v", workerReq.Bootstrap.WorkerJoinMaterial)
+	}
+	if got := workerReq.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
+		t.Fatalf("worker join discovery endpoint = %q, want init-node endpoint", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

Rewrite kubeadm join discovery material to use the selected init node's API address while preserving the declared stable endpoint in ClusterConfiguration and the operator kubeconfig. Update the bootstrap contract and cover both control-plane and worker joins.

## Why

A joining control-plane node configures Katl's managed VIP before it runs a local API server. Using that VIP for kubeadm discovery makes the node capture its own request and refuse the connection. Discovering through the already initialized node avoids that collision and retains the stable VIP for normal cluster access.

The three-control-plane stacked-etcd VM journey passes with the corrected endpoint split.
