### PR TITLE
runtime: preserve cni interface filtering defaults

### DIFF
--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -35,6 +35,8 @@ func TestRuntimeKubernetesSysctlsSupportCNIs(t *testing.T) {
 		"net.ipv4.ip_forward=1",
 		"net.ipv4.conf.all.rp_filter=0",
 		"net.ipv4.conf.default.rp_filter=0",
+		"net.ipv4.conf.lxc*.rp_filter=0",
+		"net.ipv4.conf.cilium_*.rp_filter=0",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("runtime Kubernetes sysctls missing %q", want)

--- a/internal/vmtest/agent_server.go
+++ b/internal/vmtest/agent_server.go
@@ -493,6 +493,7 @@ func defaultAgentCommands() map[string]bool {
 		"systemd-sysupdate": true,
 		"test":              true,
 		"true":              true,
+		"udevadm":           true,
 		"uname":             true,
 	}
 }

--- a/internal/vmtest/agent_test.go
+++ b/internal/vmtest/agent_test.go
@@ -233,7 +233,7 @@ func TestAgentCommandAllowlist(t *testing.T) {
 }
 
 func TestAgentDefaultAllowlistSupportsBootstrapReadiness(t *testing.T) {
-	for _, command := range []string{"bgp-api-vip-smoke", "blkid", "chmod", "crictl", "ctr", "dd", "find", "findmnt", "install", "katlc", "kubeadm", "kubectl", "kubelet", "lsmod", "modprobe", "mount", "partx", "sfdisk", "sha256sum", "sshd", "systemd-sysupdate", "test"} {
+	for _, command := range []string{"bgp-api-vip-smoke", "blkid", "chmod", "crictl", "ctr", "dd", "find", "findmnt", "install", "katlc", "kubeadm", "kubectl", "kubelet", "lsmod", "modprobe", "mount", "partx", "sfdisk", "sha256sum", "sshd", "systemd-sysupdate", "test", "udevadm"} {
 		if !commandAllowed(command, defaultAgentCommands()) {
 			t.Fatalf("%s is not allowlisted", command)
 		}

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -405,10 +405,31 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 }
 
 func assertCNISysctls(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) error {
+	const testInterface = "lxc_katltest"
+	created, err := runNodeCommandWithRetry(ctx, node, []string{
+		"ip", "link", "add", testInterface, "type", "dummy",
+	}, 16<<10)
+	if err != nil {
+		return err
+	}
+	if created.ExitStatus != 0 {
+		return commandErrorDetail(created)
+	}
+	defer func() {
+		_, _ = runNodeCommandWithRetry(ctx, node, []string{"ip", "link", "delete", testInterface}, 16<<10)
+	}()
+	settled, err := runNodeCommandWithRetry(ctx, node, []string{"udevadm", "settle"}, 16<<10)
+	if err != nil {
+		return err
+	}
+	if settled.ExitStatus != 0 {
+		return commandErrorDetail(settled)
+	}
 	result, err := runNodeCommandWithRetry(ctx, node, []string{
 		"sysctl", "-n",
 		"net.ipv4.conf.all.rp_filter",
 		"net.ipv4.conf.default.rp_filter",
+		"net.ipv4.conf." + testInterface + ".rp_filter",
 	}, 16<<10)
 	if err != nil {
 		return err
@@ -416,7 +437,7 @@ func assertCNISysctls(ctx context.Context, node vmtest.RunningInstalledRuntimeNo
 	if result.ExitStatus != 0 {
 		return commandErrorDetail(result)
 	}
-	if got, want := strings.Fields(string(result.Stdout)), []string{"0", "0"}; !reflect.DeepEqual(got, want) {
+	if got, want := strings.Fields(string(result.Stdout)), []string{"0", "0", "0"}; !reflect.DeepEqual(got, want) {
 		return fmt.Errorf("reverse-path filtering values = %v, want %v", got, want)
 	}
 	return nil

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/sysctl.d/50-katl-kubernetes.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/sysctl.d/50-katl-kubernetes.conf
@@ -1,5 +1,8 @@
 net.ipv4.ip_forward=1
 # CNI datapaths mark and redirect pod traffic in ways that reverse-path
-# filtering can reject. New CNI interfaces inherit the default value.
+# filtering can reject. Match Cilium interfaces explicitly because distro
+# wildcard defaults are reapplied when each interface is created.
 net.ipv4.conf.all.rp_filter=0
 net.ipv4.conf.default.rp_filter=0
+net.ipv4.conf.lxc*.rp_filter=0
+net.ipv4.conf.cilium_*.rp_filter=0


### PR DESCRIPTION
Add explicit Cilium interface sysctl globs so Fedora cannot re-enable reverse-path filtering when CNI links appear. Strengthen the three-control-plane VM assertion to create a representative interface and wait for udev before checking its applied value.

The root cause was Fedora per-interface policy overriding the all/default values after link creation, which broke host-to-pod traffic even though boot-time sysctl checks passed.