### PR TITLE
console: simplify runtime dashboard

### DIFF
--- a/internal/operatorconsole/collect.go
+++ b/internal/operatorconsole/collect.go
@@ -1,6 +1,7 @@
 package operatorconsole
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
@@ -24,19 +26,25 @@ type Collector struct {
 	Interfaces            func() ([]net.Interface, error)
 	Addrs                 func(net.Interface) ([]net.Addr, error)
 	DefaultRouteInterface func() (string, error)
+	ProbeControlPlanePods func(context.Context) (ControlPlanePodStatuses, error)
 	Now                   func() time.Time
 }
 
 const (
-	maxDisplayInterfaces = 3
-	maxDisplayAddresses  = 2
+	maxDisplayInterfaces  = 3
+	maxDisplayAddresses   = 2
+	kubernetesProbePeriod = 5 * time.Second
 )
 
 func (c Collector) Collect(snapshot *Snapshot) {
 	interfaces := snapshot.DisplayInterfaces
+	controlPlanePods := snapshot.ControlPlanePods
+	kubernetesStatusAt := snapshot.KubernetesStatusAt
 	*snapshot = Snapshot{
-		Mode:              c.Mode,
-		DisplayInterfaces: interfaces[:0],
+		Mode:               c.Mode,
+		DisplayInterfaces:  interfaces[:0],
+		ControlPlanePods:   controlPlanePods,
+		KubernetesStatusAt: kubernetesStatusAt,
 	}
 	if c.Mode == ModeInstaller {
 		snapshot.Version = strings.TrimSpace(c.Version)
@@ -58,6 +66,7 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	if c.Now == nil {
 		c.Now = time.Now
 	}
+	now := c.Now()
 	if hostname, err := c.Hostname(); err == nil {
 		snapshot.Hostname = hostname
 	}
@@ -86,7 +95,7 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		snapshot.StatusError = err.Error()
 	}
-	if statusCanBecomeStale(snapshot.State) && !snapshot.UpdatedAt.IsZero() && c.Now().Sub(snapshot.UpdatedAt) > 10*time.Minute {
+	if statusCanBecomeStale(snapshot.State) && !snapshot.UpdatedAt.IsZero() && now.Sub(snapshot.UpdatedAt) > 10*time.Minute {
 		snapshot.StatusStale = true
 	}
 	if snapshot.State == "" {
@@ -112,6 +121,7 @@ func (c Collector) Collect(snapshot *Snapshot) {
 	} else {
 		snapshot.KubernetesConfigured = fileExists(rooted(c.Root, "/etc/kubernetes/kubelet.conf"))
 		c.collectGeneration(snapshot)
+		c.collectKubernetes(snapshot, now)
 	}
 }
 
@@ -212,12 +222,53 @@ func normalizeManagementAddress(value string) string {
 
 func virtualInterface(name string) bool {
 	name = strings.ToLower(strings.TrimSpace(name))
-	for _, prefix := range []string{"cilium", "lxc", "veth", "docker", "br-", "virbr", "flannel", "cali", "dummy", "kube", "tun", "tap"} {
+	for _, prefix := range []string{"katl-api", "cilium", "lxc", "veth", "docker", "br-", "virbr", "flannel", "cali", "dummy", "kube", "tun", "tap"} {
 		if strings.HasPrefix(name, prefix) {
 			return true
 		}
 	}
 	return false
+}
+
+func (c Collector) collectKubernetes(snapshot *Snapshot, now time.Time) {
+	root := cleanRoot(c.Root)
+	intentAvailable := false
+	if intent, _, err := installer.ReadClusterIntent(root); err == nil {
+		intentAvailable = true
+		snapshot.ControlPlane = strings.TrimSpace(intent.SystemRole) == "control-plane"
+		snapshot.ControlPlaneEndpoint = strings.TrimSpace(intent.Inventory.ControlPlaneEndpoint)
+		if snapshot.ControlPlaneEndpoint == "" {
+			snapshot.ControlPlaneEndpoint = strings.TrimSpace(intent.Inventory.ControlPlaneEndpointVIP)
+		}
+	}
+	if !intentAvailable && fileExists(rooted(c.Root, "/etc/kubernetes/manifests/kube-apiserver.yaml")) {
+		snapshot.ControlPlane = true
+	}
+	if !snapshot.ControlPlane {
+		snapshot.ControlPlanePods = ControlPlanePodStatuses{}
+		snapshot.KubernetesStatusAt = time.Time{}
+		return
+	}
+	if !snapshot.KubernetesConfigured {
+		snapshot.ControlPlanePods = initialControlPlanePods(KubernetesPodNotStarted)
+		snapshot.KubernetesStatusAt = now
+		return
+	}
+	if !snapshot.KubernetesStatusAt.IsZero() && now.Sub(snapshot.KubernetesStatusAt) < kubernetesProbePeriod {
+		return
+	}
+	probe := c.ProbeControlPlanePods
+	if probe == nil {
+		probe = probeControlPlanePods
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pods, err := probe(ctx)
+	if err != nil {
+		pods = initialControlPlanePods(KubernetesPodUnknown)
+	}
+	snapshot.ControlPlanePods = pods
+	snapshot.KubernetesStatusAt = now
 }
 
 func readDefaultRouteInterface(path string) (string, error) {

--- a/internal/operatorconsole/kubernetes.go
+++ b/internal/operatorconsole/kubernetes.go
@@ -1,0 +1,92 @@
+package operatorconsole
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var controlPlanePodNames = [controlPlanePodCount]string{
+	"kube-apiserver",
+	"kube-controller-manager",
+	"kube-scheduler",
+	"etcd",
+}
+
+func initialControlPlanePods(state string) ControlPlanePodStatuses {
+	var pods ControlPlanePodStatuses
+	for index, name := range controlPlanePodNames {
+		pods[index] = KubernetesPodStatus{Name: name, State: state}
+	}
+	return pods
+}
+
+func probeControlPlanePods(ctx context.Context) (ControlPlanePodStatuses, error) {
+	output, err := exec.CommandContext(
+		ctx,
+		"/usr/bin/crictl",
+		"ps",
+		"--all",
+		"--namespace", "^kube-system$",
+		"--output", "json",
+	).Output()
+	if err != nil {
+		return initialControlPlanePods(KubernetesPodUnknown), fmt.Errorf("query control-plane containers: %w", err)
+	}
+	return decodeControlPlanePods(output)
+}
+
+func decodeControlPlanePods(data []byte) (ControlPlanePodStatuses, error) {
+	type container struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		State     string `json:"state"`
+		CreatedAt int64  `json:"createdAt"`
+	}
+	var response struct {
+		Containers []container `json:"containers"`
+	}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return initialControlPlanePods(KubernetesPodUnknown), fmt.Errorf("decode control-plane containers: %w", err)
+	}
+	pods := initialControlPlanePods(KubernetesPodNotStarted)
+	var newest [controlPlanePodCount]int64
+	for _, candidate := range response.Containers {
+		index := controlPlanePodIndex(candidate.Metadata.Name)
+		if index < 0 {
+			continue
+		}
+		state := criContainerState(candidate.State)
+		if state == KubernetesPodRunning || (pods[index].State != KubernetesPodRunning && candidate.CreatedAt >= newest[index]) {
+			pods[index].State = state
+			newest[index] = candidate.CreatedAt
+		}
+	}
+	return pods, nil
+}
+
+func controlPlanePodIndex(name string) int {
+	name = strings.TrimSpace(name)
+	for index, candidate := range controlPlanePodNames {
+		if name == candidate {
+			return index
+		}
+	}
+	return -1
+}
+
+func criContainerState(state string) string {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "CONTAINER_RUNNING", "RUNNING":
+		return KubernetesPodRunning
+	case "CONTAINER_CREATED", "CREATED":
+		return KubernetesPodStarting
+	case "CONTAINER_EXITED", "EXITED":
+		return KubernetesPodNotRunning
+	default:
+		return KubernetesPodUnknown
+	}
+}

--- a/internal/operatorconsole/model.go
+++ b/internal/operatorconsole/model.go
@@ -23,6 +23,10 @@ type Snapshot struct {
 	NextBootSoftware     Software
 	LiveSoftware         Software
 	KubernetesConfigured bool
+	ControlPlane         bool
+	ControlPlaneEndpoint string
+	ControlPlanePods     ControlPlanePodStatuses
+	KubernetesStatusAt   time.Time
 	DestructiveMutation  bool
 	LastError            string
 	RetryHint            string
@@ -62,10 +66,24 @@ type Presentation struct {
 type DashboardModel struct {
 	Host       Presentation
 	Kubernetes Presentation
-	Current    Software
-	NextBoot   Software
-	Live       Software
 }
+
+type KubernetesPodStatus struct {
+	Name  string
+	State string
+}
+
+const controlPlanePodCount = 4
+
+type ControlPlanePodStatuses [controlPlanePodCount]KubernetesPodStatus
+
+const (
+	KubernetesPodRunning    = "Running"
+	KubernetesPodStarting   = "Starting"
+	KubernetesPodNotRunning = "Not running"
+	KubernetesPodNotStarted = "Not started"
+	KubernetesPodUnknown    = "Unknown"
+)
 
 type NetworkInterface struct {
 	Name                string

--- a/internal/operatorconsole/operatorconsole_test.go
+++ b/internal/operatorconsole/operatorconsole_test.go
@@ -2,6 +2,7 @@ package operatorconsole
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -449,9 +450,116 @@ func TestCollectorReportsLiveBootstrapCandidateBeforeReboot(t *testing.T) {
 		t.Fatalf("software state = current %#v, live %#v, configured=%t", snapshot.CurrentSoftware, snapshot.LiveSoftware, snapshot.KubernetesConfigured)
 	}
 	rendered := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Current:generation0", "Nextboot:generationbootstrap-init-candidate", "Liveselected:generationbootstrap-init-candidate", "Version:v1.36.1", "Configured"} {
+	for _, want := range []string{"KatlOS:2026.7.0-alpha.16", "Kubelet:v1.36.1", "Configured"} {
 		if !containsIgnoringLayout(rendered, want) {
 			t.Fatalf("render missing %q:\n%s", want, rendered)
+		}
+	}
+	for _, unwanted := range []string{"Current:", "Next boot:", "Live selected:", "Live generation:"} {
+		if strings.Contains(rendered, unwanted) {
+			t.Fatalf("render contains internal generation field %q:\n%s", unwanted, rendered)
+		}
+	}
+}
+
+func TestCollectorPresentsControlPlaneStateWithoutInternalInterface(t *testing.T) {
+	root := t.TempDir()
+	for _, directory := range []string{
+		filepath.Join(root, "etc", "kubernetes"),
+		filepath.Join(root, "var", "lib", "katl", "cluster"),
+	} {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "etc", "kubernetes", "kubelet.conf"), []byte("configured\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	intent := `{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "ClusterIntent",
+  "generationID": "0",
+  "systemRole": "control-plane",
+  "identity": {"hostname": "cp-1"},
+  "inventory": {
+    "nodeName": "cp-1",
+    "controlPlaneEndpoint": "172.31.250.1:6443",
+    "controlPlaneEndpointVIP": "172.31.250.1"
+  },
+  "kubernetes": {},
+  "source": {}
+}`
+	if err := os.WriteFile(filepath.Join(root, "var", "lib", "katl", "cluster", "intent.json"), []byte(intent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	probes := 0
+	pods := initialControlPlanePods(KubernetesPodRunning)
+	pods[2].State = KubernetesPodNotRunning
+	collector := Collector{
+		Mode: ModeRuntime,
+		Root: root,
+		Interfaces: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{Name: "eno1", Flags: net.FlagUp},
+				{Name: "katl-api0", Flags: net.FlagUp},
+			}, nil
+		},
+		Addrs: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "katl-api0" {
+				return []net.Addr{testAddr("172.31.250.1/32")}, nil
+			}
+			return []net.Addr{testAddr("10.1.1.110/24")}, nil
+		},
+		DefaultRouteInterface: func() (string, error) { return "eno1", nil },
+		ProbeControlPlanePods: func(context.Context) (ControlPlanePodStatuses, error) {
+			probes++
+			return pods, nil
+		},
+		Now: func() time.Time { return now },
+	}
+	var snapshot Snapshot
+	collector.Collect(&snapshot)
+	if !snapshot.ControlPlane || snapshot.ControlPlaneEndpoint != "172.31.250.1:6443" {
+		t.Fatalf("control plane = %t endpoint = %q", snapshot.ControlPlane, snapshot.ControlPlaneEndpoint)
+	}
+	if probes != 1 || snapshot.ControlPlanePods[2].State != KubernetesPodNotRunning {
+		t.Fatalf("probe count = %d pods = %#v", probes, snapshot.ControlPlanePods)
+	}
+	if got := interfaceNames(snapshot.DisplayInterfaces); len(got) != 1 || got[0] != "eno1" {
+		t.Fatalf("host interfaces = %#v, want only eno1", got)
+	}
+
+	now = now.Add(4 * time.Second)
+	collector.Collect(&snapshot)
+	if probes != 1 {
+		t.Fatalf("cached control-plane probe count = %d", probes)
+	}
+	now = now.Add(2 * time.Second)
+	collector.Collect(&snapshot)
+	if probes != 2 {
+		t.Fatalf("refreshed control-plane probe count = %d", probes)
+	}
+}
+
+func TestDecodeControlPlanePodsReportsRuntimeState(t *testing.T) {
+	pods, err := decodeControlPlanePods([]byte(`{
+  "containers": [
+    {"metadata":{"name":"kube-apiserver"},"state":"CONTAINER_EXITED","createdAt":1},
+    {"metadata":{"name":"kube-apiserver"},"state":"CONTAINER_RUNNING","createdAt":2},
+    {"metadata":{"name":"kube-controller-manager"},"state":"CONTAINER_EXITED","createdAt":3},
+    {"metadata":{"name":"kube-scheduler"},"state":"CONTAINER_CREATED","createdAt":4},
+    {"metadata":{"name":"coredns"},"state":"CONTAINER_RUNNING","createdAt":5}
+  ]
+}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{KubernetesPodRunning, KubernetesPodNotRunning, KubernetesPodStarting, KubernetesPodNotStarted}
+	for index, state := range want {
+		if pods[index].State != state {
+			t.Fatalf("pod %s state = %q, want %q", pods[index].Name, pods[index].State, state)
 		}
 	}
 }
@@ -612,7 +720,7 @@ func TestRenderRuntimeFailure(t *testing.T) {
 		DisplayInterfaces:    []NetworkInterface{{Name: "eno1", Addresses: []string{"192.0.2.20/24"}}},
 	}
 	got := string(renderDashboard(&snapshot, nil, 80, 20, false))
-	for _, want := range []string{"Status", "Host", "Kubernetes", "Needsrepair", "Unavailable", "2026.7.0-alpha.9", "v1.36.1", "Current:generation4", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
+	for _, want := range []string{"Node", "Kubernetes", "Needsrepair", "Unavailable", "KatlOS:2026.7.0-alpha.9", "Kubelet:v1.36.1", "Error:", "boothealthcheckfailed", "SSH:katl@192.0.2.20"} {
 		if !containsIgnoringLayout(got, want) {
 			t.Errorf("render missing %q:\n%s", want, got)
 		}
@@ -664,14 +772,14 @@ func TestRenderKatlOSHealthAndColour(t *testing.T) {
 	snapshot := Snapshot{
 		Mode:             ModeRuntime,
 		State:            installstatus.StateKubeadmReady,
-		CurrentSoftware:  Software{Generation: "0"},
+		CurrentSoftware:  Software{Generation: "0", KatlOSVersion: "2026.7.0-beta.4"},
 		NextBootSoftware: Software{Generation: "0"},
 		LiveSoftware:     Software{Generation: "0"},
 		GenerationHealth: "healthy",
 		CurrentStep:      "Reboot",
 	}
 	plain := string(renderDashboard(&snapshot, nil, 80, 15, false))
-	for _, want := range []string{"KatlOS", "Status", "State:Healthy", "Current:generation0", "Journal"} {
+	for _, want := range []string{"KatlOS", "Node", "State:Healthy", "KatlOS:2026.7.0-beta.4", "Journal"} {
 		if !containsIgnoringLayout(plain, want) {
 			t.Fatalf("plain render missing %q:\n%s", want, plain)
 		}
@@ -697,25 +805,32 @@ func TestRenderRuntimeUsesNestedStatusAndJournalPanes(t *testing.T) {
 		Hostname:             "cp-1",
 		State:                installstatus.StateWaitingForClusterBootstrap,
 		GenerationHealth:     "healthy",
+		ControlPlane:         true,
+		ControlPlaneEndpoint: "172.31.250.1:6443",
+		ControlPlanePods:     initialControlPlanePods(KubernetesPodRunning),
 	}
 	got := string(renderDashboard(&snapshot, testJournal{[]byte("latest journal event")}, 80, 18, false))
 	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
-	statusRow := lineIndex(lines, "Status")
-	splitRow := lineIndexContaining(lines, "Host")
+	splitRow := lineIndexContaining(lines, "Node")
 	journalRow := lineIndex(lines, "Journal")
-	if statusRow < 0 || splitRow <= statusRow || journalRow <= splitRow {
-		t.Fatalf("pane order = status %d, split %d, journal %d:\n%s", statusRow, splitRow, journalRow, got)
+	if splitRow < 0 || journalRow <= splitRow {
+		t.Fatalf("pane order = split %d, journal %d:\n%s", splitRow, journalRow, got)
 	}
 	if !strings.Contains(lines[splitRow], "│Kubernetes") {
-		t.Fatalf("split title row = %q", lines[splitRow])
+		t.Fatalf("Node and Kubernetes titles are not aligned = %q", lines[splitRow])
 	}
 	stateRow := lines[splitRow+1]
-	if !containsIgnoringLayout(stateRow, "State:Healthy") || !containsIgnoringLayout(stateRow, "│State:Configured") {
+	if !containsIgnoringLayout(stateRow, "State:Healthy") || !containsIgnoringLayout(stateRow, "│State:Controlplanehealthy") {
 		t.Fatalf("split state row = %q", stateRow)
 	}
 	versionRow := lines[splitRow+2]
-	if !containsIgnoringLayout(versionRow, "Node:cp-1") || !containsIgnoringLayout(versionRow, "│Version:v1.36.1") {
+	if !containsIgnoringLayout(versionRow, "Node:cp-1") || !containsIgnoringLayout(versionRow, "│Kubelet:v1.36.1") {
 		t.Fatalf("split version row = %q", versionRow)
+	}
+	for _, want := range []string{"Controlplane:172.31.250.1:6443", "APIserver:Running", "Controller:Running", "Scheduler:Running", "etcd:Running"} {
+		if !containsIgnoringLayout(got, want) {
+			t.Fatalf("control-plane pane missing %q:\n%s", want, got)
+		}
 	}
 	if !strings.Contains(got, "latest journal event") {
 		t.Fatalf("journal pane missing content:\n%s", got)
@@ -749,14 +864,14 @@ func TestRenderRuntimeStacksPanesAtNarrowWidths(t *testing.T) {
 		}
 	}
 
-	hostRow := strings.Index(plain, "Host")
+	hostRow := strings.Index(plain, "Node")
 	kubernetesRow := strings.Index(plain, "Kubernetes")
 	networkRow := strings.Index(plain, "Network:")
 	journalRow := strings.Index(plain, "Journal")
-	if hostRow < 0 || kubernetesRow <= hostRow || networkRow <= kubernetesRow || journalRow <= networkRow {
+	if hostRow < 0 || networkRow <= hostRow || kubernetesRow <= networkRow || journalRow <= kubernetesRow {
 		t.Fatalf("unexpected stacked pane order:\n%s", plain)
 	}
-	for _, value := range []string{hostname, generationID, version} {
+	for _, value := range []string{hostname, "2026.7.0-alpha.12-with-a-long-build-identifier", version} {
 		if !containsIgnoringLayout(plain, value) {
 			t.Fatalf("wrapped panes lost %q:\n%s", value, plain)
 		}
@@ -1124,6 +1239,9 @@ func TestWidePaneDividerIsPaintedAfterBoundedContent(t *testing.T) {
 			KatlOSVersion:     strings.Repeat("version", 30),
 			KubernetesVersion: strings.Repeat("v1.36.1👩‍💻", 30),
 		},
+		ControlPlane:         true,
+		ControlPlaneEndpoint: strings.Repeat("api.control-plane.example.test:", 12) + "6443",
+		ControlPlanePods:     initialControlPlanePods(KubernetesPodRunning),
 	}
 	renderer.writeRuntimeStatus(&content, &snapshot)
 	divider := (content.bounds.Width - 1) / 2
@@ -1207,6 +1325,9 @@ func TestRendererBoundsArbitraryContentAtSupportedWidths(t *testing.T) {
 		LiveSoftware:         Software{Generation: string([]byte{'g', 'e', 'n', 0xff}), KatlOSVersion: strings.Repeat("version", 20), KubernetesVersion: strings.Repeat("v1.36.1", 20)},
 		GenerationHealth:     "healthy",
 		KubernetesConfigured: true,
+		ControlPlane:         true,
+		ControlPlaneEndpoint: strings.Repeat("api.control-plane.example.test:", 12) + "6443",
+		ControlPlanePods:     initialControlPlanePods(KubernetesPodRunning),
 		SSHEnabled:           true,
 		ManagementAddress:    "10.1.2.254",
 		DisplayInterfaces: []NetworkInterface{{

--- a/internal/operatorconsole/presentation.go
+++ b/internal/operatorconsole/presentation.go
@@ -13,9 +13,6 @@ func NewDashboardModel(snapshot *Snapshot) DashboardModel {
 	return DashboardModel{
 		Host:       presentHost(snapshot),
 		Kubernetes: presentKubernetes(snapshot),
-		Current:    snapshot.CurrentSoftware,
-		NextBoot:   snapshot.NextBootSoftware,
-		Live:       snapshot.LiveSoftware,
 	}
 }
 
@@ -90,6 +87,9 @@ func presentKubernetes(snapshot *Snapshot) Presentation {
 		return Presentation{State: PresentationUnknown, Label: "Not installed"}
 	}
 	if snapshot.KubernetesConfigured {
+		if snapshot.ControlPlane {
+			return presentControlPlane(snapshot.ControlPlanePods)
+		}
 		return Presentation{State: PresentationProgressing, Label: "Configured"}
 	}
 	switch snapshot.State {
@@ -100,6 +100,32 @@ func presentKubernetes(snapshot *Snapshot) Presentation {
 	default:
 		return Presentation{State: PresentationUnknown, Label: "Unknown"}
 	}
+}
+
+func presentControlPlane(pods ControlPlanePodStatuses) Presentation {
+	running := 0
+	starting := false
+	failed := false
+	for _, pod := range pods {
+		switch pod.State {
+		case KubernetesPodRunning:
+			running++
+		case KubernetesPodNotRunning:
+			failed = true
+		case KubernetesPodStarting, KubernetesPodNotStarted:
+			starting = true
+		}
+	}
+	if running == len(pods) {
+		return Presentation{State: PresentationHealthy, Label: "Control plane healthy"}
+	}
+	if failed {
+		return Presentation{State: PresentationDegraded, Label: "Control plane degraded"}
+	}
+	if starting || running > 0 {
+		return Presentation{State: PresentationProgressing, Label: "Control plane starting"}
+	}
+	return Presentation{State: PresentationUnknown, Label: "Control plane unknown"}
 }
 
 func presentationStyle(state PresentationState) Style {

--- a/internal/operatorconsole/render.go
+++ b/internal/operatorconsole/render.go
@@ -122,9 +122,7 @@ func (render *Renderer) paintDashboard(snapshot *Snapshot, journal Journal) {
 	reservedAlerts := min(measureAlertRows(contentRect.Width, alerts), max(contentRect.Height-1, 0))
 	normal := NewViewport(&render.frame, Rect{Y: contentRect.Y, Width: contentRect.Width, Height: contentRect.Height - reservedAlerts})
 	if snapshot.Mode == ModeRuntime {
-		writeHeading(&normal, "Status")
 		render.writeRuntimeStatus(&normal, snapshot)
-		writeNetwork(&normal, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces)
 	} else {
 		writeInstallerStatus(&normal, snapshot)
 	}
@@ -256,20 +254,27 @@ type paneField struct {
 
 func (render *Renderer) writeRuntimeStatus(content *Viewport, snapshot *Snapshot) {
 	model := NewDashboardModel(snapshot)
-	host := []paneField{
-		{label: "State", value: model.Host.Label, style: presentationStyle(model.Host.State)},
-		{label: "Node", value: fallback(snapshot.Hostname, "Unknown")},
-		{label: "Current", value: softwareLabel(model.Current)},
-		{label: "Next boot", value: softwareLabel(model.NextBoot)},
-		{label: "Live selected", value: softwareLabel(model.Live)},
-	}
-	kubernetes := []paneField{
-		{label: "State", value: model.Kubernetes.Label, style: presentationStyle(model.Kubernetes.State)},
-		{label: "Version", value: fallback(model.Live.KubernetesVersion, "Not installed")},
-		{label: "Live generation", value: fallback(model.Live.Generation, "Unknown")},
+	var hostStorage [3 + maxDisplayInterfaces + 1]paneField
+	host := hostStorage[:0]
+	host = append(host,
+		paneField{label: "State", value: model.Host.Label, style: presentationStyle(model.Host.State)},
+		paneField{label: "Node", value: fallback(snapshot.Hostname, "Unknown")},
+		paneField{label: "KatlOS", value: fallback(snapshot.CurrentSoftware.KatlOSVersion, "Unknown")},
+	)
+	host = appendNetworkPaneFields(host, snapshot.DisplayInterfaces, snapshot.AdditionalInterfaces)
+	var kubernetesStorage [2 + 1 + controlPlanePodCount]paneField
+	kubernetes := append(kubernetesStorage[:0],
+		paneField{label: "State", value: model.Kubernetes.Label, style: presentationStyle(model.Kubernetes.State)},
+		paneField{label: "Kubelet", value: fallback(snapshot.LiveSoftware.KubernetesVersion, "Not installed")},
+	)
+	if snapshot.ControlPlane {
+		kubernetes = append(kubernetes, paneField{label: "Control plane", value: fallback(snapshot.ControlPlaneEndpoint, "Local")})
+		for _, pod := range snapshot.ControlPlanePods {
+			kubernetes = append(kubernetes, paneField{label: controlPlanePodLabel(pod.Name), value: fallback(pod.State, KubernetesPodUnknown), style: kubernetesPodStyle(pod.State)})
+		}
 	}
 	if content.bounds.Width < wideLayoutWidth {
-		writePane(content, "Host", host)
+		writePane(content, "Node", host)
 		writePane(content, "Kubernetes", kubernetes)
 		return
 	}
@@ -278,7 +283,7 @@ func (render *Renderer) writeRuntimeStatus(content *Viewport, snapshot *Snapshot
 	dividerX := (content.bounds.Width - 1) / 2
 	left := content.sub(Rect{Y: start, Width: dividerX, Height: content.rowsRemaining()})
 	right := content.sub(Rect{X: dividerX + 1, Y: start, Width: content.bounds.Width - dividerX - 1, Height: content.rowsRemaining()})
-	writePane(&left, "Host", host)
+	writePane(&left, "Node", host)
 	writePane(&right, "Kubernetes", kubernetes)
 	used := max(left.rowsUsed(), right.rowsUsed())
 	content.advance(used)
@@ -289,18 +294,56 @@ func (render *Renderer) writeRuntimeStatus(content *Viewport, snapshot *Snapshot
 	}
 }
 
-func softwareLabel(software Software) string {
-	parts := make([]string, 0, 2)
-	if software.Generation != "" {
-		parts = append(parts, "generation "+software.Generation)
+func appendNetworkPaneFields(fields []paneField, network []NetworkInterface, additional int) []paneField {
+	if len(network) == 0 {
+		return append(fields, paneField{label: "Network", value: "Waiting for an active interface"})
 	}
-	if software.KatlOSVersion != "" {
-		parts = append(parts, "KatlOS "+software.KatlOSVersion)
+	for index, iface := range network {
+		label := ""
+		if index == 0 {
+			label = "Network"
+		}
+		value := iface.Name + ": configuring"
+		if len(iface.Addresses) > 0 {
+			value = iface.Name + ": " + strings.Join(iface.Addresses, ", ")
+		}
+		if iface.AdditionalAddresses > 0 {
+			value += "  + " + pluralCount(iface.AdditionalAddresses, "address", "addresses")
+		}
+		fields = append(fields, paneField{label: label, value: value})
 	}
-	if len(parts) == 0 {
-		return "Unknown"
+	if additional > 0 {
+		fields = append(fields, paneField{value: "+ " + pluralCount(additional, "interface", "interfaces"), style: styleDim})
 	}
-	return strings.Join(parts, ", ")
+	return fields
+}
+
+func controlPlanePodLabel(name string) string {
+	switch name {
+	case "kube-apiserver":
+		return "API server"
+	case "kube-controller-manager":
+		return "Controller"
+	case "kube-scheduler":
+		return "Scheduler"
+	case "etcd":
+		return "etcd"
+	default:
+		return fallback(name, "Pod")
+	}
+}
+
+func kubernetesPodStyle(state string) Style {
+	switch state {
+	case KubernetesPodRunning:
+		return styleGood
+	case KubernetesPodNotRunning:
+		return styleBad
+	case KubernetesPodStarting, KubernetesPodNotStarted:
+		return styleWarn
+	default:
+		return styleDim
+	}
 }
 
 func writePane(viewport *Viewport, title string, fields []paneField) {


### PR DESCRIPTION
Simplifies the installed console around operator-facing node and Kubernetes state. Adds bounded control-plane component health while hiding generation and managed-interface details.