### PR TITLE
kubernetes: reconcile cluster configuration online

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Katl produces KatlOS, an installable, upgradeable, systemd-native Kubernetes nod
 - Verify generated systemd units with `systemd-analyze verify` where practical. Risky boot, disk, update, security, or kubeadm changes also require focused review.
 - Use delete-on-success retention for routine VM gates. Keep large run output only while debugging and remove it afterwards.
 - A release should exercise the same artifacts and supported journeys users receive. Do not infer release readiness solely from unit tests or a successful artifact build.
+- Use `katldev` for hands-on UX verification of operator journeys through the public `katlctl` interface. Exercise representative happy paths, repeat applies, online configuration changes, and safe failure or recovery paths without relying on internal shortcuts. Judge the journey as a user would: verify useful progress, actionable errors, expected end state, and the absence of surprising disruption; record product gaps discovered along the way.
 
 ## Task and Delivery Workflow
 

--- a/README.md
+++ b/README.md
@@ -218,17 +218,17 @@ an interrupted bootstrap.
 
 ## Configuration and upgrades
 
-`ClusterConfig` remains the user-authored source after installation. An
-optional plan contacts the selected node but does not accept an operation:
+`ClusterConfig` remains the user-authored source after installation. Apply the
+complete retained configuration to the cluster with one command:
 
 ```sh
-katlctl node apply cp-1 --config ./cluster.yaml --plan
+katlctl cluster apply --config ./cluster.yaml
 ```
 
-Run the command without `--plan` to apply it. `katlctl` derives config versions,
-generation names, validation, and operation tracking internally.
-Supported changes compile into generation-scoped confext/sysext state and are
-applied live or on next boot according to the domain policy. See
+`katlctl` derives per-node generations, validates every node before mutation,
+and coordinates operation tracking internally. Kubeadm-produced component
+configuration is reconciled online as part of the same apply and never causes
+a node reboot. See
 [Apply runtime configuration](docs/installing.md#apply-runtime-configuration).
 
 Routine host management uses the same `ClusterConfig` as installation and

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -384,7 +384,14 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		if err != nil {
 			return activatedClusterConfig{}, fmt.Errorf("apply cluster config on %s: %w", node.Name, err)
 		}
-		result[node.Name] = generationID
+		activatedGeneration := strings.TrimSpace(terminal.GetCandidateGenerationId())
+		if activatedGeneration == "" {
+			activatedGeneration = generationID
+			if terminal.GetGenerationCommitState() == operation.GenerationCommitAbandoned {
+				activatedGeneration = input.currentGeneration
+			}
+		}
+		result[node.Name] = activatedGeneration
 	}
 	return activatedClusterConfig{generations: result, components: components}, nil
 }

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -1,55 +1,154 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/configapply"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"github.com/spf13/cobra"
 )
 
 type kubeadmControlPlaneConfigOptions struct {
-	inventoryPath, coordinator, generationID, configName string
-	rolloutID                                            string
+	configPath, inventoryPath, coordinator, generationID, configName string
+	rolloutID, component                                             string
 }
 
-func newKubeadmControlPlaneConfigCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+var kubeadmConfigNow = func() time.Time { return time.Now().UTC() }
+
+func newClusterApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := kubeadmControlPlaneConfigOptions{}
-	cmd := &cobra.Command{Use: "apply-config", Short: "Apply staged kubeadm configuration across control planes", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runKubeadmControlPlaneConfig(ctx, opts, stdout) }}
+	cmd := &cobra.Command{Use: "apply", Short: "Apply the complete ClusterConfig to a running cluster", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runClusterApply(ctx, opts, stdout) }}
 	f := cmd.Flags()
-	f.StringVar(&opts.inventoryPath, "inventory", "", "three-control-plane inventory")
+	f.StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
+	f.StringVar(&opts.inventoryPath, "inventory", "", "advanced cluster inventory")
 	f.StringVar(&opts.coordinator, "coordinator", "", "coordinator control-plane node changed last")
 	f.StringVar(&opts.generationID, "generation", "", "active desired generation ID")
 	f.StringVar(&opts.configName, "config-name", "", "selected KubeadmConfig name")
 	f.StringVar(&opts.rolloutID, "rollout-id", "", "rollout identity")
+	for _, name := range []string{"inventory", "generation", "config-name", "rollout-id"} {
+		cmd.Flags().Lookup(name).Hidden = true
+	}
 	_ = stderr
 	return cmd
 }
 
-func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout io.Writer) error {
-	inv, err := loadInventory(opts.inventoryPath)
+func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout io.Writer) error {
+	inv, err := kubeadmConfigInventory(opts)
 	if err != nil {
 		return err
 	}
-	var nodes []inventory.Node
+	if strings.TrimSpace(opts.rolloutID) == "" {
+		opts.rolloutID = "cluster-config-" + strconv.FormatInt(kubeadmConfigNow().UnixNano(), 10)
+	}
+	generations := map[string]string{}
+	components := map[string]bool{
+		"control-plane": true,
+		"kubelet":       true,
+	}
+	if strings.TrimSpace(opts.configPath) != "" {
+		var activated activatedClusterConfig
+		activated, err = activateClusterConfig(ctx, opts, inv.Nodes)
+		if err != nil {
+			return err
+		}
+		generations = activated.generations
+		components = activated.components
+	} else if strings.TrimSpace(opts.generationID) == "" {
+		return fmt.Errorf("--generation is required with --inventory")
+	}
+
+	results := map[string]any{}
+	for _, component := range []string{"control-plane", "kubelet", "kube-proxy"} {
+		if !components[component] {
+			continue
+		}
+		componentOpts := opts
+		componentOpts.component = component
+		componentOpts.rolloutID = opts.rolloutID + "-" + component
+		summary, err := runKubeadmConfigComponent(ctx, componentOpts, inv, generations)
+		if err != nil {
+			return err
+		}
+		results[component] = summary
+	}
+	return json.NewEncoder(stdout).Encode(map[string]any{
+		"nodes":      len(inv.Nodes),
+		"kubernetes": results,
+		"result":     "succeeded",
+	})
+}
+
+func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout io.Writer) error {
+	if strings.TrimSpace(opts.component) == "" {
+		opts.component = "control-plane"
+	}
+	if opts.component != "control-plane" && opts.component != "kubelet" && opts.component != "kube-proxy" {
+		return fmt.Errorf("internal component = %q, want control-plane, kubelet, or kube-proxy", opts.component)
+	}
+	inv, err := kubeadmConfigInventory(opts)
+	if err != nil {
+		return err
+	}
+	generations := map[string]string{}
+	if strings.TrimSpace(opts.configPath) != "" {
+		activated, err := activateClusterConfig(ctx, opts, inv.Nodes)
+		if err != nil {
+			return err
+		}
+		generations = activated.generations
+	}
+	summary, err := runKubeadmConfigComponent(ctx, opts, inv, generations)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(stdout).Encode(summary)
+}
+
+func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConfigOptions, inv inventory.Inventory, generations map[string]string) (map[string]any, error) {
+	var controlPlanes []inventory.Node
 	for _, node := range inv.Nodes {
 		if node.SystemRole == inventory.RoleControlPlane {
-			nodes = append(nodes, node)
+			controlPlanes = append(controlPlanes, node)
 		}
 	}
-	if len(nodes) != 3 {
-		return fmt.Errorf("exactly three control-plane nodes are required, got %d", len(nodes))
+	if len(controlPlanes) == 0 {
+		return nil, fmt.Errorf("at least one control-plane node is required")
 	}
-	nodes, err = orderControlPlanes(nodes, opts.coordinator)
+	if strings.TrimSpace(opts.coordinator) == "" {
+		sort.Slice(controlPlanes, func(i, j int) bool { return controlPlanes[i].Name < controlPlanes[j].Name })
+		opts.coordinator = controlPlanes[len(controlPlanes)-1].Name
+	}
+	if strings.TrimSpace(opts.rolloutID) == "" {
+		opts.rolloutID = "kubeadm-config-" + strconv.FormatInt(kubeadmConfigNow().UnixNano(), 10)
+	}
+	var nodes []inventory.Node
+	var err error
+	if opts.component == "kube-proxy" {
+		ordered, orderErr := orderControlPlanes(controlPlanes, opts.coordinator)
+		if orderErr != nil {
+			return nil, orderErr
+		}
+		nodes = []inventory.Node{ordered[len(ordered)-1]}
+	} else if opts.component == "kubelet" {
+		nodes, err = orderKubeletNodes(inv.Nodes, controlPlanes, opts.coordinator)
+	} else {
+		nodes, err = orderControlPlanes(controlPlanes, opts.coordinator)
+	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	type target struct {
 		node           inventory.Node
@@ -57,8 +156,9 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 		machine        string
 		payloadVersion string
 		payloadSHA256  string
+		generation     string
 	}
-	targets := make([]target, 0, 3)
+	targets := make([]target, 0, len(nodes))
 	defer func() {
 		for _, t := range targets {
 			_ = t.conn.Close()
@@ -67,22 +167,31 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 	for _, node := range nodes {
 		conn, err := dialKatlcAgent(ctx, cluster.AgentEndpoint(node.Address, "9443"))
 		if err != nil {
-			return fmt.Errorf("connect %s: %w", node.Name, err)
+			return nil, fmt.Errorf("connect %s: %w", node.Name, err)
 		}
 		status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
 		if err != nil {
-			return fmt.Errorf("status %s: %w", node.Name, err)
+			return nil, fmt.Errorf("status %s: %w", node.Name, err)
 		}
-		gen, err := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: opts.generationID, IncludeConfigApply: true})
+		generationID := strings.TrimSpace(opts.generationID)
+		if value := strings.TrimSpace(generations[node.Name]); value != "" {
+			generationID = value
+		}
+		gen, err := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: generationID, IncludeConfigApply: true})
 		if err != nil {
-			return fmt.Errorf("generation %s on %s: %w", opts.generationID, node.Name, err)
+			return nil, fmt.Errorf("generation %s on %s: %w", generationID, node.Name, err)
 		}
 		if gen.CommitState != "committed" || gen.HealthState != "healthy" {
-			return fmt.Errorf("node %s generation %s is not committed and healthy", node.Name, opts.generationID)
+			return nil, fmt.Errorf("node %s generation %s is not committed and healthy", node.Name, generationID)
 		}
-		if gen.ConfigApply == nil || !gen.ConfigApply.KubeadmActionRequired || gen.ConfigApply.SelectedKubeadmConfigName != opts.configName {
-			return fmt.Errorf("node %s generation %s does not select kubeadm config %q as action-required", node.Name, opts.generationID, opts.configName)
+		configName := strings.TrimSpace(opts.configName)
+		if configName == "" {
+			configName = strings.TrimSpace(node.KubeadmConfig.Ref)
 		}
+		if gen.ConfigApply != nil && strings.TrimSpace(gen.ConfigApply.SelectedKubeadmConfigName) != "" && gen.ConfigApply.SelectedKubeadmConfigName != configName {
+			return nil, fmt.Errorf("node %s generation %s selects kubeadm config %q instead of %q", node.Name, generationID, gen.ConfigApply.SelectedKubeadmConfigName, configName)
+		}
+		node.KubeadmConfig.Ref = configName
 		payloadVersion := ""
 		payloadSHA256 := ""
 		for _, ref := range gen.Sysexts {
@@ -93,44 +202,191 @@ func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneC
 			}
 		}
 		if payloadVersion == "" {
-			return fmt.Errorf("node %s generation %s has no active Kubernetes payload", node.Name, opts.generationID)
+			return nil, fmt.Errorf("node %s generation %s has no active Kubernetes payload", node.Name, generationID)
 		}
 		if len(targets) > 0 && (payloadVersion != targets[0].payloadVersion || payloadSHA256 != targets[0].payloadSHA256) {
-			return fmt.Errorf("node %s active Kubernetes payload does not match %s", node.Name, targets[0].node.Name)
+			return nil, fmt.Errorf("node %s active Kubernetes payload does not match %s", node.Name, targets[0].node.Name)
 		}
-		targets = append(targets, target{node: node, conn: conn, machine: status.MachineId, payloadVersion: payloadVersion, payloadSHA256: payloadSHA256})
+		targets = append(targets, target{node: node, conn: conn, machine: status.MachineId, payloadVersion: payloadVersion, payloadSHA256: payloadSHA256, generation: generationID})
 	}
 	var summary []map[string]string
 	for i, t := range targets {
-		body := kubeadmControlPlaneConfigBody(opts, t.node, uint32(i+1))
-		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-dry-run-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl kubernetes apply-config", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: opts.generationID, DryRun: true, KubeadmControlPlaneConfig: body})
+		body := kubeadmControlPlaneConfigBody(opts, t.node, t.generation, uint32(i+1), uint32(len(targets)))
+		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-dry-run-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, DryRun: true, KubeadmControlPlaneConfig: body})
 		if err != nil {
-			return fmt.Errorf("dry-run %s: %w", t.node.Name, err)
+			return nil, fmt.Errorf("dry-run %s: %w", t.node.Name, err)
 		}
 		if accepted.InitialStatus == nil || accepted.InitialStatus.Phase != "dry-run" {
-			return fmt.Errorf("node %s did not confirm kubeadm rollout dry-run", t.node.Name)
+			return nil, fmt.Errorf("node %s did not confirm kubeadm rollout dry-run", t.node.Name)
 		}
 	}
 	for i, t := range targets {
-		body := kubeadmControlPlaneConfigBody(opts, t.node, uint32(i+1))
-		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl kubernetes apply-config", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: opts.generationID, KubeadmControlPlaneConfig: body})
+		body := kubeadmControlPlaneConfigBody(opts, t.node, t.generation, uint32(i+1), uint32(len(targets)))
+		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, KubeadmControlPlaneConfig: body})
 		if err != nil {
-			return fmt.Errorf("submit %s: %w", t.node.Name, err)
+			return nil, fmt.Errorf("submit %s: %w", t.node.Name, err)
 		}
 		terminal, err := waitKubeadmControlPlaneConfig(ctx, t.conn.Client, accepted.OperationId)
 		if err != nil {
-			return fmt.Errorf("node %s: %w", t.node.Name, err)
+			return nil, fmt.Errorf("node %s: %w", t.node.Name, err)
 		}
 		if terminal.Result != operation.ResultSucceeded {
-			return fmt.Errorf("node %s stopped rollout: %s: %s", t.node.Name, terminal.Phase, terminal.FailureReason)
+			return nil, fmt.Errorf("node %s stopped rollout: %s: %s", t.node.Name, terminal.Phase, terminal.FailureReason)
 		}
-		summary = append(summary, map[string]string{"node": t.node.Name, "operationID": accepted.OperationId, "result": terminal.Result})
+		summary = append(summary, map[string]string{"node": t.node.Name, "result": terminal.Result})
 	}
-	return json.NewEncoder(stdout).Encode(map[string]any{"rolloutID": opts.rolloutID, "coordinator": opts.coordinator, "nodes": summary, "automaticRollback": false})
+	return map[string]any{"component": opts.component, "coordinator": opts.coordinator, "nodes": summary, "automaticRollback": false}, nil
 }
 
-func kubeadmControlPlaneConfigBody(opts kubeadmControlPlaneConfigOptions, node inventory.Node, position uint32) *agentapi.KubeadmControlPlaneConfigOperationRequest {
-	return &agentapi.KubeadmControlPlaneConfigOperationRequest{RolloutId: opts.rolloutID, NodePosition: position, NodeCount: 3, NodeName: node.Name, CoordinatorNode: opts.coordinator, CoordinatorUpload: node.Name == opts.coordinator, DesiredGenerationId: opts.generationID, ConfigName: opts.configName}
+func kubeadmControlPlaneConfigBody(opts kubeadmControlPlaneConfigOptions, node inventory.Node, generationID string, position, count uint32) *agentapi.KubeadmControlPlaneConfigOperationRequest {
+	component := kubeadmConfigComponentControlPlane
+	if opts.component == "kube-proxy" {
+		component = kubeadmConfigComponentKubeProxy
+	} else if opts.component == "kubelet" {
+		component = kubeadmConfigComponentKubelet
+	}
+	return &agentapi.KubeadmControlPlaneConfigOperationRequest{RolloutId: opts.rolloutID, NodePosition: position, NodeCount: count, NodeName: node.Name, CoordinatorNode: opts.coordinator, CoordinatorUpload: node.Name == opts.coordinator, DesiredGenerationId: generationID, ConfigName: node.KubeadmConfig.Ref, SupportedFieldDelta: []string{component}}
+}
+
+const (
+	kubeadmConfigComponentControlPlane = "component/control-plane"
+	kubeadmConfigComponentKubelet      = "component/kubelet"
+	kubeadmConfigComponentKubeProxy    = "component/kube-proxy"
+)
+
+func kubeadmConfigInventory(opts kubeadmControlPlaneConfigOptions) (inventory.Inventory, error) {
+	configPath := strings.TrimSpace(opts.configPath)
+	inventoryPath := strings.TrimSpace(opts.inventoryPath)
+	if (configPath == "") == (inventoryPath == "") {
+		return inventory.Inventory{}, fmt.Errorf("exactly one of --config or --inventory is required")
+	}
+	if inventoryPath != "" {
+		return loadInventory(inventoryPath)
+	}
+	return loadWipeInventory(configPath, "")
+}
+
+type activatedClusterConfig struct {
+	generations map[string]string
+	components  map[string]bool
+}
+
+func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOptions, nodes []inventory.Node) (activatedClusterConfig, error) {
+	loaded, err := loadKatlConfig(opts.configPath, configBundleCreator, configbundle.PlanningInputs{})
+	if err != nil {
+		return activatedClusterConfig{}, err
+	}
+	now := kubeadmConfigNow()
+	generationID := strings.TrimSpace(opts.generationID)
+	if generationID == "" {
+		generationID = "cluster-config-" + strconv.FormatInt(now.UnixNano(), 10)
+	}
+	desiredVersion := strconv.FormatInt(now.UnixNano(), 10)
+	type preparedInput struct {
+		node              inventory.Node
+		configYAML        []byte
+		machineID         string
+		currentGeneration string
+		noChanges         bool
+	}
+	prepared := make([]preparedInput, 0, len(nodes))
+	components := map[string]bool{}
+	for _, node := range nodes {
+		selected, err := configbundle.ReadSelectedNode(bytes.NewReader(loaded.Archive), configbundle.ReadOptions{NodeName: node.Name, AllowMissingKatlosImage: true})
+		if err != nil {
+			return activatedClusterConfig{}, fmt.Errorf("select cluster config for %s: %w", node.Name, err)
+		}
+		plan, ok := selected.KubeadmConfigs[node.KubeadmConfig.Ref]
+		if !ok {
+			return activatedClusterConfig{}, fmt.Errorf("selected kubeadm input %q for %s is missing", node.KubeadmConfig.Ref, node.Name)
+		}
+		for _, document := range plan.Documents {
+			switch document.Kind {
+			case "ClusterConfiguration":
+				components["control-plane"] = true
+			case "KubeletConfiguration":
+				components["kubelet"] = true
+			case "KubeProxyConfiguration":
+				components["kube-proxy"] = true
+			}
+		}
+		configYAML, err := configapply.RenderNodeConfigurationChange(configapply.RenderNodeRequest{
+			NodeName: selected.Node.Name, Manifest: selected.InstallManifest, KubeadmConfigs: selected.KubeadmConfigs,
+			SourceID: selected.BundleManifest.ClusterName, DesiredVersion: desiredVersion, ApplyMode: generation.ApplyModeAuto,
+		})
+		if err != nil {
+			return activatedClusterConfig{}, fmt.Errorf("render cluster config for %s: %w", node.Name, err)
+		}
+		prepared = append(prepared, preparedInput{node: node, configYAML: configYAML})
+	}
+	result := make(map[string]string, len(nodes))
+	for i := range prepared {
+		input := &prepared[i]
+		node := input.node
+		conn, err := dialKatlcAgent(ctx, cluster.AgentEndpoint(node.Address, "9443"))
+		if err != nil {
+			return activatedClusterConfig{}, fmt.Errorf("connect %s to apply cluster config: %w", node.Name, err)
+		}
+		status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+		if err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, fmt.Errorf("status %s before cluster config apply: %w", node.Name, err)
+		}
+		validation, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
+			ApiVersion: operation.APIVersion, Kind: "ValidateConfigRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
+			Actor: "katlctl cluster apply", ExpectedMachineId: status.MachineId, ApplyMode: generation.ApplyModeAuto,
+			CandidateGenerationId: generationID, NodeName: node.Name, ConfigYaml: string(input.configYAML),
+		})
+		if err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, fmt.Errorf("validate cluster config on %s: %w", node.Name, err)
+		}
+		if !validation.Accepted {
+			_ = conn.Close()
+			return activatedClusterConfig{}, fmt.Errorf("node %s rejected cluster config: %s", node.Name, firstNonEmpty(validation.FailureReason, strings.Join(validation.Diagnostics, "; ")))
+		}
+		input.machineID = status.MachineId
+		input.currentGeneration = status.CurrentGenerationId
+		input.noChanges = validation.NoChanges
+		_ = conn.Close()
+		if validation.NoChanges {
+			result[node.Name] = status.CurrentGenerationId
+			continue
+		}
+		if validation.AcceptedApplyMode != generation.ApplyModeLive {
+			return activatedClusterConfig{}, fmt.Errorf("node %s cannot apply Kubernetes configuration online (accepted mode %s)", node.Name, validation.AcceptedApplyMode)
+		}
+	}
+
+	for _, input := range prepared {
+		node := input.node
+		if input.noChanges {
+			continue
+		}
+		conn, err := dialKatlcAgent(ctx, cluster.AgentEndpoint(node.Address, "9443"))
+		if err != nil {
+			return activatedClusterConfig{}, fmt.Errorf("connect %s to apply cluster config: %w", node.Name, err)
+		}
+		accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
+			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
+			OperationKind: "generation-apply", Actor: "katlctl cluster apply", ExpectedMachineId: input.machineID, ExpectedCurrentGenerationId: input.currentGeneration,
+			ConfigApply: &agentapi.ConfigApplyOperationRequest{CandidateGenerationId: generationID, ApplyMode: generation.ApplyModeAuto, NodeName: node.Name, ConfigYaml: string(input.configYAML)},
+		})
+		if err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, fmt.Errorf("apply cluster config on %s: %w", node.Name, err)
+		}
+		terminal, err := waitAcceptedOperationStatus(ctx, conn.Client, accepted, 30*time.Minute, io.Discard)
+		if err == nil {
+			err = operationResultError(terminal)
+		}
+		_ = conn.Close()
+		if err != nil {
+			return activatedClusterConfig{}, fmt.Errorf("apply cluster config on %s: %w", node.Name, err)
+		}
+		result[node.Name] = generationID
+	}
+	return activatedClusterConfig{generations: result, components: components}, nil
 }
 
 func orderControlPlanes(nodes []inventory.Node, coordinator string) ([]inventory.Node, error) {
@@ -149,6 +405,22 @@ func orderControlPlanes(nodes []inventory.Node, coordinator string) ([]inventory
 		return nil, fmt.Errorf("coordinator %q is not a control-plane node", coordinator)
 	}
 	return append(ordered, *coordinatorNode), nil
+}
+
+func orderKubeletNodes(nodes, controlPlanes []inventory.Node, coordinator string) ([]inventory.Node, error) {
+	orderedControlPlanes, err := orderControlPlanes(controlPlanes, coordinator)
+	if err != nil {
+		return nil, err
+	}
+	coordinatorNode := orderedControlPlanes[len(orderedControlPlanes)-1]
+	remaining := make([]inventory.Node, 0, len(nodes)-1)
+	for _, node := range nodes {
+		if node.Name != coordinatorNode.Name {
+			remaining = append(remaining, node)
+		}
+	}
+	sort.Slice(remaining, func(i, j int) bool { return remaining[i].Name < remaining[j].Name })
+	return append([]inventory.Node{coordinatorNode}, remaining...), nil
 }
 
 func waitKubeadmControlPlaneConfig(ctx context.Context, client agentapi.KatlcAgentClient, id string) (*agentapi.OperationStatus, error) {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -256,6 +256,37 @@ func TestActivateClusterConfigUsesOneLiveWholeNodeGeneration(t *testing.T) {
 	}
 }
 
+func TestActivateClusterConfigKeepsCurrentGenerationAfterLateNoop(t *testing.T) {
+	configPath := writeClusterConfig(t)
+	client := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-current"},
+		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "stage-cp-1", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{OperationId: "stage-cp-1", Phase: "desired-state-current", Terminal: true, Result: operation.ResultSucceeded, GenerationCommitState: operation.GenerationCommitAbandoned},
+	}
+	previousDial := dialKatlcAgent
+	previousNow := kubeadmConfigNow
+	defer func() {
+		dialKatlcAgent = previousDial
+		kubeadmConfigNow = previousNow
+	}()
+	dialKatlcAgent = func(context.Context, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	kubeadmConfigNow = func() time.Time { return time.Unix(0, 42).UTC() }
+	inv, err := kubeadmConfigInventory(kubeadmControlPlaneConfigOptions{configPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, inv.Nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := activated.generations["cp-1"]; got != "generation-current" {
+		t.Fatalf("activated generation = %q, want current generation", got)
+	}
+}
+
 func TestOrderControlPlanesRejectsUnknownCoordinator(t *testing.T) {
 	_, err := orderControlPlanes([]inventory.Node{{Name: "cp-1"}, {Name: "cp-2"}, {Name: "cp-3"}}, "cp-4")
 	if err == nil {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/operation"
@@ -52,8 +53,8 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 	if err := runKubeadmControlPlaneConfig(context.Background(), opts, &stdout); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(stdout.String(), "requestDigest") {
-		t.Fatalf("stdout exposed request digest: %s", stdout.String())
+	if strings.Contains(stdout.String(), "requestDigest") || strings.Contains(stdout.String(), "operationID") || strings.Contains(stdout.String(), "rolloutID") {
+		t.Fatalf("stdout exposed internal operation metadata: %s", stdout.String())
 	}
 	for index, name := range []string{"cp-1", "cp-2", "cp-3"} {
 		requests := clients[name].submitRequests
@@ -65,9 +66,193 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 			t.Fatalf("%s request=%#v", name, req)
 		}
 		body := req.KubeadmControlPlaneConfig
-		if body.DesiredConfigSha256 != "" || body.ExpectedLiveConfigSha256 != "" || body.KubernetesPayloadSha256 != "" || body.SnapshotDigest != "" || len(body.SupportedFieldDelta) != 0 {
+		if body.DesiredConfigSha256 != "" || body.ExpectedLiveConfigSha256 != "" || body.KubernetesPayloadSha256 != "" || body.SnapshotDigest != "" || !reflect.DeepEqual(body.SupportedFieldDelta, []string{kubeadmConfigComponentControlPlane}) {
 			t.Fatalf("%s request exposed operator-derived state: %#v", name, body)
 		}
+	}
+}
+
+func TestRunClusterApplyReconcilesWholeConfigAndAllKubernetesComponents(t *testing.T) {
+	configPath := writeClusterConfig(t)
+	client := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
+		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "operation-1", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{OperationId: "operation-1", Terminal: true, Result: operation.ResultSucceeded},
+		generation: &agentapi.Generation{
+			GenerationId: "cluster-config-42",
+			CommitState:  "committed",
+			HealthState:  "healthy",
+			ConfigApply:  &agentapi.ConfigApplyStatus{SelectedKubeadmConfigName: "control-plane"},
+			Sysexts:      []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: strings.Repeat("c", 64)}},
+		},
+	}
+	previousDial := dialKatlcAgent
+	previousNow := kubeadmConfigNow
+	defer func() {
+		dialKatlcAgent = previousDial
+		kubeadmConfigNow = previousNow
+	}()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("endpoint = %q", endpoint)
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	kubeadmConfigNow = func() time.Time { return time.Unix(0, 42).UTC() }
+
+	var stdout bytes.Buffer
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{`"result":"succeeded"`, `"control-plane"`, `"kubelet"`} {
+		if !strings.Contains(stdout.String(), required) {
+			t.Fatalf("stdout = %s, missing %s", stdout.String(), required)
+		}
+	}
+	if client.validateRequest == nil || !strings.Contains(client.validateRequest.ConfigYaml, "identity:") || !strings.Contains(client.validateRequest.ConfigYaml, "kubeadmConfigs:") {
+		t.Fatalf("cluster validation did not receive the whole node config: %#v", client.validateRequest)
+	}
+	if len(client.submitRequests) != 5 {
+		t.Fatalf("submit requests = %d, want generation apply plus dry-run and execution for both Kubernetes components: %#v", len(client.submitRequests), client.submitRequests)
+	}
+	components := []string{
+		client.submitRequests[1].KubeadmControlPlaneConfig.SupportedFieldDelta[0],
+		client.submitRequests[3].KubeadmControlPlaneConfig.SupportedFieldDelta[0],
+	}
+	if want := []string{kubeadmConfigComponentControlPlane, kubeadmConfigComponentKubelet}; !reflect.DeepEqual(components, want) {
+		t.Fatalf("components = %#v, want %#v", components, want)
+	}
+}
+
+func TestActivateClusterConfigValidatesEveryNodeBeforeMutation(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "cluster.yaml")
+	source := configBundleSource() + `    - name: cp-2
+      controlPlane: true
+      bootstrap:
+        address: 10.0.0.12
+      install:
+        targetDisk:
+          byID: /dev/disk/by-id/ata-cp-2-root
+`
+	if err := os.WriteFile(configPath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first := &fakeKatlcAgentClient{
+		nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+	}
+	second := &fakeKatlcAgentClient{
+		nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-cp-2", CurrentGenerationId: "generation-1"},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: false, FailureReason: "unsupported online Kubernetes field"},
+	}
+	previousDial := dialKatlcAgent
+	defer func() { dialKatlcAgent = previousDial }()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		clients := map[string]*fakeKatlcAgentClient{"10.0.0.11:9443": first, "10.0.0.12:9443": second}
+		return katlcAgentConnection{Client: clients[endpoint], Close: func() error { return nil }}, nil
+	}
+
+	_, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, []inventory.Node{
+		{Name: "cp-1", Address: "10.0.0.11", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
+		{Name: "cp-2", Address: "10.0.0.12", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported online Kubernetes field") {
+		t.Fatalf("activateClusterConfig() error = %v", err)
+	}
+	if len(first.submitRequests) != 0 || len(second.submitRequests) != 0 {
+		t.Fatalf("mutation started before cluster-wide validation completed: first=%#v second=%#v", first.submitRequests, second.submitRequests)
+	}
+}
+
+func TestActivateClusterConfigDiscoversKubeProxyPhase(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "cluster.yaml")
+	source := strings.Replace(configBundleSource(), "    version: v1.36.1\n", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml\n", 1)
+	if err := os.WriteFile(configPath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	kubeadm := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\n---\napiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: nftables\n"
+	if err := os.WriteFile(filepath.Join(root, "kubeadm.yaml"), []byte(kubeadm), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeKatlcAgentClient{
+		nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+	}
+	previousDial := dialKatlcAgent
+	defer func() { dialKatlcAgent = previousDial }()
+	dialKatlcAgent = func(context.Context, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	inv, err := kubeadmConfigInventory(kubeadmControlPlaneConfigOptions{configPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, inv.Nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !activated.components["kube-proxy"] {
+		t.Fatalf("components = %#v, missing kube-proxy", activated.components)
+	}
+}
+
+func TestOrderKubeletNodesChangesCoordinatorFirst(t *testing.T) {
+	nodes := []inventory.Node{{Name: "worker-1", SystemRole: inventory.RoleWorker}, {Name: "cp-2", SystemRole: inventory.RoleControlPlane}, {Name: "cp-1", SystemRole: inventory.RoleControlPlane}}
+	ordered, err := orderKubeletNodes(nodes, nodes[1:], "cp-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := []string{ordered[0].Name, ordered[1].Name, ordered[2].Name}
+	if want := []string{"cp-2", "cp-1", "worker-1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestActivateClusterConfigUsesOneLiveWholeNodeGeneration(t *testing.T) {
+	configPath := writeClusterConfig(t)
+	client := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
+		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "stage-cp-1", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{OperationId: "stage-cp-1", Terminal: true, Result: operation.ResultSucceeded},
+	}
+	previousDial := dialKatlcAgent
+	previousNow := kubeadmConfigNow
+	defer func() {
+		dialKatlcAgent = previousDial
+		kubeadmConfigNow = previousNow
+	}()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("endpoint = %q", endpoint)
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	kubeadmConfigNow = func() time.Time { return time.Unix(0, 42).UTC() }
+	inv, err := kubeadmConfigInventory(kubeadmControlPlaneConfigOptions{configPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, inv.Nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if activated.generations["cp-1"] != "cluster-config-42" {
+		t.Fatalf("generations = %#v", activated.generations)
+	}
+	if client.validateRequest == nil || client.validateRequest.ApplyMode != "auto" || client.validateRequest.CandidateGenerationId != "cluster-config-42" {
+		t.Fatalf("validate request = %#v", client.validateRequest)
+	}
+	for _, required := range []string{"identity:", "networkd:", "controlPlaneEndpoint:", "kubeadmConfigs:"} {
+		if !strings.Contains(client.validateRequest.ConfigYaml, required) {
+			t.Fatalf("whole cluster config is missing %q:\n%s", required, client.validateRequest.ConfigYaml)
+		}
+	}
+	if client.submitRequest == nil || client.submitRequest.OperationKind != "generation-apply" || client.submitRequest.ConfigApply == nil {
+		t.Fatalf("submit request = %#v", client.submitRequest)
 	}
 }
 

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -59,13 +59,13 @@ type kubernetesUpgradeReport struct {
 }
 
 type kubernetesUpgradeTarget struct {
-	node       workstation.TopologyNode
-	role       string
-	conn       katlcAgentConnection
-	machineID  string
-	generation string
-	source     string
-	candidate  string
+	node        workstation.TopologyNode
+	upgradeRole string
+	conn        katlcAgentConnection
+	machineID   string
+	generation  string
+	source      string
+	candidate   string
 }
 
 var kubernetesUpgradeNow = func() time.Time { return time.Now().UTC() }
@@ -172,7 +172,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 		if accepted.InitialStatus == nil || accepted.InitialStatus.Phase != "accepted" && accepted.InitialStatus.Phase != "dry-run" {
 			return fmt.Errorf("node %s did not accept the Kubernetes upgrade plan", target.node.Name)
 		}
-		report.Nodes = append(report.Nodes, kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: "planned"})
+		report.Nodes = append(report.Nodes, kubernetesUpgradeNodeReport{Name: target.node.Name, Role: string(target.node.SystemRole), SourceVersion: target.source, TargetVersion: image.PayloadVersion, Result: "planned"})
 	}
 	if opts.plan {
 		return writeKubernetesUpgradeReport(stdout, opts.output, report)
@@ -193,7 +193,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 }
 
 func runKubernetesUpgradeTarget(ctx context.Context, topology workstation.ResolvedTopology, opts kubernetesUpgradeOptions, target kubernetesUpgradeTarget, image kubernetesbundle.ImageReference, stderr io.Writer) (nodeReport kubernetesUpgradeNodeReport, resultErr error) {
-	nodeReport = kubernetesUpgradeNodeReport{Name: target.node.Name, Role: target.role, SourceVersion: target.source, TargetVersion: image.PayloadVersion}
+	nodeReport = kubernetesUpgradeNodeReport{Name: target.node.Name, Role: string(target.node.SystemRole), SourceVersion: target.source, TargetVersion: image.PayloadVersion}
 	cordoned := false
 	if opts.cordon {
 		if err := setKubernetesNodeCordon(ctx, opts.kubeconfig, target.node.Name, true); err != nil {
@@ -463,11 +463,11 @@ func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.R
 			_ = target.conn.Close()
 			continue
 		}
-		target.role = "worker"
+		target.upgradeRole = "worker"
 		if target.node.SystemRole == inventory.RoleControlPlane {
-			target.role = "control-plane"
+			target.upgradeRole = "control-plane"
 			if !applySelected {
-				target.role = "apply"
+				target.upgradeRole = "apply"
 				applySelected = true
 			}
 		}
@@ -479,7 +479,7 @@ func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.R
 func kubernetesUpgradeBody(target kubernetesUpgradeTarget, image kubernetesbundle.ImageReference) *agentapi.KubernetesSysextUpdateOperationRequest {
 	return &agentapi.KubernetesSysextUpdateOperationRequest{
 		TargetPayloadVersion: targetVersion(image), CandidateGenerationId: target.candidate,
-		UpgradeRole: target.role, SourcePayloadVersion: target.source,
+		UpgradeRole: target.upgradeRole, SourcePayloadVersion: target.source,
 		KubernetesBundleSource: image.Source, KubernetesBundleRef: image.Value,
 	}
 }

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -73,9 +73,10 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 	if report.SourceVersion != "v1.36.0" || report.TargetVersion != "v1.36.1" || len(report.Nodes) != 3 || !strings.Contains(report.NextAction, "complete") {
 		t.Fatalf("report = %#v", report)
 	}
-	roles := []string{"apply", "control-plane", "worker"}
+	upgradeRoles := []string{"apply", "control-plane", "worker"}
+	reportRoles := []string{"control-plane", "control-plane", "worker"}
 	for i, name := range []string{"cp-1", "cp-2", "worker-1"} {
-		if report.Nodes[i].Name != name || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "healthy" {
+		if report.Nodes[i].Name != name || report.Nodes[i].Role != reportRoles[i] || report.Nodes[i].Result != operation.ResultSucceeded || report.Nodes[i].Phase != "healthy" {
 			t.Fatalf("node report %d = %#v", i, report.Nodes[i])
 		}
 		requests := clients[name].submitRequests
@@ -83,7 +84,7 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 			t.Fatalf("%s requests = %#v", name, requests)
 		}
 		body := requests[len(requests)-1].KubernetesSysextUpdate
-		if body.UpgradeRole != roles[i] || body.SourcePayloadVersion != "v1.36.0" || body.TargetPayloadVersion != "v1.36.1" {
+		if body.UpgradeRole != upgradeRoles[i] || body.SourcePayloadVersion != "v1.36.0" || body.TargetPayloadVersion != "v1.36.1" {
 			t.Fatalf("%s body = %#v", name, body)
 		}
 		if body.TargetSysextPath != "" || body.TargetSysextSha256 != "" || body.SnapshotDigest != "" || body.CandidateGenerationId == "" {
@@ -127,7 +128,7 @@ func TestKubernetesUpgradePlanDoesNotExecute(t *testing.T) {
 	if err := run(context.Background(), []string{"kubernetes", "upgrade", "v1.36.1", "--inventory", inv, "--plan", "--timeout", "1m", "--output", "json"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(client.submitRequests) != 1 || !client.submitRequests[0].DryRun || !strings.Contains(stdout.String(), `"result": "planned"`) {
+	if len(client.submitRequests) != 1 || !client.submitRequests[0].DryRun || !strings.Contains(stdout.String(), `"role": "control-plane"`) || strings.Contains(stdout.String(), `"role": "apply"`) || !strings.Contains(stdout.String(), `"result": "planned"`) {
 		t.Fatalf("requests=%#v output=%s", client.submitRequests, stdout.String())
 	}
 }
@@ -168,7 +169,7 @@ func TestKubernetesUpgradeCordonIsExplicitAndNonDraining(t *testing.T) {
 		t.Fatal(err)
 	}
 	report, err := runKubernetesUpgradeTarget(context.Background(), workstation.ResolvedTopology{}, kubernetesUpgradeOptions{cordon: true, kubeconfig: "/tmp/admin.conf", timeout: time.Minute}, kubernetesUpgradeTarget{
-		node: workstation.TopologyNode{Name: "worker-1", SystemRole: "worker"}, role: "worker", conn: katlcAgentConnection{Client: client}, machineID: "machine-worker-1", generation: "gen0", source: "v1.36.0", candidate: "gen1",
+		node: workstation.TopologyNode{Name: "worker-1", SystemRole: "worker"}, upgradeRole: "worker", conn: katlcAgentConnection{Client: client}, machineID: "machine-worker-1", generation: "gen0", source: "v1.36.0", candidate: "gen1",
 	}, image, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -108,14 +108,12 @@ Start with "katlctl install discover" for a waiting installer or
 	clusterCmd := &cobra.Command{Use: "cluster", Short: "Cluster lifecycle operations"}
 	clusterCmd.AddCommand(newClusterStatusCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newClusterBootstrapCommand(ctx, stdout, stderr))
+	clusterCmd.AddCommand(newClusterApplyCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe"))
 	cmd.AddCommand(clusterCmd)
 
 	kubernetesCmd := &cobra.Command{Use: "kubernetes", Short: "Kubernetes lifecycle operations"}
 	kubernetesCmd.AddCommand(newKubernetesUpgradeCommand(ctx, stdout, stderr))
-	kubeadmConfigCmd := newKubeadmControlPlaneConfigCommand(ctx, stdout, stderr)
-	kubeadmConfigCmd.Hidden = true
-	kubernetesCmd.AddCommand(kubeadmConfigCmd)
 	cmd.AddCommand(kubernetesCmd)
 
 	configCmd := &cobra.Command{Use: "config", Short: "Create and compile ClusterConfig"}
@@ -148,7 +146,9 @@ Start with "katlctl install discover" for a waiting installer or
 	nodeCmd.AddCommand(newHostRebootCommand(ctx, stdout, stderr))
 	nodeCmd.AddCommand(newHostShutdownCommand(ctx, stdout, stderr))
 	nodeCmd.AddCommand(newHostUpgradeCommand(ctx, stdout, stderr))
-	nodeCmd.AddCommand(newConfigApplyCommand(ctx, stdout, stderr))
+	nodeApplyCmd := newConfigApplyCommand(ctx, stdout, stderr)
+	nodeApplyCmd.Hidden = true
+	nodeCmd.AddCommand(nodeApplyCmd)
 	nodeCmd.AddCommand(newWipeNodeCommand(ctx, stdout, stderr, "katlctl node wipe"))
 	cmd.AddCommand(nodeCmd)
 
@@ -193,6 +193,7 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 		"katlctl version":             "katlctl version",
 		"katlctl cluster":             "katlctl cluster bootstrap --config cluster.yaml",
 		"katlctl cluster status":      "katlctl cluster status --config cluster.yaml",
+		"katlctl cluster apply":       "katlctl cluster apply --config cluster.yaml",
 		"katlctl context save":        "katlctl context save --config cluster.yaml",
 		"katlctl cluster bootstrap":   "katlctl cluster bootstrap --config cluster.yaml",
 		"katlctl cluster wipe":        "katlctl cluster wipe --config cluster.yaml --all",

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -140,8 +140,8 @@ func TestEveryCommandHelpShowsOneMinimumInvocation(t *testing.T) {
 func TestRoutineRemoteExamplesDeclareClusterConfig(t *testing.T) {
 	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
 	for _, path := range []string{
-		"cluster bootstrap", "cluster status", "cluster wipe", "kubernetes upgrade",
-		"node apply", "node reboot", "node shutdown", "node status", "node upgrade", "node wipe",
+		"cluster apply", "cluster bootstrap", "cluster status", "cluster wipe", "kubernetes upgrade",
+		"node reboot", "node shutdown", "node status", "node upgrade", "node wipe",
 		"operations list", "operations status",
 	} {
 		command, _, err := root.Find(strings.Fields(path))
@@ -215,6 +215,7 @@ func TestPublicHelpHidesInternalOperationAndTestInputs(t *testing.T) {
 
 func TestConfigInputFlagsUseOneName(t *testing.T) {
 	want := map[string]bool{
+		"katlctl cluster apply":       true,
 		"katlctl cluster status":      true,
 		"katlctl context save":        true,
 		"katlctl cluster bootstrap":   true,
@@ -263,8 +264,8 @@ func TestCommandGroupsExposeOneSupportedPath(t *testing.T) {
 		required  []string
 		forbidden []string
 	}{
-		{group: "node", required: []string{"apply", "reboot", "shutdown", "status", "upgrade", "wipe"}},
-		{group: "cluster", required: []string{"bootstrap", "status", "wipe"}, forbidden: []string{"enroll", "kubeadm-control-plane-config"}},
+		{group: "node", required: []string{"reboot", "shutdown", "status", "upgrade", "wipe"}, forbidden: []string{"apply"}},
+		{group: "cluster", required: []string{"apply", "bootstrap", "status", "wipe"}, forbidden: []string{"enroll", "kubeadm-control-plane-config"}},
 		{group: "kubernetes", required: []string{"upgrade"}, forbidden: []string{"apply-config"}},
 		{group: "config", required: []string{"bundle", "init", "schema", "validate"}, forbidden: []string{"apply", "path", "topology"}},
 		{group: "context", required: []string{"current", "list", "path", "save", "show", "use"}},
@@ -2296,9 +2297,8 @@ func TestOperatorCommandsHideIntegrityDigestFlags(t *testing.T) {
 	for _, args := range [][]string{
 		{"install", "apply", "--help"},
 		{"config", "render-node", "--help"},
-		{"node", "apply", "--help"},
+		{"cluster", "apply", "--help"},
 		{"cluster", "bootstrap", "--help"},
-		{"kubernetes", "apply-config", "--help"},
 		{"node", "upgrade", "--help"},
 		{"operations", "status", "--help"},
 	} {

--- a/cmd/katldev/build.go
+++ b/cmd/katldev/build.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+type buildCommandRunner func(context.Context, string, string, []string, io.Writer, io.Writer) error
+
+type installerISOArtifact struct {
+	Path      string
+	Metadata  string
+	Checksum  string
+	SHA256    string
+	SizeBytes int64
+}
+
+func newBuildCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "build",
+		Short: "Build development artifacts from the current checkout",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newBuildISOCommand(ctx, stdout, stderr))
+	return cmd
+}
+
+func newBuildISOCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "iso",
+		Short: "Build and verify the current checkout's installer ISO",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			repoRoot, err := repositoryRoot()
+			if err != nil {
+				return err
+			}
+			artifact, err := buildInstallerISO(ctx, repoRoot, stderr, runBuildCommand)
+			if err != nil {
+				return err
+			}
+			return writeInstallerISOArtifact(stdout, artifact)
+		},
+	}
+}
+
+func buildInstallerISO(ctx context.Context, repoRoot string, stderr io.Writer, run buildCommandRunner) (installerISOArtifact, error) {
+	if run == nil {
+		return installerISOArtifact{}, fmt.Errorf("build command runner is required")
+	}
+	iso := filepath.Join(repoRoot, "_build", "mkosi", "katl-installer.iso")
+	fmt.Fprintln(stderr, "katldev build: building the current checkout installer ISO")
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "mkosi"), []string{"build-installer-iso"}, stderr, stderr); err != nil {
+		return installerISOArtifact{}, fmt.Errorf("build installer ISO: %w", err)
+	}
+	fmt.Fprintln(stderr, "katldev build: verifying the completed installer ISO")
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "check-installer-iso"), []string{iso}, stderr, stderr); err != nil {
+		return installerISOArtifact{}, fmt.Errorf("verify installer ISO: %w", err)
+	}
+	digest, err := sha256File(iso)
+	if err != nil {
+		return installerISOArtifact{}, fmt.Errorf("identify installer ISO: %w", err)
+	}
+	info, err := os.Stat(iso)
+	if err != nil {
+		return installerISOArtifact{}, fmt.Errorf("inspect installer ISO: %w", err)
+	}
+	artifact := installerISOArtifact{
+		Path:      iso,
+		Metadata:  iso + ".json",
+		Checksum:  iso + ".sha256",
+		SHA256:    digest,
+		SizeBytes: info.Size(),
+	}
+	for _, companion := range []struct {
+		label string
+		path  string
+	}{{"metadata", artifact.Metadata}, {"checksum", artifact.Checksum}} {
+		if _, err := os.Stat(companion.path); err != nil {
+			return installerISOArtifact{}, fmt.Errorf("inspect installer ISO %s: %w", companion.label, err)
+		}
+	}
+	return artifact, nil
+}
+
+func runBuildCommand(ctx context.Context, dir, name string, args []string, stdout, stderr io.Writer) error {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Dir = dir
+	command.Stdout = stdout
+	command.Stderr = stderr
+	return command.Run()
+}
+
+func writeInstallerISOArtifact(stdout io.Writer, artifact installerISOArtifact) error {
+	_, err := fmt.Fprintf(stdout, "Installer ISO ready.\nISO: %s\nMetadata: %s\nChecksum: %s\nSHA256: %s\nSize: %d bytes\n", artifact.Path, artifact.Metadata, artifact.Checksum, artifact.SHA256, artifact.SizeBytes)
+	return err
+}

--- a/cmd/katldev/main.go
+++ b/cmd/katldev/main.go
@@ -28,6 +28,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
+	root.AddCommand(newBuildCommand(ctx, stdout, stderr))
 	root.AddCommand(newInstallerCommand(ctx, stdout, stderr))
 	root.SetArgs(args)
 	return root.Execute()

--- a/cmd/katldev/main_test.go
+++ b/cmd/katldev/main_test.go
@@ -3,7 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +20,8 @@ func TestRootAndInstallerCommandsShowHelpWithoutArguments(t *testing.T) {
 		args []string
 		want []string
 	}{
-		{want: []string{"installer"}},
+		{want: []string{"build", "installer"}},
+		{args: []string{"build"}, want: []string{"iso"}},
 		{args: []string{"installer"}, want: []string{"start", "reset", "status", "console", "stop"}},
 	} {
 		var stdout, stderr bytes.Buffer
@@ -27,6 +34,77 @@ func TestRootAndInstallerCommandsShowHelpWithoutArguments(t *testing.T) {
 				t.Fatalf("run(%v) help missing %q:\n%s", test.args, want, help)
 			}
 		}
+	}
+}
+
+func TestBuildInstallerISOComposesSupportedPipeline(t *testing.T) {
+	repo := t.TempDir()
+	iso := filepath.Join(repo, "_build", "mkosi", "katl-installer.iso")
+	contents := []byte("current checkout installer ISO")
+	type call struct {
+		dir  string
+		name string
+		args []string
+	}
+	var calls []call
+	runner := func(_ context.Context, dir, name string, args []string, _, _ io.Writer) error {
+		calls = append(calls, call{dir: dir, name: name, args: append([]string(nil), args...)})
+		if filepath.Base(name) == "mkosi" {
+			if err := os.MkdirAll(filepath.Dir(iso), 0o755); err != nil {
+				return err
+			}
+			for path, data := range map[string][]byte{iso: contents, iso + ".json": []byte("{}\n"), iso + ".sha256": []byte("checksum\n")} {
+				if err := os.WriteFile(path, data, 0o644); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	artifact, err := buildInstallerISO(context.Background(), repo, &stderr, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := []call{
+		{dir: repo, name: filepath.Join(repo, "scripts", "mkosi"), args: []string{"build-installer-iso"}},
+		{dir: repo, name: filepath.Join(repo, "scripts", "check-installer-iso"), args: []string{iso}},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("build calls = %#v, want %#v", calls, wantCalls)
+	}
+	digest := sha256.Sum256(contents)
+	if artifact.Path != iso || artifact.Metadata != iso+".json" || artifact.Checksum != iso+".sha256" || artifact.SHA256 != hex.EncodeToString(digest[:]) || artifact.SizeBytes != int64(len(contents)) {
+		t.Fatalf("artifact = %#v", artifact)
+	}
+	if err := writeInstallerISOArtifact(&stdout, artifact); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Installer ISO ready.", "ISO: " + iso, "Metadata: " + iso + ".json", "Checksum: " + iso + ".sha256", "SHA256: " + artifact.SHA256, "Size: 30 bytes"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, want := range []string{"building the current checkout", "verifying the completed installer ISO"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("progress missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestBuildInstallerISOStopsAfterBuildFailure(t *testing.T) {
+	wantErr := errors.New("builder failed")
+	calls := 0
+	runner := func(context.Context, string, string, []string, io.Writer, io.Writer) error {
+		calls++
+		return wantErr
+	}
+	_, err := buildInstallerISO(context.Background(), t.TempDir(), io.Discard, runner)
+	if !errors.Is(err, wantErr) || !strings.Contains(err.Error(), "build installer ISO") {
+		t.Fatalf("buildInstallerISO() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runner calls = %d, want 1", calls)
 	}
 }
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -133,11 +133,28 @@ installer. It needs no destructive confirmation because it can only address
 the checkout-scoped development VM. Pass `--no-build` only when deliberately
 reusing the existing `_build/mkosi/katl-installer.iso`.
 
-Build current artifacts through the supported container wrapper:
+Build and verify the current checkout's self-contained installer ISO through
+the discoverable development command:
 
 ```sh
-nix develop --command scripts/mkosi build-installer
+nix develop --command katldev build iso
 ```
+
+The command composes the existing source-fingerprinted `scripts/mkosi`
+pipeline, runs the full ISO verifier, and prints absolute paths for the ISO,
+metadata, and checksum together with the digest and byte size. Set the existing
+`KATL_VERSION` environment variable when the installed development image needs
+a particular KatlOS identity:
+
+```sh
+KATL_VERSION=2026.7.0-dev.12 nix develop --command katldev build iso
+```
+
+Copy the reported ISO to a hypervisor under a versioned name and independently
+compare the reported digest after transfer. Published images should continue
+through `katlctl node upgrade` where possible; use the ISO path for clean
+installation, wipe/reinstall recovery, and current-checkout changes which do
+not yet have a published upgrade source.
 
 The development shell includes the complete supported VM test toolchain. It
 does not configure host libvirt, `/dev/kvm`, `/dev/net/tun`, networks, storage

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -482,41 +482,35 @@ distribution or add-on manager.
 node runtime configuration. `katlctl` compiles and submits the node-agent
 request internally; operators do not maintain a second configuration schema.
 
-Optionally plan the exact per-node runtime request through the node agent:
+Apply the complete retained cluster configuration:
 
 ```text
-katlctl node apply cp-1 --config ./cluster.yaml --plan
+katlctl cluster apply --config ./cluster.yaml
 ```
 
-`katlctl` derives the source version, candidate generation, management endpoint,
-validation request, and operation tracking. These are internal
-replay and lifecycle details, not operator inputs.
+`katlctl` derives per-node generations, management endpoints, validation
+requests, Kubernetes component phases, and operation tracking. These are
+internal replay and lifecycle details, not operator inputs. Every node is
+validated before mutation begins.
 
 If the source has already been compiled, use the bundle instead of
 recompiling it:
 
 ```text
-katlctl node apply cp-1 \
-	--config ./katl-lab.katlcfg \
-	--plan
+katlctl cluster apply --config ./katl-lab.katlcfg
 ```
 
-Remove `--plan` to submit the accepted plan. The default `--mode auto` uses
-the agent's domain matrix to choose live apply or next boot; `--mode live` and
-`--mode next-boot` request an explicit policy and are rejected when unsafe.
-Keep the same configuration inputs when submitting. `katlctl` generates the
-idempotency key and follows the accepted operation to its terminal result.
+Katl applies ordinary node domains and all affected kubeadm-produced component
+configuration as one coordinated workflow. Kubernetes configuration changes
+are online-only and never require rebooting a node.
 
-The renderer carries the node's desired identity and systemd-networkd files as
-well as operation-only system role and role-dependent Kubernetes bootstrap state. The
-planner applies runtime-safe changes and reports when a lifecycle operation is
-required; it does not silently discard operation-only differences. Disk install
-selection and Kubernetes version changes use their dedicated install and
-upgrade workflows. A change to bounded native kubeadm input records that a
-kubeadm-aware action is required; normal config apply does not mutate
-kubeadm-owned cluster state. Use the dedicated operation for a supported live
-change. The node-agent request envelope is an internal API and is documented
-separately from the operator installation flow.
+The renderer carries node identity, systemd-networkd files, system role, and
+role-dependent Kubernetes intent. The planner does not silently discard
+operation-owned differences: cluster apply invokes the required internal
+kubeadm-aware phases and verifies the live result. Disk install selection and
+Kubernetes version changes keep their dedicated install and upgrade workflows.
+The node-agent request envelope remains an internal API documented separately
+from the operator installation flow.
 
 ## Upgrades
 

--- a/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
+++ b/docs/internal/adrs/adr-010-kubeadm-control-plane-config-operation.md
@@ -1,8 +1,8 @@
-# ADR-010: Control-plane configuration changes use a narrow rolling kubeadm operation
+# ADR-010: Kubeadm configuration changes use component-scoped live operations
 
 Status: accepted.
 
-Date: 2026-07-11.
+Date: 2026-07-11; expanded 2026-07-22.
 
 ## Context
 
@@ -21,51 +21,55 @@ manifests, while `kubeadm init phase upload-config kubeadm --config` uploads the
 Those phases can be composed safely only for a bounded field set and a serial
 multi-node rollout.
 
-The first KatlOS release needs one real control-plane configuration change. It
-does not need a general wrapper over every kubeadm field. Broad support would
-silently include endpoint, certificate, etcd, admission, feature-gate, host
-volume, and networking changes whose safety and rollback procedures differ.
+Katl must also apply cluster-wide `KubeletConfiguration` changes without a
+reinstall. This uses a different kubeadm phase sequence and restarts kubelet one
+node at a time. A single arbitrary-YAML transaction would hide those different
+mutation and recovery boundaries.
 
 Upstream command references used by this decision:
 
 - <https://kubernetes.io/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_all/>
 - <https://kubernetes.io/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_upload-config_kubeadm/>
 - <https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-config/>
+- <https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/>
 - <https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/>
 - <https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/>
 - <https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/>
 
 ## Decision
 
-Katl supports a distinct `kubeadm-control-plane-config` operation. It is the
-only v0.1 path that may make a desired control-plane configuration change live.
-It is separate from normal confext apply and from `kubeadm-upgrade`.
+Katl reconciles kubeadm-owned state as part of the same cluster-wide config
+apply that reconciles KatlOS node configuration. Component scopes are internal
+execution phases, not operator-selected commands.
 
-The v0.1 operation supports only setting `profiling` to `false` in these
-`ClusterConfiguration` fields:
+Cluster apply activates a generation containing changed desired kubeadm input
+live. Generation activation first changes the selected immutable input
+under `/etc/katl/kubeadm`; it records `kubeadm action required` and never invokes
+kubeadm or writes kubeadm-owned live state. After refreshing the confext overlay,
+Katl uses `systemctl try-restart kubelet.service` so an already-active kubelet
+rebinds its static-pod watcher to the restored `/etc/kubernetes` mount. This is a
+no-op before kubelet is active. Cluster apply then runs every affected
+kubeadm-aware phase online before it reports success.
+Live generation activation refreshes the systemd confext overlay after moving
+the generation link, and does the same after a pre-mutation rollback. A
+generation is not reported active-live while `/etc` still exposes the previous
+confext contents.
 
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta4
-kind: ClusterConfiguration
-apiServer:
-  extraArgs:
-    - name: profiling
-      value: "false"
-controllerManager:
-  extraArgs:
-    - name: profiling
-      value: "false"
-scheduler:
-  extraArgs:
-    - name: profiling
-      value: "false"
-```
+The internal operation supports three component phases:
 
-An operation may change any non-empty subset of those three fields. Adding the
-explicit false value is supported; removing it, setting it to true, repeating
-the argument, or changing any other live kubeadm field is unsupported in v0.1.
-This narrow allowlist proves rolling static-Pod reconfiguration without adding
-new certificates, files, sockets, volumes, API dependencies, or etcd behavior.
+- `control-plane`: changes to `extraArgs`, `extraEnvs`, or `extraVolumes` under
+  `apiServer`, `controllerManager`, or `scheduler`. Katl regenerates only the
+  affected static Pod when one component changed, or all three when several
+  changed, then uploads the shared `ClusterConfiguration` after the serial
+  rollout.
+- `kubelet`: a cluster-wide `KubeletConfiguration`. Katl uploads the desired
+  configuration once from a control-plane coordinator, downloads it through
+  `kubeadm upgrade node phase kubelet-config` on each intended node, restarts
+  kubelet, and verifies that the resulting local config contains the desired
+  fields.
+- `kube-proxy`: a cluster-wide `KubeProxyConfiguration`. The control-plane
+  coordinator runs the bounded kubeadm addon phase, verifies the resulting
+  ConfigMap, and waits for the kube-proxy DaemonSet rollout online.
 
 The selected kubeadm API must be `kubeadm.k8s.io/v1beta4`. The active
 Kubernetes payload version and digest remain unchanged for this operation. A
@@ -91,41 +95,50 @@ documents and patches.
 
 The operation accepts only a config selected by the active generation. It does
 not accept an arbitrary path or inline replacement YAML. Every participating
-control-plane node must report the same cluster-wide desired
-`ClusterConfiguration` digest after excluding node-local `InitConfiguration`
-fields.
+node must select the role-appropriate config, and all nodes in one component
+rollout must agree on that component's cluster-wide desired document.
 
 Live state is collected read-only from:
 
 ```text
 kube-system/kubeadm-config ConfigMap
+kube-system/kubelet-config ConfigMap
 /etc/kubernetes/manifests/kube-apiserver.yaml
 /etc/kubernetes/manifests/kube-controller-manager.yaml
 /etc/kubernetes/manifests/kube-scheduler.yaml
 active Kubernetes sysext metadata
 running static Pod and component health
+/var/lib/kubelet/config.yaml and kubelet health
 ```
 
-Katl canonicalizes the live ConfigMap and desired `ClusterConfiguration`
-before comparing them. The planner must show the exact three supported field
-paths that differ. Any other difference is `unsupported/manual`, not a partial
-apply.
+Katl canonicalizes the selected desired document and the relevant live state.
+Control-plane planning reports changed component field groups. Kubelet
+verification treats kubeadm-defaulted live fields as additional state but
+requires every explicitly desired field and value. Unsupported differences are
+`unsupported/manual`, not a partial apply.
+
+Before a control-plane phase runs, Katl writes an operation-private effective
+kubeadm input. It starts from the live `ClusterConfiguration`, preserving
+runtime-derived values such as the stable endpoint, cluster networking, and
+certificate state, then overlays only the supported desired component fields.
+The immutable generated input remains the desired source of truth; the
+effective file is bounded execution material and is never activated as node
+configuration.
 
 ## Validation And Refusal Rules
 
 Before accepting a rollout, `katlctl` and node-local `katlc` validate:
 
 ```text
-exactly three intended control-plane nodes are present in explicit inventory
+at least one intended control-plane node is present
 all nodes agree on cluster identity and stable control-plane endpoint
 all nodes run the same Kubernetes payload version and digest
 the desired generation is active and committed on every target node
 the selected KubeadmConfig name and cluster-wide digest agree on every node
 katlc derives the live kubeadm ConfigMap identity immediately before mutation
-the internally observed desired/live differences are supported profiling=false
-  additions only
-all three nodes are Ready and the stable API endpoint is healthy
-all three stacked-etcd members are healthy and voting
+the internally observed desired/live differences belong to the selected component
+all intended nodes are Ready and the stable API endpoint is healthy
+all stacked-etcd members are healthy and voting before control-plane mutation
 no concurrent kubeadm-state operation owns a target node
 stacked-etcd and API health pass before and after each bounded node mutation
 ```
@@ -137,22 +150,34 @@ controlPlaneEndpoint, networking, kubernetesVersion, certificates, certSANs,
   certificate directories, image repository, DNS, proxy, encryption, or
   feature-gate changes
 any etcd local/external setting or etcd static Pod patch
-apiServer, controllerManager, or scheduler arguments other than profiling=false
-extraEnvs, extraVolumes, arbitrary static Pod patches, or host-path changes
-InitConfiguration, JoinConfiguration, KubeletConfiguration, or
-  KubeProxyConfiguration changes
+control-plane fields outside extraArgs, extraEnvs, and extraVolumes
+arbitrary static Pod patches or denied host-path changes
+InitConfiguration or JoinConfiguration changes after bootstrap
 adding, removing, or replacing a control-plane or etcd member
 combined Kubernetes payload and control-plane configuration changes
-one-node or two-node execution presented as the three-control-plane release path
 parallel node mutation, unknown quorum, an unhealthy API, or desired state that
   changed after operation acceptance
 ```
 
-Katl may later expand the allowlist one field at a time with an explicit phase,
-failure contract, and VM gate. Native kubeadm passthrough remains available as
-desired input, but passthrough does not imply live-operation support.
+Katl may add further component scopes only with an explicit phase, failure
+contract, and VM gate. Native kubeadm passthrough remains available as desired
+input, but passthrough does not imply live-operation support.
 
 ## Plan And Command Surface
+
+The only supported operator entry point is:
+
+```text
+katlctl cluster apply --config cluster.yaml
+```
+
+Katl renders the complete desired configuration for every node, validates the
+whole cluster before mutation, activates each node's desired generation, and
+then runs all affected Kubernetes component phases in dependency order. A
+Kubernetes configuration change is online-only: it is never accepted as a
+next-boot change and never asks the operator to reboot. If a field lacks a safe
+online reconciler, preflight rejects the whole cluster plan before mutation and
+names that field.
 
 Planning is read-only. The explicit plan reports:
 
@@ -161,7 +186,7 @@ config name and desired generation
 internally derived desired and live canonical identities
 internally observed supported field-level delta
 active Kubernetes payload version and identity
-three-node order and coordinator
+component-specific node order and coordinator
 etcd member and API health preconditions
 static manifest digests before mutation
 commands that would run
@@ -177,56 +202,71 @@ Execution uses the kubeadm binary from the active Kubernetes sysext. Target
 kubeadm private-mount access is unnecessary because the Kubernetes version is
 unchanged.
 
-On each node, the node-local mutating phase is:
+For a control-plane component, the node-local mutating phase is:
 
 ```text
-kubeadm init phase control-plane all \
-  --config /etc/katl/kubeadm/<name>/config.yaml
+kubeadm init phase control-plane <apiserver|controller-manager|scheduler|all> \
+  --config /var/lib/katl/operations/<operation>/effective-kubeadm.yaml
 ```
 
 After every node succeeds, the coordinator runs once:
 
 ```text
 kubeadm init phase upload-config kubeadm \
-  --config /etc/katl/kubeadm/<name>/config.yaml
+  --config /var/lib/katl/operations/<operation>/effective-kubeadm.yaml
 ```
 
-Dry-run or rendered-output inspection must occur before the first mutation and
-must prove that only the three control-plane manifests can change. Katl does not
-run the `etcd local`, certificate, kubeconfig, kubelet, addon, bootstrap-token,
-or upgrade phases for this operation.
+For kubelet configuration, the coordinator first runs
+`kubeadm init phase upload-config kubelet --config ...`. Each node then runs
+`kubeadm upgrade node phase kubelet-config --config ...` followed by
+`systemctl restart kubelet.service`. Every supported kubeadm phase is dry-run
+before the first mutation on that node.
 
-## Three-Control-Plane Ordering
+Katl does not run the `etcd local`, certificate, kubeconfig, CoreDNS addon, or
+bootstrap-token phases for this operation.
+
+## Rollout Ordering
 
 `katlctl` is the rollout coordinator; each node's `katlc` remains the authority
 for its local mutation and `OperationRecord`. The explicit inventory identifies
-one coordinator. The coordinator node is changed last:
+one coordinator. For control-plane configuration the coordinator is changed
+last:
 
 ```text
 1. acquire the rollout plan and verify all cluster-wide preconditions
 2. create and verify the required etcd snapshot evidence
 3. mutate the first non-coordinator control plane
-4. wait for its three static Pods, local API, node Ready state, stable API VIP,
+4. wait for the affected static Pods, local API, node Ready state, stable API VIP,
    and etcd health
 5. mutate the second non-coordinator and repeat every health check
 6. mutate the coordinator and repeat every health check
 7. upload the shared kubeadm ClusterConfiguration from the coordinator
-8. verify the live ConfigMap digest, all manifest digests, three Ready nodes,
-   stable API VIP, and three healthy etcd members
+8. verify the live ConfigMap digest, manifest digests, all intended Ready nodes,
+   stable API VIP, and healthy etcd members
 ```
 
 Only one node may own the mutating phase at a time. The coordinator stops at the
 first refusal, timeout, failed command, or failed health check. It never moves
 to the next node after an ambiguous result.
 
-Katl cordons a node before its manifest mutation and restores its original
-schedulability only after local and cluster health pass. The v0.1 operation does
-not drain: the node is not rebooted, kubelet is not restarted, and evicting
-ordinary workloads would add disruption unrelated to the three static Pods.
+Katl cordons a node before a control-plane manifest mutation and restores its
+original schedulability only after local and cluster health pass. It does not
+drain or reboot the node.
 
-Regenerating a node's three manifests causes kubelet to restart those static
-Pods. The rollout must observe new container identities and `profiling=false`
-arguments for all three components before declaring that node complete.
+Kubelet configuration starts at the coordinator so the shared ConfigMap is
+uploaded before any other node downloads it. Nodes are then updated serially;
+each local config backup, restart, Ready transition, and post-health result is
+recorded before proceeding.
+
+Reconciliation is idempotent. A control-plane node whose supported fields
+already match performs no kubeadm phase or cordon. A node whose local kubelet
+config already contains the desired fields is not restarted, and the
+coordinator uploads the shared kubelet ConfigMap only when its canonical
+configuration differs.
+
+Kube-proxy configuration runs once on the coordinator. Katl performs the
+kubeadm addon dry-run, applies the desired ConfigMap and DaemonSet, and waits
+for the DaemonSet rollout. It does not reboot a host or restart kubelet.
 
 ## Etcd And Static Pod Safety
 
@@ -246,9 +286,10 @@ claim that live kubeadm state was restored.
 
 ## Online, Generation, And Rollback Semantics
 
-This is an online live-state operation. It does not create or select another
-generation and does not require a reboot. The desired configuration must
-already be selected by the active committed generation.
+This is an online live-state operation and does not require a reboot. The
+operator command first activates a kubeadm-input-only generation when desired
+input changed; the node-local kubeadm operation itself requires that committed
+generation and never changes generation selection.
 
 Normal `katlc apply` may render and select a different desired kubeadm config,
 but it only records `action-required`. It must not invoke kubeadm, kubectl,
@@ -258,7 +299,7 @@ Rolling a Katl generation backward changes desired input only. It does not
 reverse static manifests or the kubeadm ConfigMap. Reversing a completed live
 change requires a new explicit `kubeadm-control-plane-config` rollout whose
 desired and expected-live digests describe that reverse transition. There is no
-automatic post-mutation rollback in v0.1.
+automatic post-mutation rollback.
 
 Failure before the first pre-exec mutation marker abandons the attempt without
 claiming live change. Failure after any manifest write or ConfigMap upload stops
@@ -273,6 +314,7 @@ Each node writes an `OperationRecord` with:
 
 ```text
 operationKind: kubeadm-control-plane-config
+internal component phase: control-plane, kubelet, or kube-proxy
 scope and resource lock: kubeadm-state
 rollout ID, node position, node count, and coordinator identity
 actor, expected machine ID, cluster identity, and stable endpoint
@@ -285,6 +327,7 @@ snapshot reference, digest, revision, member-list digest, source etcd version,
   creation time, storage location, and operator identity
 original node schedulability
 before/after SHA-256 for all three control-plane manifests
+before/after SHA-256 for local kubelet config when selected
 before/after static Pod container identities and component health
 API VIP, node Ready, and etcd member/endpoint health evidence
 pre-exec mutation markers and redacted kubeadm invocations
@@ -292,7 +335,7 @@ whether the coordinator ConfigMap upload ran
 terminal result, recoveryRequired, and next action
 ```
 
-The node phase plan is:
+The control-plane phase plan is:
 
 ```text
 accepted
@@ -315,17 +358,21 @@ kubeadm-config-upload-complete
 post-upload-health-complete
 ```
 
-`katlctl` retains a non-authoritative rollout summary that references every
-node-local operation ID. Node-local journals retain internally derived request,
-desired-state, live-state, payload, and manifest identities and remain the
-mutation authority.
+The kubelet phase plan replaces the manifest phases with kubelet config backup,
+optional coordinator upload, local kubelet-config download, kubelet restart,
+and post-kubelet health phases.
+
+The public `katlctl` summary reports node outcomes without exposing operation
+IDs or integrity plumbing. Node-local journals retain internally derived
+request, desired-state, live-state, payload, and manifest identities and remain
+the mutation authority.
 
 ## Consequences
 
-The first release proves a meaningful live kubeadm-owned change while keeping
-the safety surface small enough to validate exhaustively. Operators cannot use
-this path as an arbitrary component-flag editor, but unsupported desired input
-is reported precisely instead of being silently applied.
+Operators can change kubeadm-owned control-plane manifest settings and
+cluster-wide kubelet settings from the same ClusterConfig without reinstalling
+or rebooting nodes. Unsupported desired input is reported precisely instead of
+being silently or partially applied.
 
 The coordinator and node-local executor are separate responsibilities. A
 client interruption cannot make `katlc` forget a local mutation, and a node

--- a/docs/internal/katlc-agent-architecture.md
+++ b/docs/internal/katlc-agent-architecture.md
@@ -109,12 +109,9 @@ a separate local CLI contract.
 Target `katlctl` commands own workstation orchestration:
 
 ```text
-katlctl node apply
-katlctl node apply status
-katlctl bootstrap init
-katlctl bootstrap join-control-plane
-katlctl bootstrap join-worker
-katlctl kubeconfig get
+katlctl cluster apply
+katlctl cluster bootstrap
+katlctl cluster status
 katlctl operations list
 katlctl operations status
 ```

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -1,7 +1,8 @@
-# Apply KatlOS Node Configuration
+# Apply Cluster Configuration
 
-Use `katlctl node apply` for supported node configuration after installation. It is not
-a general Kubernetes, disk, kubeadm, or operating-system upgrade mechanism.
+Use `katlctl cluster apply` for supported configuration changes after
+installation. The same `ClusterConfig` remains the source of truth for every
+node and for kubeadm-owned Kubernetes configuration.
 
 ## Supported Input
 
@@ -12,52 +13,40 @@ renderer carries:
 - systemd-networkd files; and
 - operation-only system role and role-dependent Kubernetes bootstrap state.
 
-Runtime-safe fields can apply normally. Operation-only differences are planned
-and reported as requiring an explicit lifecycle action; node apply does not
-run kubeadm. Disk/install selection and Kubernetes version changes use the
-dedicated install and Kubernetes upgrade workflows.
+Runtime-safe fields apply normally. Katl coordinates affected node generations
+and kubeadm phases internally. Disk/install selection and Kubernetes version
+changes use the dedicated install and Kubernetes upgrade workflows.
 
-If `spec.kubernetes.kubeadm` changes, planning reports a kubeadm-aware action.
-Normal node apply does not rewrite live kubeadm or Kubernetes state; use the
-dedicated operation for a supported change, or follow the reported manual
-boundary when Katl does not support that transition.
+If `spec.kubernetes.kubeadm` changes, cluster apply validates every node before
+mutation and then reconciles every affected Kubernetes component online. A
+Kubernetes configuration change never falls back to next-boot application or
+requires a host reboot.
 
-## Plan an Apply
+## Apply The Cluster
 
-An optional plan compiles the selected node configuration and asks the node to
-validate it without accepting an operation:
+Apply the source configuration directly:
 
 ```sh
-katlctl node apply cp-1 --config ./cluster.yaml \
-	--plan
+katlctl cluster apply --config ./cluster.yaml
 ```
 
-Validation reports the changed domains and accepted apply mode without
-accepting an operation. The default `auto` lets the domain policy select live or
-next-boot application. Request `--mode live` or `--mode next-boot` only when you
-intend to constrain that policy; unsafe requests are refused.
+Katl compiles every selected node configuration, validates the whole cluster,
+and starts no mutation if any node rejects the plan. It then applies node
+configuration and all affected Kubernetes component phases in a safe serial
+order, returning only after the cluster is healthy.
 
 If the source has already been compiled, pass the bundle through the same flag:
 
 ```sh
-katlctl node apply cp-1 --config ./katl-lab.katlcfg --plan
+katlctl cluster apply --config ./katl-lab.katlcfg
 ```
 
 Katl derives and verifies the bundle's integrity metadata from the file.
 
-## Apply the Reviewed Request
-
-Run the same arguments without `--plan`:
-
-```sh
-katlctl node apply cp-1 --config ./cluster.yaml
-```
-
-`katlctl` resolves the selected workstation context, reads the node credential,
-derives the monotonically increasing desired version and candidate generation,
-validates the change, follows the durable apply, and exits only after a terminal
-result. Require `terminal: true` and `result: succeeded`. If `recoveryRequired`
-is true, stop and follow `failureReason` and `nextAction`.
+`katlctl` derives per-node generations, component phases, rollout ordering, and
+operation identities internally. A successful return means the complete
+supported configuration is active; partial or unsupported plans fail with the
+node, field, and recovery action.
 
 ## Check Status
 
@@ -73,5 +62,5 @@ On-node evidence remains available under:
 /var/lib/katl/boot/selection.json
 ```
 
-If status reports rollback failure, `failed-needs-repair`, or a kubeadm action
-requirement, stop and classify it before submitting another configuration.
+If status reports rollback failure or `failed-needs-repair`, stop and follow the
+reported recovery action before submitting another cluster apply.

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -121,7 +121,13 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	result := Result{Plan: plan, DryRun: request.DryRun}
 	emitAgentProgress(deps, AgentBootstrapProgress{Phase: "planning"})
 	result.addPhase("plan", "", "", "passed")
-	bootstrap, err := prepareBootstrap(mergeBootstrap(planBootstrap(plan.Bootstrap), request.Bootstrap))
+	bootstrapInput := mergeBootstrap(planBootstrap(plan.Bootstrap), request.Bootstrap)
+	nodeManifests, err := nodeLabelManifests(plan)
+	if err != nil {
+		return result, err
+	}
+	bootstrapInput.Manifests = append(nodeManifests, bootstrapInput.Manifests...)
+	bootstrap, err := prepareBootstrap(bootstrapInput)
 	if err != nil {
 		return result, err
 	}

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -48,6 +48,7 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	inv := validSingleNodeInventory()
 	inv.ControlPlaneEndpoint = "api.katl.test:6443"
 	inv.ControlPlaneEndpointManaged = true
+	inv.Nodes[0].Labels = map[string]string{"topology.kubernetes.io/zone": "rack-a"}
 	inv.Nodes = append(inv.Nodes, inventory.Node{
 		Name:              "cp-2",
 		Address:           "10.0.0.12",
@@ -100,6 +101,7 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 		"cp-1": cpClient,
 		"cp-2": cp2Client,
 	})
+	bootstrapRunner := &fakeBootstrapRunner{result: BootstrapResult{StableEndpointReady: true}}
 	out := filepath.Join(t.TempDir(), "operator.conf")
 	result, err := RunAgentBootstrap(context.Background(), Request{
 		Inventory:           inv,
@@ -109,12 +111,12 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	}, AgentBootstrapDependencies{
 		Connector:       connector,
 		Actor:           "test-actor",
-		BootstrapRunner: &fakeBootstrapRunner{result: BootstrapResult{StableEndpointReady: true}},
+		BootstrapRunner: bootstrapRunner,
 	})
 	if err != nil {
 		t.Fatalf("RunAgentBootstrap() error = %v", err)
 	}
-	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "bootstrap-init", "stable-endpoint", "control-plane-join", "kubeconfig"}) {
+	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "bootstrap-init", "stable-endpoint", "control-plane-join", "user-bootstrap", "kubeconfig"}) {
 		t.Fatalf("phases = %#v", got)
 	}
 	if result.Phases[2].OperationID != "bootstrap-init-1" || result.Phases[4].OperationID != "bootstrap-join-control-plane-1" {
@@ -150,6 +152,19 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	}
 	if got := cpClient.createMaterial.GetWorkerJoinMaterial().GetJoinArgv()[2]; got != "api.katl.test:6443" {
 		t.Fatalf("source join material endpoint = %q, want unmodified agent response", got)
+	}
+	if len(bootstrapRunner.requests) != 2 {
+		t.Fatalf("bootstrap requests = %d, want stable endpoint check and node labels", len(bootstrapRunner.requests))
+	}
+	labelRequest := bootstrapRunner.requests[1]
+	if len(labelRequest.Manifests) != 1 {
+		t.Fatalf("node label manifests = %#v", labelRequest.Manifests)
+	}
+	manifest := string(labelRequest.Manifests[0].Content)
+	for _, want := range []string{"kind: Node", "name: cp-1", "topology.kubernetes.io/zone: rack-a"} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("node label manifest = %q, want %q", manifest, want)
+		}
 	}
 }
 

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -164,7 +164,13 @@ func Run(ctx context.Context, request Request, deps Dependencies) (Result, error
 	}
 	result := Result{Plan: plan, DryRun: request.DryRun}
 	result.addPhase("plan", "", "", "passed")
-	bootstrap, err := prepareBootstrap(mergeBootstrap(planBootstrap(plan.Bootstrap), request.Bootstrap))
+	bootstrapInput := mergeBootstrap(planBootstrap(plan.Bootstrap), request.Bootstrap)
+	nodeManifests, err := nodeLabelManifests(plan)
+	if err != nil {
+		return result, err
+	}
+	bootstrapInput.Manifests = append(nodeManifests, bootstrapInput.Manifests...)
+	bootstrap, err := prepareBootstrap(bootstrapInput)
 	if err != nil {
 		return result, err
 	}
@@ -409,6 +415,28 @@ func mergeBootstrap(plan, request UserBootstrap) UserBootstrap {
 	result.PreWaits = append(result.PreWaits, request.PreWaits...)
 	result.Waits = append(result.Waits, request.Waits...)
 	return result
+}
+
+func nodeLabelManifests(plan inventory.Plan) ([]BootstrapManifest, error) {
+	manifests := make([]BootstrapManifest, 0, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		if len(node.Labels) == 0 {
+			continue
+		}
+		content, err := yaml.Marshal(map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Node",
+			"metadata": map[string]any{
+				"name":   node.Name,
+				"labels": node.Labels,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render labels for node %s: %w", node.Name, err)
+		}
+		manifests = append(manifests, BootstrapManifest{Content: content})
+	}
+	return manifests, nil
 }
 
 func loadBootstrapManifest(manifest BootstrapManifest) (BootstrapManifest, error) {

--- a/internal/bootstrap/inventory/inventory.go
+++ b/internal/bootstrap/inventory/inventory.go
@@ -64,12 +64,13 @@ type BootstrapWait struct {
 }
 
 type Node struct {
-	Name              string        `json:"name"`
-	Address           string        `json:"address,omitempty"`
-	SystemRole        SystemRole    `json:"systemRole"`
-	Access            Access        `json:"access"`
-	KubeadmConfig     KubeadmConfig `json:"kubeadmConfig"`
-	KubernetesVersion string        `json:"kubernetesVersion"`
+	Name              string            `json:"name"`
+	Address           string            `json:"address,omitempty"`
+	SystemRole        SystemRole        `json:"systemRole"`
+	Access            Access            `json:"access"`
+	KubeadmConfig     KubeadmConfig     `json:"kubeadmConfig"`
+	KubernetesVersion string            `json:"kubernetesVersion"`
+	Labels            map[string]string `json:"labels,omitempty"`
 }
 
 type Access struct {
@@ -103,13 +104,14 @@ type Plan struct {
 }
 
 type PlannedNode struct {
-	Name              string          `json:"name"`
-	Address           string          `json:"address"`
-	SystemRole        SystemRole      `json:"systemRole"`
-	Action            BootstrapAction `json:"action"`
-	Access            Access          `json:"access"`
-	KubeadmConfig     KubeadmConfig   `json:"kubeadmConfig"`
-	KubernetesVersion string          `json:"kubernetesVersion"`
+	Name              string            `json:"name"`
+	Address           string            `json:"address"`
+	SystemRole        SystemRole        `json:"systemRole"`
+	Action            BootstrapAction   `json:"action"`
+	Access            Access            `json:"access"`
+	KubeadmConfig     KubeadmConfig     `json:"kubeadmConfig"`
+	KubernetesVersion string            `json:"kubernetesVersion"`
+	Labels            map[string]string `json:"labels,omitempty"`
 }
 
 type AddressOverride struct {
@@ -314,7 +316,19 @@ func normalizeNode(node Node, inventoryVersion string) (PlannedNode, error) {
 		Access:            access,
 		KubeadmConfig:     config,
 		KubernetesVersion: version,
+		Labels:            copyLabels(node.Labels),
 	}, nil
+}
+
+func copyLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(labels))
+	for key, value := range labels {
+		out[key] = value
+	}
+	return out
 }
 
 func normalizeAccess(node string, access Access) (Access, error) {

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -313,6 +313,7 @@ func compileNode(config Config, name string, role inventory.SystemRole, layer No
 		Access:            layer.Bootstrap.Access,
 		KubeadmConfig:     kubeadmConfig,
 		KubernetesVersion: kubernetes.version,
+		Labels:            copyLabels(layer.Kubernetes.NodeLabels),
 	}
 	return NodeMaterial{
 		Name:                   name,

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -29,6 +29,9 @@ func TestCompileClusterPlan(t *testing.T) {
 	if got := plan.BootstrapInventory.Nodes[0].Name; got != "cp-1" {
 		t.Fatalf("first inventory node = %q", got)
 	}
+	if got := plan.BootstrapInventory.Nodes[0].Labels["katl.dev/zone"]; got != "rack-a" {
+		t.Fatalf("first inventory node zone = %q", got)
+	}
 	cp := plan.Nodes[0]
 	if cp.Name != "cp-1" || cp.SystemRole != inventory.RoleControlPlane || cp.BootstrapAddress != "10.0.0.11" {
 		t.Fatalf("control-plane material = %#v", cp)

--- a/internal/installer/clusterplan/testdata/basic.golden.json
+++ b/internal/installer/clusterplan/testdata/basic.golden.json
@@ -283,7 +283,11 @@
           "path": "/etc/katl/kubeadm/control-plane/config.yaml",
           "intent": "control-plane"
         },
-        "kubernetesVersion": "v1.36.1"
+        "kubernetesVersion": "v1.36.1",
+        "labels": {
+          "katl.dev/zone": "rack-a",
+          "node-role.kubernetes.io/control-plane": ""
+        }
       },
       {
         "name": "worker-1",
@@ -298,7 +302,10 @@
           "path": "/etc/katl/kubeadm/worker/config.yaml",
           "intent": "worker"
         },
-        "kubernetesVersion": "v1.36.1"
+        "kubernetesVersion": "v1.36.1",
+        "labels": {
+          "katl.dev/pool": "workers"
+        }
       }
     ]
   }

--- a/internal/installer/configapply/executor.go
+++ b/internal/installer/configapply/executor.go
@@ -91,6 +91,9 @@ func (e Executor) ExecuteLive(ctx context.Context, plan Result) (generation.Conf
 	if err := e.Activator.Activate(ctx, plan.GenerationRecord); err != nil {
 		return e.failAndRollback(ctx, status, plan, fmt.Errorf("activate selected confext: %w", err), false)
 	}
+	if err := e.refreshConfext(ctx); err != nil {
+		return e.failAndRollback(ctx, status, plan, err, false)
+	}
 
 	if err := e.runActions(ctx, &status); err != nil {
 		return e.failAndRollback(ctx, status, plan, err, true)
@@ -150,8 +153,20 @@ func (e Executor) endpointAdvertisementEnabled(record generation.Record) (bool, 
 }
 
 func (e Executor) runActions(ctx context.Context, status *generation.ConfigApplyStatus) error {
+	kubeletRebound := false
 	for i := range status.DomainActions {
 		action := &status.DomainActions[i]
+		if action.Status == generation.ConfigApplyActionSkipped {
+			continue
+		}
+		if kubeadmInputDomain(action.Domain) && kubeletRebound {
+			action.Status = generation.ConfigApplyActionPassed
+			action.Diagnostic = ""
+			if err := e.writeStatus(*status); err != nil {
+				return err
+			}
+			continue
+		}
 		commands, err := e.commandsForDomain(action.Domain)
 		if err != nil {
 			action.Status = generation.ConfigApplyActionFailed
@@ -175,6 +190,9 @@ func (e Executor) runActions(ctx context.Context, status *generation.ConfigApply
 				return err
 			}
 		}
+		if kubeadmInputDomain(action.Domain) {
+			kubeletRebound = true
+		}
 		action.Status = generation.ConfigApplyActionPassed
 		action.Diagnostic = ""
 		if err := e.writeStatus(*status); err != nil {
@@ -185,7 +203,13 @@ func (e Executor) runActions(ctx context.Context, status *generation.ConfigApply
 }
 
 func (e Executor) preflight(actions []generation.ConfigApplyDomainAction) error {
+	if err := validateBoundedCommand(e.confextRefreshCommand()); err != nil {
+		return err
+	}
 	for _, action := range actions {
+		if action.Status == generation.ConfigApplyActionSkipped {
+			continue
+		}
 		commands, err := e.commandsForDomain(action.Domain)
 		if err != nil {
 			return err
@@ -199,6 +223,26 @@ func (e Executor) preflight(actions []generation.ConfigApplyDomainAction) error 
 	return nil
 }
 
+func (e Executor) confextRefreshCommand() Command {
+	return Command{
+		Name:    "systemd-confext-refresh",
+		Argv:    []string{"systemd-confext", "refresh"},
+		Timeout: e.timeout(),
+	}
+}
+
+func (e Executor) refreshConfext(ctx context.Context) error {
+	command := e.confextRefreshCommand()
+	result, err := e.Runner.Run(ctx, command)
+	if err != nil {
+		return fmt.Errorf("%s: %w", command.Name, err)
+	}
+	if result.ExitStatus != 0 {
+		return commandFailure(command, result)
+	}
+	return nil
+}
+
 func (e Executor) commandsForDomain(domain string) ([]Command, error) {
 	if commands, ok := e.ActionCommands[domain]; ok {
 		return withDefaults(commands, e.timeout()), nil
@@ -208,6 +252,8 @@ func (e Executor) commandsForDomain(domain string) ([]Command, error) {
 		Argv: []string{"systemctl", "daemon-reload"},
 	}}
 	switch domain {
+	case DomainKubeadmConfig, DomainSelectedKubeadmConfig:
+		commands = []Command{{Name: "kubelet-config-watcher-rebind", Argv: []string{"systemctl", "try-restart", "kubelet.service"}}}
 	case DomainResolved:
 		commands = append(commands, Command{Name: "systemd-resolved-reload", Argv: []string{"systemctl", "reload-or-restart", "systemd-resolved.service"}})
 	case DomainSysctl:
@@ -248,6 +294,9 @@ func (e Executor) failAndRollback(ctx context.Context, status generation.ConfigA
 	if rollbackErr := e.Activator.Rollback(ctx, target); rollbackErr != nil {
 		return e.markRollbackFailed(status, target, cause, rollbackErr)
 	}
+	if refreshErr := e.refreshConfext(ctx); refreshErr != nil {
+		return e.markRollbackFailed(status, target, cause, refreshErr)
+	}
 	if replayActions {
 		if replayErr := e.replayRollbackActions(ctx, status.DomainActions); replayErr != nil {
 			return e.markRollbackFailed(status, target, cause, replayErr)
@@ -264,7 +313,14 @@ func (e Executor) failAndRollback(ctx context.Context, status generation.ConfigA
 }
 
 func (e Executor) replayRollbackActions(ctx context.Context, actions []generation.ConfigApplyDomainAction) error {
+	kubeletRebound := false
 	for _, action := range actions {
+		if action.Status == generation.ConfigApplyActionSkipped {
+			continue
+		}
+		if kubeadmInputDomain(action.Domain) && kubeletRebound {
+			continue
+		}
 		commands, err := e.commandsForDomain(action.Domain)
 		if err != nil {
 			return err
@@ -278,8 +334,15 @@ func (e Executor) replayRollbackActions(ctx context.Context, actions []generatio
 				return fmt.Errorf("rollback %w", commandFailure(command, result))
 			}
 		}
+		if kubeadmInputDomain(action.Domain) {
+			kubeletRebound = true
+		}
 	}
 	return nil
+}
+
+func kubeadmInputDomain(domain string) bool {
+	return domain == DomainKubeadmConfig || domain == DomainSelectedKubeadmConfig
 }
 
 func (e Executor) markRollbackFailed(status generation.ConfigApplyStatus, target string, cause error, rollbackErr error) (generation.ConfigApplyStatus, error) {

--- a/internal/installer/configapply/executor_test.go
+++ b/internal/installer/configapply/executor_test.go
@@ -38,10 +38,10 @@ func TestExecutorActivatesSelectedConfextAndRecordsSuccess(t *testing.T) {
 			t.Fatalf("action = %#v, want passed", action)
 		}
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,systemd-sysctl"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,systemd-sysctl"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
-	if got, want := runner.commands[1].Argv, []string{"/usr/lib/systemd/systemd-sysctl", "/run/confexts/katl-node/etc/sysctl.d/90-katl.conf"}; strings.Join(got, " ") != strings.Join(want, " ") {
+	if got, want := runner.commands[2].Argv, []string{"/usr/lib/systemd/systemd-sysctl", "/run/confexts/katl-node/etc/sysctl.d/90-katl.conf"}; strings.Join(got, " ") != strings.Join(want, " ") {
 		t.Fatalf("systemd-sysctl argv = %#v, want %#v", got, want)
 	}
 	persisted, err := generation.ReadConfigApplyStatus(statusPath)
@@ -50,6 +50,34 @@ func TestExecutorActivatesSelectedConfextAndRecordsSuccess(t *testing.T) {
 	}
 	if persisted.Phase != generation.ConfigApplyPhaseActive || persisted.DomainActions[0].Status != generation.ConfigApplyActionPassed {
 		t.Fatalf("persisted status = %#v", persisted)
+	}
+}
+
+func TestExecutorRebindsKubeletWatcherOnceForKubeadmInput(t *testing.T) {
+	plan := liveExecutorPlan(t, []Change{
+		{Domain: DomainKubeadmConfig},
+		{Domain: DomainSelectedKubeadmConfig},
+	})
+	runner := &fakeCommandRunner{}
+
+	status, err := Executor{
+		Runner:    runner,
+		Activator: &fakeActivator{},
+		Now:       fixedNow,
+	}.ExecuteLive(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("ExecuteLive() error = %v", err)
+	}
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,kubelet-config-watcher-rebind"; got != want {
+		t.Fatalf("commands = %q, want %q", got, want)
+	}
+	if got, want := runner.commands[1].Argv, []string{"systemctl", "try-restart", "kubelet.service"}; strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("kubelet rebind argv = %#v, want %#v", got, want)
+	}
+	for _, action := range status.DomainActions {
+		if action.Status != generation.ConfigApplyActionPassed {
+			t.Fatalf("action = %#v, want passed", action)
+		}
 	}
 }
 
@@ -85,7 +113,7 @@ func TestExecutorFailureRecordsRollbackAndRedactsStatus(t *testing.T) {
 	if !strings.Contains(status.FailureReason, "[REDACTED BOOTSTRAP TOKEN]") {
 		t.Fatalf("failure reason = %q, want redacted token marker", status.FailureReason)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,systemd-sysctl,systemd-daemon-reload,systemd-sysctl"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,systemd-sysctl,systemd-confext-refresh,systemd-daemon-reload,systemd-sysctl"; got != want {
 		t.Fatalf("commands = %q, want failed apply followed by rollback replay %q", got, want)
 	}
 	data, err := os.ReadFile(statusPath)
@@ -156,7 +184,7 @@ func TestExecutorRecordsRollbackReplayFailure(t *testing.T) {
 	if strings.Contains(status.Rollback.Reason, "secret-token") || !strings.Contains(status.Rollback.Reason, "Bearer [REDACTED]") {
 		t.Fatalf("rollback reason was not redacted: %q", status.Rollback.Reason)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,systemd-daemon-reload"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,systemd-confext-refresh,systemd-daemon-reload"; got != want {
 		t.Fatalf("commands = %q, want failed apply followed by rollback replay %q", got, want)
 	}
 }
@@ -273,7 +301,7 @@ func TestExecutorRunsBirdWhenVIPAdvertisementIsEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExecuteLive() error = %v", err)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
 }

--- a/internal/installer/configapply/matrix.go
+++ b/internal/installer/configapply/matrix.go
@@ -293,7 +293,7 @@ var domainPolicies = map[string]domainPolicy{
 		NextBootAllowed: true,
 	},
 	DomainBootstrapNodeMetadata: {
-		Classification:  ClassificationStagedOnly,
+		Classification:  ClassificationOnlineApplicable,
 		NextBootAllowed: true,
 	},
 	DomainNodeIdentity: {
@@ -317,10 +317,9 @@ var domainPolicies = map[string]domainPolicy{
 		NextBootAllowed: true,
 	},
 	DomainKubeadmConfig: {
-		Classification:      ClassificationOperationOnly,
-		NextBootAllowed:     true,
-		LiveRejectionReason: "kubeadm desired state changes require an explicit kubeadm-aware operation",
-		RequiredOperation:   "kubeadm-aware operation",
+		Classification:    ClassificationOnlineApplicable,
+		NextBootAllowed:   true,
+		RequiredOperation: "kubeadm-aware operation",
 	},
 	DomainSystemRole: {
 		Classification:      ClassificationOperationOnly,
@@ -328,10 +327,9 @@ var domainPolicies = map[string]domainPolicy{
 		RequiredOperation:   "wipe-reinstall",
 	},
 	DomainSelectedKubeadmConfig: {
-		Classification:      ClassificationOperationOnly,
-		NextBootAllowed:     true,
-		LiveRejectionReason: "selected kubeadm config changes require an explicit kubeadm-aware action",
-		RequiredOperation:   "kubeadm-aware operation",
+		Classification:    ClassificationOnlineApplicable,
+		NextBootAllowed:   true,
+		RequiredOperation: "kubeadm-aware operation",
 	},
 	DomainSelectedKubernetesSysext: {
 		Classification:      ClassificationOperationOnly,

--- a/internal/installer/configapply/matrix_test.go
+++ b/internal/installer/configapply/matrix_test.go
@@ -16,15 +16,15 @@ func TestDomainClassificationMatrix(t *testing.T) {
 		{DomainSysctl, ClassificationOnlineApplicable},
 		{DomainTmpfiles, ClassificationStagedOnly},
 		{DomainNetworkd, ClassificationStagedOnly},
-		{DomainBootstrapNodeMetadata, ClassificationStagedOnly},
+		{DomainBootstrapNodeMetadata, ClassificationOnlineApplicable},
 		{DomainNodeIdentity, ClassificationStagedOnly},
 		{DomainModulesLoad, ClassificationStagedOnly},
 		{DomainMountUnits, ClassificationStagedOnly},
 		{DomainExtraDisks, ClassificationStagedOnly},
 		{DomainSSHOperatorAccess, ClassificationStagedOnly},
-		{DomainKubeadmConfig, ClassificationOperationOnly},
+		{DomainKubeadmConfig, ClassificationOnlineApplicable},
 		{DomainSystemRole, ClassificationOperationOnly},
-		{DomainSelectedKubeadmConfig, ClassificationOperationOnly},
+		{DomainSelectedKubeadmConfig, ClassificationOnlineApplicable},
 		{DomainSelectedKubernetesSysext, ClassificationOperationOnly},
 		{DomainKubeletNodeIdentity, ClassificationOperationOnly},
 		{DomainHostAccountPolicy, ClassificationRejected},
@@ -130,7 +130,6 @@ func TestPlanTreatsStagedOnlyDomainsAsNextBoot(t *testing.T) {
 		DomainResolved,
 		DomainTmpfiles,
 		DomainNetworkd,
-		DomainBootstrapNodeMetadata,
 		DomainControlPlaneEndpointBootstrap,
 	} {
 		t.Run(domain, func(t *testing.T) {
@@ -203,28 +202,38 @@ func TestPlanRejectsOperationOnlyAndUnsupportedMutations(t *testing.T) {
 	}
 }
 
-func TestPlanStagesKubeadmInputAsActionRequired(t *testing.T) {
+func TestPlanActivatesKubeadmInputLiveWithoutApplyingIt(t *testing.T) {
 	for _, domain := range []string{DomainKubeadmConfig, DomainSelectedKubeadmConfig} {
 		t.Run(domain, func(t *testing.T) {
-			for _, mode := range []string{generation.ApplyModeAuto, generation.ApplyModeNextBoot} {
+			for _, mode := range []string{generation.ApplyModeAuto, generation.ApplyModeLive} {
 				decision, err := Plan(mode, []Change{{Domain: domain}})
 				if err != nil {
 					t.Fatalf("Plan(%s) error = %v, decision = %#v", mode, err, decision)
 				}
-				if decision.AcceptedMode != generation.ApplyModeNextBoot || len(decision.Diagnostics) != 1 {
+				if decision.AcceptedMode != generation.ApplyModeLive || len(decision.Diagnostics) != 0 {
 					t.Fatalf("Plan(%s) decision = %#v", mode, decision)
-				}
-				diagnostic := decision.Diagnostics[0]
-				if diagnostic.Decision != DecisionActionRequired || diagnostic.Classification != ClassificationOperationOnly || diagnostic.RequiredOperation != "kubeadm-aware operation" {
-					t.Fatalf("Plan(%s) diagnostic = %#v", mode, diagnostic)
 				}
 			}
 
-			decision, err := Plan(generation.ApplyModeLive, []Change{{Domain: domain}})
-			if err == nil || len(decision.Diagnostics) != 1 || decision.Diagnostics[0].Decision != DecisionRejected {
-				t.Fatalf("Plan(live) error = %v, decision = %#v", err, decision)
+			decision, err := Plan(generation.ApplyModeNextBoot, []Change{{Domain: domain}})
+			if err != nil || decision.AcceptedMode != generation.ApplyModeNextBoot {
+				t.Fatalf("Plan(next-boot) error = %v, decision = %#v", err, decision)
 			}
 		})
+	}
+}
+
+func TestPlanActivatesSelectedKubeadmConfigAndNodeMetadataLive(t *testing.T) {
+	decision, err := Plan(generation.ApplyModeLive, []Change{
+		{Domain: DomainSelectedKubeadmConfig},
+		{Domain: DomainBootstrapNodeMetadata},
+		{Domain: DomainKubeadmConfig},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v, decision = %#v", err, decision)
+	}
+	if decision.AcceptedMode != generation.ApplyModeLive || len(decision.Diagnostics) != 0 {
+		t.Fatalf("decision = %#v", decision)
 	}
 }
 
@@ -286,17 +295,14 @@ func TestPlanMixedLiveRequestFailsAtomically(t *testing.T) {
 	if decision.AcceptedMode != "" {
 		t.Fatalf("accepted mode = %q, want empty rejected decision", decision.AcceptedMode)
 	}
-	if len(decision.Diagnostics) != 3 {
-		t.Fatalf("diagnostics = %#v, want staged networkd, operation-only kubeadm, and rejected /etc/kubernetes", decision.Diagnostics)
+	if len(decision.Diagnostics) != 2 {
+		t.Fatalf("diagnostics = %#v, want staged networkd and rejected /etc/kubernetes", decision.Diagnostics)
 	}
 	if decision.Diagnostics[0].Domain != DomainNetworkd || decision.Diagnostics[0].Decision != DecisionStagedRequired {
 		t.Fatalf("first diagnostic = %#v", decision.Diagnostics[0])
 	}
-	if decision.Diagnostics[1].Domain != DomainKubeadmConfig || decision.Diagnostics[1].Decision != DecisionRejected || decision.Diagnostics[1].RequiredOperation != "kubeadm-aware operation" {
+	if decision.Diagnostics[1].Domain != DomainEtcKubernetes || decision.Diagnostics[1].Decision != DecisionRejected {
 		t.Fatalf("second diagnostic = %#v", decision.Diagnostics[1])
-	}
-	if decision.Diagnostics[2].Domain != DomainEtcKubernetes || decision.Diagnostics[2].Decision != DecisionRejected {
-		t.Fatalf("third diagnostic = %#v", decision.Diagnostics[2])
 	}
 	if got, want := strings.Join(decision.ChangedDomains, ","), "sysctl,networkd,kubeadm-config,etc-kubernetes"; got != want {
 		t.Fatalf("changed domains = %q, want %q", got, want)

--- a/internal/installer/configapply/planner.go
+++ b/internal/installer/configapply/planner.go
@@ -163,14 +163,19 @@ func domainActions(acceptedMode string, domains []string) []generation.ConfigApp
 		action := generation.ConfigApplyDomainAction{
 			Domain: domain,
 		}
-		if acceptedMode == generation.ApplyModeNextBoot {
-			if domain == DomainKubeadmConfig || domain == DomainSelectedKubeadmConfig {
-				action.Action = "kubeadm-operation-required"
-				action.Diagnostic = "desired kubeadm input staged; live state requires an explicit kubeadm-aware operation"
+		if domain == DomainKubeadmConfig || domain == DomainSelectedKubeadmConfig {
+			if acceptedMode == generation.ApplyModeLive {
+				action.Action = "kubelet-config-watcher-rebind"
+				action.Diagnostic = "kubelet will be restarted if active so it observes the refreshed /etc mount tree; live kubeadm state still requires an explicit kubeadm-aware operation"
+				action.Status = generation.ConfigApplyActionPlanned
 			} else {
-				action.Action = "stage-next-boot"
-				action.Diagnostic = "domain staged into next boot generation"
+				action.Action = "kubeadm-operation-required"
+				action.Diagnostic = "desired kubeadm input activated; live state requires an explicit kubeadm-aware operation"
+				action.Status = generation.ConfigApplyActionSkipped
 			}
+		} else if acceptedMode == generation.ApplyModeNextBoot {
+			action.Action = "stage-next-boot"
+			action.Diagnostic = "domain staged into next boot generation"
 			action.Status = generation.ConfigApplyActionSkipped
 		} else {
 			action.Action = liveAction(domain)

--- a/internal/installer/configapply/planner_test.go
+++ b/internal/installer/configapply/planner_test.go
@@ -94,7 +94,7 @@ func TestPlanChangeRejectsUnsupportedLiveChangeBeforeCandidateRecord(t *testing.
 	if err == nil {
 		t.Fatalf("PlanChange() error = nil, result = %#v", result)
 	}
-	if result.Decision.AcceptedMode != "" || len(result.Decision.Diagnostics) != 3 {
+	if result.Decision.AcceptedMode != "" || len(result.Decision.Diagnostics) != 2 {
 		t.Fatalf("decision = %#v", result.Decision)
 	}
 	if result.GenerationRecord.Kind != "" || result.Status.Kind != "" {
@@ -105,7 +105,7 @@ func TestPlanChangeRejectsUnsupportedLiveChangeBeforeCandidateRecord(t *testing.
 	}
 }
 
-func TestPlanChangeStagesKubeadmInputWithoutLiveAction(t *testing.T) {
+func TestPlanChangeActivatesKubeadmInputAndRebindsKubeletWatcher(t *testing.T) {
 	live, err := PlanChange(currentRecord(), NodeConfigurationChange{
 		APIVersion:       generation.APIVersion,
 		Kind:             NodeConfigurationChangeKind,
@@ -115,11 +115,11 @@ func TestPlanChangeStagesKubeadmInputWithoutLiveAction(t *testing.T) {
 		Changes:          []Change{{Domain: DomainKubeadmConfig}},
 		GeneratedConfext: candidateConfext("2026.06.05-002"),
 	})
-	if err == nil {
-		t.Fatalf("PlanChange(live kubeadm) error = nil, result = %#v", live)
+	if err != nil {
+		t.Fatalf("PlanChange(live kubeadm) error = %v, result = %#v", err, live)
 	}
-	if len(live.Decision.Diagnostics) != 1 || live.Decision.Diagnostics[0].Decision != DecisionRejected || live.Decision.Diagnostics[0].RequiredOperation != "kubeadm-aware operation" {
-		t.Fatalf("live kubeadm diagnostics = %#v", live.Decision.Diagnostics)
+	if live.Decision.AcceptedMode != generation.ApplyModeLive || len(live.Status.DomainActions) != 1 || live.Status.DomainActions[0].Action != "kubelet-config-watcher-rebind" || live.Status.DomainActions[0].Status != generation.ConfigApplyActionPlanned {
+		t.Fatalf("live kubeadm result = %#v", live)
 	}
 
 	next, err := PlanChange(currentRecord(), NodeConfigurationChange{
@@ -140,7 +140,7 @@ func TestPlanChangeStagesKubeadmInputWithoutLiveAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlanChange(next kubeadm) error = %v, result = %#v", err, next)
 	}
-	if next.Decision.AcceptedMode != generation.ApplyModeNextBoot || len(next.Decision.Diagnostics) != 1 || next.Decision.Diagnostics[0].Decision != DecisionActionRequired {
+	if next.Decision.AcceptedMode != generation.ApplyModeNextBoot || len(next.Decision.Diagnostics) != 0 {
 		t.Fatalf("next kubeadm decision = %#v", next.Decision)
 	}
 	if !next.Status.Kubeadm.Required || next.Status.Kubeadm.SelectedConfigName != "control-plane" || next.Status.PreviousGeneration == "" {

--- a/internal/installer/configapply/render.go
+++ b/internal/installer/configapply/render.go
@@ -18,6 +18,7 @@ type RenderNodeRequest struct {
 	SourceID       string
 	DesiredVersion string
 	ApplyMode      string
+	KubeadmOnly    bool
 }
 
 type renderedNodeConfigurationChange struct {
@@ -39,11 +40,11 @@ type renderedNodeConfigurationChangeSpec struct {
 }
 
 type renderedNodeConfigurationOverlay struct {
-	Identity             renderedNodeIdentity        `yaml:"identity"`
-	SystemRole           string                      `yaml:"systemRole,omitempty"`
-	Networkd             manifest.NetworkdConfig     `yaml:"networkd"`
-	Kubernetes           *manifest.KubernetesConfig  `yaml:"kubernetes,omitempty"`
-	ControlPlaneEndpoint controlPlaneEndpointOverlay `yaml:"controlPlaneEndpoint"`
+	Identity             *renderedNodeIdentity        `yaml:"identity,omitempty"`
+	SystemRole           string                       `yaml:"systemRole,omitempty"`
+	Networkd             *manifest.NetworkdConfig     `yaml:"networkd,omitempty"`
+	Kubernetes           *manifest.KubernetesConfig   `yaml:"kubernetes,omitempty"`
+	ControlPlaneEndpoint *controlPlaneEndpointOverlay `yaml:"controlPlaneEndpoint,omitempty"`
 }
 
 type renderedNodeIdentity struct {
@@ -74,6 +75,19 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	overlay := renderedNodeConfigurationOverlay{
+		Identity: &renderedNodeIdentity{
+			Hostname:       node.Identity.Hostname,
+			AuthorizedKeys: append([]string{}, node.Identity.SSH.AuthorizedKeys...),
+		},
+		SystemRole:           node.SystemRole,
+		Networkd:             &node.Networkd,
+		Kubernetes:           &node.Kubernetes,
+		ControlPlaneEndpoint: renderedControlPlaneEndpoint(node.ControlPlaneEndpoint),
+	}
+	if request.KubeadmOnly {
+		overlay = renderedNodeConfigurationOverlay{Kubernetes: &node.Kubernetes}
+	}
 	document := renderedNodeConfigurationChange{
 		APIVersion: NodeConfigurationChangeAPIVersion,
 		Kind:       NodeConfigurationChangeKind,
@@ -85,16 +99,7 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 		Spec: renderedNodeConfigurationChangeSpec{
 			KubeadmConfigs: kubeadmConfigs,
 			NodeOverrides: map[string]renderedNodeConfigurationOverlay{
-				nodeName: {
-					Identity: renderedNodeIdentity{
-						Hostname:       node.Identity.Hostname,
-						AuthorizedKeys: append([]string{}, node.Identity.SSH.AuthorizedKeys...),
-					},
-					SystemRole:           node.SystemRole,
-					Networkd:             node.Networkd,
-					Kubernetes:           &node.Kubernetes,
-					ControlPlaneEndpoint: renderedControlPlaneEndpoint(node.ControlPlaneEndpoint),
-				},
+				nodeName: overlay,
 			},
 		},
 	}
@@ -105,8 +110,8 @@ func RenderNodeConfigurationChange(request RenderNodeRequest) ([]byte, error) {
 	return data, nil
 }
 
-func renderedControlPlaneEndpoint(config *controlplaneendpoint.Config) controlPlaneEndpointOverlay {
-	return controlPlaneEndpointOverlay{Managed: config != nil, Config: config}
+func renderedControlPlaneEndpoint(config *controlplaneendpoint.Config) *controlPlaneEndpointOverlay {
+	return &controlPlaneEndpointOverlay{Managed: config != nil, Config: config}
 }
 
 func renderKubeadmConfigs(ref string, configs map[string]kubeadmconfig.Plan) (map[string]inlineKubeadmConfig, error) {

--- a/internal/installer/configapply/render_test.go
+++ b/internal/installer/configapply/render_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
+	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
@@ -139,6 +140,37 @@ func TestRenderNodeConfigurationChangeCarriesSelectedKubeadmInput(t *testing.T) 
 	}
 	if !request.NodeOverrides["cp-1"].KubeadmChanged {
 		t.Fatal("rendered kubeadm input was not planned as an operation-only change")
+	}
+}
+
+func TestRenderNodeConfigurationChangeCanSelectOnlyKubeadmInput(t *testing.T) {
+	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
+		NodeName: "cp-1",
+		Manifest: manifest.Manifest{Node: manifest.NodeConfig{
+			Identity:   manifest.NodeIdentity{Hostname: "cp-1"},
+			Kubernetes: manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: "control-plane"}},
+		}},
+		KubeadmConfigs: map[string]kubeadmconfig.Plan{
+			"control-plane": {Name: "control-plane", Config: kubeadmconfig.File{Content: []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\n")}},
+		},
+		SourceID: "lab", DesiredVersion: "2", ApplyMode: generation.ApplyModeAuto, KubeadmOnly: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, absent := range []string{"identity:", "networkd:", "controlPlaneEndpoint:"} {
+		if strings.Contains(text, absent) {
+			t.Fatalf("kubeadm-only change contains %q:\n%s", absent, text)
+		}
+	}
+	request, err := DecodeNodeConfigurationChange(strings.NewReader(text), TrustedBundleRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	overlay := request.NodeOverrides["cp-1"]
+	if overlay.Kubernetes == nil || overlay.Kubernetes.Kubeadm.ConfigRef != "control-plane" || len(request.KubeadmConfigs) != 1 {
+		t.Fatalf("decoded request = %#v", request)
 	}
 }
 

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -192,7 +192,7 @@ func TestApplyTrustedBundleReloadsEnabledEndpointRouting(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(result.Tree.ConfextDir, "etc/katl/apps/bgp-api-vip/advertisement-enabled")); err != nil {
 		t.Fatalf("candidate advertisement marker: %v", err)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
 }
@@ -300,7 +300,7 @@ func TestApplyTrustedBundleRendersAndExecutesLiveSysctl(t *testing.T) {
 	if !strings.Contains(string(data), "net.ipv4.ip_forward = 1") {
 		t.Fatalf("sysctl content = %q", data)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,systemd-sysctl"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,systemd-sysctl"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
 	persisted, err := generation.ReadConfigApplyStatus(result.StatusPath)
@@ -335,7 +335,7 @@ func TestApplyTrustedBundleDefaultsAutoToLiveForSysctl(t *testing.T) {
 	if result.Plan.Decision.RequestedMode != generation.ApplyModeAuto || result.Plan.Decision.AcceptedMode != generation.ApplyModeLive {
 		t.Fatalf("decision = %#v", result.Plan.Decision)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-daemon-reload,systemd-sysctl"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,systemd-sysctl"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
 	persisted, err := generation.ReadConfigApplyStatus(result.StatusPath)
@@ -477,7 +477,7 @@ func TestApplyTrustedBundleStagesKubeadmInputWithoutSideEffects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyTrustedBundle() error = %v, result = %#v", err, result)
 	}
-	if result.Audit.Decision != DecisionAccepted || result.Audit.AcceptedApplyMode != generation.ApplyModeNextBoot || len(result.Audit.Diagnostics) != 1 || result.Audit.Diagnostics[0].Decision != DecisionActionRequired {
+	if result.Audit.Decision != DecisionAccepted || result.Audit.AcceptedApplyMode != generation.ApplyModeNextBoot || len(result.Audit.Diagnostics) != 0 {
 		t.Fatalf("audit = %#v", result.Audit)
 	}
 	configPath := filepath.Join(result.Tree.ConfextDir, "etc/katl/kubeadm/control-plane-v2/config.yaml")

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -494,7 +494,7 @@ func SourceControlPlaneEndpoint(source SourceConfig) string {
 }
 
 func defaultKubeadmInitConfig(version string) string {
-	config := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n"
+	config := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n  taints: []\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n"
 	if version != "" {
 		config += "kubernetesVersion: " + version + "\n"
 	}

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -219,8 +219,8 @@ spec:
 	if selected.NodeMaterial.KubeadmConfig.Ref != "control-plane" || selected.KubeadmConfigs["control-plane"].Config.RenderPath == "" {
 		t.Fatalf("defaulted kubeadm = material %#v configs %#v", selected.NodeMaterial.KubeadmConfig, selected.KubeadmConfigs)
 	}
-	if config := string(selected.KubeadmConfigs["control-plane"].Config.Content); !strings.Contains(config, "volumePluginDir: /var/lib/kubelet/plugins/volume/exec") {
-		t.Fatalf("defaulted kubeadm does not keep plugins on writable state:\n%s", config)
+	if config := string(selected.KubeadmConfigs["control-plane"].Config.Content); !strings.Contains(config, "volumePluginDir: /var/lib/kubelet/plugins/volume/exec") || !strings.Contains(config, "taints: []") {
+		t.Fatalf("defaulted kubeadm does not keep plugins on writable state and allow control-plane scheduling:\n%s", config)
 	}
 }
 

--- a/internal/installer/kubeadmconfig/kubeadmconfig.go
+++ b/internal/installer/kubeadmconfig/kubeadmconfig.go
@@ -346,7 +346,7 @@ func validateKubeadmYAML(data []byte, patchesRenderDir string) ([]Document, erro
 		if !allowedDocument(apiVersion, kind) {
 			return nil, fmt.Errorf("unsupported kubeadm YAML document %d: apiVersion=%q kind=%q", index+1, apiVersion, kind)
 		}
-		if err := validateYAMLPaths(&node, patchesRenderDir); err != nil {
+		if err := validateYAMLPaths(&node, patchesRenderDir, kind); err != nil {
 			return nil, fmt.Errorf("kubeadm YAML document %d: %w", index+1, err)
 		}
 		documents = append(documents, Document{
@@ -422,7 +422,7 @@ func allowedDocument(apiVersion, kind string) bool {
 	return false
 }
 
-func validateYAMLPaths(node *yaml.Node, patchesRenderDir string) error {
+func validateYAMLPaths(node *yaml.Node, patchesRenderDir, kind string) error {
 	return walkYAML(node, nil, func(path []string, value string) error {
 		if value == "" {
 			return nil
@@ -436,7 +436,7 @@ func validateYAMLPaths(node *yaml.Node, patchesRenderDir string) error {
 		if len(path) == 1 && path[0] == "certificatesDir" && value == "/etc/kubernetes/pki" {
 			return nil
 		}
-		if len(path) == 1 && path[0] == "volumePluginDir" && value == KubeletVolumePluginDir {
+		if kind == "KubeletConfiguration" && allowedKubeletHostPath(path, value) {
 			return nil
 		}
 		if strings.HasPrefix(value, "/") && deniedHostPath(value) {
@@ -444,6 +444,16 @@ func validateYAMLPaths(node *yaml.Node, patchesRenderDir string) error {
 		}
 		return nil
 	})
+}
+
+func allowedKubeletHostPath(path []string, value string) bool {
+	allowed := map[string]string{
+		"authentication.x509.clientCAFile": "/etc/kubernetes/pki/ca.crt",
+		"resolvConf":                       "/run/systemd/resolve/resolv.conf",
+		"staticPodPath":                    "/etc/kubernetes/manifests",
+		"volumePluginDir":                  KubeletVolumePluginDir,
+	}
+	return allowed[strings.Join(path, ".")] == value
 }
 
 func walkYAML(node *yaml.Node, path []string, visit func(path []string, value string) error) error {

--- a/internal/installer/kubeadmconfig/kubeadmconfig_test.go
+++ b/internal/installer/kubeadmconfig/kubeadmconfig_test.go
@@ -163,7 +163,7 @@ kind: KubeadmConfig
 
 func TestResolveRejectsUnsafeInputs(t *testing.T) {
 	repo := t.TempDir()
-	writeFile(t, filepath.Join(repo, "kubeadm", "bad.yaml"), strings.Replace(initConfig(), "cgroupDriver: systemd", "staticPodPath: /etc/kubernetes/manifests", 1))
+	writeFile(t, filepath.Join(repo, "kubeadm", "bad.yaml"), strings.Replace(initConfig(), "cgroupDriver: systemd", "staticPodPath: /etc/kubernetes/other", 1))
 	writeFile(t, filepath.Join(repo, "kubeadm", "usr.yaml"), strings.Replace(initConfig(), "cgroupDriver: systemd", "staticPodPath: /usr/lib/kubernetes/manifests", 1))
 	writeFile(t, filepath.Join(repo, "kubeadm", "unknown.yaml"), `apiVersion: kubeadm.k8s.io/v1beta4
 kind: ResetConfiguration
@@ -217,7 +217,7 @@ kind: ResetConfiguration
 		{
 			name:   "denied host path",
 			object: kubeadmObject("control-plane", "kubeadm/bad.yaml"),
-			want:   "host path /etc/kubernetes/manifests is denied",
+			want:   "host path /etc/kubernetes/other is denied",
 		},
 		{
 			name:   "other denied host path",
@@ -323,6 +323,57 @@ func TestPlanFromRenderedFilesAllowsStandardCertificatesDirectory(t *testing.T) 
 	}})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPlanFromRenderedFilesAllowsStandardKubeletPaths(t *testing.T) {
+	_, err := PlanFromRenderedFiles("control-plane", []File{{
+		RenderPath: "/etc/katl/kubeadm/control-plane/config.yaml",
+		Content: []byte(`apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+resolvConf: /run/systemd/resolve/resolv.conf
+staticPodPath: /etc/kubernetes/manifests
+volumePluginDir: /var/lib/kubelet/plugins/volume/exec
+`),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPlanFromRenderedFilesRejectsOtherKubeletPaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{
+			name: "client CA file",
+			config: `authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/admin.conf
+`,
+			want: "host path /etc/kubernetes/admin.conf is denied",
+		},
+		{
+			name:   "static pod path",
+			config: "staticPodPath: /etc/kubernetes/other\n",
+			want:   "host path /etc/kubernetes/other is denied",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PlanFromRenderedFiles("control-plane", []File{{
+				RenderPath: "/etc/katl/kubeadm/control-plane/config.yaml",
+				Content:    []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\n" + tt.config),
+			}})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("PlanFromRenderedFiles() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/installer/kubeadmplan/control_plane_config.go
+++ b/internal/installer/kubeadmplan/control_plane_config.go
@@ -14,7 +14,15 @@ import (
 )
 
 func CanonicalClusterConfigurationSHA256(data []byte) (string, error) {
-	config, err := clusterConfiguration(data)
+	return CanonicalDocumentSHA256(data, "kubeadm.k8s.io/v1beta4", "ClusterConfiguration")
+}
+
+func CanonicalKubeletConfigurationSHA256(data []byte) (string, error) {
+	return CanonicalDocumentSHA256(data, "kubelet.config.k8s.io/v1beta1", "KubeletConfiguration")
+}
+
+func CanonicalKubeProxyConfigurationSHA256(data []byte) (string, error) {
+	config, err := configurationDocumentByKind(data, "KubeProxyConfiguration")
 	if err != nil {
 		return "", err
 	}
@@ -26,7 +34,204 @@ func CanonicalClusterConfigurationSHA256(data []byte) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
+func CanonicalDocumentSHA256(data []byte, apiVersion, kind string) (string, error) {
+	config, err := configurationDocument(data, apiVersion, kind)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func KubeletConfigurationContains(actual, desired []byte) error {
+	actualConfig, err := configurationDocument(actual, "kubelet.config.k8s.io/v1beta1", "KubeletConfiguration")
+	if err != nil {
+		return fmt.Errorf("actual: %w", err)
+	}
+	desiredConfig, err := configurationDocument(desired, "kubelet.config.k8s.io/v1beta1", "KubeletConfiguration")
+	if err != nil {
+		return fmt.Errorf("desired: %w", err)
+	}
+	if endpoint, ok := desiredConfig["containerRuntimeEndpoint"].(string); ok && endpoint == "" {
+		delete(actualConfig, "containerRuntimeEndpoint")
+		delete(desiredConfig, "containerRuntimeEndpoint")
+	}
+	if !containsValue(actualConfig, desiredConfig) {
+		return fmt.Errorf("live KubeletConfiguration does not contain the desired fields")
+	}
+	return nil
+}
+
+func KubeProxyConfigurationContains(actual, desired []byte) error {
+	actualConfig, err := configurationDocumentByKind(actual, "KubeProxyConfiguration")
+	if err != nil {
+		return fmt.Errorf("actual: %w", err)
+	}
+	desiredConfig, err := configurationDocumentByKind(desired, "KubeProxyConfiguration")
+	if err != nil {
+		return fmt.Errorf("desired: %w", err)
+	}
+	if !containsValue(actualConfig, desiredConfig) {
+		return fmt.Errorf("live KubeProxyConfiguration does not contain the desired fields")
+	}
+	return nil
+}
+
+func containsValue(actual, desired any) bool {
+	switch desiredValue := desired.(type) {
+	case map[string]any:
+		actualValue, ok := actual.(map[string]any)
+		if !ok {
+			return false
+		}
+		for key, desiredChild := range desiredValue {
+			actualChild, exists := actualValue[key]
+			if !exists || !containsValue(actualChild, desiredChild) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		actualValue, ok := actual.([]any)
+		return ok && reflect.DeepEqual(actualValue, desiredValue)
+	default:
+		return reflect.DeepEqual(actual, desired)
+	}
+}
+
 var profilingComponents = []string{"apiServer", "controllerManager", "scheduler"}
+
+var controlPlaneManifestFields = []string{"extraArgs", "extraEnvs", "extraVolumes"}
+
+func SupportedControlPlaneComponentDelta(desired, live []byte) ([]string, error) {
+	desiredConfig, err := clusterConfiguration(desired)
+	if err != nil {
+		return nil, fmt.Errorf("desired: %w", err)
+	}
+	liveConfig, err := clusterConfiguration(live)
+	if err != nil {
+		return nil, fmt.Errorf("live: %w", err)
+	}
+	var delta []string
+	for _, component := range profilingComponents {
+		desiredSection, err := configurationSection(desiredConfig, component)
+		if err != nil {
+			return nil, err
+		}
+		liveSection, err := configurationSection(liveConfig, component)
+		if err != nil {
+			return nil, err
+		}
+		for _, field := range controlPlaneManifestFields {
+			desiredValue, desiredSet := desiredSection[field]
+			liveValue, liveSet := liveSection[field]
+			if desiredSet != liveSet || !reflect.DeepEqual(desiredValue, liveValue) {
+				delta = append(delta, "ClusterConfiguration."+component+"."+field)
+			}
+			delete(desiredSection, field)
+			delete(liveSection, field)
+		}
+		removeEmptySection(desiredConfig, component, desiredSection)
+		removeEmptySection(liveConfig, component, liveSection)
+	}
+	if !containsValue(liveConfig, desiredConfig) {
+		return nil, fmt.Errorf("unsupported ClusterConfiguration difference outside control-plane manifest fields")
+	}
+	sort.Strings(delta)
+	return delta, nil
+}
+
+func EffectiveControlPlaneConfiguration(desired, live []byte) ([]byte, []string, error) {
+	delta, err := SupportedControlPlaneComponentDelta(desired, live)
+	if err != nil {
+		return nil, nil, err
+	}
+	desiredConfig, err := clusterConfiguration(desired)
+	if err != nil {
+		return nil, nil, fmt.Errorf("desired: %w", err)
+	}
+	effectiveConfig, err := clusterConfiguration(live)
+	if err != nil {
+		return nil, nil, fmt.Errorf("live: %w", err)
+	}
+	for _, component := range profilingComponents {
+		desiredSection, err := configurationSection(desiredConfig, component)
+		if err != nil {
+			return nil, nil, err
+		}
+		effectiveSection, err := configurationSection(effectiveConfig, component)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, field := range controlPlaneManifestFields {
+			value, set := desiredSection[field]
+			if set {
+				effectiveSection[field] = value
+			} else {
+				delete(effectiveSection, field)
+			}
+		}
+		if len(effectiveSection) == 0 {
+			delete(effectiveConfig, component)
+		} else {
+			effectiveConfig[component] = effectiveSection
+		}
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(desired))
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	found := false
+	for {
+		var document map[string]any
+		err := decoder.Decode(&document)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			_ = encoder.Close()
+			return nil, nil, err
+		}
+		if document["apiVersion"] == "kubeadm.k8s.io/v1beta4" && document["kind"] == "ClusterConfiguration" {
+			document = effectiveConfig
+			found = true
+		}
+		if err := encoder.Encode(document); err != nil {
+			_ = encoder.Close()
+			return nil, nil, err
+		}
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, nil, err
+	}
+	if !found {
+		return nil, nil, fmt.Errorf("kubeadm.k8s.io/v1beta4 ClusterConfiguration is required")
+	}
+	return out.Bytes(), delta, nil
+}
+
+func configurationSection(config map[string]any, name string) (map[string]any, error) {
+	value, ok := config[name]
+	if !ok {
+		return map[string]any{}, nil
+	}
+	section, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a mapping", name)
+	}
+	return section, nil
+}
+
+func removeEmptySection(config map[string]any, name string, section map[string]any) {
+	if len(section) == 0 {
+		delete(config, name)
+	}
+}
 
 func SupportedControlPlaneProfilingDelta(desired, live []byte) ([]string, error) {
 	desiredConfig, err := clusterConfiguration(desired)
@@ -69,6 +274,10 @@ func SupportedControlPlaneProfilingDelta(desired, live []byte) ([]string, error)
 }
 
 func clusterConfiguration(data []byte) (map[string]any, error) {
+	return configurationDocument(data, "kubeadm.k8s.io/v1beta4", "ClusterConfiguration")
+}
+
+func configurationDocument(data []byte, apiVersion, kind string) (map[string]any, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	for {
 		var doc map[string]any
@@ -79,11 +288,29 @@ func clusterConfiguration(data []byte) (map[string]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		if doc["apiVersion"] == "kubeadm.k8s.io/v1beta4" && doc["kind"] == "ClusterConfiguration" {
+		if doc["apiVersion"] == apiVersion && doc["kind"] == kind {
 			return doc, nil
 		}
 	}
-	return nil, fmt.Errorf("kubeadm.k8s.io/v1beta4 ClusterConfiguration is required")
+	return nil, fmt.Errorf("%s %s is required", apiVersion, kind)
+}
+
+func configurationDocumentByKind(data []byte, kind string) (map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var doc map[string]any
+		err := decoder.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if doc["kind"] == kind {
+			return doc, nil
+		}
+	}
+	return nil, fmt.Errorf("%s is required", kind)
 }
 
 func removeProfiling(config map[string]any, component string) (string, bool, error) {

--- a/internal/installer/kubeadmplan/control_plane_config_test.go
+++ b/internal/installer/kubeadmplan/control_plane_config_test.go
@@ -6,6 +6,61 @@ import (
 	"testing"
 )
 
+func TestCanonicalKubeletConfigurationSHA256SelectsKubeletDocument(t *testing.T) {
+	multiDocument := []byte(`apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+maxPods: 120
+`)
+	kubeletOnly := []byte(`kind: KubeletConfiguration
+maxPods: 120
+apiVersion: kubelet.config.k8s.io/v1beta1
+`)
+	got, err := CanonicalKubeletConfigurationSHA256(multiDocument)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := CanonicalKubeletConfigurationSHA256(kubeletOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("digest = %q, want %q", got, want)
+	}
+}
+
+func TestKubeProxyConfigurationIdentityAndContainment(t *testing.T) {
+	desired := []byte("apiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: nftables\n")
+	actual := []byte("apiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: nftables\nbindAddress: 0.0.0.0\n")
+	if _, err := CanonicalKubeProxyConfigurationSHA256(desired); err != nil {
+		t.Fatalf("CanonicalKubeProxyConfigurationSHA256() error = %v", err)
+	}
+	if err := KubeProxyConfigurationContains(actual, desired); err != nil {
+		t.Fatalf("KubeProxyConfigurationContains() error = %v", err)
+	}
+	if err := KubeProxyConfigurationContains([]byte("apiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: iptables\n"), desired); err == nil {
+		t.Fatal("KubeProxyConfigurationContains() error = nil for mismatched mode")
+	}
+}
+
+func TestKubeletConfigurationContainsAllowsDefaultedLiveFields(t *testing.T) {
+	desired := []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\ncontainerRuntimeEndpoint: \"\"\nmaxPods: 120\n")
+	actual := []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\ncontainerRuntimeEndpoint: unix:///run/containerd/containerd.sock\nmaxPods: 120\ncgroupDriver: systemd\n")
+	if err := KubeletConfigurationContains(actual, desired); err != nil {
+		t.Fatal(err)
+	}
+	actual = []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\ncontainerRuntimeEndpoint: unix:///run/containerd/containerd.sock\nmaxPods: 110\ncgroupDriver: systemd\n")
+	if err := KubeletConfigurationContains(actual, desired); err == nil {
+		t.Fatal("KubeletConfigurationContains() error = nil, want mismatched desired value")
+	}
+	desired = []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\ncontainerRuntimeEndpoint: unix:///run/crio/crio.sock\nmaxPods: 120\n")
+	if err := KubeletConfigurationContains(actual, desired); err == nil {
+		t.Fatal("KubeletConfigurationContains() error = nil, want non-empty endpoint mismatch")
+	}
+}
+
 func TestSupportedControlPlaneProfilingDelta(t *testing.T) {
 	live := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n")
 	desired := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\napiServer:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\nscheduler:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\n")
@@ -16,6 +71,63 @@ func TestSupportedControlPlaneProfilingDelta(t *testing.T) {
 	want := []string{"ClusterConfiguration.apiServer.extraArgs.profiling=false", "ClusterConfiguration.scheduler.extraArgs.profiling=false"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("delta=%v want %v", got, want)
+	}
+}
+
+func TestSupportedControlPlaneComponentDeltaAllowsManifestFields(t *testing.T) {
+	live := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n")
+	desired := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\napiServer:\n  extraArgs:\n    - name: audit-log-maxage\n      value: '7'\nscheduler:\n  extraEnvs:\n    - name: KATL_TEST\n      value: enabled\n")
+	got, err := SupportedControlPlaneComponentDelta(desired, live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"ClusterConfiguration.apiServer.extraArgs", "ClusterConfiguration.scheduler.extraEnvs"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("delta = %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveControlPlaneConfigurationPreservesLiveClusterState(t *testing.T) {
+	live := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\ncontrolPlaneEndpoint: api.katl.test:6443\nkubernetesVersion: v1.36.1\napiServer:\n  certSANs: [api.katl.test]\n  extraArgs:\n    - name: profiling\n      value: 'true'\n")
+	desired := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\napiServer:\n  extraArgs:\n    - name: profiling\n      value: 'false'\n")
+	effective, delta, err := EffectiveControlPlaneConfiguration(desired, live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"ClusterConfiguration.apiServer.extraArgs"}; !reflect.DeepEqual(delta, want) {
+		t.Fatalf("delta = %v, want %v", delta, want)
+	}
+	text := string(effective)
+	for _, want := range []string{"kind: InitConfiguration", "controlPlaneEndpoint: api.katl.test:6443", "certSANs:", "value: \"false\""} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("effective config missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestSupportedControlPlaneComponentDeltaAllowsNoChange(t *testing.T) {
+	live := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n")
+	desired := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\n")
+	delta, err := SupportedControlPlaneComponentDelta(desired, live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(delta) != 0 {
+		t.Fatalf("delta = %v, want no changes", delta)
+	}
+}
+
+func TestSupportedControlPlaneComponentDeltaRejectsCertificateAndClusterChanges(t *testing.T) {
+	live := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\n")
+	for name, desired := range map[string][]byte{
+		"certificate": []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\napiServer:\n  certSANs: [api.example.test]\n"),
+		"version":     []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.2\n"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := SupportedControlPlaneComponentDelta(desired, live); err == nil || !strings.Contains(err.Error(), "outside control-plane") {
+				t.Fatalf("error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -162,6 +162,7 @@ type ConfigApplyRequest struct {
 }
 
 type KubeadmControlPlaneConfig struct {
+	Component                 string            `json:"component"`
 	RolloutID                 string            `json:"rolloutID"`
 	NodePosition              uint32            `json:"nodePosition"`
 	NodeCount                 uint32            `json:"nodeCount"`
@@ -187,6 +188,8 @@ type KubeadmControlPlaneConfig struct {
 	ConfigUploadRan           bool              `json:"configUploadRan"`
 	BeforeManifestSHA256      map[string]string `json:"beforeManifestSHA256,omitempty"`
 	AfterManifestSHA256       map[string]string `json:"afterManifestSHA256,omitempty"`
+	BeforeKubeletConfigSHA256 string            `json:"beforeKubeletConfigSHA256,omitempty"`
+	AfterKubeletConfigSHA256  string            `json:"afterKubeletConfigSHA256,omitempty"`
 	OriginalNodeUnschedulable bool              `json:"originalNodeUnschedulable"`
 }
 
@@ -1058,6 +1061,10 @@ func kubeadmControlPlaneConfigTransitionAllowed(previous *KubeadmControlPlaneCon
 	nextComparable.BeforeManifestSHA256 = nil
 	previousComparable.AfterManifestSHA256 = nil
 	nextComparable.AfterManifestSHA256 = nil
+	previousComparable.BeforeKubeletConfigSHA256 = ""
+	nextComparable.BeforeKubeletConfigSHA256 = ""
+	previousComparable.AfterKubeletConfigSHA256 = ""
+	nextComparable.AfterKubeletConfigSHA256 = ""
 	previousComparable.OriginalNodeUnschedulable = false
 	nextComparable.OriginalNodeUnschedulable = false
 	previousComparable.ExpectedLiveConfigSHA256 = ""
@@ -1747,6 +1754,9 @@ func validateConfigApplyRequest(request ConfigApplyRequest) error {
 }
 
 func validateKubeadmControlPlaneConfig(request KubeadmControlPlaneConfig) error {
+	if request.Component != "control-plane" && request.Component != "kubelet" && request.Component != "kube-proxy" {
+		return fmt.Errorf("kubeadmControlPlaneConfig component must be control-plane, kubelet, or kube-proxy")
+	}
 	required := map[string]string{
 		"rolloutID": request.RolloutID, "coordinatorNode": request.CoordinatorNode,
 		"nodeName": request.NodeName, "desiredGenerationID": request.DesiredGenerationID,
@@ -1758,8 +1768,8 @@ func validateKubeadmControlPlaneConfig(request KubeadmControlPlaneConfig) error 
 			return fmt.Errorf("kubeadmControlPlaneConfig %s is required", name)
 		}
 	}
-	if request.NodeCount != 3 || request.NodePosition < 1 || request.NodePosition > request.NodeCount {
-		return fmt.Errorf("kubeadmControlPlaneConfig node position must identify one of exactly three nodes")
+	if request.NodeCount < 1 || request.NodePosition < 1 || request.NodePosition > request.NodeCount {
+		return fmt.Errorf("kubeadmControlPlaneConfig node position must identify one node in the rollout")
 	}
 	if filepath.Base(request.ConfigName) != request.ConfigName || request.ConfigPath != "/etc/katl/kubeadm/"+request.ConfigName+"/config.yaml" {
 		return fmt.Errorf("kubeadmControlPlaneConfig config path is invalid")
@@ -1796,6 +1806,16 @@ func validateKubeadmControlPlaneConfig(request KubeadmControlPlaneConfig) error 
 	for name, digest := range request.AfterManifestSHA256 {
 		if err := validateSHA256Hex("kubeadmControlPlaneConfig after manifest "+name, digest); err != nil {
 			return err
+		}
+	}
+	for name, digest := range map[string]string{
+		"before kubelet config": request.BeforeKubeletConfigSHA256,
+		"after kubelet config":  request.AfterKubeletConfigSHA256,
+	} {
+		if strings.TrimSpace(digest) != "" {
+			if err := validateSHA256Hex("kubeadmControlPlaneConfig "+name, digest); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/installer/operation/store_test.go
+++ b/internal/installer/operation/store_test.go
@@ -982,6 +982,7 @@ func TestStoreRejectsControlPlaneConfigBodyMismatch(t *testing.T) {
 
 func validControlPlaneConfigBody() *KubeadmControlPlaneConfig {
 	return &KubeadmControlPlaneConfig{
+		Component: "control-plane",
 		RolloutID: "rollout-1", NodePosition: 1, NodeCount: 3, CoordinatorNode: "cp-3", NodeName: "cp-1",
 		DesiredGenerationID: "generation-1", ConfigName: "control-plane", ConfigPath: "/etc/katl/kubeadm/control-plane/config.yaml",
 		DesiredConfigSHA256: strings.Repeat("a", 64), ExpectedLiveConfigSHA256: strings.Repeat("b", 64),

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -30,6 +30,7 @@ const (
 
 	OperationKindGenerationApply = "generation-apply"
 	OperationKindGenerationStage = "generation-stage"
+	configApplyNoopPhase         = "desired-state-current"
 )
 
 func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfigRequest) (*agentapi.ConfigValidationResult, error) {
@@ -428,6 +429,9 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 	decoded.GenerationID = record.ConfigApplyRequest.CandidateGenerationID
 	plan, err := configapply.PlanTrustedBundle(decoded)
 	if err != nil {
+		if errors.Is(err, configapply.ErrNoChanges) {
+			return e.completeConfigApplyNoop(record, e.clock())
+		}
 		cause := err
 		if diagnostics := strings.TrimSpace(strings.Join(configApplyDiagnostics(plan.Plan.Decision), "\n")); diagnostics != "" {
 			_, artifactErr := e.Store.AddDiagnosticArtifact(record.OperationID, "config-apply-plan-diagnostics", []byte(inventory.Redact(diagnostics)+"\n"), e.clock())
@@ -505,6 +509,26 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 		return record, nil
 	})
 	return updateErr
+}
+
+func (e *Executor) completeConfigApplyNoop(record operation.OperationRecord, now time.Time) error {
+	_, err := e.Store.Update(record.OperationID, "operation-complete", "operation-complete", func(record operation.OperationRecord) (operation.OperationRecord, error) {
+		record.Phase = configApplyNoopPhase
+		record.PhasePlan = []string{"accepted", "render-generation", configApplyNoopPhase}
+		record.CompletedPhases = appendMissing(record.CompletedPhases, "render-generation", configApplyNoopPhase)
+		record.PhaseIndex = len(record.CompletedPhases)
+		record.CandidateGenerationID = ""
+		record.GenerationCommitState = operation.GenerationCommitAbandoned
+		record.Terminal = true
+		record.Result = operation.ResultSucceeded
+		record.RecoveryRequired = false
+		record.FailureReason = ""
+		record.NextAction = "desired runtime configuration already matches; no generation changes were required"
+		record.CompletedAt = &now
+		record.UpdatedAt = now
+		return record, nil
+	})
+	return err
 }
 
 func (e *Executor) markLiveConfigApplyStarted(operationID string, result configapply.TrustedBundleResult, now time.Time) error {

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -661,7 +661,7 @@ func configApplyBase(root string, nodeName string, generationID string, now func
 	if strings.TrimSpace(nodeName) == "" {
 		nodeName = currentManifest.Node.Identity.Hostname
 	}
-	kubeadmConfigs, err := installedKubeadmConfigs(root, currentManifest)
+	kubeadmConfigs, err := activeGenerationKubeadmConfigs(root, currentID, currentManifest)
 	if err != nil {
 		return configapply.TrustedBundleRequest{}, err
 	}
@@ -742,15 +742,32 @@ func currentKubernetesActivationPath(record generation.Record) string {
 	return ""
 }
 
-func installedKubeadmConfigs(root string, currentManifest manifest.Manifest) (map[string]kubeadmconfig.Plan, error) {
+func activeGenerationKubeadmConfigs(root string, currentGenerationID string, currentManifest manifest.Manifest) (map[string]kubeadmconfig.Plan, error) {
 	ref := strings.TrimSpace(currentManifest.Node.Kubernetes.Kubeadm.ConfigRef)
 	if ref == "" {
 		return nil, nil
 	}
-	dir, err := installer.StoredKubeadmInputDir(root, ref)
+	generationDir, err := generation.GenerationDir(root, currentGenerationID)
 	if err != nil {
 		return nil, err
 	}
+	dir := filepath.Join(generationDir, "confext", "etc", "katl", "kubeadm", ref)
+	if info, statErr := os.Stat(dir); statErr == nil {
+		if !info.IsDir() {
+			return nil, fmt.Errorf("active generation kubeadm config %q is not a directory", ref)
+		}
+		return kubeadmConfigsFromDir(ref, dir, "active generation")
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect active generation kubeadm config %q: %w", ref, statErr)
+	}
+	dir, err = installer.StoredKubeadmInputDir(root, ref)
+	if err != nil {
+		return nil, err
+	}
+	return kubeadmConfigsFromDir(ref, dir, "installed")
+}
+
+func kubeadmConfigsFromDir(ref string, dir string, source string) (map[string]kubeadmconfig.Plan, error) {
 	var files []kubeadmconfig.File
 	if err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -764,14 +781,14 @@ func installedKubeadmConfigs(root string, currentManifest manifest.Manifest) (ma
 			return err
 		}
 		if !info.Mode().IsRegular() {
-			return fmt.Errorf("stored kubeadm input %s is not a regular file", path)
+			return fmt.Errorf("%s kubeadm input %s is not a regular file", source, path)
 		}
 		rel, err := filepath.Rel(dir, path)
 		if err != nil {
 			return err
 		}
 		if strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
-			return fmt.Errorf("stored kubeadm input %s escapes input directory", path)
+			return fmt.Errorf("%s kubeadm input %s escapes input directory", source, path)
 		}
 		content, err := os.ReadFile(path)
 		if err != nil {
@@ -784,7 +801,7 @@ func installedKubeadmConfigs(root string, currentManifest manifest.Manifest) (ma
 		})
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("read installed kubeadm config %q: %w", ref, err)
+		return nil, fmt.Errorf("read %s kubeadm config %q: %w", source, ref, err)
 	}
 	plan, err := kubeadmconfig.PlanFromRenderedFiles(ref, files)
 	if err != nil {

--- a/internal/katlc/agent/kubeadm_control_plane_config.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config.go
@@ -470,7 +470,7 @@ func (e *Executor) executeKubeProxyConfig(ctx context.Context, record operation.
 		return nil
 	}
 	argv := []string{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", request.ConfigPath}
-	if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kube-proxy-dry-run", append(append([]string{}, argv...), "--dry-run"), false); err != nil {
+	if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kube-proxy-config-validate", []string{"/usr/bin/kubeadm", "config", "validate", "--config", request.ConfigPath}, false); err != nil {
 		return err
 	}
 	if _, err := e.Store.Update(record.OperationID, "preflight-complete", "preflight-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {

--- a/internal/katlc/agent/kubeadm_control_plane_config.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -22,10 +24,19 @@ import (
 
 const OperationKindKubeadmControlPlaneConfig = "kubeadm-control-plane-config"
 
+const (
+	kubeadmConfigComponentControlPlane = "component/control-plane"
+	kubeadmConfigComponentKubelet      = "component/kubelet"
+	kubeadmConfigComponentKubeProxy    = "component/kube-proxy"
+)
+
 var supportedControlPlaneConfigFields = map[string]bool{
 	"ClusterConfiguration.apiServer.extraArgs.profiling=false":         true,
 	"ClusterConfiguration.controllerManager.extraArgs.profiling=false": true,
 	"ClusterConfiguration.scheduler.extraArgs.profiling=false":         true,
+	kubeadmConfigComponentControlPlane:                                 true,
+	kubeadmConfigComponentKubelet:                                      true,
+	kubeadmConfigComponentKubeProxy:                                    true,
 }
 
 func validateKubeadmControlPlaneConfigRequest(kind string, req *agentapi.KubeadmControlPlaneConfigOperationRequest) error {
@@ -35,8 +46,8 @@ func validateKubeadmControlPlaneConfigRequest(kind string, req *agentapi.Kubeadm
 	if strings.TrimSpace(req.GetRolloutId()) == "" {
 		return fmt.Errorf("rolloutID is required")
 	}
-	if req.GetNodeCount() != 3 || req.GetNodePosition() < 1 || req.GetNodePosition() > 3 {
-		return fmt.Errorf("node position must identify one of exactly three control-plane nodes")
+	if req.GetNodeCount() < 1 || req.GetNodePosition() < 1 || req.GetNodePosition() > req.GetNodeCount() {
+		return fmt.Errorf("node position must identify one node in the rollout")
 	}
 	if strings.TrimSpace(req.GetCoordinatorNode()) == "" || strings.TrimSpace(req.GetDesiredGenerationId()) == "" {
 		return fmt.Errorf("coordinatorNode and desiredGenerationID are required")
@@ -56,18 +67,47 @@ func validateKubeadmControlPlaneConfigRequest(kind string, req *agentapi.Kubeadm
 		}
 	}
 	seen := map[string]bool{}
+	component := ""
 	for _, field := range req.GetSupportedFieldDelta() {
 		if !supportedControlPlaneConfigFields[field] || seen[field] {
 			return fmt.Errorf("unsupported or repeated field delta %q", field)
 		}
+		if field == kubeadmConfigComponentControlPlane || field == kubeadmConfigComponentKubelet || field == kubeadmConfigComponentKubeProxy {
+			if component != "" {
+				return fmt.Errorf("exactly one kubeadm component may be selected")
+			}
+			component = field
+		}
 		seen[field] = true
+	}
+	if (component == kubeadmConfigComponentKubelet || component == kubeadmConfigComponentKubeProxy) && len(seen) != 1 {
+		return fmt.Errorf("%s configuration does not accept control-plane field deltas", strings.TrimPrefix(component, "component/"))
 	}
 	return nil
 }
 
+func kubeadmConfigComponentFromFields(fields []string) string {
+	for _, field := range fields {
+		if field == kubeadmConfigComponentKubeProxy {
+			return "kube-proxy"
+		}
+		if field == kubeadmConfigComponentKubelet {
+			return "kubelet"
+		}
+	}
+	return "control-plane"
+}
+
 func controlPlaneConfigFromProto(req *agentapi.KubeadmControlPlaneConfigOperationRequest) operation.KubeadmControlPlaneConfig {
+	component := kubeadmConfigComponentFromFields(req.GetSupportedFieldDelta())
+	var fields []string
+	for _, field := range req.GetSupportedFieldDelta() {
+		if field != kubeadmConfigComponentControlPlane && field != kubeadmConfigComponentKubelet && field != kubeadmConfigComponentKubeProxy {
+			fields = append(fields, field)
+		}
+	}
 	return operation.KubeadmControlPlaneConfig{
-		RolloutID: req.GetRolloutId(), NodePosition: req.GetNodePosition(), NodeCount: req.GetNodeCount(), CoordinatorNode: req.GetCoordinatorNode(), NodeName: req.GetNodeName(), CoordinatorUpload: req.GetCoordinatorUpload(), DesiredGenerationID: req.GetDesiredGenerationId(), ConfigName: req.GetConfigName(), ConfigPath: "/etc/katl/kubeadm/" + req.GetConfigName() + "/config.yaml", DesiredConfigSHA256: req.GetDesiredConfigSha256(), ExpectedLiveConfigSHA256: req.GetExpectedLiveConfigSha256(), KubernetesPayloadVersion: req.GetKubernetesPayloadVersion(), KubernetesPayloadSHA256: req.GetKubernetesPayloadSha256(), SupportedFieldDelta: append([]string(nil), req.GetSupportedFieldDelta()...), SnapshotRef: req.GetSnapshotRef(), SnapshotDigest: req.GetSnapshotDigest(), SnapshotRevision: req.GetSnapshotRevision(), CapturedMemberListDigest: req.GetCapturedMemberListDigest(), SourceEtcdVersion: req.GetSourceEtcdVersion(), SnapshotCreatedAt: req.GetSnapshotCreatedAt(), SnapshotStorageLocation: req.GetSnapshotStorageLocation(), SnapshotOperatorIdentity: req.GetSnapshotOperatorIdentity(),
+		Component: component, RolloutID: req.GetRolloutId(), NodePosition: req.GetNodePosition(), NodeCount: req.GetNodeCount(), CoordinatorNode: req.GetCoordinatorNode(), NodeName: req.GetNodeName(), CoordinatorUpload: req.GetCoordinatorUpload(), DesiredGenerationID: req.GetDesiredGenerationId(), ConfigName: req.GetConfigName(), ConfigPath: "/etc/katl/kubeadm/" + req.GetConfigName() + "/config.yaml", DesiredConfigSHA256: req.GetDesiredConfigSha256(), ExpectedLiveConfigSHA256: req.GetExpectedLiveConfigSha256(), KubernetesPayloadVersion: req.GetKubernetesPayloadVersion(), KubernetesPayloadSHA256: req.GetKubernetesPayloadSha256(), SupportedFieldDelta: fields, SnapshotRef: req.GetSnapshotRef(), SnapshotDigest: req.GetSnapshotDigest(), SnapshotRevision: req.GetSnapshotRevision(), CapturedMemberListDigest: req.GetCapturedMemberListDigest(), SourceEtcdVersion: req.GetSourceEtcdVersion(), SnapshotCreatedAt: req.GetSnapshotCreatedAt(), SnapshotStorageLocation: req.GetSnapshotStorageLocation(), SnapshotOperatorIdentity: req.GetSnapshotOperatorIdentity(),
 	}
 }
 
@@ -76,13 +116,24 @@ func (s *Server) acceptKubeadmControlPlaneConfigOperation(req *agentapi.SubmitOp
 	if err != nil {
 		return operation.OperationRecord{}, nil, err
 	}
-	phases := []string{"accepted", "preflight-complete", "cordon-complete", "manifest-backup-complete", "control-plane-manifests-running", "control-plane-manifests-complete", "post-manifest-health-complete"}
-	if body.CoordinatorUpload {
-		phases = append(phases, "kubeadm-config-upload-running", "kubeadm-config-upload-complete", "post-upload-health-complete")
+	var phases []string
+	if body.Component == "kube-proxy" {
+		phases = []string{"accepted", "preflight-complete", "kube-proxy-config-running", "kube-proxy-rollout-complete", operation.HostBookkeepingCompletionPhase}
+	} else if body.Component == "kubelet" {
+		phases = []string{"accepted", "preflight-complete", "kubelet-config-backup-complete"}
+		if body.CoordinatorUpload {
+			phases = append(phases, "kubelet-config-upload-running", "kubelet-config-upload-complete")
+		}
+		phases = append(phases, "kubelet-config-running", "kubelet-config-complete", "kubelet-restart-running", "post-kubelet-health-complete", operation.HostBookkeepingCompletionPhase)
+	} else {
+		phases = []string{"accepted", "preflight-complete", "cordon-complete", "manifest-backup-complete", "control-plane-manifests-running", "control-plane-manifests-complete", "post-manifest-health-complete"}
+		if body.CoordinatorUpload {
+			phases = append(phases, "kubeadm-config-upload-running", "kubeadm-config-upload-complete", "post-upload-health-complete")
+		}
+		phases = append(phases, "uncordon-complete", operation.HostBookkeepingCompletionPhase)
 	}
-	phases = append(phases, "uncordon-complete", operation.HostBookkeepingCompletionPhase)
 	record := operation.OperationRecord{
-		OperationID: id, OperationKind: req.OperationKind, Scope: "kubeadm-state", ClientRequestID: req.ClientRequestId, Actor: req.Actor, ExpectedMachineID: req.ExpectedMachineId, ExpectedCurrentGenerationID: req.ExpectedCurrentGenerationId, ExpectedClusterIntentDigest: req.ExpectedClusterIntentDigest, RequestDigest: digest, Phase: "accepted", PhasePlan: phases, PreviousGenerationID: body.DesiredGenerationID, KubeadmControlPlaneConfig: &body, ActivationMode: operation.ActivationModeLive, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCommitted, ResourceLocks: locks, NextAction: "run bounded kubeadm control-plane configuration phases",
+		OperationID: id, OperationKind: req.OperationKind, Scope: "kubeadm-state", ClientRequestID: req.ClientRequestId, Actor: req.Actor, ExpectedMachineID: req.ExpectedMachineId, ExpectedCurrentGenerationID: req.ExpectedCurrentGenerationId, ExpectedClusterIntentDigest: req.ExpectedClusterIntentDigest, RequestDigest: digest, Phase: "accepted", PhasePlan: phases, PreviousGenerationID: body.DesiredGenerationID, KubeadmControlPlaneConfig: &body, ActivationMode: operation.ActivationModeLive, ActivationState: operation.ActivationStatePending, GenerationCommitState: operation.GenerationCommitCommitted, ResourceLocks: locks, NextAction: "run bounded kubeadm configuration phases",
 	}
 	created, err := s.Store.Create(record, "accepted", now)
 	if err != nil {
@@ -100,7 +151,14 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 	if err != nil {
 		return body, fmt.Errorf("read selected kubeadm config: %w", err)
 	}
-	desiredDigest, err := kubeadmplan.CanonicalClusterConfigurationSHA256(data)
+	var desiredDigest string
+	if body.Component == "kube-proxy" {
+		desiredDigest, err = kubeadmplan.CanonicalKubeProxyConfigurationSHA256(data)
+	} else if body.Component == "kubelet" {
+		desiredDigest, err = kubeadmplan.CanonicalKubeletConfigurationSHA256(data)
+	} else {
+		desiredDigest, err = kubeadmplan.CanonicalClusterConfigurationSHA256(data)
+	}
 	if err != nil {
 		return body, fmt.Errorf("read selected kubeadm config identity: %w", err)
 	}
@@ -112,13 +170,27 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 	if err != nil {
 		return body, fmt.Errorf("read desired generation: %w", err)
 	}
+	metadata, err := os.ReadFile(rootedRuntimePath(s.Root, "/etc/katl/node.json"))
+	if err != nil {
+		return body, fmt.Errorf("read active node metadata: %w", err)
+	}
+	var node struct {
+		Kubeadm struct {
+			ConfigRef string `json:"configRef"`
+		} `json:"kubeadm"`
+	}
+	if err := json.Unmarshal(metadata, &node); err != nil {
+		return body, fmt.Errorf("decode active node metadata: %w", err)
+	}
+	if strings.TrimSpace(node.Kubeadm.ConfigRef) != body.ConfigName {
+		return body, fmt.Errorf("active generation does not select kubeadm config %q", body.ConfigName)
+	}
 	applyStatusPath, err := generation.ConfigApplyStatusPath(s.Root, body.DesiredGenerationID)
 	if err != nil {
 		return body, err
 	}
-	applyStatus, err := generation.ReadConfigApplyStatus(applyStatusPath)
-	if err != nil || applyStatus.Kubeadm.SelectedConfigName != body.ConfigName || !applyStatus.Kubeadm.Required {
-		return body, fmt.Errorf("active generation does not select kubeadm config %q as action-required", body.ConfigName)
+	if applyStatus, readErr := generation.ReadConfigApplyStatus(applyStatusPath); readErr == nil && strings.TrimSpace(applyStatus.Kubeadm.SelectedConfigName) != "" && applyStatus.Kubeadm.SelectedConfigName != body.ConfigName {
+		return body, fmt.Errorf("generation status selects kubeadm config %q instead of %q", applyStatus.Kubeadm.SelectedConfigName, body.ConfigName)
 	}
 	var matchedPayload *generation.ExtensionRef
 	for _, ref := range spec.Sysexts {
@@ -144,6 +216,12 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 
 func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record operation.OperationRecord) error {
 	request := record.KubeadmControlPlaneConfig
+	if request.Component == "kube-proxy" {
+		return e.executeKubeProxyConfig(ctx, record)
+	}
+	if request.Component == "kubelet" {
+		return e.executeKubeletConfig(ctx, record)
+	}
 	desired, err := os.ReadFile(rootedRuntimePath(e.Root, request.ConfigPath))
 	if err != nil {
 		return e.failControlPlaneConfig(record, "preflight", err)
@@ -156,11 +234,16 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 	if liveResult.Err != nil || liveResult.ExitStatus != 0 {
 		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("collect live kubeadm config: %s", toolFailure(liveResult)))
 	}
-	delta, err := kubeadmplan.SupportedControlPlaneProfilingDelta(desired, liveResult.Stdout)
+	effective, delta, err := kubeadmplan.EffectiveControlPlaneConfiguration(desired, liveResult.Stdout)
 	if err != nil {
 		return e.failControlPlaneConfig(record, "preflight", err)
 	}
-	requestedDelta := append([]string(nil), request.SupportedFieldDelta...)
+	requestedDelta := make([]string, 0, len(request.SupportedFieldDelta))
+	for _, field := range request.SupportedFieldDelta {
+		if field != kubeadmConfigComponentControlPlane {
+			requestedDelta = append(requestedDelta, field)
+		}
+	}
 	sort.Strings(requestedDelta)
 	if len(requestedDelta) > 0 && !reflect.DeepEqual(delta, requestedDelta) {
 		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("observed supported delta %v does not match request %v", delta, request.SupportedFieldDelta))
@@ -172,7 +255,36 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 	if request.ExpectedLiveConfigSHA256 != "" && liveDigest != request.ExpectedLiveConfigSHA256 {
 		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("live kubeadm config digest is stale"))
 	}
-	if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-dry-run", []string{"/usr/bin/kubeadm", "init", "phase", "control-plane", "all", "--config", request.ConfigPath, "--dry-run"}, false); err != nil {
+	if len(delta) == 0 {
+		manifests, err := e.digestControlPlaneManifests()
+		if err != nil {
+			return e.failControlPlaneConfig(record, "preflight", err)
+		}
+		completedAt := e.clock()
+		if _, err := e.Store.Update(record.OperationID, "no-change", operation.HostBookkeepingCompletionPhase, func(current operation.OperationRecord) (operation.OperationRecord, error) {
+			current.KubeadmControlPlaneConfig.ExpectedLiveConfigSHA256 = liveDigest
+			current.KubeadmControlPlaneConfig.SupportedFieldDelta = []string{}
+			current.KubeadmControlPlaneConfig.BeforeManifestSHA256 = manifests
+			current.KubeadmControlPlaneConfig.AfterManifestSHA256 = maps.Clone(manifests)
+			current.Phase = operation.HostBookkeepingCompletionPhase
+			current.CompletedPhases = appendMissing(current.CompletedPhases, "preflight-complete", operation.HostBookkeepingCompletionPhase)
+			current.CompletedAt = &completedAt
+			current.Terminal = true
+			current.Result = operation.ResultSucceeded
+			current.NextAction = "desired control-plane configuration already matches live state"
+			current.UpdatedAt = completedAt
+			return current, nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	effectivePath, err := e.writeEffectiveControlPlaneConfig(record.OperationID, effective)
+	if err != nil {
+		return e.failControlPlaneConfig(record, "preflight", err)
+	}
+	component := controlPlanePhaseTarget(delta)
+	if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-dry-run", []string{"/usr/bin/kubeadm", "init", "phase", "control-plane", component, "--config", effectivePath, "--dry-run"}, false); err != nil {
 		return err
 	}
 	schedResult := e.toolRunner()(ctx, []string{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "get", "node", request.NodeName, "-o", "jsonpath={.spec.unschedulable}"}, nil)
@@ -213,7 +325,7 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 	}); err != nil {
 		return err
 	}
-	argv := []string{"/usr/bin/kubeadm", "init", "phase", "control-plane", "all", "--config", request.ConfigPath}
+	argv := []string{"/usr/bin/kubeadm", "init", "phase", "control-plane", component, "--config", effectivePath}
 	if err := e.runControlPlaneConfigCommand(ctx, record, "control-plane-manifests-running", argv, true); err != nil {
 		return err
 	}
@@ -241,7 +353,7 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 		return err
 	}
 	if request.CoordinatorUpload {
-		upload := []string{"/usr/bin/kubeadm", "init", "phase", "upload-config", "kubeadm", "--config", request.ConfigPath}
+		upload := []string{"/usr/bin/kubeadm", "init", "phase", "upload-config", "kubeadm", "--config", effectivePath}
 		if err := e.runControlPlaneConfigCommand(ctx, record, "kubeadm-config-upload-running", upload, true); err != nil {
 			return err
 		}
@@ -286,6 +398,280 @@ func (e *Executor) executeKubeadmControlPlaneConfig(ctx context.Context, record 
 		return err
 	}
 	return e.finalizeSuccessfulOperation(ctx, record.OperationID)
+}
+
+func (e *Executor) writeEffectiveControlPlaneConfig(operationID string, data []byte) (string, error) {
+	const name = "effective-kubeadm.yaml"
+	path := filepath.Join(e.Store.Root, operationID, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(filepath.Join("/var/lib/katl/operations", operationID, name)), nil
+}
+
+func controlPlanePhaseTarget(delta []string) string {
+	components := map[string]string{}
+	for _, field := range delta {
+		parts := strings.Split(field, ".")
+		if len(parts) < 3 {
+			return "all"
+		}
+		switch parts[1] {
+		case "apiServer":
+			components[parts[1]] = "apiserver"
+		case "controllerManager":
+			components[parts[1]] = "controller-manager"
+		case "scheduler":
+			components[parts[1]] = "scheduler"
+		default:
+			return "all"
+		}
+	}
+	if len(components) != 1 {
+		return "all"
+	}
+	for _, component := range components {
+		return component
+	}
+	return "all"
+}
+
+func (e *Executor) executeKubeProxyConfig(ctx context.Context, record operation.OperationRecord) error {
+	request := record.KubeadmControlPlaneConfig
+	desired, err := os.ReadFile(rootedRuntimePath(e.Root, request.ConfigPath))
+	if err != nil {
+		return e.failControlPlaneConfig(record, "preflight", err)
+	}
+	desiredDigest, err := kubeadmplan.CanonicalKubeProxyConfigurationSHA256(desired)
+	if err != nil || desiredDigest != request.DesiredConfigSHA256 {
+		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("selected kube-proxy configuration changed after operation acceptance"))
+	}
+	collect := func() ToolResult {
+		return e.toolRunner()(ctx, []string{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kube-proxy", "-o", "jsonpath={.data.config\\.conf}"}, nil)
+	}
+	liveBefore := collect()
+	if liveBefore.Err != nil || liveBefore.ExitStatus != 0 {
+		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("collect live kube-proxy config: %s", toolFailure(liveBefore)))
+	}
+	if kubeadmplan.KubeProxyConfigurationContains(liveBefore.Stdout, desired) == nil {
+		completedAt := e.clock()
+		if _, err := e.Store.Update(record.OperationID, "no-change", operation.HostBookkeepingCompletionPhase, func(current operation.OperationRecord) (operation.OperationRecord, error) {
+			current.Phase = operation.HostBookkeepingCompletionPhase
+			current.CompletedPhases = appendMissing(current.CompletedPhases, "preflight-complete", operation.HostBookkeepingCompletionPhase)
+			current.CompletedAt = &completedAt
+			current.Terminal = true
+			current.Result = operation.ResultSucceeded
+			current.NextAction = "desired kube-proxy configuration already matches live state"
+			current.UpdatedAt = completedAt
+			return current, nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	argv := []string{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", request.ConfigPath}
+	if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kube-proxy-dry-run", append(append([]string{}, argv...), "--dry-run"), false); err != nil {
+		return err
+	}
+	if _, err := e.Store.Update(record.OperationID, "preflight-complete", "preflight-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "preflight-complete"
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	if err := e.runControlPlaneConfigCommand(ctx, record, "kube-proxy-config-running", argv, true); err != nil {
+		return err
+	}
+	liveAfter := collect()
+	if liveAfter.Err != nil || liveAfter.ExitStatus != 0 {
+		return e.failControlPlaneConfig(record, "kube-proxy-config-verify", fmt.Errorf("collect updated kube-proxy config: %s", toolFailure(liveAfter)))
+	}
+	if err := kubeadmplan.KubeProxyConfigurationContains(liveAfter.Stdout, desired); err != nil {
+		return e.failControlPlaneConfig(record, "kube-proxy-config-verify", err)
+	}
+	rollout := e.toolRunner()(ctx, []string{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "rollout", "status", "daemonset/kube-proxy", "--timeout=5m"}, nil)
+	if rollout.Err != nil || rollout.ExitStatus != 0 {
+		return e.failControlPlaneConfig(record, "kube-proxy-rollout", fmt.Errorf("kube-proxy rollout failed: %s", toolFailure(rollout)))
+	}
+	if _, err := e.Store.Update(record.OperationID, "kube-proxy-rollout-complete", "kube-proxy-rollout-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "kube-proxy-rollout-complete"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "kube-proxy-rollout-complete")
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	if _, err := e.Store.Update(record.OperationID, "record-operation-complete", operation.HostBookkeepingCompletionPhase, func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = operation.HostBookkeepingCompletionPhase
+		current.CompletedPhases = appendMissing(current.CompletedPhases, operation.HostBookkeepingCompletionPhase)
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	return e.finalizeSuccessfulOperation(ctx, record.OperationID)
+}
+
+func (e *Executor) executeKubeletConfig(ctx context.Context, record operation.OperationRecord) error {
+	request := record.KubeadmControlPlaneConfig
+	desired, err := os.ReadFile(rootedRuntimePath(e.Root, request.ConfigPath))
+	if err != nil {
+		return e.failControlPlaneConfig(record, "preflight", err)
+	}
+	desiredDigest, err := kubeadmplan.CanonicalKubeletConfigurationSHA256(desired)
+	if err != nil || desiredDigest != request.DesiredConfigSHA256 {
+		return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("selected kubelet configuration changed after operation acceptance"))
+	}
+	localBefore, err := os.ReadFile(rootedRuntimePath(e.Root, "/var/lib/kubelet/config.yaml"))
+	if err != nil {
+		return e.failControlPlaneConfig(record, "preflight", err)
+	}
+	localMatches := kubeadmplan.KubeletConfigurationContains(localBefore, desired) == nil
+	uploadNeeded := request.CoordinatorUpload
+	if request.CoordinatorUpload {
+		liveResult := e.toolRunner()(ctx, []string{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kubelet-config", "-o", "jsonpath={.data.kubelet}"}, nil)
+		if liveResult.Err != nil || liveResult.ExitStatus != 0 {
+			return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("collect live kubelet config: %s", toolFailure(liveResult)))
+		}
+		liveDigest, err := kubeadmplan.CanonicalKubeletConfigurationSHA256(liveResult.Stdout)
+		if err != nil {
+			return e.failControlPlaneConfig(record, "preflight", fmt.Errorf("identify live kubelet config: %w", err))
+		}
+		uploadNeeded = liveDigest != desiredDigest
+	}
+	before := sha256Bytes(localBefore)
+	if !uploadNeeded && localMatches {
+		completedAt := e.clock()
+		if _, err := e.Store.Update(record.OperationID, "no-change", operation.HostBookkeepingCompletionPhase, func(current operation.OperationRecord) (operation.OperationRecord, error) {
+			current.KubeadmControlPlaneConfig.BeforeKubeletConfigSHA256 = before
+			current.KubeadmControlPlaneConfig.AfterKubeletConfigSHA256 = before
+			current.Phase = operation.HostBookkeepingCompletionPhase
+			current.CompletedPhases = appendMissing(current.CompletedPhases, "preflight-complete", operation.HostBookkeepingCompletionPhase)
+			current.CompletedAt = &completedAt
+			current.Terminal = true
+			current.Result = operation.ResultSucceeded
+			current.NextAction = "desired kubelet configuration already matches live state"
+			current.UpdatedAt = completedAt
+			return current, nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if uploadNeeded {
+		argv := []string{"/usr/bin/kubeadm", "config", "validate", "--config", request.ConfigPath}
+		if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kubelet-config-validate", argv, false); err != nil {
+			return err
+		}
+	}
+	if !localMatches {
+		if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kubelet-config-dry-run", []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config", "--dry-run"}, false); err != nil {
+			return err
+		}
+	}
+	if _, err := e.Store.Update(record.OperationID, "preflight-complete", "preflight-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "preflight-complete"
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	if !localMatches {
+		before, err = e.backupKubeletConfig(record.OperationID)
+		if err != nil {
+			return e.failControlPlaneConfig(record, "kubelet-config-backup", err)
+		}
+	}
+	if _, err := e.Store.Update(record.OperationID, "kubelet-config-backup-complete", "kubelet-config-backup-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.KubeadmControlPlaneConfig.BeforeKubeletConfigSHA256 = before
+		current.Phase = "kubelet-config-backup-complete"
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	if uploadNeeded {
+		argv := []string{"/usr/bin/kubeadm", "init", "phase", "upload-config", "kubelet", "--config", request.ConfigPath}
+		if err := e.runControlPlaneConfigCommand(ctx, record, "kubelet-config-upload-running", argv, true); err != nil {
+			return err
+		}
+		if _, err := e.Store.Update(record.OperationID, "kubelet-config-upload-complete", "kubelet-config-upload-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+			current.KubeadmControlPlaneConfig.ConfigUploadRan = true
+			current.Phase = "kubelet-config-upload-complete"
+			current.UpdatedAt = e.clock()
+			return current, nil
+		}); err != nil {
+			return err
+		}
+	}
+	afterData := localBefore
+	if !localMatches {
+		if err := e.runControlPlaneConfigCommand(ctx, record, "kubelet-config-running", []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config"}, true); err != nil {
+			return err
+		}
+		afterData, err = os.ReadFile(rootedRuntimePath(e.Root, "/var/lib/kubelet/config.yaml"))
+		if err != nil {
+			return e.failControlPlaneConfig(record, "kubelet-config-verify", err)
+		}
+		if err := kubeadmplan.KubeletConfigurationContains(afterData, desired); err != nil {
+			return e.failControlPlaneConfig(record, "kubelet-config-verify", err)
+		}
+	}
+	after := sha256Bytes(afterData)
+	if _, err := e.Store.Update(record.OperationID, "kubelet-config-complete", "kubelet-config-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.KubeadmControlPlaneConfig.AfterKubeletConfigSHA256 = after
+		current.Phase = "kubelet-config-complete"
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	if !localMatches {
+		if err := e.runControlPlaneConfigCommand(ctx, record, "kubelet-restart-running", []string{"/usr/bin/systemctl", "restart", "kubelet.service"}, true); err != nil {
+			return err
+		}
+	}
+	if result := e.runControlPlaneConfigHealth(ctx, request.NodeName); result.Err != nil || result.ExitStatus != 0 {
+		return e.failControlPlaneConfig(record, "post-kubelet-health", fmt.Errorf("post-kubelet health failed: %s", toolFailure(result)))
+	}
+	if _, err := e.Store.Update(record.OperationID, "post-kubelet-health-complete", "post-kubelet-health-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = "post-kubelet-health-complete"
+		current.CompletedPhases = appendMissing(current.CompletedPhases, "post-kubelet-health-complete")
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	if _, err := e.Store.Update(record.OperationID, "record-operation-complete", "record-operation-complete", func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = operation.HostBookkeepingCompletionPhase
+		current.CompletedPhases = appendMissing(current.CompletedPhases, operation.HostBookkeepingCompletionPhase)
+		current.UpdatedAt = e.clock()
+		return current, nil
+	}); err != nil {
+		return err
+	}
+	return e.finalizeSuccessfulOperation(ctx, record.OperationID)
+}
+
+func (e *Executor) backupKubeletConfig(operationID string) (string, error) {
+	data, err := os.ReadFile(rootedRuntimePath(e.Root, "/var/lib/kubelet/config.yaml"))
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(e.Store.Root, operationID, "kubelet-config-backup")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), data, 0o600); err != nil {
+		return "", err
+	}
+	return sha256Bytes(data), nil
+}
+
+func sha256Bytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func (e *Executor) runControlPlaneConfigHealth(ctx context.Context, nodeName string) ToolResult {

--- a/internal/katlc/agent/kubeadm_control_plane_config_test.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config_test.go
@@ -441,7 +441,7 @@ func TestExecuteKubeProxyConfigUpdatesAddonOnline(t *testing.T) {
 	}
 	want := [][]string{
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kube-proxy", "-o", "jsonpath={.data.config\\.conf}"},
-		{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", "/etc/katl/kubeadm/control-plane/config.yaml", "--dry-run"},
+		{"/usr/bin/kubeadm", "config", "validate", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
 		{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kube-proxy", "-o", "jsonpath={.data.config\\.conf}"},
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "rollout", "status", "daemonset/kube-proxy", "--timeout=5m"},

--- a/internal/katlc/agent/kubeadm_control_plane_config_test.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config_test.go
@@ -28,6 +28,16 @@ func TestValidateKubeadmControlPlaneConfigRequest(t *testing.T) {
 	}
 }
 
+func TestValidateKubeadmKubeletConfigRequestAllowsAnyRolloutSize(t *testing.T) {
+	req := validControlPlaneConfigRequest()
+	req.NodeCount = 1
+	req.NodePosition = 1
+	req.SupportedFieldDelta = []string{kubeadmConfigComponentKubelet}
+	if err := validateKubeadmControlPlaneConfigRequest(OperationKindKubeadmControlPlaneConfig, req); err != nil {
+		t.Fatalf("validate request: %v", err)
+	}
+}
+
 func TestAcceptKubeadmControlPlaneConfigBindsActiveGeneration(t *testing.T) {
 	server := newTestServer(t)
 	writeConfigApplyBaseState(t, server.Root)
@@ -37,6 +47,9 @@ func TestAcceptKubeadmControlPlaneConfigBindsActiveGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(server.Root, "etc/katl/node.json"), []byte(`{"kubeadm":{"configRef":"control-plane"}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	status, err := generation.NewConfigApplyStatus(generation.ConfigApplyStatusRequest{GenerationID: "generation-0", PreviousGeneration: "previous", RequestedApplyMode: generation.ApplyModeNextBoot, AcceptedApplyMode: generation.ApplyModeNextBoot, ChangedDomains: []string{"selected-kubeadm-config"}, HealthState: "healthy", Kubeadm: generation.KubeadmActionRequired{Required: true, SelectedConfigName: "control-plane"}, UpdatedAt: time.Now().UTC()})
@@ -80,8 +93,8 @@ func TestExecuteKubeadmControlPlaneConfigRunsBoundedPhases(t *testing.T) {
 	body.CoordinatorUpload = true
 	body.KubernetesPayloadVersion = "v1.36.1"
 	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
-	liveConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n"
-	desiredConfig := liveConfig + "apiServer:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\n"
+	liveConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\ncontrolPlaneEndpoint: api.katl.test:6443\nkubernetesVersion: v1.36.1\n"
+	desiredConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\napiServer:\n  extraArgs:\n    - name: audit-log-maxage\n      value: \"7\"\n"
 	desiredPath := filepath.Join(root, "etc/katl/kubeadm/control-plane/config.yaml")
 	if err := os.MkdirAll(filepath.Dir(desiredPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -121,11 +134,11 @@ func TestExecuteKubeadmControlPlaneConfigRunsBoundedPhases(t *testing.T) {
 	}
 	want := [][]string{
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kubeadm-config", "-o", "jsonpath={.data.ClusterConfiguration}"},
-		{"/usr/bin/kubeadm", "init", "phase", "control-plane", "all", "--config", "/etc/katl/kubeadm/control-plane/config.yaml", "--dry-run"},
+		{"/usr/bin/kubeadm", "init", "phase", "control-plane", "apiserver", "--config", "/var/lib/katl/operations/cp-config-1/effective-kubeadm.yaml", "--dry-run"},
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "get", "node", "cp-1", "-o", "jsonpath={.spec.unschedulable}"},
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "cordon", "cp-1"},
-		{"/usr/bin/kubeadm", "init", "phase", "control-plane", "all", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
-		{"/usr/bin/kubeadm", "init", "phase", "upload-config", "kubeadm", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
+		{"/usr/bin/kubeadm", "init", "phase", "control-plane", "apiserver", "--config", "/var/lib/katl/operations/cp-config-1/effective-kubeadm.yaml"},
+		{"/usr/bin/kubeadm", "init", "phase", "upload-config", "kubeadm", "--config", "/var/lib/katl/operations/cp-config-1/effective-kubeadm.yaml"},
 		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "uncordon", "cp-1"},
 	}
 	if !reflect.DeepEqual(commands, want) {
@@ -137,6 +150,61 @@ func TestExecuteKubeadmControlPlaneConfigRunsBoundedPhases(t *testing.T) {
 	}
 	if completed.KubeadmControlPlaneConfig.ExpectedLiveConfigSHA256 == "" || len(completed.KubeadmControlPlaneConfig.SupportedFieldDelta) != 1 {
 		t.Fatalf("operation did not persist internally observed state: %#v", completed.KubeadmControlPlaneConfig)
+	}
+	effective, err := os.ReadFile(filepath.Join(store.Root, record.OperationID, "effective-kubeadm.yaml"))
+	if err != nil || !strings.Contains(string(effective), "controlPlaneEndpoint: api.katl.test:6443") {
+		t.Fatalf("effective kubeadm config did not preserve live endpoint: %v\n%s", err, effective)
+	}
+}
+
+func TestExecuteKubeadmControlPlaneConfigNoChangeIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n"
+	desiredConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nkubernetesVersion: v1.36.1\n"
+	path := filepath.Join(root, "etc/katl/kubeadm/control-plane/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(desiredConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range controlPlaneManifestNames {
+		manifest := filepath.Join(root, "etc/kubernetes/manifests", name)
+		if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(manifest, []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
+	body.DesiredConfigSHA256, _ = kubeadmplan.CanonicalClusterConfigurationSHA256([]byte(desiredConfig))
+	record, err := store.Create(operation.OperationRecord{OperationID: "cp-config-no-change", OperationKind: OperationKindKubeadmControlPlaneConfig, Scope: "kubeadm-state", RequestDigest: strings.Repeat("b", 64), Phase: "accepted", KubeadmControlPlaneConfig: &body}, "accepted", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var commands [][]string
+	executor := NewExecutor(root, store, "agent-start")
+	executor.Async = false
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		commands = append(commands, append([]string(nil), argv...))
+		return ToolResult{Stdout: []byte(liveConfig)}
+	}
+	if err := executor.Execute(context.Background(), record); err != nil {
+		t.Fatal(err)
+	}
+	if len(commands) != 1 || !slices.Contains(commands[0], "jsonpath={.data.ClusterConfiguration}") {
+		t.Fatalf("commands = %#v, want only read-only live config collection", commands)
+	}
+	completed, err := store.Read(record.OperationID)
+	if err != nil || !completed.Terminal || completed.Result != operation.ResultSucceeded || completed.MutatingToolRan {
+		t.Fatalf("completed = %#v, err = %v", completed, err)
 	}
 }
 
@@ -185,6 +253,205 @@ func TestExecuteKubeadmControlPlaneConfigStopsAfterMutationUncertainty(t *testin
 	}
 	if !strings.Contains(failed.NextAction, "stop rollout") {
 		t.Fatalf("next action = %q", failed.NextAction)
+	}
+}
+
+func TestExecuteKubeletConfigUploadsUpdatesAndRestarts(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	desiredConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\n---\napiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 120\n"
+	desiredPath := filepath.Join(root, "etc/katl/kubeadm/control-plane/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(desiredPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(desiredPath, []byte(desiredConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	livePath := filepath.Join(root, "var/lib/kubelet/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(livePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(livePath, []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 110\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
+	body.NodeCount = 1
+	body.NodePosition = 1
+	body.CoordinatorUpload = true
+	body.Component = "kubelet"
+	body.SupportedFieldDelta = nil
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
+	body.DesiredConfigSHA256, err = kubeadmplan.CanonicalKubeletConfigurationSHA256([]byte(desiredConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(operation.OperationRecord{OperationID: "kubelet-config-1", OperationKind: OperationKindKubeadmControlPlaneConfig, Scope: "kubeadm-state", RequestDigest: strings.Repeat("d", 64), Phase: "accepted", KubeadmControlPlaneConfig: &body, ResourceLocks: []string{"kubeadm-state.lock"}}, "accepted", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var commands [][]string
+	executor := NewExecutor(root, store, "agent-start")
+	executor.Async = false
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		commands = append(commands, append([]string(nil), argv...))
+		if slices.Contains(argv, "jsonpath={.data.kubelet}") {
+			return ToolResult{Stdout: []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 110\n")}
+		}
+		if reflect.DeepEqual(argv, []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config"}) {
+			data := "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 120\ncgroupDriver: systemd\n"
+			if err := os.WriteFile(livePath, []byte(data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return ToolResult{}
+	}
+	executor.RunPostHealth = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
+	if err := executor.Execute(context.Background(), record); err != nil {
+		t.Fatal(err)
+	}
+	want := [][]string{
+		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kubelet-config", "-o", "jsonpath={.data.kubelet}"},
+		{"/usr/bin/kubeadm", "config", "validate", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
+		{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config", "--dry-run"},
+		{"/usr/bin/kubeadm", "init", "phase", "upload-config", "kubelet", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
+		{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config"},
+		{"/usr/bin/systemctl", "restart", "kubelet.service"},
+	}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %#v, want %#v", commands, want)
+	}
+	completed, err := store.Read(record.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !completed.Terminal || completed.Result != operation.ResultSucceeded || !completed.KubeadmControlPlaneConfig.ConfigUploadRan || completed.KubeadmControlPlaneConfig.BeforeKubeletConfigSHA256 == "" || completed.KubeadmControlPlaneConfig.AfterKubeletConfigSHA256 == "" {
+		t.Fatalf("completed = %#v", completed)
+	}
+	if _, err := os.Stat(filepath.Join(store.Root, record.OperationID, "kubelet-config-backup", "config.yaml")); err != nil {
+		t.Fatalf("backup kubelet config: %v", err)
+	}
+}
+
+func TestExecuteKubeletConfigNoChangeDoesNotRestart(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	desiredConfig := "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 120\n"
+	desiredPath := filepath.Join(root, "etc/katl/kubeadm/worker/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(desiredPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(desiredPath, []byte(desiredConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	livePath := filepath.Join(root, "var/lib/kubelet/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(livePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(livePath, []byte(desiredConfig+"cgroupDriver: systemd\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
+	body.Component = "kubelet"
+	body.ConfigName = "worker"
+	body.ConfigPath = "/etc/katl/kubeadm/worker/config.yaml"
+	body.CoordinatorUpload = false
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
+	body.DesiredConfigSHA256, _ = kubeadmplan.CanonicalKubeletConfigurationSHA256([]byte(desiredConfig))
+	record, err := store.Create(operation.OperationRecord{OperationID: "kubelet-config-no-change", OperationKind: OperationKindKubeadmControlPlaneConfig, Scope: "kubeadm-state", RequestDigest: strings.Repeat("e", 64), Phase: "accepted", KubeadmControlPlaneConfig: &body}, "accepted", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var commands [][]string
+	executor := NewExecutor(root, store, "agent-start")
+	executor.Async = false
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		commands = append(commands, append([]string(nil), argv...))
+		return ToolResult{}
+	}
+	if err := executor.Execute(context.Background(), record); err != nil {
+		t.Fatal(err)
+	}
+	if len(commands) != 0 {
+		t.Fatalf("commands = %#v, want no kubeadm or restart calls", commands)
+	}
+	completed, err := store.Read(record.OperationID)
+	if err != nil || !completed.Terminal || completed.Result != operation.ResultSucceeded || completed.MutatingToolRan {
+		t.Fatalf("completed = %#v, err = %v", completed, err)
+	}
+}
+
+func TestExecuteKubeProxyConfigUpdatesAddonOnline(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	desiredConfig := "apiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: nftables\n"
+	desiredPath := filepath.Join(root, "etc/katl/kubeadm/control-plane/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(desiredPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(desiredPath, []byte(desiredConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
+	body.NodeCount = 1
+	body.NodePosition = 1
+	body.CoordinatorUpload = true
+	body.Component = "kube-proxy"
+	body.SupportedFieldDelta = nil
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
+	body.DesiredConfigSHA256, err = kubeadmplan.CanonicalKubeProxyConfigurationSHA256([]byte(desiredConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(operation.OperationRecord{OperationID: "kube-proxy-config-1", OperationKind: OperationKindKubeadmControlPlaneConfig, Scope: "kubeadm-state", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", KubeadmControlPlaneConfig: &body, ResourceLocks: []string{"kubeadm-state.lock"}}, "accepted", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := false
+	var commands [][]string
+	executor := NewExecutor(root, store, "agent-start")
+	executor.Async = false
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		commands = append(commands, append([]string(nil), argv...))
+		if slices.Contains(argv, "jsonpath={.data.config\\.conf}") {
+			mode := "iptables"
+			if updated {
+				mode = "nftables"
+			}
+			return ToolResult{Stdout: []byte("apiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: " + mode + "\n")}
+		}
+		if reflect.DeepEqual(argv, []string{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"}) {
+			updated = true
+		}
+		return ToolResult{}
+	}
+	if err := executor.Execute(context.Background(), record); err != nil {
+		t.Fatal(err)
+	}
+	want := [][]string{
+		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kube-proxy", "-o", "jsonpath={.data.config\\.conf}"},
+		{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", "/etc/katl/kubeadm/control-plane/config.yaml", "--dry-run"},
+		{"/usr/bin/kubeadm", "init", "phase", "addon", "kube-proxy", "--config", "/etc/katl/kubeadm/control-plane/config.yaml"},
+		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "get", "configmap", "kube-proxy", "-o", "jsonpath={.data.config\\.conf}"},
+		{"/usr/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "-n", "kube-system", "rollout", "status", "daemonset/kube-proxy", "--timeout=5m"},
+	}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %#v, want %#v", commands, want)
+	}
+	completed, err := store.Read(record.OperationID)
+	if err != nil || !completed.Terminal || completed.Result != operation.ResultSucceeded || !completed.MutatingToolRan {
+		t.Fatalf("completed = %#v, err = %v", completed, err)
 	}
 }
 

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -889,6 +889,46 @@ func TestValidateConfigAcceptsDesiredStateThatAlreadyMatches(t *testing.T) {
 	}
 }
 
+func TestSubmittedConfigApplyCompletesAsNoopWhenDesiredStateAlreadyMatches(t *testing.T) {
+	server := newTestServer(t)
+	writeConfigApplyBaseState(t, server.Root)
+	executor := NewExecutor(server.Root, server.Store, server.AgentStartID)
+	executor.Async = false
+	server.Dispatcher = executor
+
+	accepted, err := server.SubmitOperation(context.Background(), &agentapi.SubmitOperationRequest{
+		ApiVersion:      APIVersion,
+		Kind:            RequestKind,
+		ClientRequestId: "req-no-change-submit",
+		OperationKind:   OperationKindGenerationApply,
+		Actor:           "test-actor",
+		ConfigApply: &agentapi.ConfigApplyOperationRequest{
+			CandidateGenerationId: "generation-no-change-submit",
+			ApplyMode:             generation.ApplyModeAuto,
+			ConfigYaml:            configApplyNoChangesYAML(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := server.Store.Read(accepted.OperationId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !record.Terminal || record.Result != operation.ResultSucceeded || record.Phase != configApplyNoopPhase || record.RecoveryRequired {
+		t.Fatalf("record = %+v, want terminal successful no-op", record)
+	}
+	if record.CandidateGenerationID != "" || record.GenerationCommitState != operation.GenerationCommitAbandoned || record.ExternalMutationStarted {
+		t.Fatalf("record lifecycle = %+v, want abandoned candidate without mutation", record)
+	}
+	if record.FailureReason != "" || !strings.Contains(record.NextAction, "already matches") {
+		t.Fatalf("record guidance = failure %q next %q", record.FailureReason, record.NextAction)
+	}
+	if _, err := os.Stat(filepath.Join(server.Root, "var/lib/katl/generations/generation-no-change-submit")); !os.IsNotExist(err) {
+		t.Fatalf("no-op candidate generation exists: %v", err)
+	}
+}
+
 func TestValidateConfigRejectsMissingKubeadmConfigRefWithoutRecord(t *testing.T) {
 	server := newTestServer(t)
 	writeConfigApplyBaseState(t, server.Root)
@@ -2739,6 +2779,26 @@ func configApplyYAML(mode string) string {
 		"            Name=ens3",
 		"            [Network]",
 		"            DHCP=yes",
+		"",
+	}, "\n")
+}
+
+func configApplyNoChangesYAML() string {
+	return strings.Join([]string{
+		"apiVersion: katl.dev/v1alpha1",
+		"kind: NodeConfigurationChange",
+		"metadata:",
+		"  sourceID: operator",
+		"  desiredVersion: \"4\"",
+		"apply:",
+		"  mode: auto",
+		"spec:",
+		"  clusterDefaults:",
+		"    identity:",
+		"      hostname: node-a",
+		"      authorizedKeys:",
+		"        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl",
+		"    systemRole: control-plane",
 		"",
 	}, "\n")
 }

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"google.golang.org/grpc/codes"
@@ -826,7 +827,6 @@ func TestValidateConfigReturnsDeterministicPlanDiagnostics(t *testing.T) {
 	}
 	wantDiagnostics := []string{
 		"node-identity: staged-required: domain is staged-only for normal runtime configuration apply",
-		"bootstrap-node-metadata: staged-required: domain is staged-only for normal runtime configuration apply",
 		"networkd: staged-required: domain is staged-only for normal runtime configuration apply",
 	}
 	if first.Accepted || second.Accepted {
@@ -838,7 +838,7 @@ func TestValidateConfigReturnsDeterministicPlanDiagnostics(t *testing.T) {
 	if !reflect.DeepEqual(first.Diagnostics, wantDiagnostics) || !reflect.DeepEqual(second.Diagnostics, wantDiagnostics) {
 		t.Fatalf("diagnostics = %#v/%#v, want %#v", first.Diagnostics, second.Diagnostics, wantDiagnostics)
 	}
-	if first.FailureReason != second.FailureReason || !strings.Contains(first.FailureReason, "config apply live request rejected for 3 domain(s)") {
+	if first.FailureReason != second.FailureReason || !strings.Contains(first.FailureReason, "config apply live request rejected for 2 domain(s)") {
 		t.Fatalf("failure reasons = %q/%q, want stable plan rejection", first.FailureReason, second.FailureReason)
 	}
 	if entries, err := os.ReadDir(server.Store.Root); err != nil && !os.IsNotExist(err) {
@@ -1255,6 +1255,35 @@ func TestConfigApplyBaseLoadsRetainedEndpointAdvertiser(t *testing.T) {
 	}
 	if base.EndpointAdvertiserSysext == nil || base.EndpointAdvertiserSysext.Name != "endpoint-advertiser" || base.EndpointAdvertiserSysext.Path != installer.EndpointAdvertiserArtifactPath {
 		t.Fatalf("retained endpoint advertiser = %#v", base.EndpointAdvertiserSysext)
+	}
+}
+
+func TestActiveGenerationKubeadmConfigsPreferActiveConfext(t *testing.T) {
+	root := t.TempDir()
+	const ref = "control-plane-profiled"
+	currentManifest := manifest.Manifest{Node: manifest.NodeConfig{
+		Kubernetes: manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: ref}},
+	}}
+	writeStoredKubeadmConfig(t, root, ref)
+	generationDir, err := generation.GenerationDir(root, "generation-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(generationDir, "confext", "etc", "katl", "kubeadm", ref)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	const active = "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 120\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(active), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configs, err := activeGenerationKubeadmConfigs(root, "generation-live", currentManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(configs[ref].Config.Content); got != active {
+		t.Fatalf("active config = %q, want %q", got, active)
 	}
 }
 

--- a/internal/katlc/config/validate.go
+++ b/internal/katlc/config/validate.go
@@ -218,11 +218,43 @@ func validateOverlay(node *yaml.Node, path string, options Options, result *Resu
 			validateSysctl(pair.value, pair.path, result)
 		case "kubernetes":
 			validateKubernetes(pair.value, pair.path, options, result)
+		case "controlPlaneEndpoint":
+			validateControlPlaneEndpoint(pair.value, pair.path, result)
 		case "livePreflight":
 			// The apply matrix validates the domain names and requested mode.
 		default:
 			result.add(unsupportedCode(pair.key), pair.path, "configuration domain is not supported")
 		}
+	}
+}
+
+func validateControlPlaneEndpoint(node *yaml.Node, path string, result *Result) {
+	if node.Kind != yaml.MappingNode {
+		result.add("invalid-field", path, "controlPlaneEndpoint must be a mapping")
+		return
+	}
+	for _, pair := range mappingPairsWithPath(node, path) {
+		switch pair.key {
+		case "managed", "config":
+		default:
+			result.add("unsupported-field", pair.path, "controlPlaneEndpoint field is not supported")
+		}
+	}
+	managed := mappingValue(node, "managed")
+	if managed == nil {
+		result.add("missing-field", path+".managed", "managed is required")
+		return
+	}
+	if managed.Kind != yaml.ScalarNode || managed.Tag != "!!bool" {
+		result.add("invalid-field", path+".managed", "managed must be true or false")
+		return
+	}
+	config := mappingValue(node, "config")
+	if managed.Value == "true" && config == nil {
+		result.add("missing-field", path+".config", "config is required when managed is true")
+	}
+	if managed.Value == "false" && config != nil {
+		result.add("invalid-field", path+".config", "config must be omitted when managed is false")
 	}
 }
 

--- a/internal/katlc/config/validate_test.go
+++ b/internal/katlc/config/validate_test.go
@@ -105,6 +105,73 @@ spec:
 	}
 }
 
+func TestValidateNodeConfigurationChangeAcceptsControlPlaneEndpointOwnership(t *testing.T) {
+	tests := map[string]string{
+		"external": `
+      controlPlaneEndpoint:
+        managed: false`,
+		"managed": `
+      controlPlaneEndpoint:
+        managed: true
+        config:
+          host: 192.0.2.10
+          advertisement:
+            vip: 192.0.2.10
+            bgp:
+              localASN: 64512
+              peers:
+                - address: 192.0.2.1
+                  asn: 64512`,
+	}
+	for name, overlay := range tests {
+		t.Run(name, func(t *testing.T) {
+			input := `
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: operator
+  desiredVersion: "2"
+apply:
+  mode: auto
+spec:
+  nodeOverrides:
+    cp-1:` + overlay + "\n"
+			result := ValidateNodeConfigurationChange(input, Options{})
+			if !result.Accepted() {
+				t.Fatalf("diagnostics = %#v, want accepted", result.Strings())
+			}
+		})
+	}
+}
+
+func TestValidateNodeConfigurationChangeRejectsInvalidControlPlaneEndpointOwnership(t *testing.T) {
+	input := `
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: operator
+  desiredVersion: "2"
+apply:
+  mode: auto
+spec:
+  nodeOverrides:
+    cp-1:
+      controlPlaneEndpoint:
+        managed: false
+        config:
+          host: 192.0.2.10
+        internal: true
+`
+	result := ValidateNodeConfigurationChange(input, Options{})
+	want := []string{
+		`invalid-field: spec.nodeOverrides.cp-1.controlPlaneEndpoint.config: config must be omitted when managed is false`,
+		`unsupported-field: spec.nodeOverrides.cp-1.controlPlaneEndpoint.internal: controlPlaneEndpoint field is not supported`,
+	}
+	if got := result.Strings(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got, want)
+	}
+}
+
 func TestValidateNodeConfigurationChangeAcceptsInlineKubeadmRef(t *testing.T) {
 	input := `
 apiVersion: katl.dev/v1alpha1

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -81,8 +81,6 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
 		"_build/go-cache",
 		"_build/go-mod",
 		"_build/mkosi/builddir",
-		"_build/mkosi/cache",
-		"_build/mkosi/package-cache",
 		"_build/mkosi/workspace",
 		"_build/mkosi/workspace/installer",
 		"_build/mkosi/workspace/runtime",

--- a/internal/vmtest/agent_server.go
+++ b/internal/vmtest/agent_server.go
@@ -513,6 +513,7 @@ func defaultAgentFilePaths() []string {
 		"/var/lib/katl/identity/",
 		"/var/lib/katl/install/status.json",
 		"/var/lib/katl/operations/",
+		"/var/lib/kubelet/config.yaml",
 		"/usr/lib/os-release",
 		"/var/lib/katl/generations/",
 		"/var/lib/katl/test-artifacts/",

--- a/internal/vmtest/agent_test.go
+++ b/internal/vmtest/agent_test.go
@@ -248,6 +248,7 @@ func TestAgentDefaultAllowlistSupportsBootstrapReadiness(t *testing.T) {
 		"/var/lib/katl/identity/machine-id",
 		"/var/lib/katl/install/status.json",
 		"/var/lib/katl/operations/bootstrap-init-1/record.json",
+		"/var/lib/kubelet/config.yaml",
 	} {
 		if !pathAllowed(path, defaultAgentFilePaths()) {
 			t.Fatalf("%s is not allowlisted", path)

--- a/internal/vmtest/first_install_world.go
+++ b/internal/vmtest/first_install_world.go
@@ -1346,6 +1346,7 @@ kind: InitConfiguration
 nodeRegistration:
   name: ` + nodeName + `
   criSocket: unix:///run/containerd/containerd.sock
+  taints: []
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration

--- a/internal/vmtest/first_install_world_test.go
+++ b/internal/vmtest/first_install_world_test.go
@@ -493,7 +493,7 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 	if data, err := os.ReadFile(filepath.Join(manifestDir, "kubeadm-configs", "control-plane.yaml")); err != nil || !strings.Contains(string(data), "configFile: kubeadm/control-plane.yaml") {
 		t.Fatalf("generated KubeadmConfig = %q, err = %v", data, err)
 	}
-	if data, err := os.ReadFile(filepath.Join(manifestDir, "kubeadm", "control-plane.yaml")); err != nil || !strings.Contains(string(data), "kind: InitConfiguration") || !strings.Contains(string(data), "kubernetesVersion: v1.36.0") {
+	if data, err := os.ReadFile(filepath.Join(manifestDir, "kubeadm", "control-plane.yaml")); err != nil || !strings.Contains(string(data), "kind: InitConfiguration") || !strings.Contains(string(data), "kubernetesVersion: v1.36.0") || !strings.Contains(string(data), "taints: []") {
 		t.Fatalf("generated kubeadm config = %q, err = %v", data, err)
 	}
 	scenarioManifest := readScenarioManifest(t, run.Scenario.ManifestPath)

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -322,7 +322,6 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 	}
 	assertOperationKubernetesBundle(t, cp1Record, kubernetesBundle)
 	assertGenerationKubernetesBundle(t, ctx, cp1Node, filepath.Join(evidenceDir, "cp-1"), cp1Record, kubernetesBundle)
-	bootstrapGenerations := map[string]string{"cp-1": cp1Record.CandidateGenerationID}
 	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp2Node, cp3Node} {
 		_, record, err := collectOperationEvidence(ctx, node, filepath.Join(evidenceDir, node.Name), "bootstrap-join-control-plane")
 		if err != nil {
@@ -335,7 +334,6 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 		}
 		assertOperationKubernetesBundle(t, record, kubernetesBundle)
 		assertGenerationKubernetesBundle(t, ctx, node, filepath.Join(evidenceDir, node.Name), record, kubernetesBundle)
-		bootstrapGenerations[node.Name] = record.CandidateGenerationID
 	}
 
 	output, err := waitForKubectlNodes(ctx, kubeconfigPath, kubectlOut, 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3")
@@ -382,7 +380,7 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 		t.Fatalf("write etcd report: %v", err)
 	}
 	if smoke.WorkloadProof {
-		if err := runThreeControlPlaneConfigOperationProof(t, ctx, result, nodes, addresses, bootstrapGenerations, inventoryPath, kubeconfigPath, kubernetesBundle, cniFixtures, etcdReport); err != nil {
+		if err := runThreeControlPlaneConfigOperationProof(t, ctx, result, nodes, addresses, inventoryPath, kubeconfigPath, kubernetesBundle, etcdReport); err != nil {
 			collectKubectlDiagnostics(kubeconfigPath, result.RunDir)
 			collectTwoNodeDiagnostics("", nodes...)
 			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
@@ -443,28 +441,13 @@ func assertCNISysctls(ctx context.Context, node vmtest.RunningInstalledRuntimeNo
 	return nil
 }
 
-func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context, result vmtest.Result, nodes []vmtest.RunningInstalledRuntimeNode, addresses, bootstrapGenerations map[string]string, inventoryPath, kubeconfigPath string, bundle threeControlPlaneKubernetesPayloadBundle, cniFixtures map[string]nodeCNIFixture, snapshot threeControlPlaneEtcdReport) error {
+func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context, result vmtest.Result, nodes []vmtest.RunningInstalledRuntimeNode, addresses map[string]string, inventoryPath, kubeconfigPath string, bundle threeControlPlaneKubernetesPayloadBundle, snapshot threeControlPlaneEtcdReport) error {
 	t.Helper()
 	const generationID = "2026.07.11-vmtest-control-plane-config"
 	const configName = "control-plane-profiled"
 	proofDir := filepath.Join(result.RunDir, "kubeadm-control-plane-config")
 	if err := os.MkdirAll(proofDir, 0o755); err != nil {
 		return err
-	}
-	for _, node := range nodes {
-		bootstrapGeneration := bootstrapGenerations[node.Name]
-		if bootstrapGeneration == "" {
-			return fmt.Errorf("bootstrap generation for %s is missing", node.Name)
-		}
-		if err := rebootIntoGeneration(ctx, node, bootstrapGeneration); err != nil {
-			return fmt.Errorf("boot %s into committed bootstrap generation: %w", node.Name, err)
-		}
-		if err := activateNodeCNIFixture(ctx, node, cniFixtures[node.Name]); err != nil {
-			return fmt.Errorf("reactivate %s CNI fixture after bootstrap generation boot: %w", node.Name, err)
-		}
-		if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-after-bootstrap-generation-"+node.Name+".txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
-			return fmt.Errorf("wait for cluster readiness after booting %s bootstrap generation: %w", node.Name, err)
-		}
 	}
 	liveConfig, err := kubectlOutput(ctx, kubeconfigPath, "-n", "kube-system", "get", "configmap", "kubeadm-config", "-o", "jsonpath={.data.ClusterConfiguration}")
 	if err != nil {
@@ -481,61 +464,62 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	if err != nil {
 		return err
 	}
+	liveKubeletConfig, err := kubectlOutput(ctx, kubeconfigPath, "-n", "kube-system", "get", "configmap", "kubelet-config", "-o", "jsonpath={.data.kubelet}")
+	if err != nil {
+		return fmt.Errorf("collect live kubelet config: %w", err)
+	}
+	desiredKubeletConfig, err := kubeletMaxPodsConfig(liveKubeletConfig, 120)
+	if err != nil {
+		return err
+	}
+	desiredKubeletDigest, err := kubeadmplan.CanonicalKubeletConfigurationSHA256(desiredKubeletConfig)
+	if err != nil {
+		return err
+	}
+	desiredConfig = append(bytes.TrimSpace(desiredConfig), []byte("\n---\n")...)
+	desiredConfig = append(desiredConfig, desiredKubeletConfig...)
 	if err := os.WriteFile(filepath.Join(proofDir, "desired-config.yaml"), desiredConfig, 0o600); err != nil {
 		return err
 	}
 	requestPath := filepath.Join(proofDir, "config-apply.yaml")
 	inlineConfig := strings.ReplaceAll(strings.TrimSuffix(string(desiredConfig), "\n"), "\n", "\n        ")
-	request := fmt.Appendf(nil, "apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\nmetadata:\n  sourceID: vmtest\n  desiredVersion: \"20260711\"\napply:\n  mode: next-boot\nspec:\n  kubeadmConfigs:\n    %s:\n      config: |\n        %s\n  clusterDefaults:\n    kubernetes:\n      kubeadm:\n        configRef: %s\n", configName, inlineConfig, configName)
+	request := fmt.Appendf(nil, "apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\nmetadata:\n  sourceID: vmtest\n  desiredVersion: \"20260711\"\napply:\n  mode: live\nspec:\n  kubeadmConfigs:\n    %s:\n      config: |\n        %s\n  clusterDefaults:\n    kubernetes:\n      kubeadm:\n        configRef: %s\n", configName, inlineConfig, configName)
 	if err := os.WriteFile(requestPath, request, 0o600); err != nil {
 		return err
 	}
 	katlctl := buildKatlctlCommand(t, ctx, katlRepoRoot(t))
 	for _, node := range nodes {
 		stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "stage-"+node.Name,
-			"node", "apply", "--endpoint", net.JoinHostPort(addresses[node.Name], "9443"), "--config", requestPath, "--mode", "next-boot", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof", "--output", "json")
+			"node", "apply", "--endpoint", net.JoinHostPort(addresses[node.Name], "9443"), "--config", requestPath, "--mode", "live", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof", "--output", "json")
 		if err != nil {
-			return fmt.Errorf("stage desired generation on %s: %w: %s", node.Name, err, stderr)
+			return fmt.Errorf("activate desired generation on %s: %w: %s", node.Name, err, stderr)
 		}
-		if err := decodeGenerationStageResult(stdout, generationID); err != nil {
-			return fmt.Errorf("decode %s staged generation result: %w", node.Name, err)
-		}
-		if err := waitForConfigGeneration(ctx, katlctl, proofDir, node, addresses[node.Name], generationID, configName, false); err != nil {
-			return err
-		}
-	}
-	for _, node := range nodes {
-		if err := rebootIntoGeneration(ctx, node, generationID); err != nil {
-			return err
-		}
-		if err := activateNodeCNIFixture(ctx, node, cniFixtures[node.Name]); err != nil {
-			return fmt.Errorf("reactivate %s CNI fixture: %w", node.Name, err)
+		if err := decodeGenerationApplyResult(stdout, generationID); err != nil {
+			return fmt.Errorf("decode %s activated generation result: %w", node.Name, err)
 		}
 		if err := waitForConfigGeneration(ctx, katlctl, proofDir, node, addresses[node.Name], generationID, configName, true); err != nil {
 			return err
-		}
-		if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-after-reboot-"+node.Name+".txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
-			return fmt.Errorf("wait for cluster readiness after rebooting %s: %w", node.Name, err)
 		}
 	}
 	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-before-operation.txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
 		return err
 	}
-	args := []string{"kubernetes", "apply-config", "--inventory", inventoryPath, "--coordinator", "cp-3", "--generation", generationID, "--config-name", configName, "--rollout-id", "2026.07.11-vmtest-control-plane-config"}
+	const rolloutID = "2026.07.11-vmtest-cluster-config"
+	args := []string{"cluster", "apply", "--inventory", inventoryPath, "--coordinator", "cp-3", "--generation", generationID, "--config-name", configName, "--rollout-id", rolloutID}
 	stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "rollout", args...)
 	if err != nil {
 		return fmt.Errorf("run serial control-plane config rollout: %w: %s", err, stderr)
 	}
-	if !bytes.Contains(stdout, []byte(`"automaticRollback":false`)) {
+	if !bytes.Contains(stdout, []byte(`"automaticRollback":false`)) || !bytes.Contains(stdout, []byte(`"result":"succeeded"`)) {
 		return fmt.Errorf("rollout summary did not record automaticRollback=false: %s", stdout)
 	}
 	for position, node := range nodes {
-		_, record, err := collectOperationEvidence(ctx, node, filepath.Join(proofDir, node.Name), "kubeadm-control-plane-config")
+		_, record, err := collectOperationEvidenceForRollout(ctx, node, filepath.Join(proofDir, node.Name), "kubeadm-control-plane-config", rolloutID+"-control-plane")
 		if err != nil {
 			return fmt.Errorf("collect %s config operation evidence: %w", node.Name, err)
 		}
 		body := record.KubeadmControlPlaneConfig
-		if body == nil || body.NodePosition != uint32(position+1) || body.CoordinatorUpload != (node.Name == "cp-3") || record.Result != operation.ResultSucceeded || body.DesiredConfigSHA256 != desiredDigest || len(body.BeforeManifestSHA256) != 3 || len(body.AfterManifestSHA256) != 3 {
+		if body == nil || body.Component != "control-plane" || body.NodePosition != uint32(position+1) || body.CoordinatorUpload != (node.Name == "cp-3") || record.Result != operation.ResultSucceeded || body.DesiredConfigSHA256 != desiredDigest || len(body.BeforeManifestSHA256) != 3 || len(body.AfterManifestSHA256) != 3 {
 			return fmt.Errorf("%s control-plane config operation evidence is incomplete: %#v", node.Name, record)
 		}
 	}
@@ -555,7 +539,48 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 			}
 		}
 	}
+	expectedPosition := map[string]uint32{"cp-3": 1, "cp-1": 2, "cp-2": 3}
+	for _, node := range nodes {
+		_, record, err := collectOperationEvidenceForRollout(ctx, node, filepath.Join(proofDir, node.Name+"-kubelet"), "kubeadm-control-plane-config", rolloutID+"-kubelet")
+		if err != nil {
+			return fmt.Errorf("collect %s kubelet config operation evidence: %w", node.Name, err)
+		}
+		body := record.KubeadmControlPlaneConfig
+		if body == nil || body.Component != "kubelet" || body.NodePosition != expectedPosition[node.Name] || body.CoordinatorUpload != (node.Name == "cp-3") || body.ConfigUploadRan != (node.Name == "cp-3") || record.Result != operation.ResultSucceeded || body.DesiredConfigSHA256 != desiredKubeletDigest {
+			return fmt.Errorf("%s kubelet config operation evidence is incomplete: %#v", node.Name, record)
+		}
+		actual, err := readNodeFileWithRetry(ctx, node, "/var/lib/kubelet/config.yaml", 2<<20, 30*time.Second)
+		if err != nil {
+			return fmt.Errorf("read %s kubelet config: %w", node.Name, err)
+		}
+		if err := kubeadmplan.KubeletConfigurationContains(actual, desiredKubeletConfig); err != nil {
+			return fmt.Errorf("verify %s kubelet config: %w", node.Name, err)
+		}
+	}
+	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(proofDir, "kubectl-after-cluster-apply.txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
+		return err
+	}
 	return nil
+}
+
+func kubeletMaxPodsConfig(live []byte, maxPods int) ([]byte, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(live, &document); err != nil {
+		return nil, err
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("live KubeletConfiguration must be one YAML mapping")
+	}
+	root := document.Content[0]
+	value := yamlMappingValue(root, "maxPods")
+	if value == nil {
+		value = &yaml.Node{}
+		root.Content = append(root.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "maxPods"}, value)
+	}
+	value.Kind = yaml.ScalarNode
+	value.Tag = "!!int"
+	value.Value = strconv.Itoa(maxPods)
+	return yaml.Marshal(&document)
 }
 
 func waitForKubectlOutputContains(ctx context.Context, kubeconfigPath string, timeout time.Duration, needle []byte, args ...string) ([]byte, error) {
@@ -642,13 +667,13 @@ func runProofKatlctl(ctx context.Context, binary, dir, name string, args ...stri
 	return stdout.Bytes(), stderr.String(), err
 }
 
-func decodeGenerationStageResult(data []byte, generationID string) error {
+func decodeGenerationApplyResult(data []byte, generationID string) error {
 	var status agentapi.OperationStatus
 	if err := protojson.Unmarshal(data, &status); err != nil {
 		return err
 	}
-	if status.OperationKind != "generation-stage" || !status.Terminal || status.Result != operation.ResultSucceeded || status.CandidateGenerationId != generationID {
-		return fmt.Errorf("unexpected generation stage status: %s", status.String())
+	if status.OperationKind != "generation-apply" || !status.Terminal || status.Result != operation.ResultSucceeded || status.CandidateGenerationId != generationID || status.ActivationState != operation.ActivationStateActiveLive {
+		return fmt.Errorf("unexpected live generation apply status: %s", status.String())
 	}
 	return nil
 }
@@ -2304,20 +2329,21 @@ func TestResolvedBundleDigestMatching(t *testing.T) {
 	}
 }
 
-func TestDecodeGenerationStageResultUsesTerminalStatus(t *testing.T) {
+func TestDecodeGenerationApplyResultUsesTerminalStatus(t *testing.T) {
 	status := &agentapi.OperationStatus{
-		OperationKind:         "generation-stage",
+		OperationKind:         "generation-apply",
 		Phase:                 operation.HostBookkeepingCompletionPhase,
 		Terminal:              true,
 		Result:                operation.ResultSucceeded,
 		CandidateGenerationId: "generation-1",
+		ActivationState:       operation.ActivationStateActiveLive,
 	}
 	data, err := protojson.Marshal(status)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := decodeGenerationStageResult(data, "generation-1"); err != nil {
-		t.Fatalf("decodeGenerationStageResult() error = %v", err)
+	if err := decodeGenerationApplyResult(data, "generation-1"); err != nil {
+		t.Fatalf("decodeGenerationApplyResult() error = %v", err)
 	}
 }
 

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -2859,6 +2859,10 @@ func assertGeneration0Selection(t *testing.T, data []byte) {
 }
 
 func collectOperationEvidence(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, evidenceDir, expectedKind string) (string, operation.OperationRecord, error) {
+	return collectOperationEvidenceForRollout(ctx, node, evidenceDir, expectedKind, "")
+}
+
+func collectOperationEvidenceForRollout(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, evidenceDir, expectedKind, expectedRolloutID string) (string, operation.OperationRecord, error) {
 	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 		return "", operation.OperationRecord{}, err
 	}
@@ -2885,7 +2889,7 @@ func collectOperationEvidence(ctx context.Context, node vmtest.RunningInstalledR
 		if err := os.WriteFile(filepath.Join(evidenceDir, "operation-record-"+firstString(record.OperationID, filepath.Base(filepath.Dir(path)))+".json"), data, 0o600); err != nil {
 			return "", operation.OperationRecord{}, err
 		}
-		if record.OperationKind != expectedKind {
+		if record.OperationKind != expectedKind || expectedRolloutID != "" && (record.KubeadmControlPlaneConfig == nil || record.KubeadmControlPlaneConfig.RolloutID != expectedRolloutID) {
 			continue
 		}
 		if selectedPath != "" {
@@ -2895,7 +2899,11 @@ func collectOperationEvidence(ctx context.Context, node vmtest.RunningInstalledR
 		selected = record
 	}
 	if selectedPath == "" {
-		return "", operation.OperationRecord{}, fmt.Errorf("%s operation record not found; found records: %s", expectedKind, strings.Join(found, ", "))
+		qualifier := ""
+		if expectedRolloutID != "" {
+			qualifier = " for rollout " + expectedRolloutID
+		}
+		return "", operation.OperationRecord{}, fmt.Errorf("%s operation record%s not found; found records: %s", expectedKind, qualifier, strings.Join(found, ", "))
 	}
 	hostRecord := filepath.Join(evidenceDir, expectedKind+"-record.json")
 	data, err := readNodeFileWithRetry(ctx, node, selectedPath, 2<<20, 30*time.Second)

--- a/internal/vmtest/scenarios/testdata/bootstrap/cross-node-workload.yaml
+++ b/internal/vmtest/scenarios/testdata/bootstrap/cross-node-workload.yaml
@@ -65,13 +65,6 @@ spec:
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: cp-1
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: client
         image: localhost/katl-vmtest/net-client:latest

--- a/internal/vmtest/scenarios/testdata/bootstrap/release-workload-stack.yaml
+++ b/internal/vmtest/scenarios/testdata/bootstrap/release-workload-stack.yaml
@@ -59,13 +59,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: cp-1
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: operator-fixture
         image: localhost/katl-vmtest/net-server:latest
@@ -93,13 +86,6 @@ spec:
       labels:
         app.kubernetes.io/name: echo
     spec:
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: echo
         image: localhost/katl-vmtest/net-server:latest
@@ -145,13 +131,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: cp-1
-      tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: gateway
         image: localhost/katl-vmtest/gateway-proxy:latest

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -2,10 +2,29 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
+git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+shared_repo_root="$repo_root"
+if [[ "$(basename "$git_common_dir")" == .git ]]; then
+    shared_repo_root="$(dirname "$git_common_dir")"
+fi
 image="${KATL_MKOSI_IMAGE:-localhost/katl-mkosi-builder:fedora-44-go-squashfs}"
 runtime="${KATL_CONTAINER_RUNTIME:-}"
 build_commit="${KATL_BUILD_COMMIT:-${KATL_VERSION:-0.0.0-dev}}"
 build_dir="${KATL_MKOSI_BUILD_DIR:-$repo_root/_build/mkosi}"
+if [[ -n "${KATL_MKOSI_CACHE_DIR:-}" ]]; then
+    cache_dir="$KATL_MKOSI_CACHE_DIR"
+elif [[ -n "${KATL_MKOSI_BUILD_DIR:-}" ]]; then
+    cache_dir="$build_dir/cache"
+else
+    cache_dir="$shared_repo_root/_build/mkosi/cache"
+fi
+if [[ -n "${KATL_MKOSI_PACKAGE_CACHE_DIR:-}" ]]; then
+    package_cache_dir="$KATL_MKOSI_PACKAGE_CACHE_DIR"
+elif [[ -n "${KATL_MKOSI_BUILD_DIR:-}" ]]; then
+    package_cache_dir="$build_dir/package-cache"
+else
+    package_cache_dir="$shared_repo_root/_build/mkosi/package-cache"
+fi
 stamp_dir="$build_dir/.katl-stamps"
 go_mod_cache="${KATL_GO_MOD_CACHE:-$repo_root/_build/go-mod}"
 go_build_cache="${KATL_GO_BUILD_CACHE:-$repo_root/_build/go-cache}"
@@ -30,15 +49,15 @@ mkosi_installer_package_set=""
 container_mkosi_storage_args=(
     --output-directory /mkosi-build
     --workspace-directory /mkosi-build/workspace
-    --cache-directory /mkosi-build/cache
-    --package-cache-directory /mkosi-build/package-cache
+    --cache-directory /mkosi-cache
+    --package-cache-directory /mkosi-package-cache
     --build-directory /mkosi-build/builddir
 )
 
 prepare_build_dirs() {
     mkdir -p \
-        "$build_dir/cache" \
-        "$build_dir/package-cache" \
+        "$cache_dir" \
+        "$package_cache_dir" \
         "$build_dir/builddir" \
         "$build_dir/workspace" \
         "$build_dir/workspace/installer" \
@@ -596,8 +615,8 @@ if [[ "$runtime" == direct ]]; then
     mkdir -p "$direct_workspace"
     direct_mkosi_storage_args=(
         --workspace-directory "$direct_workspace"
-        --cache-directory "$build_dir/cache"
-        --package-cache-directory "$build_dir/package-cache"
+        --cache-directory "$cache_dir"
+        --package-cache-directory "$package_cache_dir"
         --build-directory "$build_dir/builddir"
     )
     export GOCACHE="${GOCACHE:-$go_build_cache}"
@@ -627,6 +646,8 @@ fi
 
 prepare_build_dirs
 run_flags+=(--volume "$build_dir:/mkosi-build")
+run_flags+=(--volume "$cache_dir:/mkosi-cache")
+run_flags+=(--volume "$package_cache_dir:/mkosi-package-cache")
 
 if [[ -n "$installer_package_set" ]]; then
     mkosi_installer_package_set="/work/$installer_package_set"
@@ -663,8 +684,8 @@ set +e
         /work/_build/mkosi/workspace \
         /work/_build/mkosi/workspace/installer \
         /work/_build/mkosi/workspace/runtime \
-        /mkosi-build/cache \
-        /mkosi-build/package-cache \
+        /mkosi-cache \
+        /mkosi-package-cache \
         /mkosi-build/builddir \
         /mkosi-build/workspace
     export GOCACHE=/work/_build/go-cache
@@ -679,7 +700,7 @@ set +e
         go run ./cmd/katl-mkosi-artifacts "$@"
     }
     if [[ "$status" -eq 0 && -n "${KATL_INSTALLER_PACKAGE_SET:-}" ]]; then
-        installer_cache_root=/mkosi-build/cache/fedora~44~x86-64~main.cache
+        installer_cache_root=/mkosi-cache/fedora~44~x86-64~main.cache
         if [[ ! -d "$installer_cache_root/usr/lib/sysimage/rpm" ]]; then
             echo "error: installer RPM database not found: $installer_cache_root/usr/lib/sysimage/rpm" >&2
             status=1
@@ -850,7 +871,7 @@ set +e
     if [[ "${KATL_CHOWN_BUILD:-1}" == 1 && -d _build ]]; then
         chown -R "$HOST_UID:$HOST_GID" _build || true
     elif [[ -d _build/mkosi ]]; then
-        find _build/mkosi/cache _build/mkosi/package-cache _build/mkosi/builddir _build/mkosi/workspace -type d -exec chmod u+rwx,go+rx {} + 2>/dev/null || true
+        find /mkosi-cache /mkosi-package-cache _build/mkosi/builddir _build/mkosi/workspace -type d -exec chmod u+rwx,go+rx {} + 2>/dev/null || true
         chown -h "$HOST_UID:$HOST_GID" \
             _build/mkosi/artifacts.json \
             _build/mkosi/katl-* \


### PR DESCRIPTION
Make whole-cluster apply reconcile declared node labels and kubeadm-managed control-plane, kubelet, and kube-proxy configuration online, with idempotent no-op handling and topology roles in upgrade results. Add a current-worktree katldev ISO build backed by shared mkosi caches, and require public katlctl journeys for UX verification.\n\nThe failures came from rejecting compiler-owned endpoint metadata, treating a late no-change plan as a failed or missing candidate generation, and using a kube-proxy dry-run path that required a temporary admin kubeconfig. The release-only ISO loop made those operator-facing defects unnecessarily slow to uncover.