### PR TITLE
bootstrap: route managed joins through init

### DIFF
--- a/docs/internal/cluster-bootstrap-cli.md
+++ b/docs/internal/cluster-bootstrap-cli.md
@@ -377,9 +377,10 @@ fixtures.
 
 When join material is needed on a node, `katlctl` supplies it through the
 operation request or transport. Node-local `katlc` materializes any temporary
-restricted join configuration needed to run kubeadm. Any temporary file is mode
-`0600`, lives outside `/etc/katl`, is deleted on a best-effort basis after use,
-and is never copied into the normal `OperationRecord` or invocation summary.
+restricted join configuration and discovery kubeconfig needed to run kubeadm.
+Those temporary files are mode `0600`, live outside `/etc/katl`, are deleted on
+a best-effort basis after use, and are never copied into the normal
+`OperationRecord` or invocation summary.
 
 Normal output redacts:
 
@@ -403,7 +404,9 @@ The command supports two endpoint shapes:
 
 ```text
 initial kubeadm endpoint
-  join discovery uses the selected init node address
+  managed-VIP control-plane joins discover through the selected init node
+  worker and externally managed endpoint joins use ordinary kubeadm token
+    discovery through the cluster endpoint
   multi-node bootstrap requires an explicit --control-plane-endpoint or an
   equivalent endpoint from the compiled plan for ClusterConfiguration
 
@@ -413,16 +416,21 @@ stable endpoint verification
 ```
 
 The discovery endpoint and the cluster control-plane endpoint deliberately have
-different jobs. Katl rewrites the short-lived join material to discover through
-the already initialized node. The uploaded kubeadm `ClusterConfiguration` and
-the final operator kubeconfig retain the declared stable endpoint. This avoids
-capturing discovery traffic on a joining control-plane node which has already
-configured the managed VIP but does not yet run a local API server.
+different jobs for a Katl-managed VIP. Kubeadm token discovery trusts the
+signed `cluster-info` kubeconfig, whose server is the durable cluster endpoint.
+That endpoint is locally assigned on every managed-VIP control-plane node, so a
+joining node would capture the request before its API server exists. Katl
+therefore derives an ephemeral authenticated file-discovery kubeconfig from the
+init operation's CA and bootstrap token, points it at the already initialized
+node, and supplies it only to managed-VIP control-plane joins. The uploaded
+kubeadm `ClusterConfiguration`, ordinary worker discovery, and final operator
+kubeconfig retain the declared stable endpoint.
 
-Katl does not own BIRD, VIP, kube-vip, ingress, load balancer, or DNS lifecycle
-as part of this command. The command may verify a declared stable endpoint before
-exporting kubeconfig output that uses it. It does not apply the user resources
-that might later advertise or replace that endpoint.
+When managed advertisement is configured, Katl's endpoint application owns the
+VIP and BIRD lifecycle and this command waits for the resulting stable endpoint.
+For an externally managed endpoint, the command only verifies reachability; it
+does not own kube-vip, ingress, load balancer, or DNS lifecycle, or apply user
+resources that advertise or replace that endpoint.
 
 Do not add kubePrism as an initial requirement.
 

--- a/docs/internal/cluster-bootstrap-cli.md
+++ b/docs/internal/cluster-bootstrap-cli.md
@@ -322,8 +322,8 @@ The bootstrap command runs phases in this order:
 
 These are control-client phases. Phases that run `kubeadm init` or
 `kubeadm join` are executed by node-local `katlc` and must update the
-corresponding `bootstrap-init` or `bootstrap-join-worker` `OperationRecord`.
-Additional control-plane joins are not part of the day-one operation set.
+corresponding `bootstrap-init`, `bootstrap-join-control-plane`, or
+`bootstrap-join-worker` `OperationRecord`.
 
 ```text
 1. load and validate inventory or compiled plan
@@ -336,8 +336,8 @@ Additional control-plane joins are not part of the day-one operation set.
    katl-kubeadm-ready.target on nodes before their kubeadm phase
 7. ask katlc to run kubeadm init only on the selected init node
 8. collect or create join material
-9. ask katlc to join remaining worker nodes
-10. join additional control-plane nodes later, when that path is implemented
+9. ask katlc to join remaining control-plane nodes serially
+10. ask katlc to join remaining worker nodes
 11. wait for API readiness using the init or declared endpoint
 12. katlc runs post-kubeadm health checks and commits each successful candidate
     generation
@@ -347,12 +347,9 @@ Additional control-plane joins are not part of the day-one operation set.
 15. print next steps and exit
 ```
 
-Worker joins must not start until init succeeds and join material exists.
-Additional control-plane joins require certificate-key handling and may be
-implemented after worker joins. The durable contract is that every non-init
-control-plane node is classified for a later control-plane join from
-`systemRole`; until that implementation exists, multi-control-plane plans fail
-with a clear unsupported message after init-node selection validation.
+Joins must not start until init succeeds and join material exists. Additional
+control-plane joins use short-lived uploaded certificate material and complete
+before worker joins.
 
 The greenfield multi-control-plane target is kubeadm stacked etcd. Its data
 ownership, quorum, join ordering, and rollback limits are defined in
@@ -406,14 +403,21 @@ The command supports two endpoint shapes:
 
 ```text
 initial kubeadm endpoint
-  single-node bootstrap may use the selected init node address
+  join discovery uses the selected init node address
   multi-node bootstrap requires an explicit --control-plane-endpoint or an
-  equivalent endpoint from the compiled plan
+  equivalent endpoint from the compiled plan for ClusterConfiguration
 
 stable endpoint verification
   use a user-declared VIP, DNS name, routed endpoint, or load balancer as the
   stable operator-facing API endpoint
 ```
+
+The discovery endpoint and the cluster control-plane endpoint deliberately have
+different jobs. Katl rewrites the short-lived join material to discover through
+the already initialized node. The uploaded kubeadm `ClusterConfiguration` and
+the final operator kubeconfig retain the declared stable endpoint. This avoids
+capturing discovery traffic on a joining control-plane node which has already
+configured the managed VIP but does not yet run a local API server.
 
 Katl does not own BIRD, VIP, kube-vip, ingress, load balancer, or DNS lifecycle
 as part of this command. The command may verify a declared stable endpoint before

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -17,6 +17,7 @@ import (
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -178,7 +179,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	}
 	for _, node := range controlPlaneJoinNodes(plan) {
 		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, Kind: "bootstrap-join-control-plane", Phase: "creating-join-material"})
-		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, deps)
+		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, initResult.Credentials, plan.ControlPlaneEndpointManaged, deps)
 		if err != nil {
 			result.addPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "failed")
 			return result, fmt.Errorf("control-plane join material for %s: %s", node.Name, inventory.Redact(err.Error()))
@@ -435,15 +436,25 @@ func submitAndWaitBootstrapInit(ctx context.Context, node inventory.PlannedNode,
 	return result, nil
 }
 
-func createControlPlaneJoinMaterial(ctx context.Context, initNode, controlPlane inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
-	return createJoinMaterial(ctx, initNode, controlPlane, status, initOperationID, deps, "control-plane")
+func createControlPlaneJoinMaterial(ctx context.Context, initNode, controlPlane inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, credentials AdminCredentials, managedEndpoint bool, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
+	discovery := joinDiscoveryOverride{}
+	if managedEndpoint {
+		discovery.Endpoint = endpointForNode(initNode)
+		discovery.CertificateAuthorityData = credentials.CertificateAuthorityData
+	}
+	return createJoinMaterial(ctx, initNode, controlPlane, status, initOperationID, deps, "control-plane", discovery)
 }
 
 func createWorkerJoinMaterial(ctx context.Context, initNode, worker inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
-	return createJoinMaterial(ctx, initNode, worker, status, initOperationID, deps, "worker")
+	return createJoinMaterial(ctx, initNode, worker, status, initOperationID, deps, "worker", joinDiscoveryOverride{})
 }
 
-func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies, role string) (workerJoinMaterial, error) {
+type joinDiscoveryOverride struct {
+	Endpoint                 string
+	CertificateAuthorityData string
+}
+
+func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies, role string, discovery joinDiscoveryOverride) (workerJoinMaterial, error) {
 	conn, err := deps.Connector.Connect(ctx, initNode)
 	if err != nil {
 		return workerJoinMaterial{}, fmt.Errorf("connect to katlc agent: %w", err)
@@ -470,9 +481,11 @@ func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.Planne
 	if strings.TrimSpace(material.GetExpiresAt()) == "" {
 		return workerJoinMaterial{}, fmt.Errorf("agent returned %s join material without expiry", role)
 	}
-	material, err = joinMaterialWithDiscoveryEndpoint(material, endpointForNode(initNode))
-	if err != nil {
-		return workerJoinMaterial{}, fmt.Errorf("prepare %s join material: %w", role, err)
+	if strings.TrimSpace(discovery.Endpoint) != "" {
+		material, err = joinMaterialWithDiscoveryEndpoint(material, discovery.Endpoint, discovery.CertificateAuthorityData)
+		if err != nil {
+			return workerJoinMaterial{}, fmt.Errorf("prepare %s join material: %w", role, err)
+		}
 	}
 	ref := strings.TrimSpace(response.GetMaterialRef())
 	if ref == "" {
@@ -481,7 +494,7 @@ func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.Planne
 	return workerJoinMaterial{Ref: ref, Material: material}, nil
 }
 
-func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, endpoint string) (*agentapi.WorkerJoinMaterial, error) {
+func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, endpoint, certificateAuthorityData string) (*agentapi.WorkerJoinMaterial, error) {
 	argv := append([]string(nil), material.GetJoinArgv()...)
 	if len(argv) < 3 || argv[0] != "kubeadm" || argv[1] != "join" {
 		return nil, errors.New("join material must start with kubeadm join and an API endpoint")
@@ -490,10 +503,45 @@ func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, en
 	if err := validateEndpointLike(endpoint); err != nil {
 		return nil, fmt.Errorf("init-node discovery endpoint: %w", err)
 	}
+	token := strings.TrimSpace(flagValue(argv, "--token"))
+	if token == "" {
+		return nil, errors.New("join material is missing bootstrap token")
+	}
+	certificateAuthorityData = strings.TrimSpace(certificateAuthorityData)
+	if certificateAuthorityData == "" {
+		return nil, errors.New("join discovery is missing certificate authority data")
+	}
 	argv[2] = endpoint
+	discoveryKubeconfig, err := yaml.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Config",
+		"clusters": []any{map[string]any{
+			"name": "katl-discovery",
+			"cluster": map[string]any{
+				"certificate-authority-data": certificateAuthorityData,
+				"server":                     "https://" + endpoint,
+			},
+		}},
+		"contexts": []any{map[string]any{
+			"name": "katl-discovery",
+			"context": map[string]any{
+				"cluster": "katl-discovery",
+				"user":    "katl-bootstrap",
+			},
+		}},
+		"current-context": "katl-discovery",
+		"users": []any{map[string]any{
+			"name": "katl-bootstrap",
+			"user": map[string]any{"token": token},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("render join discovery kubeconfig: %w", err)
+	}
 	return &agentapi.WorkerJoinMaterial{
-		JoinArgv:  argv,
-		ExpiresAt: material.GetExpiresAt(),
+		JoinArgv:            argv,
+		ExpiresAt:           material.GetExpiresAt(),
+		DiscoveryKubeconfig: discoveryKubeconfig,
 	}, nil
 }
 

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -470,11 +470,31 @@ func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.Planne
 	if strings.TrimSpace(material.GetExpiresAt()) == "" {
 		return workerJoinMaterial{}, fmt.Errorf("agent returned %s join material without expiry", role)
 	}
+	material, err = joinMaterialWithDiscoveryEndpoint(material, endpointForNode(initNode))
+	if err != nil {
+		return workerJoinMaterial{}, fmt.Errorf("prepare %s join material: %w", role, err)
+	}
 	ref := strings.TrimSpace(response.GetMaterialRef())
 	if ref == "" {
 		ref = requestRef
 	}
 	return workerJoinMaterial{Ref: ref, Material: material}, nil
+}
+
+func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, endpoint string) (*agentapi.WorkerJoinMaterial, error) {
+	argv := append([]string(nil), material.GetJoinArgv()...)
+	if len(argv) < 3 || argv[0] != "kubeadm" || argv[1] != "join" {
+		return nil, errors.New("join material must start with kubeadm join and an API endpoint")
+	}
+	endpoint = strings.TrimSpace(endpoint)
+	if err := validateEndpointLike(endpoint); err != nil {
+		return nil, fmt.Errorf("init-node discovery endpoint: %w", err)
+	}
+	argv[2] = endpoint
+	return &agentapi.WorkerJoinMaterial{
+		JoinArgv:  argv,
+		ExpiresAt: material.GetExpiresAt(),
+	}, nil
 }
 
 func submitAndWaitControlPlaneJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) (operationReference, error) {

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -47,6 +47,7 @@ func TestRunAgentBootstrapDryRunContactsAgentAndPropagatesOverride(t *testing.T)
 func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	inv := validSingleNodeInventory()
 	inv.ControlPlaneEndpoint = "api.katl.test:6443"
+	inv.ControlPlaneEndpointManaged = true
 	inv.Nodes = append(inv.Nodes, inventory.Node{
 		Name:              "cp-2",
 		Address:           "10.0.0.12",
@@ -105,14 +106,18 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 		InitNode:            "cp-1",
 		KubeconfigOut:       out,
 		OverwriteKubeconfig: true,
-	}, AgentBootstrapDependencies{Connector: connector, Actor: "test-actor"})
+	}, AgentBootstrapDependencies{
+		Connector:       connector,
+		Actor:           "test-actor",
+		BootstrapRunner: &fakeBootstrapRunner{result: BootstrapResult{StableEndpointReady: true}},
+	})
 	if err != nil {
 		t.Fatalf("RunAgentBootstrap() error = %v", err)
 	}
-	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "bootstrap-init", "control-plane-join", "kubeconfig"}) {
+	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "bootstrap-init", "stable-endpoint", "control-plane-join", "kubeconfig"}) {
 		t.Fatalf("phases = %#v", got)
 	}
-	if result.Phases[2].OperationID != "bootstrap-init-1" || result.Phases[3].OperationID != "bootstrap-join-control-plane-1" {
+	if result.Phases[2].OperationID != "bootstrap-init-1" || result.Phases[4].OperationID != "bootstrap-join-control-plane-1" {
 		t.Fatalf("operation phases = %#v", result.Phases)
 	}
 	if len(cpClient.createMaterialRequests) != 1 {
@@ -133,6 +138,12 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	}
 	if got := cp2Req.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
 		t.Fatalf("control-plane join discovery endpoint = %q, want init-node endpoint", got)
+	}
+	discovery := string(cp2Req.Bootstrap.WorkerJoinMaterial.GetDiscoveryKubeconfig())
+	for _, want := range []string{"server: https://10.0.0.11:6443", "certificate-authority-data: " + testCA, "token: abcdef.0123456789abcdef"} {
+		if !strings.Contains(discovery, want) {
+			t.Fatalf("control-plane discovery kubeconfig = %q, want %q", discovery, want)
+		}
 	}
 	if got := cp2Req.Bootstrap.ControlPlaneEndpoint; got != "api.katl.test:6443" {
 		t.Fatalf("control-plane endpoint = %q, want stable cluster endpoint", got)
@@ -535,8 +546,11 @@ func TestRunAgentBootstrapMintsWorkerJoinMaterialAndSubmitsWorkerJoin(t *testing
 	if workerReq.Bootstrap.WorkerJoinMaterial == nil || workerReq.Bootstrap.WorkerJoinMaterial.ExpiresAt != "2026-06-16T13:00:00Z" {
 		t.Fatalf("worker join material = %#v", workerReq.Bootstrap.WorkerJoinMaterial)
 	}
-	if got := workerReq.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
-		t.Fatalf("worker join discovery endpoint = %q, want init-node endpoint", got)
+	if got := workerReq.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "api.katl.test:6443" {
+		t.Fatalf("worker join discovery endpoint = %q, want stable endpoint", got)
+	}
+	if len(workerReq.Bootstrap.WorkerJoinMaterial.GetDiscoveryKubeconfig()) != 0 {
+		t.Fatalf("worker join unexpectedly received file discovery material")
 	}
 }
 

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -131,6 +131,15 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	if cp2Req.Bootstrap.JoinMaterialRef != "operation:bootstrap-init-1/control-plane:cp-2" {
 		t.Fatalf("join material ref = %q", cp2Req.Bootstrap.JoinMaterialRef)
 	}
+	if got := cp2Req.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
+		t.Fatalf("control-plane join discovery endpoint = %q, want init-node endpoint", got)
+	}
+	if got := cp2Req.Bootstrap.ControlPlaneEndpoint; got != "api.katl.test:6443" {
+		t.Fatalf("control-plane endpoint = %q, want stable cluster endpoint", got)
+	}
+	if got := cpClient.createMaterial.GetWorkerJoinMaterial().GetJoinArgv()[2]; got != "api.katl.test:6443" {
+		t.Fatalf("source join material endpoint = %q, want unmodified agent response", got)
+	}
 }
 
 func TestRunAgentBootstrapPreservesFailedOperationReference(t *testing.T) {
@@ -525,6 +534,9 @@ func TestRunAgentBootstrapMintsWorkerJoinMaterialAndSubmitsWorkerJoin(t *testing
 	}
 	if workerReq.Bootstrap.WorkerJoinMaterial == nil || workerReq.Bootstrap.WorkerJoinMaterial.ExpiresAt != "2026-06-16T13:00:00Z" {
 		t.Fatalf("worker join material = %#v", workerReq.Bootstrap.WorkerJoinMaterial)
+	}
+	if got := workerReq.Bootstrap.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
+		t.Fatalf("worker join discovery endpoint = %q, want init-node endpoint", got)
 	}
 }
 

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -117,7 +117,8 @@ type AdminCredentials struct {
 }
 
 type JoinMaterial struct {
-	Argv []string
+	Argv                []string
+	DiscoveryKubeconfig []byte
 }
 
 type Result struct {
@@ -1233,7 +1234,7 @@ func renderInitConfig(base []byte, controlPlaneEndpoint string) ([]byte, error) 
 	return RenderInitConfig(base, controlPlaneEndpoint)
 }
 
-func renderJoinConfig(base []byte, material JoinMaterial, controlPlane bool) ([]byte, error) {
+func renderJoinConfig(base []byte, material JoinMaterial, controlPlane bool, discoveryKubeconfigPath ...string) ([]byte, error) {
 	endpoint, token, hashes, err := joinDiscovery(material)
 	if err != nil {
 		return nil, err
@@ -1258,13 +1259,29 @@ func renderJoinConfig(base []byte, material JoinMaterial, controlPlane bool) ([]
 	if len(joinDocs) == 0 {
 		return nil, errors.New("kubeadm join config did not contain JoinConfiguration")
 	}
+	discoveryPath := ""
+	if len(material.DiscoveryKubeconfig) > 0 {
+		if len(discoveryKubeconfigPath) != 1 || strings.TrimSpace(discoveryKubeconfigPath[0]) == "" {
+			return nil, errors.New("join discovery kubeconfig path is required")
+		}
+		discoveryPath = strings.TrimSpace(discoveryKubeconfigPath[0])
+	}
 	for _, doc := range joinDocs {
-		doc["discovery"] = map[string]any{
-			"bootstrapToken": map[string]any{
-				"apiServerEndpoint": endpoint,
-				"token":             token,
-				"caCertHashes":      hashes,
-			},
+		if discoveryPath != "" {
+			doc["discovery"] = map[string]any{
+				"file": map[string]any{
+					"kubeConfigPath": discoveryPath,
+				},
+				"tlsBootstrapToken": token,
+			}
+		} else {
+			doc["discovery"] = map[string]any{
+				"bootstrapToken": map[string]any{
+					"apiServerEndpoint": endpoint,
+					"token":             token,
+					"caCertHashes":      hashes,
+				},
+			}
 		}
 		if controlPlane {
 			cp, _ := doc["controlPlane"].(map[string]any)
@@ -1278,7 +1295,7 @@ func renderJoinConfig(base []byte, material JoinMaterial, controlPlane bool) ([]
 	return encodeYAMLDocuments(joinDocs)
 }
 
-func RenderWorkerJoinConfig(base []byte, material JoinMaterial) ([]byte, error) {
+func RenderWorkerJoinConfig(base []byte, material JoinMaterial, discoveryKubeconfigPath ...string) ([]byte, error) {
 	if len(material.Argv) == 0 {
 		return nil, errors.New("worker join material is required")
 	}
@@ -1288,10 +1305,10 @@ func RenderWorkerJoinConfig(base []byte, material JoinMaterial) ([]byte, error) 
 	if flagValue(material.Argv, "--certificate-key") != "" {
 		return nil, errors.New("worker join material must not include --certificate-key")
 	}
-	return renderJoinConfig(base, material, false)
+	return renderJoinConfig(base, material, false, discoveryKubeconfigPath...)
 }
 
-func RenderControlPlaneJoinConfig(base []byte, material JoinMaterial) ([]byte, error) {
+func RenderControlPlaneJoinConfig(base []byte, material JoinMaterial, discoveryKubeconfigPath ...string) ([]byte, error) {
 	if len(material.Argv) == 0 {
 		return nil, errors.New("control-plane join material is required")
 	}
@@ -1301,7 +1318,7 @@ func RenderControlPlaneJoinConfig(base []byte, material JoinMaterial) ([]byte, e
 	if flagValue(material.Argv, "--certificate-key") == "" {
 		return nil, errors.New("control-plane join material must include --certificate-key")
 	}
-	return renderJoinConfig(base, material, true)
+	return renderJoinConfig(base, material, true, discoveryKubeconfigPath...)
 }
 
 func ControlPlaneJoinMaterial(output string, certificateKey string) (JoinMaterial, error) {

--- a/internal/bootstrap/cluster/cluster_test.go
+++ b/internal/bootstrap/cluster/cluster_test.go
@@ -1588,6 +1588,42 @@ patches:
 	}
 }
 
+func TestRenderControlPlaneJoinUsesEphemeralFileDiscovery(t *testing.T) {
+	base := []byte(`apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+`)
+	material := JoinMaterial{
+		Argv: []string{
+			"kubeadm", "join", "10.0.0.11:6443",
+			"--token", "abcdef.0123456789abcdef",
+			"--discovery-token-ca-cert-hash", testDiscoveryHash,
+			"--control-plane",
+			"--certificate-key", strings.Repeat("a", 64),
+		},
+		DiscoveryKubeconfig: []byte("ephemeral discovery credentials"),
+	}
+	rendered, err := RenderControlPlaneJoinConfig(base, material, "/run/katl/bootstrap-join/op/discovery.conf")
+	if err != nil {
+		t.Fatalf("RenderControlPlaneJoinConfig() error = %v", err)
+	}
+	text := string(rendered)
+	for _, want := range []string{
+		"file:",
+		"kubeConfigPath: /run/katl/bootstrap-join/op/discovery.conf",
+		"tlsBootstrapToken: abcdef.0123456789abcdef",
+		"certificateKey: " + strings.Repeat("a", 64),
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("rendered join config = %q, want %q", text, want)
+		}
+	}
+	if strings.Contains(text, "bootstrapToken:") || strings.Contains(text, "caCertHashes:") {
+		t.Fatalf("rendered join config retained mutually exclusive token discovery:\n%s", rendered)
+	}
+}
+
 func adminKubeconfig() string {
 	return `apiVersion: v1
 kind: Config

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -965,6 +965,7 @@ func cleanupTemporaryJoinConfig(root string, record operation.OperationRecord) {
 		root = "/"
 	}
 	target := filepath.Join(filepath.Clean(root), strings.TrimPrefix(path, "/"))
+	_ = os.Remove(filepath.Join(filepath.Dir(target), "discovery.conf"))
 	_ = os.Remove(target)
 	_ = os.Remove(filepath.Dir(target))
 }

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -558,6 +558,16 @@ func TestSubmitOperationCommitsWorkerGenerationAfterJoinHealth(t *testing.T) {
 			t.Fatalf("temporary join config mode = %#o, want 0600", info.Mode().Perm())
 		}
 		assertFileContains(t, configPath, "abcdef.0123456789abcdef")
+		discoveryPath := filepath.Join(filepath.Dir(configPath), "discovery.conf")
+		discoveryInfo, err := os.Stat(discoveryPath)
+		if err != nil {
+			t.Fatalf("temporary discovery kubeconfig was not materialized: %v", err)
+		}
+		if discoveryInfo.Mode().Perm() != 0o600 {
+			t.Fatalf("temporary discovery kubeconfig mode = %#o, want 0600", discoveryInfo.Mode().Perm())
+		}
+		assertFileContains(t, configPath, "kubeConfigPath: /run/katl/bootstrap-join/bootstrap-join-worker-01/discovery.conf")
+		assertFileContains(t, discoveryPath, "ephemeral discovery credentials")
 		started(456)
 		return ToolResult{
 			Stdout:     []byte("joined node using token abcdef.0123456789abcdef\n"),
@@ -578,6 +588,7 @@ func TestSubmitOperationCommitsWorkerGenerationAfterJoinHealth(t *testing.T) {
 	req.OperationKind = "bootstrap-join-worker"
 	req.Bootstrap.SystemRole = "worker"
 	req.Bootstrap.WorkerJoinMaterial = validWorkerJoinMaterial()
+	req.Bootstrap.WorkerJoinMaterial.DiscoveryKubeconfig = []byte("ephemeral discovery credentials\n")
 	accepted, err := server.SubmitOperation(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -601,6 +612,9 @@ func TestSubmitOperationCommitsWorkerGenerationAfterJoinHealth(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(server.Root, "run/katl/bootstrap-join/bootstrap-join-worker-01/config.yaml")); !os.IsNotExist(err) {
 		t.Fatalf("temporary join config was not deleted after kubeadm: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(server.Root, "run/katl/bootstrap-join/bootstrap-join-worker-01/discovery.conf")); !os.IsNotExist(err) {
+		t.Fatalf("temporary discovery kubeconfig was not deleted after kubeadm: %v", err)
 	}
 }
 

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -1298,24 +1298,36 @@ func (s *Server) materializeJoinConfig(req *agentapi.SubmitOperationRequest, ope
 	if err != nil {
 		return workerJoinMetadata{}, fmt.Errorf("read stored kubeadm config: %w", err)
 	}
+	runtimePath := temporaryJoinConfigPath(operationID)
+	discoveryPath := ""
+	if len(material.DiscoveryKubeconfig) > 0 {
+		discoveryPath = temporaryJoinDiscoveryPath(operationID)
+	}
 	var rendered []byte
 	switch req.OperationKind {
 	case "bootstrap-join-control-plane":
-		rendered, err = cluster.RenderControlPlaneJoinConfig(base, material)
+		rendered, err = cluster.RenderControlPlaneJoinConfig(base, material, discoveryPath)
 	case "bootstrap-join-worker":
-		rendered, err = cluster.RenderWorkerJoinConfig(base, material)
+		rendered, err = cluster.RenderWorkerJoinConfig(base, material, discoveryPath)
 	default:
 		return workerJoinMetadata{}, fmt.Errorf("operationKind %q is not a join operation", req.OperationKind)
 	}
 	if err != nil {
 		return workerJoinMetadata{}, err
 	}
-	runtimePath := temporaryJoinConfigPath(operationID)
 	target := filepath.Join(filepath.Clean(s.Root), strings.TrimPrefix(runtimePath, "/"))
 	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
 		return workerJoinMetadata{}, fmt.Errorf("create temporary join config directory: %w", err)
 	}
+	if discoveryPath != "" {
+		discoveryTarget := filepath.Join(filepath.Clean(s.Root), strings.TrimPrefix(discoveryPath, "/"))
+		if err := os.WriteFile(discoveryTarget, material.DiscoveryKubeconfig, 0o600); err != nil {
+			cleanupTemporaryJoinConfig(s.Root, operation.OperationRecord{BootstrapRequest: &operation.BootstrapRequest{TemporaryJoinConfigPath: runtimePath}})
+			return workerJoinMetadata{}, fmt.Errorf("write temporary join discovery kubeconfig: %w", err)
+		}
+	}
 	if err := os.WriteFile(target, rendered, 0o600); err != nil {
+		cleanupTemporaryJoinConfig(s.Root, operation.OperationRecord{BootstrapRequest: &operation.BootstrapRequest{TemporaryJoinConfigPath: runtimePath}})
 		return workerJoinMetadata{}, fmt.Errorf("write temporary join config: %w", err)
 	}
 	return workerJoinMetadata{
@@ -1327,6 +1339,10 @@ func (s *Server) materializeJoinConfig(req *agentapi.SubmitOperationRequest, ope
 
 func temporaryJoinConfigPath(operationID string) string {
 	return "/run/katl/bootstrap-join/" + operationID + "/config.yaml"
+}
+
+func temporaryJoinDiscoveryPath(operationID string) string {
+	return "/run/katl/bootstrap-join/" + operationID + "/discovery.conf"
 }
 
 func joinMaterial(material *agentapi.WorkerJoinMaterial) (cluster.JoinMaterial, error) {
@@ -1341,7 +1357,12 @@ func joinMaterial(material *agentapi.WorkerJoinMaterial) (cluster.JoinMaterial, 
 		}
 		argv = append(argv, arg)
 	}
-	return cluster.ParseJoinMaterial(strings.Join(argv, " "))
+	parsed, err := cluster.ParseJoinMaterial(strings.Join(argv, " "))
+	if err != nil {
+		return cluster.JoinMaterial{}, err
+	}
+	parsed.DiscoveryKubeconfig = append([]byte(nil), material.GetDiscoveryKubeconfig()...)
+	return parsed, nil
 }
 
 func validateWorkerJoinMaterial(material cluster.JoinMaterial) error {
@@ -1447,12 +1468,19 @@ func workerJoinTTL(value string) (time.Duration, error) {
 }
 
 func workerJoinMaterialDigest(material *agentapi.WorkerJoinMaterial) string {
+	discoveryDigest := ""
+	if len(material.GetDiscoveryKubeconfig()) > 0 {
+		sum := sha256.Sum256(material.GetDiscoveryKubeconfig())
+		discoveryDigest = hex.EncodeToString(sum[:])
+	}
 	payload := struct {
-		JoinArgv  []string `json:"joinArgv"`
-		ExpiresAt string   `json:"expiresAt"`
+		JoinArgv              []string `json:"joinArgv"`
+		ExpiresAt             string   `json:"expiresAt"`
+		DiscoveryConfigSHA256 string   `json:"discoveryConfigSHA256,omitempty"`
 	}{
-		JoinArgv:  append([]string(nil), material.GetJoinArgv()...),
-		ExpiresAt: strings.TrimSpace(material.GetExpiresAt()),
+		JoinArgv:              append([]string(nil), material.GetJoinArgv()...),
+		ExpiresAt:             strings.TrimSpace(material.GetExpiresAt()),
+		DiscoveryConfigSHA256: discoveryDigest,
 	}
 	data, _ := json.Marshal(payload)
 	sum := sha256.Sum256(data)

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -1597,6 +1597,7 @@ func TestSubmitOperationRecordsWorkerJoinMaterializationFailureBeforeDispatch(t 
 	req.OperationKind = "bootstrap-join-worker"
 	req.Bootstrap.SystemRole = "worker"
 	req.Bootstrap.WorkerJoinMaterial = validWorkerJoinMaterial()
+	req.Bootstrap.WorkerJoinMaterial.DiscoveryKubeconfig = []byte("token: discovery-secret-must-not-persist\n")
 
 	accepted, err := server.SubmitOperation(context.Background(), req)
 	if err != nil {
@@ -1646,8 +1647,8 @@ func TestSubmitOperationDoesNotPersistRawWorkerJoinMaterial(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(string(data), "abcdef.0123456789abcdef") {
-			return fmt.Errorf("%s contains raw bootstrap token", path)
+		if strings.Contains(string(data), "abcdef.0123456789abcdef") || strings.Contains(string(data), "discovery-secret-must-not-persist") {
+			return fmt.Errorf("%s contains raw join credentials", path)
 		}
 		return nil
 	})

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -770,11 +770,12 @@ func (x *BootstrapOperationRequest) GetKubernetesBundleRef() string {
 }
 
 type WorkerJoinMaterial struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	JoinArgv      []string               `protobuf:"bytes,1,rep,name=join_argv,json=joinArgv,proto3" json:"join_argv,omitempty"`
-	ExpiresAt     string                 `protobuf:"bytes,2,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	JoinArgv            []string               `protobuf:"bytes,1,rep,name=join_argv,json=joinArgv,proto3" json:"join_argv,omitempty"`
+	ExpiresAt           string                 `protobuf:"bytes,2,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	DiscoveryKubeconfig []byte                 `protobuf:"bytes,3,opt,name=discovery_kubeconfig,json=discoveryKubeconfig,proto3" json:"discovery_kubeconfig,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *WorkerJoinMaterial) Reset() {
@@ -819,6 +820,13 @@ func (x *WorkerJoinMaterial) GetExpiresAt() string {
 		return x.ExpiresAt
 	}
 	return ""
+}
+
+func (x *WorkerJoinMaterial) GetDiscoveryKubeconfig() []byte {
+	if x != nil {
+		return x.DiscoveryKubeconfig
+	}
+	return nil
 }
 
 type ValidateConfigRequest struct {
@@ -3680,11 +3688,12 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x14worker_join_material\x18\n" +
 	" \x01(\v2!.katl.agent.v1.WorkerJoinMaterialR\x12workerJoinMaterial\x128\n" +
 	"\x18kubernetes_bundle_source\x18\v \x01(\tR\x16kubernetesBundleSource\x122\n" +
-	"\x15kubernetes_bundle_ref\x18\f \x01(\tR\x13kubernetesBundleRef\"P\n" +
+	"\x15kubernetes_bundle_ref\x18\f \x01(\tR\x13kubernetesBundleRef\"\x83\x01\n" +
 	"\x12WorkerJoinMaterial\x12\x1b\n" +
 	"\tjoin_argv\x18\x01 \x03(\tR\bjoinArgv\x12\x1d\n" +
 	"\n" +
-	"expires_at\x18\x02 \x01(\tR\texpiresAt\"\xc5\x03\n" +
+	"expires_at\x18\x02 \x01(\tR\texpiresAt\x121\n" +
+	"\x14discovery_kubeconfig\x18\x03 \x01(\fR\x13discoveryKubeconfig\"\xc5\x03\n" +
 	"\x15ValidateConfigRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -105,6 +105,7 @@ message BootstrapOperationRequest {
 message WorkerJoinMaterial {
   repeated string join_argv = 1;
   string expires_at = 2;
+  bytes discovery_kubeconfig = 3;
 }
 
 message ValidateConfigRequest {


### PR DESCRIPTION
Use an ephemeral authenticated kubeadm file-discovery kubeconfig for control-plane nodes that already own a Katl-managed VIP locally. Workers and externally managed endpoints keep ordinary token discovery, while the durable kubeadm control-plane endpoint and user-owned kubeadm defaults remain unchanged.

The previous join fix changed only the initial token-discovery address. Kubeadm then trusted the signed `cluster-info` kubeconfig and returned to the stable VIP, which the joining node captured before its local API server existed.

The full Go gate and the libvirt-backed three-control-plane stacked-etcd bootstrap journey pass.
