### PR TITLE
runtime: allow CNI host-to-pod traffic

### DIFF
--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -25,6 +25,23 @@ func TestRuntimeInitrdIncludesLibseccomp(t *testing.T) {
 	}
 }
 
+func TestRuntimeKubernetesSysctlsSupportCNIs(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join(repoRoot(t), "mkosi.profiles", "runtime", "mkosi.extra", "usr", "lib", "sysctl.d", "50-katl-kubernetes.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(config)
+	for _, want := range []string{
+		"net.ipv4.ip_forward=1",
+		"net.ipv4.conf.all.rp_filter=0",
+		"net.ipv4.conf.default.rp_filter=0",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("runtime Kubernetes sysctls missing %q", want)
+		}
+	}
+}
+
 func TestRuntimeBuildExcludesVMTestSupportByDefault(t *testing.T) {
 	repo := repoRoot(t)
 	bin := filepath.Join(t.TempDir(), "bin")

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -246,6 +246,11 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 
 	nodes := []vmtest.RunningInstalledRuntimeNode{cp1Node, cp2Node, cp3Node}
 	for _, node := range nodes {
+		if err := assertCNISysctls(ctx, node); err != nil {
+			collectTwoNodeDiagnostics("", nodes...)
+			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+			t.Fatalf("check CNI sysctls on %s: %v", node.Name, err)
+		}
 		if err := installKubernetesBundleCA(ctx, node, kubernetesBundle); err != nil {
 			collectTwoNodeDiagnostics("", nodes...)
 			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
@@ -397,6 +402,24 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 		}
 	}
 	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
+}
+
+func assertCNISysctls(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) error {
+	result, err := runNodeCommandWithRetry(ctx, node, []string{
+		"sysctl", "-n",
+		"net.ipv4.conf.all.rp_filter",
+		"net.ipv4.conf.default.rp_filter",
+	}, 16<<10)
+	if err != nil {
+		return err
+	}
+	if result.ExitStatus != 0 {
+		return commandErrorDetail(result)
+	}
+	if got, want := strings.Fields(string(result.Stdout)), []string{"0", "0"}; !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("reverse-path filtering values = %v, want %v", got, want)
+	}
+	return nil
 }
 
 func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context, result vmtest.Result, nodes []vmtest.RunningInstalledRuntimeNode, addresses, bootstrapGenerations map[string]string, inventoryPath, kubeconfigPath string, bundle threeControlPlaneKubernetesPayloadBundle, cniFixtures map[string]nodeCNIFixture, snapshot threeControlPlaneEtcdReport) error {

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/sysctl.d/50-katl-kubernetes.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/sysctl.d/50-katl-kubernetes.conf
@@ -1,1 +1,5 @@
 net.ipv4.ip_forward=1
+# CNI datapaths mark and redirect pod traffic in ways that reverse-path
+# filtering can reject. New CNI interfaces inherit the default value.
+net.ipv4.conf.all.rp_filter=0
+net.ipv4.conf.default.rp_filter=0


### PR DESCRIPTION
## What changed

Set KatlOS's native IPv4 reverse-path filtering defaults to zero so dynamically created CNI interfaces inherit a compatible value. Add image-content and booted-node coverage for the runtime contract.

## Why

Cilium's sysctl helper cannot write its persistent override under KatlOS's immutable `/etc`, so Fedora's `rp_filter=2` default was inherited by `lxc*` interfaces. Cilium endpoints appeared ready, but host-to-local-pod and pod-to-host or underlay traffic timed out. Applying the new values live immediately restored Cilium health.

The three-control-plane VM gate passes with the effective sysctl assertion on every node.
