### PR TITLE
bootstrap: route same-link joins through init

### DIFF
--- a/docs/internal/cluster-bootstrap-cli.md
+++ b/docs/internal/cluster-bootstrap-cli.md
@@ -426,11 +426,16 @@ node, and supplies it only to managed-VIP control-plane joins. Because later
 kubeadm phases intentionally return to the durable `controlPlaneEndpoint`, the
 joining node also withdraws its route and takes its Katl-owned dummy VIP
 interface off the local path before running kubeadm. Stable-endpoint traffic
-then follows the fabric route to an existing healthy control plane. After
-kubeadm has started the joining node's local API, the agent restores the VIP
-interface and resumes health-gated advertisement. A failed join leaves the VIP
-off the local path so the broken node cannot capture endpoint traffic. The
-uploaded kubeadm `ClusterConfiguration`, ordinary worker discovery, and final
+then follows the fabric route to an existing healthy control plane. When the
+selected init node is directly on-link, the agent installs an operation-scoped
+host route for the VIP through that node so a same-link fabric hairpin cannot
+produce an asymmetric API path. It verifies a complete Kubernetes HTTPS request
+through the stable endpoint before starting kubeadm and removes the temporary
+route when kubeadm returns. After kubeadm has started the joining node's local
+API, the agent restores the VIP interface and resumes health-gated
+advertisement. A failed join leaves the VIP off the local path so the broken
+node cannot capture endpoint traffic. The uploaded kubeadm
+`ClusterConfiguration`, ordinary worker discovery, and final
 operator kubeconfig retain the declared stable endpoint throughout.
 
 When managed advertisement is configured, Katl's endpoint application owns the

--- a/internal/katlc/agent/endpoint_lifecycle.go
+++ b/internal/katlc/agent/endpoint_lifecycle.go
@@ -2,12 +2,19 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -15,11 +22,19 @@ const (
 	endpointAdvertiserCommand = "/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser"
 	managedEndpointInterface  = "/usr/bin/networkctl"
 	managedEndpointIP         = "/usr/bin/ip"
+	managedEndpointKubectl    = "/usr/bin/kubectl"
 )
 
 type managedJoinEndpoint struct {
 	VIP       string
 	Interface string
+	API       string
+}
+
+type managedJoinRoute struct {
+	VIP     string
+	NextHop string
+	Device  string
 }
 
 func pauseManagedEndpoint(ctx context.Context, root string, run ToolRunner) (bool, error) {
@@ -60,26 +75,124 @@ func resumeManagedEndpoint(ctx context.Context, root string, run ToolRunner) err
 // capturing stable-endpoint traffic before its local API server exists. The
 // generated endpoint uses a Katl-owned dummy device, so taking that device
 // offline does not disturb the node's management network.
-func suspendManagedEndpointForJoin(ctx context.Context, root string, run ToolRunner) (bool, error) {
+func suspendManagedEndpointForJoin(ctx context.Context, root, discoveryPath string, run ToolRunner) (bool, *managedJoinRoute, error) {
 	endpoint, configured, err := managedJoinEndpointConfig(root)
 	if err != nil || !configured {
-		return false, err
+		return false, nil, err
 	}
 	if run == nil {
-		return false, fmt.Errorf("endpoint lifecycle runner is not configured")
+		return false, nil, fmt.Errorf("endpoint lifecycle runner is not configured")
 	}
 	if _, err := pauseManagedEndpoint(ctx, root, run); err != nil {
-		return false, err
+		return false, nil, err
 	}
 	result := run(ctx, []string{managedEndpointInterface, "down", endpoint.Interface}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		return false, fmt.Errorf("take managed control-plane endpoint off the local path: %s", toolFailure(result))
+		return false, nil, fmt.Errorf("take managed control-plane endpoint off the local path: %s", toolFailure(result))
 	}
 	result = run(ctx, []string{managedEndpointIP, "address", "flush", "dev", endpoint.Interface, "to", endpoint.VIP}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		return false, fmt.Errorf("remove managed control-plane endpoint address from the local path: %s", toolFailure(result))
+		return false, nil, fmt.Errorf("remove managed control-plane endpoint address from the local path: %s", toolFailure(result))
 	}
-	return true, nil
+	route, err := installManagedJoinRoute(ctx, root, discoveryPath, endpoint, run)
+	if err != nil {
+		return false, nil, err
+	}
+	result = run(ctx, []string{
+		managedEndpointKubectl,
+		"--kubeconfig", rootedRuntimePath(root, discoveryPath),
+		"--server", endpoint.API,
+		"--request-timeout=10s",
+		"get", "--raw=/version",
+	}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		cleanupErr := removeManagedJoinRoute(ctx, route, run)
+		return false, nil, errors.Join(fmt.Errorf("verify managed control-plane endpoint through the join path: %s", toolFailure(result)), cleanupErr)
+	}
+	return true, route, nil
+}
+
+func installManagedJoinRoute(ctx context.Context, root, discoveryPath string, endpoint managedJoinEndpoint, run ToolRunner) (*managedJoinRoute, error) {
+	discoveryHost, err := joinDiscoveryHost(root, discoveryPath)
+	if err != nil {
+		return nil, err
+	}
+	result := run(ctx, []string{managedEndpointIP, "-json", "route", "get", discoveryHost}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return nil, fmt.Errorf("inspect init-node route for managed control-plane join: %s", toolFailure(result))
+	}
+	var routes []struct {
+		Destination string `json:"dst"`
+		Gateway     string `json:"gateway"`
+		Device      string `json:"dev"`
+	}
+	if err := json.Unmarshal(result.Stdout, &routes); err != nil || len(routes) != 1 {
+		return nil, fmt.Errorf("inspect init-node route for managed control-plane join: invalid ip route response")
+	}
+	// A gateway means the init node is already reached through the fabric. The
+	// direct override is only needed when the fabric would hairpin the stable
+	// endpoint back onto the joining node's own link.
+	device := strings.TrimSpace(routes[0].Device)
+	if strings.TrimSpace(routes[0].Gateway) != "" {
+		return nil, nil
+	}
+	nextHop, err := netip.ParseAddr(strings.TrimSpace(routes[0].Destination))
+	if err != nil {
+		return nil, fmt.Errorf("inspect init-node route for managed control-plane join: direct route has no IP destination")
+	}
+	vip, err := netip.ParsePrefix(endpoint.VIP)
+	if err != nil {
+		return nil, fmt.Errorf("inspect managed control-plane endpoint route: invalid VIP prefix")
+	}
+	if vip.Addr().Is4() != nextHop.Is4() {
+		return nil, nil
+	}
+	if device == "" {
+		return nil, fmt.Errorf("inspect init-node route for managed control-plane join: direct route has no device")
+	}
+	route := &managedJoinRoute{VIP: endpoint.VIP, NextHop: nextHop.String(), Device: device}
+	result = run(ctx, []string{managedEndpointIP, "route", "add", route.VIP, "via", route.NextHop, "dev", route.Device}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return nil, fmt.Errorf("install temporary managed control-plane join route: %s", toolFailure(result))
+	}
+	return route, nil
+}
+
+func removeManagedJoinRoute(ctx context.Context, route *managedJoinRoute, run ToolRunner) error {
+	if route == nil {
+		return nil
+	}
+	result := run(ctx, []string{managedEndpointIP, "route", "del", route.VIP, "via", route.NextHop, "dev", route.Device}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return fmt.Errorf("remove temporary managed control-plane join route: %s", toolFailure(result))
+	}
+	return nil
+}
+
+func joinDiscoveryHost(root, discoveryPath string) (string, error) {
+	discoveryPath = strings.TrimSpace(discoveryPath)
+	if !strings.HasPrefix(discoveryPath, "/run/katl/bootstrap-join/") || filepath.Base(discoveryPath) != "discovery.conf" {
+		return "", fmt.Errorf("managed control-plane join requires an operation-scoped discovery kubeconfig")
+	}
+	data, err := os.ReadFile(rootedRuntimePath(root, discoveryPath))
+	if err != nil {
+		return "", fmt.Errorf("read managed control-plane join discovery kubeconfig: %w", err)
+	}
+	var config struct {
+		Clusters []struct {
+			Cluster struct {
+				Server string `yaml:"server"`
+			} `yaml:"cluster"`
+		} `yaml:"clusters"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil || len(config.Clusters) != 1 {
+		return "", fmt.Errorf("read managed control-plane join discovery kubeconfig: expected one cluster")
+	}
+	server, err := url.Parse(strings.TrimSpace(config.Clusters[0].Cluster.Server))
+	if err != nil || server.Scheme != "https" || server.Hostname() == "" {
+		return "", fmt.Errorf("read managed control-plane join discovery kubeconfig: invalid HTTPS server")
+	}
+	return server.Hostname(), nil
 }
 
 func resumeManagedEndpointAfterJoin(ctx context.Context, root string, run ToolRunner) error {
@@ -128,6 +241,7 @@ func managedJoinEndpointConfig(root string) (managedJoinEndpoint, bool, error) {
 	return managedJoinEndpoint{
 		VIP:       strings.TrimSpace(config.Endpoint.VIP),
 		Interface: strings.TrimSpace(config.VIPInterface.Name),
+		API:       "https://" + net.JoinHostPort(config.Endpoint.Host, strconv.Itoa(config.Endpoint.Port)),
 	}, true, nil
 }
 

--- a/internal/katlc/agent/endpoint_lifecycle_test.go
+++ b/internal/katlc/agent/endpoint_lifecycle_test.go
@@ -50,15 +50,22 @@ func TestManagedEndpointLifecycleFollowsGeneratedEnablement(t *testing.T) {
 func TestManagedEndpointJoinLifecycleRemovesAndRestoresLocalVIP(t *testing.T) {
 	root := t.TempDir()
 	writeManagedEndpointTestConfig(t, root)
+	discoveryPath := writeJoinDiscoveryTestConfig(t, root, "10.0.0.10")
 	var calls [][]string
 	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
 		calls = append(calls, append([]string(nil), argv...))
+		if reflect.DeepEqual(argv, []string{managedEndpointIP, "-json", "route", "get", "10.0.0.10"}) {
+			return ToolResult{Stdout: []byte(`[{"dst":"10.0.0.10","dev":"enp1s0"}]`)}
+		}
 		return ToolResult{}
 	}
 
-	suspended, err := suspendManagedEndpointForJoin(context.Background(), root, run)
+	suspended, route, err := suspendManagedEndpointForJoin(context.Background(), root, discoveryPath, run)
 	if err != nil || !suspended {
 		t.Fatalf("suspendManagedEndpointForJoin() = %v, %v", suspended, err)
+	}
+	if err := removeManagedJoinRoute(context.Background(), route, run); err != nil {
+		t.Fatalf("removeManagedJoinRoute(): %v", err)
 	}
 	if err := resumeManagedEndpointAfterJoin(context.Background(), root, run); err != nil {
 		t.Fatalf("resumeManagedEndpointAfterJoin(): %v", err)
@@ -68,6 +75,10 @@ func TestManagedEndpointJoinLifecycleRemovesAndRestoresLocalVIP(t *testing.T) {
 		{endpointAdvertiserCommand, "withdraw"},
 		{managedEndpointInterface, "down", "katl-api0"},
 		{managedEndpointIP, "address", "flush", "dev", "katl-api0", "to", "10.40.0.10/32"},
+		{managedEndpointIP, "-json", "route", "get", "10.0.0.10"},
+		{managedEndpointIP, "route", "add", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"},
+		{managedEndpointKubectl, "--kubeconfig", filepath.Join(root, discoveryPath), "--server", "https://api.home.example:6443", "--request-timeout=10s", "get", "--raw=/version"},
+		{managedEndpointIP, "route", "del", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"},
 		{managedEndpointInterface, "up", "katl-api0"},
 		{managedEndpointIP, "address", "replace", "10.40.0.10/32", "dev", "katl-api0"},
 		{"systemctl", "start", endpointAdvertiserUnit},
@@ -80,6 +91,7 @@ func TestManagedEndpointJoinLifecycleRemovesAndRestoresLocalVIP(t *testing.T) {
 func TestManagedEndpointJoinLifecycleFailsClosed(t *testing.T) {
 	root := t.TempDir()
 	writeManagedEndpointTestConfig(t, root)
+	discoveryPath := writeJoinDiscoveryTestConfig(t, root, "10.0.0.10")
 	var calls int
 	run := func(_ context.Context, _ []string, _ func(int)) ToolResult {
 		calls++
@@ -89,13 +101,74 @@ func TestManagedEndpointJoinLifecycleFailsClosed(t *testing.T) {
 		return ToolResult{}
 	}
 
-	suspended, err := suspendManagedEndpointForJoin(context.Background(), root, run)
+	suspended, route, err := suspendManagedEndpointForJoin(context.Background(), root, discoveryPath, run)
 	if err == nil || suspended {
 		t.Fatalf("suspendManagedEndpointForJoin() = %v, %v", suspended, err)
+	}
+	if route != nil {
+		t.Fatalf("route = %#v, want nil", route)
 	}
 	if calls != 3 {
 		t.Fatalf("commands after interface failure = %d, want 3", calls)
 	}
+}
+
+func TestManagedEndpointJoinUsesExistingFabricRouteForOffLinkInit(t *testing.T) {
+	root := t.TempDir()
+	writeManagedEndpointTestConfig(t, root)
+	discoveryPath := writeJoinDiscoveryTestConfig(t, root, "10.50.0.10")
+	var calls [][]string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		calls = append(calls, append([]string(nil), argv...))
+		if reflect.DeepEqual(argv, []string{managedEndpointIP, "-json", "route", "get", "10.50.0.10"}) {
+			return ToolResult{Stdout: []byte(`[{"dst":"10.50.0.10","gateway":"10.0.0.1","dev":"enp1s0"}]`)}
+		}
+		return ToolResult{}
+	}
+
+	suspended, route, err := suspendManagedEndpointForJoin(context.Background(), root, discoveryPath, run)
+	if err != nil || !suspended || route != nil {
+		t.Fatalf("suspendManagedEndpointForJoin() = %v, %#v, %v", suspended, route, err)
+	}
+	for _, call := range calls {
+		if len(call) > 2 && call[0] == managedEndpointIP && call[1] == "route" && call[2] == "add" {
+			t.Fatalf("off-link init installed a direct route: %#v", call)
+		}
+	}
+}
+
+func TestManagedEndpointJoinProbeFailureRemovesTemporaryRoute(t *testing.T) {
+	root := t.TempDir()
+	writeManagedEndpointTestConfig(t, root)
+	discoveryPath := writeJoinDiscoveryTestConfig(t, root, "10.0.0.10")
+	var calls [][]string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		calls = append(calls, append([]string(nil), argv...))
+		switch {
+		case reflect.DeepEqual(argv, []string{managedEndpointIP, "-json", "route", "get", "10.0.0.10"}):
+			return ToolResult{Stdout: []byte(`[{"dst":"10.0.0.10","dev":"enp1s0"}]`)}
+		case len(argv) > 0 && argv[0] == managedEndpointKubectl:
+			return ToolResult{Err: errors.New("API request timed out"), ExitStatus: 1}
+		default:
+			return ToolResult{}
+		}
+	}
+
+	suspended, route, err := suspendManagedEndpointForJoin(context.Background(), root, discoveryPath, run)
+	if err == nil || suspended || route != nil {
+		t.Fatalf("suspendManagedEndpointForJoin() = %v, %#v, %v", suspended, route, err)
+	}
+	wantLast := []string{managedEndpointIP, "route", "del", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"}
+	if !reflect.DeepEqual(calls[len(calls)-1], wantLast) {
+		t.Fatalf("last command = %#v, want route cleanup %#v", calls[len(calls)-1], wantLast)
+	}
+}
+
+func writeJoinDiscoveryTestConfig(t *testing.T, root, host string) string {
+	t.Helper()
+	path := "/run/katl/bootstrap-join/test/discovery.conf"
+	writeTestFile(t, filepath.Join(root, path), "apiVersion: v1\nkind: Config\nclusters:\n  - name: katl-discovery\n    cluster:\n      server: https://"+host+":6443\n")
+	return path
 }
 
 func TestManagedEndpointPauseFailsClosed(t *testing.T) {

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -223,9 +223,10 @@ func (e *Executor) Execute(ctx context.Context, record operation.OperationRecord
 		return markErr
 	}
 	endpointSuspended := false
+	var managedRoute *managedJoinRoute
 	if record.OperationKind == bootstrapplan.OperationKindJoinControlPlane {
 		lifecycleCtx, lifecycleCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		endpointSuspended, err = suspendManagedEndpointForJoin(lifecycleCtx, e.Root, e.endpointLifecycleRunner())
+		endpointSuspended, managedRoute, err = suspendManagedEndpointForJoin(lifecycleCtx, e.Root, joinDiscoveryConfigPath(record), e.endpointLifecycleRunner())
 		lifecycleCancel()
 		if err != nil {
 			_, markErr := e.failRecordPhase(record.OperationID, "managed-endpoint-suspend-failed", "managed-endpoint-lifecycle", "suspend-managed-endpoint", "repair the managed endpoint lifecycle before retrying the control-plane join", err)
@@ -309,6 +310,17 @@ func (e *Executor) Execute(ctx context.Context, record operation.OperationRecord
 			startMu.Unlock()
 		}
 	})
+	if managedRoute != nil {
+		lifecycleCtx, lifecycleCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		routeErr := removeManagedJoinRoute(lifecycleCtx, managedRoute, e.endpointLifecycleRunner())
+		lifecycleCancel()
+		if routeErr != nil {
+			result.Err = errors.Join(result.Err, routeErr)
+			if result.ExitStatus == 0 {
+				result.ExitStatus = -1
+			}
+		}
+	}
 	if errors.Is(toolCtx.Err(), context.DeadlineExceeded) && result.Err == nil {
 		result.Err = toolCtx.Err()
 		result.ExitStatus = -1
@@ -1021,6 +1033,17 @@ func cleanupTemporaryJoinConfig(root string, record operation.OperationRecord) {
 	_ = os.Remove(filepath.Join(filepath.Dir(target), "discovery.conf"))
 	_ = os.Remove(target)
 	_ = os.Remove(filepath.Dir(target))
+}
+
+func joinDiscoveryConfigPath(record operation.OperationRecord) string {
+	if record.BootstrapRequest == nil {
+		return ""
+	}
+	path := strings.TrimSpace(record.BootstrapRequest.TemporaryJoinConfigPath)
+	if !strings.HasPrefix(path, "/run/katl/bootstrap-join/") || strings.Contains(path, "\x00") {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(path), "discovery.conf")
 }
 
 func expiredJoinMaterial(record operation.OperationRecord, now time.Time) string {

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -632,7 +632,14 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 		return ToolResult{}
 	}
 	executor.RunEndpointLifecycle = func(_ context.Context, argv []string, _ func(int)) ToolResult {
-		sequence = append(sequence, strings.Join(argv, " "))
+		command := strings.Join(argv, " ")
+		if len(argv) > 0 && argv[0] == managedEndpointKubectl {
+			command = managedEndpointKubectl + " probe-stable-endpoint"
+		}
+		sequence = append(sequence, command)
+		if reflect.DeepEqual(argv, []string{managedEndpointIP, "-json", "route", "get", "10.0.0.11"}) {
+			return ToolResult{Stdout: []byte(`[{"dst":"10.0.0.11","dev":"enp1s0"}]`)}
+		}
 		return ToolResult{}
 	}
 	executor.RunTool = func(_ context.Context, _ []string, started func(int)) ToolResult {
@@ -642,6 +649,9 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 			endpointAdvertiserCommand + " withdraw",
 			managedEndpointInterface + " down katl-api0",
 			managedEndpointIP + " address flush dev katl-api0 to 10.40.0.10/32",
+			managedEndpointIP + " -json route get 10.0.0.11",
+			managedEndpointIP + " route add 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
+			managedEndpointKubectl + " probe-stable-endpoint",
 		}
 		if !reflect.DeepEqual(sequence, wantPrefix) {
 			t.Fatalf("sequence before kubeadm = %#v, want %#v", sequence, wantPrefix)
@@ -660,7 +670,7 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 	setSubmitRequestBundle(req, source, ref)
 	req.OperationKind = "bootstrap-join-control-plane"
 	req.Bootstrap.WorkerJoinMaterial = validControlPlaneJoinMaterial()
-	req.Bootstrap.WorkerJoinMaterial.DiscoveryKubeconfig = []byte("ephemeral discovery credentials\n")
+	req.Bootstrap.WorkerJoinMaterial.DiscoveryKubeconfig = []byte("apiVersion: v1\nkind: Config\nclusters:\n  - name: katl-discovery\n    cluster:\n      server: https://10.0.0.11:6443\nusers:\n  - name: katl-bootstrap\n    user:\n      token: ephemeral\n")
 	accepted, err := server.SubmitOperation(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -671,7 +681,11 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 		endpointAdvertiserCommand + " withdraw",
 		managedEndpointInterface + " down katl-api0",
 		managedEndpointIP + " address flush dev katl-api0 to 10.40.0.10/32",
+		managedEndpointIP + " -json route get 10.0.0.11",
+		managedEndpointIP + " route add 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
+		managedEndpointKubectl + " probe-stable-endpoint",
 		"kubeadm",
+		managedEndpointIP + " route del 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
 		managedEndpointInterface + " up katl-api0",
 		managedEndpointIP + " address replace 10.40.0.10/32 dev katl-api0",
 		"systemctl start " + endpointAdvertiserUnit,


### PR DESCRIPTION
## What changed

Managed-VIP control-plane joins now route the stable endpoint directly through the selected init node when it is on-link, verify a complete API request, and remove that temporary route when kubeadm returns.

## Why

Taking the joining node's dummy VIP offline fixed local endpoint capture, but same-subnet fabric forwarding still produced an asymmetric path: TCP connected while Kubernetes HTTPS responses timed out. The operation-scoped host route avoids that hairpin without changing the user-owned kubeadm configuration or defaults.
