### PR TITLE
upgrade: tolerate versioned root slot labels

### DIFF
--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -54,11 +54,11 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("read current generation: %w", err))
 	}
-	inactiveSlot, inactiveLabel, activeLabel, err := inactiveRoot(previousSpec.Root.Slot)
+	inactiveSlot, err := inactiveRoot(previousSpec.Root.Slot)
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", err)
 	}
-	slots, err := e.inspectRootSlots(ctx, activeLabel, inactiveLabel)
+	slots, err := e.inspectRootSlots(ctx, previousSpec.Root.PartitionUUID)
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", err)
 	}
@@ -262,18 +262,44 @@ type rootSlots struct {
 	InactivePartUUID string
 }
 
-func (e *Executor) inspectRootSlots(ctx context.Context, activeLabel, inactiveLabel string) (rootSlots, error) {
-	active, err := e.toolOutput(ctx, "blkid", "-t", "PARTLABEL="+activeLabel, "-o", "device")
+func (e *Executor) inspectRootSlots(ctx context.Context, activePartUUID string) (rootSlots, error) {
+	active, err := e.toolOutput(ctx, "blkid", "-t", "PARTUUID="+activePartUUID, "-o", "device")
 	if err != nil {
 		return rootSlots{}, fmt.Errorf("find active root slot: %w", err)
-	}
-	inactive, err := e.toolOutput(ctx, "blkid", "-t", "PARTLABEL="+inactiveLabel, "-o", "device")
-	if err != nil {
-		return rootSlots{}, fmt.Errorf("find inactive root slot: %w", err)
 	}
 	activeDisk, activePart, err := e.partitionIdentity(ctx, active)
 	if err != nil {
 		return rootSlots{}, err
+	}
+	activeType, err := e.toolOutput(ctx, "lsblk", "-no", "PARTTYPE", active)
+	if err != nil {
+		return rootSlots{}, fmt.Errorf("inspect active root partition type: %w", err)
+	}
+	partitionTable, err := e.toolOutput(ctx, "lsblk", "-rno", "PATH,PARTTYPE", activeDisk)
+	if err != nil {
+		return rootSlots{}, fmt.Errorf("inspect root partitions on %s: %w", activeDisk, err)
+	}
+	rootDevices := make([]string, 0, 2)
+	for _, line := range strings.Split(partitionTable, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && strings.EqualFold(fields[1], activeType) {
+			rootDevices = append(rootDevices, fields[0])
+		}
+	}
+	if len(rootDevices) != 2 {
+		return rootSlots{}, fmt.Errorf("find inactive root slot: found %d root partitions with type %q on %s, want 2", len(rootDevices), activeType, activeDisk)
+	}
+	inactive := ""
+	activeFound := false
+	for _, device := range rootDevices {
+		if device == active {
+			activeFound = true
+			continue
+		}
+		inactive = device
+	}
+	if !activeFound || inactive == "" {
+		return rootSlots{}, fmt.Errorf("find inactive root slot: active device %s is not one of %v", active, rootDevices)
 	}
 	inactiveDisk, inactivePart, err := e.partitionIdentity(ctx, inactive)
 	if err != nil {
@@ -339,14 +365,14 @@ func (e *Executor) failHostUpgrade(record operation.OperationRecord, phase strin
 	return errors.Join(cause, err)
 }
 
-func inactiveRoot(current string) (string, string, string, error) {
+func inactiveRoot(current string) (string, error) {
 	switch current {
 	case string(disk.RootSlotA):
-		return string(disk.RootSlotB), disk.GPTLabelRootB, disk.GPTLabelRootA, nil
+		return string(disk.RootSlotB), nil
 	case string(disk.RootSlotB):
-		return string(disk.RootSlotA), disk.GPTLabelRootA, disk.GPTLabelRootB, nil
+		return string(disk.RootSlotA), nil
 	default:
-		return "", "", "", fmt.Errorf("current generation root slot %q is unsupported", current)
+		return "", fmt.Errorf("current generation root slot %q is unsupported", current)
 	}
 }
 

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -118,23 +118,35 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 		return nil
 	}
 	executor.SetBootOneshot = func(_ context.Context, _ string, entry string) error { oneshoot = entry; return nil }
+	var toolCalls []string
 	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		toolCalls = append(toolCalls, strings.Join(argv, " "))
 		switch filepath.Base(argv[0]) {
 		case "blkid":
 			joined := strings.Join(argv, " ")
 			switch {
-			case strings.Contains(joined, "PARTLABEL=KATL_ROOT_A"):
+			case strings.Contains(joined, "PARTUUID=aaaaaaaa-1111-2222-3333-444444444444"):
 				return ToolResult{Stdout: []byte(activeDevice + "\n")}
-			case strings.Contains(joined, "PARTLABEL=KATL_ROOT_B"):
-				return ToolResult{Stdout: []byte(inactiveDevice + "\n")}
-			default:
+			case argv[len(argv)-1] == inactiveDevice:
 				return ToolResult{Stdout: []byte("bbbbbbbb-1111-2222-3333-444444444444\n")}
+			default:
+				return ToolResult{Err: os.ErrNotExist, ExitStatus: 2}
 			}
 		case "lsblk":
+			joined := strings.Join(argv, " ")
+			switch {
+			case strings.Contains(joined, "-no PARTTYPE "):
+				return ToolResult{Stdout: []byte("4f68bce3-e8cd-4db1-96e7-fbcaf984b709\n")}
+			case strings.Contains(joined, "-rno PATH,PARTTYPE "):
+				return ToolResult{Stdout: []byte("/dev/vda\n/dev/vda1 c12a7328-f81f-11d2-ba4b-00a0c93ec93b\n" + activeDevice + " 4f68bce3-e8cd-4db1-96e7-fbcaf984b709\n" + inactiveDevice + " 4f68bce3-e8cd-4db1-96e7-fbcaf984b709\n/dev/vda4 0fc63daf-8483-4772-8e79-3d69d8477de4\n")}
+			}
 			if argv[len(argv)-1] == activeDevice {
 				return ToolResult{Stdout: []byte("vda 2\n")}
 			}
-			return ToolResult{Stdout: []byte("vda 3\n")}
+			if argv[len(argv)-1] == inactiveDevice {
+				return ToolResult{Stdout: []byte("vda 3\n")}
+			}
+			return ToolResult{Err: os.ErrNotExist, ExitStatus: 1}
 		case "sfdisk", "partx":
 			return ToolResult{}
 		case "systemd-sysupdate":
@@ -151,6 +163,9 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	}
 	if err := executor.Execute(context.Background(), record); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+	if calls := strings.Join(toolCalls, "\n"); strings.Contains(calls, "PARTLABEL=") {
+		t.Fatalf("host upgrade discovered mutable partition labels:\n%s", calls)
 	}
 	if oneshoot != "loader/entries/katl-gen1.conf" {
 		t.Fatalf("oneshot entry = %q", oneshoot)
@@ -179,6 +194,52 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	}
 	if !completed.Terminal || completed.Result != operation.ResultSucceeded || !completed.BootHealthPending {
 		t.Fatalf("completed operation = %+v", completed)
+	}
+}
+
+func TestInspectRootSlotsRejectsAmbiguousPartitionLayout(t *testing.T) {
+	const rootType = "4f68bce3-e8cd-4db1-96e7-fbcaf984b709"
+	for _, test := range []struct {
+		name      string
+		partition string
+		want      string
+	}{
+		{
+			name:      "missing peer",
+			partition: "/dev/vda2 " + rootType + "\n",
+			want:      "found 1 root partitions",
+		},
+		{
+			name:      "extra peer",
+			partition: "/dev/vda2 " + rootType + "\n/dev/vda3 " + rootType + "\n/dev/vda4 " + rootType + "\n",
+			want:      "found 3 root partitions",
+		},
+		{
+			name:      "active absent",
+			partition: "/dev/vda3 " + rootType + "\n/dev/vda4 " + rootType + "\n",
+			want:      "active device /dev/vda2 is not one of",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			executor := &Executor{RunTool: func(_ context.Context, argv []string, _ func(int)) ToolResult {
+				switch strings.Join(argv, " ") {
+				case "blkid -t PARTUUID=active-partuuid -o device":
+					return ToolResult{Stdout: []byte("/dev/vda2\n")}
+				case "lsblk -no PKNAME,PARTN /dev/vda2":
+					return ToolResult{Stdout: []byte("vda 2\n")}
+				case "lsblk -no PARTTYPE /dev/vda2":
+					return ToolResult{Stdout: []byte(rootType + "\n")}
+				case "lsblk -rno PATH,PARTTYPE /dev/vda":
+					return ToolResult{Stdout: []byte(test.partition)}
+				default:
+					return ToolResult{Err: os.ErrNotExist, ExitStatus: 1}
+				}
+			}}
+			_, err := executor.inspectRootSlots(context.Background(), "active-partuuid")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("inspectRootSlots() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -116,28 +116,12 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 		conn.Close()
 		t.Fatalf("read node status before host upgrade: %v", err)
 	}
-	accepted, err := katlc.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-		ApiVersion:                  operation.APIVersion,
-		Kind:                        agent.RequestKind,
-		ClientRequestId:             "vmtest-host-upgrade-" + candidateGeneration,
-		OperationKind:               agent.OperationKindHostUpgrade,
-		Actor:                       "installed runtime host upgrade vmtest",
-		ExpectedMachineId:           nodeStatus.GetMachineId(),
-		ExpectedCurrentGenerationId: previousGeneration,
-		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
-			ImageLocalRef:         localRef,
-			CandidateGenerationId: candidateGeneration,
-		},
-	})
 	conn.Close()
-	if err != nil {
-		t.Fatalf("submit host upgrade operation: %v", err)
-	}
-	status := waitKatlcOperationTerminal(t, ctx, endpoint, accepted.GetOperationId())
+	operationID, status := submitHostUpgradeAndWait(t, ctx, endpoint, nodeStatus.GetMachineId(), previousGeneration, candidateGeneration, localRef)
 	if status.GetResult() != operation.ResultSucceeded || !status.GetBootHealthPending() || status.GetCandidateGenerationId() != candidateGeneration {
 		t.Fatalf("host upgrade operation status = %+v", status)
 	}
-	recordData := readGuestFile(t, ctx, guest, "/var/lib/katl/operations/"+accepted.GetOperationId()+"/record.json")
+	recordData := readGuestFile(t, ctx, guest, "/var/lib/katl/operations/"+operationID+"/record.json")
 	envelope, err := persistedrecord.DecodeEnvelope([]byte(recordData))
 	if err != nil {
 		t.Fatalf("decode host upgrade operation envelope: %v", err)
@@ -191,9 +175,22 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 	if previousSpec.RuntimeVersion == candidateSpec.RuntimeVersion || previousSpec.Boot.UKIPath == candidateSpec.Boot.UKIPath || previousSpec.Root.Slot == candidateSpec.Root.Slot {
 		t.Fatalf("upgrade did not produce distinct version, root slot, and UKI identities: previous=%#v candidate=%#v", previousSpec, candidateSpec)
 	}
+	repeatedGeneration := candidateGeneration + "-repeat"
+	_, repeatedStatus := submitHostUpgradeAndWait(t, ctx, endpoint, nodeStatus.GetMachineId(), previousGeneration, repeatedGeneration, localRef)
+	if repeatedStatus.GetResult() != operation.ResultSucceeded || !repeatedStatus.GetBootHealthPending() || repeatedStatus.GetCandidateGenerationId() != repeatedGeneration {
+		t.Fatalf("repeated host upgrade operation status = %+v", repeatedStatus)
+	}
+	repeatedSpec := generationFromGuest(t, ctx, guest, repeatedGeneration)
+	if repeatedSpec.Root.Slot != candidateSpec.Root.Slot || repeatedSpec.Root.PartitionUUID != candidateSpec.Root.PartitionUUID {
+		t.Fatalf("repeated host upgrade root = %#v, want previously upgraded peer %#v", repeatedSpec.Root, candidateSpec.Root)
+	}
+	repeatedTrial := bootSelectionFromGuest(t, ctx, guest)
+	if repeatedTrial.TrialGenerationID != repeatedGeneration || repeatedTrial.PreviousKnownGoodGenerationID != previousGeneration || !repeatedTrial.PendingHealthValidation {
+		t.Fatalf("repeated host upgrade trial selection = %#v", repeatedTrial)
+	}
 	guestCommand(t, ctx, guest, "boot-health-evidence", "systemctl", "show", "katl-boot-health.service", "--property=Result,ExecMainStatus")
 	guestCommand(t, ctx, guest, "boot-complete-evidence", "systemctl", "is-active", "katl-boot-complete.target")
-	t.Log("host upgrade and rollback are serialized per node in v0.1; multi-node rollout orchestration remains operator-controlled")
+	t.Log("host upgrade, rollback, and repeated upgrade staging are serialized per node in v0.1; multi-node rollout orchestration remains operator-controlled")
 	powerOffGuestForCleanSuccess(t, ctx, &node, guest, client)
 	client = nil
 
@@ -206,6 +203,29 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 			t.Fatalf("write world scenario result: %v", err)
 		}
 	}
+}
+
+func submitHostUpgradeAndWait(t *testing.T, ctx context.Context, endpoint, machineID, currentGeneration, candidateGeneration, localRef string) (string, *agentapi.OperationStatus) {
+	t.Helper()
+	conn, katlc := dialKatlcAgentForVMTest(t, ctx, endpoint)
+	accepted, err := katlc.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
+		ApiVersion:                  operation.APIVersion,
+		Kind:                        agent.RequestKind,
+		ClientRequestId:             "vmtest-host-upgrade-" + candidateGeneration,
+		OperationKind:               agent.OperationKindHostUpgrade,
+		Actor:                       "installed runtime host upgrade vmtest",
+		ExpectedMachineId:           machineID,
+		ExpectedCurrentGenerationId: currentGeneration,
+		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
+			ImageLocalRef:         localRef,
+			CandidateGenerationId: candidateGeneration,
+		},
+	})
+	conn.Close()
+	if err != nil {
+		t.Fatalf("submit host upgrade operation: %v", err)
+	}
+	return accepted.GetOperationId(), waitKatlcOperationTerminal(t, ctx, endpoint, accepted.GetOperationId())
 }
 
 type builtUpgradeImage struct {


### PR DESCRIPTION
Fix repeated KatlOS upgrades after systemd-sysupdate replaces the installer root labels. The agent now resolves the active root from the committed generation PARTUUID and identifies the peer by GPT partition type on the same disk, failing closed unless the layout has exactly two root partitions. The installed-runtime journey covers upgrade, rollback, and repeated upgrade staging.