### PR TITLE
upgrade: stream local KatlOS artifacts

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/katl-dev/katl/internal/installer/operation"
@@ -33,7 +34,9 @@ import (
 	vmtestpb "github.com/katl-dev/katl/internal/vmtest/proto"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -240,6 +243,7 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 
 type hostUpgradeOptions struct {
 	version         string
+	artifact        string
 	target          managementTargetOptions
 	clientRequestID string
 	actor           string
@@ -257,31 +261,52 @@ type hostUpgradeReport struct {
 	BootHealth string `json:"bootHealth"`
 }
 
+type hostUpgradeArtifact struct {
+	Path         string
+	Version      string
+	Architecture string
+	SHA256       string
+	SizeBytes    uint64
+}
+
 var katlOSReleasePattern = regexp.MustCompile(`^[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 
 func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := hostUpgradeOptions{actor: "katlctl node upgrade", waitTimeout: 30 * time.Minute, output: "text"}
 	cmd := &cobra.Command{
-		Use:   "upgrade VERSION [NODE]",
+		Use:   "upgrade [VERSION] [NODE]",
 		Short: "Upgrade one KatlOS node and verify its next boot",
-		Long: `Upgrade one KatlOS node to a published KatlOS release, reboot it, and verify that it returns healthy.
+		Long: `Upgrade one KatlOS node to a published KatlOS release or a locally built image, reboot it, and verify that it returns healthy.
 
-Use the same ClusterConfig used to install the node. --endpoint can override its recorded address when DHCP or local routing changed. A saved katlctl context is optional shorthand for repeated commands.`,
+Use the same ClusterConfig used to install the node. --artifact accepts an upgrade image and its generated .json metadata without requiring a published release. --endpoint can override the node's recorded address when DHCP or local routing changed. A saved katlctl context is optional shorthand for repeated commands.`,
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(command *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return command.Help()
-			}
-			opts.version = args[0]
-			if len(args) == 2 {
-				if err := selectHostNode(&opts.target.nodeName, args[1:]); err != nil {
+			if strings.TrimSpace(opts.artifact) != "" {
+				if len(args) > 1 {
+					return fmt.Errorf("--artifact accepts at most one positional NODE")
+				}
+				if len(args) == 1 && katlOSReleasePattern.MatchString(strings.TrimPrefix(strings.TrimSpace(args[0]), "v")) {
+					return fmt.Errorf("VERSION cannot be combined with --artifact; pass NODE as the positional argument or with --node")
+				}
+				if err := selectHostNode(&opts.target.nodeName, args); err != nil {
 					return err
+				}
+			} else {
+				if len(args) == 0 {
+					return command.Help()
+				}
+				opts.version = args[0]
+				if len(args) == 2 {
+					if err := selectHostNode(&opts.target.nodeName, args[1:]); err != nil {
+						return err
+					}
 				}
 			}
 			return runHostUpgrade(ctx, opts, stdout, stderr)
 		},
 	}
 	addManagementTargetFlags(cmd, &opts.target)
+	cmd.Flags().StringVar(&opts.artifact, "artifact", "", "locally built KatlOS upgrade image (uses PATH.json metadata)")
 	cmd.Flags().StringVar(&opts.clientRequestID, "client-request-id", "", "optional idempotency key for advanced retry control")
 	cmd.Flags().Lookup("client-request-id").Hidden = true
 	cmd.Flags().StringVar(&opts.actor, "actor", opts.actor, "operation actor")
@@ -299,17 +324,27 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
 	}
-	version, err := katlOSVersion(opts.version)
-	if err != nil {
-		return err
+	var localArtifact *hostUpgradeArtifact
+	if strings.TrimSpace(opts.artifact) != "" {
+		artifact, err := readHostUpgradeArtifact(opts.artifact)
+		if err != nil {
+			return fmt.Errorf("--artifact: %w", err)
+		}
+		localArtifact = &artifact
+		opts.version = artifact.Version
+	} else {
+		version, err := katlOSVersion(opts.version)
+		if err != nil {
+			return err
+		}
+		opts.version = version
 	}
-	opts.version = version
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
 		return err
 	}
 	request := operation.HostUpgrade{
-		CandidateGenerationID: "katlos-" + version,
+		CandidateGenerationID: "katlos-" + opts.version,
 	}
 	target, err := resolveManagementTarget(opts.target)
 	if err != nil {
@@ -332,7 +367,19 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if err != nil {
 		return err
 	}
-	request.ImageURL = katlOSReleaseURL(opts.version, architecture)
+	image := ""
+	if localArtifact != nil {
+		if architecture != localArtifact.Architecture {
+			return fmt.Errorf("local KatlOS image architecture %q does not match node architecture %q", localArtifact.Architecture, architecture)
+		}
+		request.ImageLocalRef = hostUpgradeArtifactLocalRef(localArtifact.SHA256)
+		request.ImageSHA256 = localArtifact.SHA256
+		request.ImageSizeBytes = localArtifact.SizeBytes
+		image = localArtifact.Path
+	} else {
+		request.ImageURL = katlOSReleaseURL(opts.version, architecture)
+		image = request.ImageURL
+	}
 	if err := operation.ValidateHostUpgrade(request); err != nil {
 		return err
 	}
@@ -341,7 +388,17 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		if node == "" {
 			node = target.endpoint
 		}
-		return writeHostUpgradeReport(stdout, opts.output, hostUpgradeReport{Node: node, Version: opts.version, Image: request.ImageURL, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy})
+		return writeHostUpgradeReport(stdout, opts.output, hostUpgradeReport{Node: node, Version: opts.version, Image: image, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy})
+	}
+	if localArtifact != nil && !opts.plan {
+		localRef, err := stageHostUpgradeArtifact(ctx, conn.Client, strings.TrimSpace(opts.actor), status.GetMachineId(), *localArtifact, target.nodeName, stderr)
+		if err != nil {
+			return err
+		}
+		request.ImageLocalRef = localRef
+		if err := operation.ValidateHostUpgrade(request); err != nil {
+			return fmt.Errorf("validate staged KatlOS image: %w", err)
+		}
 	}
 	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 		ApiVersion:                  operation.APIVersion,
@@ -355,13 +412,15 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
 			ImageUrl:              request.ImageURL,
 			ImageLocalRef:         request.ImageLocalRef,
+			ImageSha256:           request.ImageSHA256,
+			ImageSizeBytes:        request.ImageSizeBytes,
 			CandidateGenerationId: request.CandidateGenerationID,
 		},
 	})
 	if err != nil {
 		return err
 	}
-	report := hostUpgradeReport{Node: target.nodeName, Version: opts.version, Image: request.ImageURL, Result: "planned", BootHealth: "not-run"}
+	report := hostUpgradeReport{Node: target.nodeName, Version: opts.version, Image: image, Result: "planned", BootHealth: "not-run"}
 	if report.Node == "" {
 		report.Node = target.endpoint
 	}
@@ -458,6 +517,108 @@ func katlOSReleaseURL(version, architecture string) string {
 	tag := "v" + version
 	name := "katlos-upgrade-" + version + "-" + architecture + ".squashfs"
 	return "https://github.com/katl-dev/katl/releases/download/" + tag + "/" + name
+}
+
+func readHostUpgradeArtifact(path string) (hostUpgradeArtifact, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return hostUpgradeArtifact{}, fmt.Errorf("path is required")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return hostUpgradeArtifact{}, fmt.Errorf("resolve path: %w", err)
+	}
+	metadata, err := katlosimage.ReadArtifactMetadata(absolute+".json", katlosimage.RoleUpgrade)
+	if err != nil {
+		return hostUpgradeArtifact{}, err
+	}
+	if err := metadata.VerifyFile(absolute); err != nil {
+		return hostUpgradeArtifact{}, err
+	}
+	version, err := katlOSVersion(metadata.Version)
+	if err != nil {
+		return hostUpgradeArtifact{}, fmt.Errorf("metadata version: %w", err)
+	}
+	architecture, ok := supportedArtifactArchitecture(metadata.Architecture)
+	if !ok {
+		return hostUpgradeArtifact{}, fmt.Errorf("metadata architecture %q is unsupported", metadata.Architecture)
+	}
+	return hostUpgradeArtifact{
+		Path:         absolute,
+		Version:      version,
+		Architecture: architecture,
+		SHA256:       metadata.SHA256,
+		SizeBytes:    uint64(metadata.SizeBytes),
+	}, nil
+}
+
+func hostUpgradeArtifactLocalRef(sha256 string) string {
+	return "host-upgrade/uploads/" + sha256 + ".squashfs"
+}
+
+func stageHostUpgradeArtifact(ctx context.Context, client agentapi.KatlcAgentClient, actor, machineID string, artifact hostUpgradeArtifact, node string, stderr io.Writer) (string, error) {
+	stream, err := client.StageHostUpgradeArtifact(ctx)
+	if err != nil {
+		return "", localArtifactStageError(err)
+	}
+	file, err := os.Open(artifact.Path)
+	if err != nil {
+		return "", fmt.Errorf("open local KatlOS image: %w", err)
+	}
+	defer file.Close()
+	if strings.TrimSpace(node) == "" {
+		node = "node"
+	}
+	fmt.Fprintf(stderr, "%s: uploading local KatlOS %s image (%d bytes)\n", node, artifact.Version, artifact.SizeBytes)
+	buffer := make([]byte, 1<<20)
+	first := true
+	var sent uint64
+	var lastProgress uint64
+	for {
+		n, readErr := file.Read(buffer)
+		if n > 0 {
+			request := &agentapi.StageHostUpgradeArtifactRequest{Chunk: append([]byte(nil), buffer[:n]...)}
+			if first {
+				request.ApiVersion = operation.APIVersion
+				request.Kind = "StageHostUpgradeArtifactRequest"
+				request.Actor = actor
+				request.ExpectedMachineId = machineID
+				request.Sha256 = artifact.SHA256
+				request.SizeBytes = artifact.SizeBytes
+				first = false
+			}
+			if err := stream.Send(request); err != nil {
+				return "", localArtifactStageError(err)
+			}
+			sent += uint64(n)
+			if sent < artifact.SizeBytes && sent-lastProgress >= 256<<20 {
+				fmt.Fprintf(stderr, "%s: uploaded %d%%\n", node, sent*100/artifact.SizeBytes)
+				lastProgress = sent
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return "", fmt.Errorf("read local KatlOS image: %w", readErr)
+		}
+	}
+	staged, err := stream.CloseAndRecv()
+	if err != nil {
+		return "", localArtifactStageError(err)
+	}
+	if staged.GetLocalRef() != hostUpgradeArtifactLocalRef(artifact.SHA256) || staged.GetSha256() != artifact.SHA256 || staged.GetSizeBytes() != artifact.SizeBytes {
+		return "", fmt.Errorf("node returned an inconsistent staged KatlOS image identity")
+	}
+	fmt.Fprintf(stderr, "%s: local KatlOS image uploaded; staging the upgrade\n", node)
+	return staged.GetLocalRef(), nil
+}
+
+func localArtifactStageError(err error) error {
+	if grpcstatus.Code(err) == codes.Unimplemented {
+		return fmt.Errorf("node does not support local KatlOS artifact delivery; upgrade it once from a published release, then retry --artifact")
+	}
+	return fmt.Errorf("upload local KatlOS image: %w", err)
 }
 
 func writeJSON(stdout io.Writer, value any) error {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +24,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"github.com/katl-dev/katl/internal/katlctl/workstation"
@@ -29,6 +32,8 @@ import (
 	vmtestpb "github.com/katl-dev/katl/internal/vmtest/proto"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -362,7 +367,7 @@ func TestHostUpgradeWithoutVersionPrintsHelp(t *testing.T) {
 	if err := run(context.Background(), []string{"node", "upgrade"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
-	for _, want := range []string{"Usage:", "katlctl node upgrade VERSION", "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml"} {
+	for _, want := range []string{"Usage:", "katlctl node upgrade [VERSION]", "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
 		}
@@ -392,6 +397,7 @@ func TestHostUpgradeHelpLeadsWithClusterConfig(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Use the same ClusterConfig used to install the node",
+		"--artifact string",
 		"--config string",
 		"--node string",
 		"--endpoint string",
@@ -1971,6 +1977,157 @@ func TestHostUpgradeUsesRuntimeArchitectureWithoutKubernetesExtension(t *testing
 	}
 }
 
+func TestHostUpgradeLocalArtifactUploadsStagesRebootsAndVerifiesHealth(t *testing.T) {
+	artifact, contents, digest := writeHostUpgradeArtifact(t, "2026.7.0-dev.12", "x86_64", 1<<20+17)
+	fake := readyHostUpgradeClient()
+	installKatlcDial(t, func(endpoint string) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("dial endpoint = %q", endpoint)
+		}
+	}, fake)
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"node", "upgrade", "cp-1", "--artifact", artifact, "--config", writeClusterConfig(t), "--timeout", "1m", "--output", "json"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if len(fake.stageArtifact) != 2 {
+		t.Fatalf("artifact chunks = %d, want 2", len(fake.stageArtifact))
+	}
+	first := fake.stageArtifact[0]
+	if first.ApiVersion != operation.APIVersion || first.Kind != "StageHostUpgradeArtifactRequest" || first.ExpectedMachineId != "machine-a" || first.Sha256 != digest || first.SizeBytes != uint64(len(contents)) {
+		t.Fatalf("first artifact chunk = %#v", first)
+	}
+	if next := fake.stageArtifact[1]; next.ApiVersion != "" || next.Kind != "" || next.Sha256 != "" || next.SizeBytes != 0 {
+		t.Fatalf("later artifact chunk repeated metadata = %#v", next)
+	}
+	var uploaded []byte
+	for _, chunk := range fake.stageArtifact {
+		uploaded = append(uploaded, chunk.Chunk...)
+	}
+	if !bytes.Equal(uploaded, contents) {
+		t.Fatal("uploaded artifact differs from local file")
+	}
+	request := fake.submitRequest.GetHostUpgrade()
+	if request.GetImageUrl() != "" || request.GetImageLocalRef() != hostUpgradeArtifactLocalRef(digest) || request.GetImageSha256() != digest || request.GetImageSizeBytes() != uint64(len(contents)) || request.GetCandidateGenerationId() != "katlos-2026.7.0-dev.12" {
+		t.Fatalf("host upgrade request = %#v", request)
+	}
+	if !strings.Contains(stderr.String(), "uploading local KatlOS 2026.7.0-dev.12 image") || !strings.Contains(stderr.String(), "local KatlOS image uploaded; staging the upgrade") {
+		t.Fatalf("progress = %q", stderr.String())
+	}
+	var report hostUpgradeReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	absolute, _ := filepath.Abs(artifact)
+	if report.Image != absolute || report.Version != "2026.7.0-dev.12" || report.Result != operation.ResultSucceeded || !report.Rebooted {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestHostUpgradeLocalArtifactPlanValidatesWithoutUploading(t *testing.T) {
+	artifact, contents, digest := writeHostUpgradeArtifact(t, "2026.7.0-dev.13", "x86_64", 1024)
+	fake := readyHostUpgradeClient()
+	installKatlcDial(t, func(endpoint string) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("dial endpoint = %q", endpoint)
+		}
+	}, fake)
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"node", "upgrade", "cp-1", "--artifact", artifact, "--config", writeClusterConfig(t), "--plan", "--output", "json"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
+	}
+	if len(fake.stageArtifact) != 0 {
+		t.Fatalf("plan uploaded %d chunks", len(fake.stageArtifact))
+	}
+	if !fake.submitRequest.GetDryRun() {
+		t.Fatalf("plan request = %#v", fake.submitRequest)
+	}
+	request := fake.submitRequest.GetHostUpgrade()
+	if request.GetImageLocalRef() != hostUpgradeArtifactLocalRef(digest) || request.GetImageSha256() != digest || request.GetImageSizeBytes() != uint64(len(contents)) {
+		t.Fatalf("plan host upgrade request = %#v", request)
+	}
+	if len(fake.rebootRequests) != 0 {
+		t.Fatalf("plan reboot requests = %d", len(fake.rebootRequests))
+	}
+}
+
+func TestHostUpgradeLocalArtifactExplainsAgentUpgradeRequirement(t *testing.T) {
+	artifact, _, _ := writeHostUpgradeArtifact(t, "2026.7.0-dev.14", "x86_64", 1024)
+	fake := readyHostUpgradeClient()
+	fake.stageArtifactErr = grpcstatus.Error(codes.Unimplemented, "unknown method")
+	installKatlcDial(t, func(endpoint string) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("dial endpoint = %q", endpoint)
+		}
+	}, fake)
+
+	err := run(context.Background(), []string{"node", "upgrade", "cp-1", "--artifact", artifact, "--config", writeClusterConfig(t)}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "upgrade it once from a published release, then retry --artifact") {
+		t.Fatalf("run() error = %v", err)
+	}
+}
+
+func TestHostUpgradeLocalArtifactRejectsRedundantVersion(t *testing.T) {
+	err := run(context.Background(), []string{"node", "upgrade", "2026.7.0-dev.14", "--artifact", "upgrade.squashfs", "--config", writeClusterConfig(t)}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "VERSION cannot be combined with --artifact") {
+		t.Fatalf("run() error = %v", err)
+	}
+}
+
+func readyHostUpgradeClient() *fakeKatlcAgentClient {
+	fake := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current"},
+		generation:      &agentapi.Generation{GenerationId: "generation-current", RuntimeArchitecture: "x86_64"},
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "host-upgrade-01", OperationKind: "host-upgrade"},
+		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "arm-trial-boot"},
+	}
+	fake.onReboot = func(request *agentapi.RebootRequest) {
+		fake.nodeStatus.AgentStartId = "after"
+		fake.nodeStatus.CurrentGenerationId = request.TargetGenerationId
+		fake.generation = &agentapi.Generation{GenerationId: request.TargetGenerationId, CommitState: generation.CommitStateCommitted, BootState: generation.BootStateGood, HealthState: generation.HealthStateHealthy}
+	}
+	return fake
+}
+
+func writeHostUpgradeArtifact(t *testing.T, version, architecture string, size int) (string, []byte, string) {
+	t.Helper()
+	directory := t.TempDir()
+	path := filepath.Join(directory, "katlos-upgrade-"+version+"-"+architecture+".squashfs")
+	contents := bytes.Repeat([]byte("k"), size)
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digestBytes := sha256.Sum256(contents)
+	digest := hex.EncodeToString(digestBytes[:])
+	metadata := katlosimage.ArtifactMetadata{
+		APIVersion:        katlosimage.APIVersion,
+		Kind:              katlosimage.ArtifactMetadataKind,
+		ImageRole:         katlosimage.RoleUpgrade,
+		Format:            katlosimage.FormatSquashFS,
+		Version:           version,
+		BuildID:           "test-build",
+		Architecture:      architecture,
+		RuntimeInterface:  "katl-runtime-1",
+		Path:              filepath.Base(path),
+		SizeBytes:         int64(size),
+		SHA256:            digest,
+		ChecksumPath:      filepath.Base(path) + ".sha256",
+		EmbeddedIndexPath: "katlos/image.json",
+		CreatedAt:         "2026-07-23T12:00:00Z",
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+".json", append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path, contents, digest
+}
+
 func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\n"), 0o600); err != nil {
@@ -2349,6 +2506,13 @@ type fakeKatlcAgentClient struct {
 	onReboot          func(*agentapi.RebootRequest)
 	shutdownRequests  []*agentapi.ShutdownRequest
 	onShutdown        func(*agentapi.ShutdownRequest)
+	stageArtifact     []*agentapi.StageHostUpgradeArtifactRequest
+	stageArtifactErr  error
+}
+
+type fakeHostUpgradeArtifactClient struct {
+	grpc.ClientStream
+	client *fakeKatlcAgentClient
 }
 
 type fakeWipeClusterConnector struct {
@@ -2441,6 +2605,29 @@ func (c *fakeKatlcAgentClient) ApplyGeneration(_ context.Context, req *agentapi.
 func (c *fakeKatlcAgentClient) StageGeneration(_ context.Context, req *agentapi.GenerationApplyRequest, _ ...grpc.CallOption) (*agentapi.OperationAccepted, error) {
 	c.stageRequest = req
 	return c.stageAccepted, nil
+}
+
+func (c *fakeKatlcAgentClient) StageHostUpgradeArtifact(context.Context, ...grpc.CallOption) (grpc.ClientStreamingClient[agentapi.StageHostUpgradeArtifactRequest, agentapi.HostUpgradeArtifactStaged], error) {
+	return &fakeHostUpgradeArtifactClient{client: c}, nil
+}
+
+func (s *fakeHostUpgradeArtifactClient) Send(request *agentapi.StageHostUpgradeArtifactRequest) error {
+	copyRequest := *request
+	copyRequest.Chunk = append([]byte(nil), request.Chunk...)
+	s.client.stageArtifact = append(s.client.stageArtifact, &copyRequest)
+	return s.client.stageArtifactErr
+}
+
+func (s *fakeHostUpgradeArtifactClient) CloseAndRecv() (*agentapi.HostUpgradeArtifactStaged, error) {
+	if s.client.stageArtifactErr != nil {
+		return nil, s.client.stageArtifactErr
+	}
+	first := s.client.stageArtifact[0]
+	return &agentapi.HostUpgradeArtifactStaged{
+		LocalRef:  hostUpgradeArtifactLocalRef(first.Sha256),
+		Sha256:    first.Sha256,
+		SizeBytes: first.SizeBytes,
+	}, nil
 }
 
 func (c *fakeKatlcAgentClient) SubmitOperation(_ context.Context, req *agentapi.SubmitOperationRequest, _ ...grpc.CallOption) (*agentapi.OperationAccepted, error) {

--- a/cmd/katldev/build.go
+++ b/cmd/katldev/build.go
@@ -7,11 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
 
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/spf13/cobra"
 )
 
-type buildCommandRunner func(context.Context, string, string, []string, io.Writer, io.Writer) error
+type buildCommandRunner func(context.Context, string, string, []string, []string, io.Writer, io.Writer) error
 
 type installerISOArtifact struct {
 	Path      string
@@ -20,6 +24,8 @@ type installerISOArtifact struct {
 	SHA256    string
 	SizeBytes int64
 }
+
+var katlOSBuildVersionPattern = regexp.MustCompile(`^[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 
 func newBuildCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -30,6 +36,29 @@ func newBuildCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Comma
 		},
 	}
 	cmd.AddCommand(newBuildISOCommand(ctx, stdout, stderr))
+	cmd.AddCommand(newBuildUpgradeCommand(ctx, stdout, stderr))
+	return cmd
+}
+
+func newBuildUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	var version string
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Build and verify a KatlOS upgrade image from the current checkout",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			repoRoot, err := repositoryRoot()
+			if err != nil {
+				return err
+			}
+			artifact, err := buildKatlOSUpgrade(ctx, repoRoot, version, stderr, runBuildCommand)
+			if err != nil {
+				return err
+			}
+			return writeKatlOSUpgradeArtifact(stdout, artifact)
+		},
+	}
+	cmd.Flags().StringVar(&version, "version", "", "KatlOS version to embed in the locally built image")
 	return cmd
 }
 
@@ -58,11 +87,11 @@ func buildInstallerISO(ctx context.Context, repoRoot string, stderr io.Writer, r
 	}
 	iso := filepath.Join(repoRoot, "_build", "mkosi", "katl-installer.iso")
 	fmt.Fprintln(stderr, "katldev build: building the current checkout installer ISO")
-	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "mkosi"), []string{"build-installer-iso"}, stderr, stderr); err != nil {
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "mkosi"), []string{"build-installer-iso"}, nil, stderr, stderr); err != nil {
 		return installerISOArtifact{}, fmt.Errorf("build installer ISO: %w", err)
 	}
 	fmt.Fprintln(stderr, "katldev build: verifying the completed installer ISO")
-	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "check-installer-iso"), []string{iso}, stderr, stderr); err != nil {
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "check-installer-iso"), []string{iso}, nil, stderr, stderr); err != nil {
 		return installerISOArtifact{}, fmt.Errorf("verify installer ISO: %w", err)
 	}
 	digest, err := sha256File(iso)
@@ -91,12 +120,101 @@ func buildInstallerISO(ctx context.Context, repoRoot string, stderr io.Writer, r
 	return artifact, nil
 }
 
-func runBuildCommand(ctx context.Context, dir, name string, args []string, stdout, stderr io.Writer) error {
+func runBuildCommand(ctx context.Context, dir, name string, args, environment []string, stdout, stderr io.Writer) error {
 	command := exec.CommandContext(ctx, name, args...)
 	command.Dir = dir
+	command.Env = append(os.Environ(), environment...)
 	command.Stdout = stdout
 	command.Stderr = stderr
 	return command.Run()
+}
+
+func buildKatlOSUpgrade(ctx context.Context, repoRoot, version string, stderr io.Writer, run buildCommandRunner) (hostUpgradeBuildArtifact, error) {
+	if run == nil {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("build command runner is required")
+	}
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if version == "" {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("--version is required")
+	}
+	if !katlOSBuildVersionPattern.MatchString(version) {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("--version %q must look like 2026.7.0-dev.1", version)
+	}
+	architecture, err := developmentArtifactArchitecture(runtime.GOARCH)
+	if err != nil {
+		return hostUpgradeBuildArtifact{}, err
+	}
+	buildID := version
+	if revision, dirty := checkoutRevision(repoRoot); revision != "" {
+		buildID = revision
+		if dirty {
+			buildID += "-dirty"
+		}
+	}
+	image := filepath.Join(repoRoot, "_build", "mkosi", "katlos-upgrade-"+version+"-"+architecture+".squashfs")
+	fmt.Fprintf(stderr, "katldev build: building KatlOS %s upgrade image from the current checkout\n", version)
+	environment := []string{"KATL_VERSION=" + version, "KATL_UPGRADE_VERSION=" + version, "KATL_ARCHITECTURE=" + architecture, "KATL_BUILD_COMMIT=" + buildID}
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "mkosi"), []string{"build-katlos-upgrade-image"}, environment, stderr, stderr); err != nil {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("build KatlOS upgrade image: %w", err)
+	}
+	fmt.Fprintln(stderr, "katldev build: verifying the completed KatlOS upgrade image")
+	metadata, err := katlosimage.ReadArtifactMetadata(image+".json", katlosimage.RoleUpgrade)
+	if err != nil {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("verify KatlOS upgrade metadata: %w", err)
+	}
+	if metadata.Version != version {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("KatlOS upgrade metadata version %q does not match requested %q", metadata.Version, version)
+	}
+	if metadata.Architecture != architecture {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("KatlOS upgrade metadata architecture %q does not match requested %q", metadata.Architecture, architecture)
+	}
+	if metadata.BuildID != buildID {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("KatlOS upgrade metadata buildID %q does not match current checkout %q", metadata.BuildID, buildID)
+	}
+	if err := metadata.VerifyFile(image); err != nil {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("verify KatlOS upgrade image: %w", err)
+	}
+	checksum := image + ".sha256"
+	if info, err := os.Stat(checksum); err != nil {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("inspect KatlOS upgrade checksum: %w", err)
+	} else if !info.Mode().IsRegular() {
+		return hostUpgradeBuildArtifact{}, fmt.Errorf("KatlOS upgrade checksum is not a regular file")
+	}
+	return hostUpgradeBuildArtifact{
+		Path:         image,
+		Metadata:     image + ".json",
+		Checksum:     checksum,
+		Version:      metadata.Version,
+		Architecture: metadata.Architecture,
+		SHA256:       metadata.SHA256,
+		SizeBytes:    metadata.SizeBytes,
+	}, nil
+}
+
+type hostUpgradeBuildArtifact struct {
+	Path         string
+	Metadata     string
+	Checksum     string
+	Version      string
+	Architecture string
+	SHA256       string
+	SizeBytes    int64
+}
+
+func developmentArtifactArchitecture(goarch string) (string, error) {
+	switch goarch {
+	case "amd64":
+		return "x86_64", nil
+	case "arm64":
+		return "aarch64", nil
+	default:
+		return "", fmt.Errorf("host architecture %q cannot build a supported KatlOS image", goarch)
+	}
+}
+
+func writeKatlOSUpgradeArtifact(stdout io.Writer, artifact hostUpgradeBuildArtifact) error {
+	_, err := fmt.Fprintf(stdout, "KatlOS upgrade image ready.\nImage: %s\nUse with:\n  katlctl node upgrade NODE --config cluster.yaml --artifact %s\n", artifact.Path, artifact.Path)
+	return err
 }
 
 func writeInstallerISOArtifact(stdout io.Writer, artifact installerISOArtifact) error {

--- a/cmd/katldev/main_test.go
+++ b/cmd/katldev/main_test.go
@@ -5,14 +5,18 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
 )
 
 func TestRootAndInstallerCommandsShowHelpWithoutArguments(t *testing.T) {
@@ -21,7 +25,7 @@ func TestRootAndInstallerCommandsShowHelpWithoutArguments(t *testing.T) {
 		want []string
 	}{
 		{want: []string{"build", "installer"}},
-		{args: []string{"build"}, want: []string{"iso"}},
+		{args: []string{"build"}, want: []string{"iso", "upgrade"}},
 		{args: []string{"installer"}, want: []string{"start", "reset", "status", "console", "stop"}},
 	} {
 		var stdout, stderr bytes.Buffer
@@ -45,10 +49,11 @@ func TestBuildInstallerISOComposesSupportedPipeline(t *testing.T) {
 		dir  string
 		name string
 		args []string
+		env  []string
 	}
 	var calls []call
-	runner := func(_ context.Context, dir, name string, args []string, _, _ io.Writer) error {
-		calls = append(calls, call{dir: dir, name: name, args: append([]string(nil), args...)})
+	runner := func(_ context.Context, dir, name string, args, environment []string, _, _ io.Writer) error {
+		calls = append(calls, call{dir: dir, name: name, args: append([]string(nil), args...), env: append([]string(nil), environment...)})
 		if filepath.Base(name) == "mkosi" {
 			if err := os.MkdirAll(filepath.Dir(iso), 0o755); err != nil {
 				return err
@@ -95,7 +100,7 @@ func TestBuildInstallerISOComposesSupportedPipeline(t *testing.T) {
 func TestBuildInstallerISOStopsAfterBuildFailure(t *testing.T) {
 	wantErr := errors.New("builder failed")
 	calls := 0
-	runner := func(context.Context, string, string, []string, io.Writer, io.Writer) error {
+	runner := func(context.Context, string, string, []string, []string, io.Writer, io.Writer) error {
 		calls++
 		return wantErr
 	}
@@ -105,6 +110,105 @@ func TestBuildInstallerISOStopsAfterBuildFailure(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("runner calls = %d, want 1", calls)
+	}
+}
+
+func TestBuildKatlOSUpgradeComposesAndVerifiesSupportedPipeline(t *testing.T) {
+	repo := t.TempDir()
+	version := "2026.7.0-dev.12"
+	architecture, err := developmentArtifactArchitecture(runtime.GOARCH)
+	if err != nil {
+		t.Skip(err)
+	}
+	image := filepath.Join(repo, "_build", "mkosi", "katlos-upgrade-"+version+"-"+architecture+".squashfs")
+	contents := []byte("current checkout KatlOS upgrade image")
+	digest := sha256.Sum256(contents)
+	metadata := katlosimage.ArtifactMetadata{
+		APIVersion:        katlosimage.APIVersion,
+		Kind:              katlosimage.ArtifactMetadataKind,
+		ImageRole:         katlosimage.RoleUpgrade,
+		Format:            katlosimage.FormatSquashFS,
+		Version:           version,
+		BuildID:           version,
+		Architecture:      architecture,
+		RuntimeInterface:  "katl-runtime-1",
+		Path:              filepath.Base(image),
+		SizeBytes:         int64(len(contents)),
+		SHA256:            hex.EncodeToString(digest[:]),
+		ChecksumPath:      filepath.Base(image) + ".sha256",
+		EmbeddedIndexPath: "katlos/image.json",
+		CreatedAt:         "2026-07-23T12:00:00Z",
+	}
+	type call struct {
+		dir  string
+		name string
+		args []string
+		env  []string
+	}
+	var calls []call
+	runner := func(_ context.Context, dir, name string, args, environment []string, _, _ io.Writer) error {
+		calls = append(calls, call{dir: dir, name: name, args: append([]string(nil), args...), env: append([]string(nil), environment...)})
+		if err := os.MkdirAll(filepath.Dir(image), 0o755); err != nil {
+			return err
+		}
+		metadataJSON, err := json.Marshal(metadata)
+		if err != nil {
+			return err
+		}
+		for path, data := range map[string][]byte{
+			image:             contents,
+			image + ".json":   append(metadataJSON, '\n'),
+			image + ".sha256": []byte(metadata.SHA256 + "  " + filepath.Base(image) + "\n"),
+		} {
+			if err := os.WriteFile(path, data, 0o644); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	artifact, err := buildKatlOSUpgrade(context.Background(), repo, version, &stderr, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := []call{{
+		dir:  repo,
+		name: filepath.Join(repo, "scripts", "mkosi"),
+		args: []string{"build-katlos-upgrade-image"},
+		env:  []string{"KATL_VERSION=" + version, "KATL_UPGRADE_VERSION=" + version, "KATL_ARCHITECTURE=" + architecture, "KATL_BUILD_COMMIT=" + version},
+	}}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("build calls = %#v, want %#v", calls, wantCalls)
+	}
+	if artifact.Path != image || artifact.Version != version || artifact.Architecture != architecture || artifact.SHA256 != metadata.SHA256 || artifact.SizeBytes != int64(len(contents)) {
+		t.Fatalf("artifact = %#v", artifact)
+	}
+	if err := writeKatlOSUpgradeArtifact(&stdout, artifact); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"KatlOS upgrade image ready.", "Image: " + image, "katlctl node upgrade NODE --config cluster.yaml --artifact " + image} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, internal := range []string{"SHA256:", "Checksum:", "Metadata:"} {
+		if strings.Contains(stdout.String(), internal) {
+			t.Fatalf("output exposed internal integrity field %q:\n%s", internal, stdout.String())
+		}
+	}
+	for _, want := range []string{"building KatlOS " + version, "verifying the completed KatlOS upgrade image"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("progress missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestBuildKatlOSUpgradeRequiresVersion(t *testing.T) {
+	_, err := buildKatlOSUpgrade(context.Background(), t.TempDir(), "", io.Discard, func(context.Context, string, string, []string, []string, io.Writer, io.Writer) error {
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "--version is required") {
+		t.Fatalf("buildKatlOSUpgrade() error = %v", err)
 	}
 }
 

--- a/internal/installer/katlosimage/artifact.go
+++ b/internal/installer/katlosimage/artifact.go
@@ -1,0 +1,138 @@
+package katlosimage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const ArtifactMetadataKind = "KatlOSImageArtifact"
+
+// ArtifactMetadata describes a complete KatlOS image file produced by the
+// supported image build pipeline. It is the workstation-side contract used
+// before an image is offered to an installer or running node.
+type ArtifactMetadata struct {
+	APIVersion        string `json:"apiVersion"`
+	Kind              string `json:"kind"`
+	ImageRole         string `json:"imageRole"`
+	Format            string `json:"format"`
+	Version           string `json:"version"`
+	BuildID           string `json:"buildID"`
+	Architecture      string `json:"architecture"`
+	RuntimeInterface  string `json:"runtimeInterface"`
+	Path              string `json:"path"`
+	SizeBytes         int64  `json:"sizeBytes"`
+	SHA256            string `json:"sha256"`
+	ChecksumPath      string `json:"checksumPath"`
+	EmbeddedIndexPath string `json:"embeddedIndexPath"`
+	CreatedAt         string `json:"createdAt"`
+}
+
+func ReadArtifactMetadata(path string, expectedRole string) (ArtifactMetadata, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return ArtifactMetadata{}, fmt.Errorf("open KatlOS image metadata: %w", err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	var metadata ArtifactMetadata
+	if err := decoder.Decode(&metadata); err != nil {
+		return ArtifactMetadata{}, fmt.Errorf("decode KatlOS image metadata: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return ArtifactMetadata{}, fmt.Errorf("decode KatlOS image metadata: multiple JSON values")
+	}
+	if err := metadata.Validate(expectedRole); err != nil {
+		return ArtifactMetadata{}, err
+	}
+	return metadata, nil
+}
+
+func (m ArtifactMetadata) Validate(expectedRole string) error {
+	if m.APIVersion != APIVersion {
+		return fmt.Errorf("KatlOS image metadata apiVersion must be %s", APIVersion)
+	}
+	if m.Kind != ArtifactMetadataKind {
+		return fmt.Errorf("KatlOS image metadata kind must be %s", ArtifactMetadataKind)
+	}
+	if expectedRole != RoleInstall && expectedRole != RoleUpgrade {
+		return fmt.Errorf("expected KatlOS image role %q is unsupported", expectedRole)
+	}
+	if m.ImageRole != expectedRole {
+		return fmt.Errorf("KatlOS image metadata role must be %s", expectedRole)
+	}
+	if m.Format != FormatSquashFS {
+		return fmt.Errorf("KatlOS image metadata format must be %s", FormatSquashFS)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "version", value: m.Version},
+		{name: "buildID", value: m.BuildID},
+		{name: "architecture", value: m.Architecture},
+		{name: "runtimeInterface", value: m.RuntimeInterface},
+		{name: "path", value: m.Path},
+		{name: "checksumPath", value: m.ChecksumPath},
+		{name: "embeddedIndexPath", value: m.EmbeddedIndexPath},
+		{name: "createdAt", value: m.CreatedAt},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("KatlOS image metadata %s is required", field.name)
+		}
+	}
+	if err := validateRelativePath(m.Path); err != nil {
+		return fmt.Errorf("KatlOS image metadata path: %w", err)
+	}
+	if filepath.Base(filepath.FromSlash(m.Path)) != filepath.FromSlash(m.Path) {
+		return fmt.Errorf("KatlOS image metadata path %q must name a companion file", m.Path)
+	}
+	if err := validateRelativePath(m.ChecksumPath); err != nil {
+		return fmt.Errorf("KatlOS image metadata checksumPath: %w", err)
+	}
+	if err := validateRelativePath(m.EmbeddedIndexPath); err != nil {
+		return fmt.Errorf("KatlOS image metadata embeddedIndexPath: %w", err)
+	}
+	if m.SizeBytes <= 0 {
+		return fmt.Errorf("KatlOS image metadata size must be positive")
+	}
+	if err := validateSHA256(m.SHA256); err != nil {
+		return fmt.Errorf("KatlOS image metadata SHA-256 is invalid: %w", err)
+	}
+	return nil
+}
+
+func (m ArtifactMetadata) VerifyFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat KatlOS image: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("KatlOS image is not a regular file")
+	}
+	if filepath.Base(path) != filepath.FromSlash(m.Path) {
+		return fmt.Errorf("KatlOS image filename %q does not match metadata %q", filepath.Base(path), m.Path)
+	}
+	if info.Size() != m.SizeBytes {
+		return fmt.Errorf("KatlOS image size %d does not match metadata %d", info.Size(), m.SizeBytes)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open KatlOS image: %w", err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("hash KatlOS image: %w", err)
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); got != m.SHA256 {
+		return fmt.Errorf("KatlOS image SHA-256 %s does not match metadata %s", got, m.SHA256)
+	}
+	return nil
+}

--- a/internal/installer/katlosimage/artifact_test.go
+++ b/internal/installer/katlosimage/artifact_test.go
@@ -1,0 +1,81 @@
+package katlosimage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestArtifactMetadataVerifiesCompanionImage(t *testing.T) {
+	directory := t.TempDir()
+	image := filepath.Join(directory, "katlos-upgrade-2026.7.0-dev.12-x86_64.squashfs")
+	content := []byte("KatlOS upgrade image")
+	if err := os.WriteFile(image, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(content)
+	metadata := ArtifactMetadata{
+		APIVersion:        APIVersion,
+		Kind:              ArtifactMetadataKind,
+		ImageRole:         RoleUpgrade,
+		Format:            FormatSquashFS,
+		Version:           "2026.7.0-dev.12",
+		BuildID:           "test-build",
+		Architecture:      "x86_64",
+		RuntimeInterface:  "katl-runtime-1",
+		Path:              filepath.Base(image),
+		SizeBytes:         int64(len(content)),
+		SHA256:            hex.EncodeToString(digest[:]),
+		ChecksumPath:      filepath.Base(image) + ".sha256",
+		EmbeddedIndexPath: "katlos/image.json",
+		CreatedAt:         "2026-07-23T12:00:00Z",
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadataPath := image + ".json"
+	if err := os.WriteFile(metadataPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadArtifactMetadata(metadataPath, RoleUpgrade)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := got.VerifyFile(image); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(image, []byte("modified upgrade image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := got.VerifyFile(image); err == nil || (!strings.Contains(err.Error(), "size") && !strings.Contains(err.Error(), "SHA-256")) {
+		t.Fatalf("VerifyFile() error = %v", err)
+	}
+}
+
+func TestArtifactMetadataRejectsWrongRole(t *testing.T) {
+	metadata := ArtifactMetadata{
+		APIVersion:        APIVersion,
+		Kind:              ArtifactMetadataKind,
+		ImageRole:         RoleInstall,
+		Format:            FormatSquashFS,
+		Version:           "2026.7.0",
+		BuildID:           "test-build",
+		Architecture:      "x86_64",
+		RuntimeInterface:  "katl-runtime-1",
+		Path:              "katlos-install.squashfs",
+		SizeBytes:         1,
+		SHA256:            strings.Repeat("a", 64),
+		ChecksumPath:      "katlos-install.squashfs.sha256",
+		EmbeddedIndexPath: "katlos/image.json",
+		CreatedAt:         "2026-07-23T12:00:00Z",
+	}
+	if err := metadata.Validate(RoleUpgrade); err == nil || !strings.Contains(err.Error(), "role must be upgrade") {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}

--- a/internal/katlc/agent/host_upgrade_artifact.go
+++ b/internal/katlc/agent/host_upgrade_artifact.go
@@ -1,0 +1,179 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	StageHostUpgradeArtifactRequestKind = "StageHostUpgradeArtifactRequest"
+	maxHostUpgradeArtifactSize          = uint64(8 << 30)
+	maxHostUpgradeArtifactChunkSize     = 2 << 20
+	hostUpgradeUploadDirectory          = "host-upgrade/uploads"
+)
+
+func (s *Server) StageHostUpgradeArtifact(stream grpc.ClientStreamingServer[agentapi.StageHostUpgradeArtifactRequest, agentapi.HostUpgradeArtifactStaged]) error {
+	first, err := stream.Recv()
+	if errors.Is(err, io.EOF) {
+		return status.Error(codes.InvalidArgument, "artifact metadata and content are required")
+	}
+	if err != nil {
+		return err
+	}
+	if err := s.validateHostUpgradeArtifactMetadata(first); err != nil {
+		return err
+	}
+
+	s.submitMu.Lock()
+	defer s.submitMu.Unlock()
+	active, err := s.activeOperationIDs()
+	if err != nil {
+		return status.Errorf(codes.Internal, "read operation locks: %v", err)
+	}
+	if len(active) > 0 {
+		return status.Errorf(codes.FailedPrecondition, "cannot stage a KatlOS upgrade while operation %s is active", strings.Join(active, ","))
+	}
+
+	directory := filepath.Join(runtimeRoot(s.Root), "var/lib/katl/artifacts", filepath.FromSlash(hostUpgradeUploadDirectory))
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return status.Errorf(codes.Internal, "prepare KatlOS artifact staging directory: %v", err)
+	}
+	temporary, err := os.CreateTemp(directory, "."+first.Sha256+"-*.partial")
+	if err != nil {
+		return status.Errorf(codes.Internal, "create KatlOS artifact staging file: %v", err)
+	}
+	temporaryPath := temporary.Name()
+	committed := false
+	defer func() {
+		_ = temporary.Close()
+		if !committed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return status.Errorf(codes.Internal, "protect KatlOS artifact staging file: %v", err)
+	}
+
+	hash := sha256.New()
+	var received uint64
+	writeChunk := func(chunk []byte) error {
+		if len(chunk) > maxHostUpgradeArtifactChunkSize {
+			return status.Errorf(codes.ResourceExhausted, "artifact chunk exceeds %d bytes", maxHostUpgradeArtifactChunkSize)
+		}
+		if received > first.SizeBytes || uint64(len(chunk)) > first.SizeBytes-received {
+			return status.Errorf(codes.InvalidArgument, "artifact content exceeds declared size %d", first.SizeBytes)
+		}
+		if len(chunk) == 0 {
+			return nil
+		}
+		written, err := temporary.Write(chunk)
+		if err != nil {
+			return status.Errorf(codes.Internal, "write KatlOS artifact: %v", err)
+		}
+		if written != len(chunk) {
+			return status.Error(codes.Internal, "write KatlOS artifact: short write")
+		}
+		_, _ = hash.Write(chunk)
+		received += uint64(written)
+		return nil
+	}
+	if err := writeChunk(first.Chunk); err != nil {
+		return err
+	}
+	for {
+		request, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if request.ApiVersion != "" || request.Kind != "" || request.Actor != "" || request.ExpectedMachineId != "" || request.Sha256 != "" || request.SizeBytes != 0 {
+			return status.Error(codes.InvalidArgument, "artifact metadata is only allowed in the first chunk")
+		}
+		if err := writeChunk(request.Chunk); err != nil {
+			return err
+		}
+	}
+	if received != first.SizeBytes {
+		return status.Errorf(codes.InvalidArgument, "artifact content size %d does not match declared size %d", received, first.SizeBytes)
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); got != first.Sha256 {
+		return status.Errorf(codes.InvalidArgument, "artifact SHA-256 %s does not match declared identity", got)
+	}
+	if err := temporary.Sync(); err != nil {
+		return status.Errorf(codes.Internal, "sync KatlOS artifact: %v", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return status.Errorf(codes.Internal, "close KatlOS artifact: %v", err)
+	}
+	filename := first.Sha256 + ".squashfs"
+	finalPath := filepath.Join(directory, filename)
+	if err := os.Rename(temporaryPath, finalPath); err != nil {
+		return status.Errorf(codes.Internal, "commit KatlOS artifact: %v", err)
+	}
+	committed = true
+	if directoryHandle, err := os.Open(directory); err == nil {
+		_ = directoryHandle.Sync()
+		_ = directoryHandle.Close()
+	}
+	localRef := filepath.ToSlash(filepath.Join(hostUpgradeUploadDirectory, filename))
+	return stream.SendAndClose(&agentapi.HostUpgradeArtifactStaged{
+		LocalRef:  localRef,
+		Sha256:    first.Sha256,
+		SizeBytes: first.SizeBytes,
+	})
+}
+
+func (s *Server) validateHostUpgradeArtifactMetadata(request *agentapi.StageHostUpgradeArtifactRequest) error {
+	if request == nil {
+		return status.Error(codes.InvalidArgument, "request is required")
+	}
+	if request.ApiVersion != APIVersion {
+		return status.Errorf(codes.InvalidArgument, "apiVersion must be %q", APIVersion)
+	}
+	if request.Kind != StageHostUpgradeArtifactRequestKind {
+		return status.Errorf(codes.InvalidArgument, "kind must be %q", StageHostUpgradeArtifactRequestKind)
+	}
+	if strings.TrimSpace(request.Actor) == "" {
+		return status.Error(codes.InvalidArgument, "actor is required")
+	}
+	machineID, err := s.machineID()
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
+	}
+	if strings.TrimSpace(request.ExpectedMachineId) == "" || request.ExpectedMachineId != machineID {
+		return status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
+	}
+	if err := validateArtifactSHA256(request.Sha256); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	if request.SizeBytes == 0 {
+		return status.Error(codes.InvalidArgument, "artifact sizeBytes must be positive")
+	}
+	if request.SizeBytes > maxHostUpgradeArtifactSize {
+		return status.Errorf(codes.ResourceExhausted, "artifact sizeBytes exceeds %d", maxHostUpgradeArtifactSize)
+	}
+	return nil
+}
+
+func validateArtifactSHA256(value string) error {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return fmt.Errorf("artifact sha256 must be %d lowercase hexadecimal characters", sha256.Size*2)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("artifact sha256 must be %d lowercase hexadecimal characters", sha256.Size*2)
+	}
+	return nil
+}

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -28,8 +29,10 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	}
 	payload, err := resolve(ctx, *record.HostUpgradeRequest)
 	if err != nil {
+		e.cleanupManagedHostUpgradeArtifact(*record.HostUpgradeRequest)
 		return e.failHostUpgrade(record, "verify-katlos-image", err)
 	}
+	defer e.cleanupManagedHostUpgradeArtifact(*record.HostUpgradeRequest)
 	defer e.cleanupHostUpgradeMount(payload)
 	if strings.TrimSpace(payload.ImageSHA256) == "" || payload.ImageSizeBytes == 0 {
 		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("resolved KatlOS image identity is incomplete"))
@@ -168,6 +171,20 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 		return current, nil
 	})
 	return err
+}
+
+func (e *Executor) cleanupManagedHostUpgradeArtifact(request operation.HostUpgrade) {
+	localRef := filepath.ToSlash(filepath.Clean(strings.TrimSpace(request.ImageLocalRef)))
+	if path.Dir(localRef) != hostUpgradeUploadDirectory {
+		return
+	}
+	name := path.Base(localRef)
+	digest := strings.TrimSuffix(name, ".squashfs")
+	if name != digest+".squashfs" || validateArtifactSHA256(digest) != nil {
+		return
+	}
+	artifactPath := filepath.Join(runtimeRoot(e.Root), "var/lib/katl/artifacts", filepath.FromSlash(localRef))
+	_ = os.Remove(artifactPath)
 }
 
 func (e *Executor) cleanupHostUpgradeMount(payload katlosimage.Payload) {

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -16,6 +16,31 @@ import (
 	"github.com/katl-dev/katl/internal/installer/operation"
 )
 
+func TestCleanupManagedHostUpgradeArtifactRemovesOnlyUploadedImage(t *testing.T) {
+	root := t.TempDir()
+	digest := strings.Repeat("a", 64)
+	managedRef := hostUpgradeUploadDirectory + "/" + digest + ".squashfs"
+	managedPath := filepath.Join(root, "var/lib/katl/artifacts", filepath.FromSlash(managedRef))
+	unmanagedPath := filepath.Join(root, "var/lib/katl/artifacts/operator-image.squashfs")
+	for _, path := range []string{managedPath, unmanagedPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	executor := &Executor{Root: root}
+	executor.cleanupManagedHostUpgradeArtifact(operation.HostUpgrade{ImageLocalRef: managedRef})
+	executor.cleanupManagedHostUpgradeArtifact(operation.HostUpgrade{ImageLocalRef: "operator-image.squashfs"})
+	if _, err := os.Stat(managedPath); !os.IsNotExist(err) {
+		t.Fatalf("managed artifact stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(unmanagedPath); err != nil {
+		t.Fatalf("unmanaged artifact was removed: %v", err)
+	}
+}
+
 func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{"etc", "efi/EFI/Linux", "dev/disk/by-partlabel"} {

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -1,11 +1,13 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -23,6 +25,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -32,6 +35,95 @@ type dispatchFunc func(context.Context, operation.OperationRecord) error
 
 func (f dispatchFunc) Dispatch(ctx context.Context, record operation.OperationRecord) error {
 	return f(ctx, record)
+}
+
+func TestStageHostUpgradeArtifactCommitsVerifiedContent(t *testing.T) {
+	server := newTestServer(t)
+	content := append(bytes.Repeat([]byte{'a'}, 1<<20), bytes.Repeat([]byte{'b'}, 31)...)
+	digestBytes := sha256.Sum256(content)
+	digest := hex.EncodeToString(digestBytes[:])
+	stream := newHostUpgradeArtifactServerStream(
+		&agentapi.StageHostUpgradeArtifactRequest{
+			ApiVersion:        APIVersion,
+			Kind:              StageHostUpgradeArtifactRequestKind,
+			Actor:             "katlctl node upgrade",
+			ExpectedMachineId: "0123456789abcdef0123456789abcdef",
+			Sha256:            digest,
+			SizeBytes:         uint64(len(content)),
+			Chunk:             content[:1<<20],
+		},
+		&agentapi.StageHostUpgradeArtifactRequest{Chunk: content[1<<20:]},
+	)
+	if err := server.StageHostUpgradeArtifact(stream); err != nil {
+		t.Fatal(err)
+	}
+	wantRef := hostUpgradeUploadDirectory + "/" + digest + ".squashfs"
+	if stream.response.GetLocalRef() != wantRef || stream.response.GetSha256() != digest || stream.response.GetSizeBytes() != uint64(len(content)) {
+		t.Fatalf("staged response = %#v", stream.response)
+	}
+	path := filepath.Join(server.Root, "var/lib/katl/artifacts", filepath.FromSlash(wantRef))
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, content) {
+		t.Fatal("staged content differs")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("staged mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestStageHostUpgradeArtifactRejectsMismatchAndCleansPartialFile(t *testing.T) {
+	server := newTestServer(t)
+	content := []byte("not the declared artifact")
+	stream := newHostUpgradeArtifactServerStream(&agentapi.StageHostUpgradeArtifactRequest{
+		ApiVersion:        APIVersion,
+		Kind:              StageHostUpgradeArtifactRequestKind,
+		Actor:             "katlctl node upgrade",
+		ExpectedMachineId: "0123456789abcdef0123456789abcdef",
+		Sha256:            strings.Repeat("a", 64),
+		SizeBytes:         uint64(len(content)),
+		Chunk:             content,
+	})
+	err := server.StageHostUpgradeArtifact(stream)
+	if status.Code(err) != codes.InvalidArgument || !strings.Contains(err.Error(), "does not match declared identity") {
+		t.Fatalf("StageHostUpgradeArtifact() error = %v", err)
+	}
+	directory := filepath.Join(server.Root, "var/lib/katl/artifacts", filepath.FromSlash(hostUpgradeUploadDirectory))
+	entries, readErr := os.ReadDir(directory)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging directory contains partial files: %v", entries)
+	}
+}
+
+func TestStageHostUpgradeArtifactRejectsMetadataAfterFirstChunk(t *testing.T) {
+	server := newTestServer(t)
+	content := []byte("artifact")
+	digestBytes := sha256.Sum256(content)
+	stream := newHostUpgradeArtifactServerStream(
+		&agentapi.StageHostUpgradeArtifactRequest{
+			ApiVersion:        APIVersion,
+			Kind:              StageHostUpgradeArtifactRequestKind,
+			Actor:             "katlctl node upgrade",
+			ExpectedMachineId: "0123456789abcdef0123456789abcdef",
+			Sha256:            hex.EncodeToString(digestBytes[:]),
+			SizeBytes:         uint64(len(content)),
+			Chunk:             content[:4],
+		},
+		&agentapi.StageHostUpgradeArtifactRequest{Actor: "repeated", Chunk: content[4:]},
+	)
+	err := server.StageHostUpgradeArtifact(stream)
+	if status.Code(err) != codes.InvalidArgument || !strings.Contains(err.Error(), "only allowed in the first chunk") {
+		t.Fatalf("StageHostUpgradeArtifact() error = %v", err)
+	}
 }
 
 func TestSubmitOperationCreatesRecord(t *testing.T) {
@@ -2915,6 +3007,35 @@ type watchStream struct {
 	agentapi.KatlcAgent_WatchOperationServer
 	ctx    context.Context
 	events []*agentapi.OperationEvent
+}
+
+type hostUpgradeArtifactServerStream struct {
+	grpc.ServerStream
+	ctx      context.Context
+	requests []*agentapi.StageHostUpgradeArtifactRequest
+	response *agentapi.HostUpgradeArtifactStaged
+}
+
+func newHostUpgradeArtifactServerStream(requests ...*agentapi.StageHostUpgradeArtifactRequest) *hostUpgradeArtifactServerStream {
+	return &hostUpgradeArtifactServerStream{ctx: context.Background(), requests: requests}
+}
+
+func (s *hostUpgradeArtifactServerStream) Recv() (*agentapi.StageHostUpgradeArtifactRequest, error) {
+	if len(s.requests) == 0 {
+		return nil, io.EOF
+	}
+	request := s.requests[0]
+	s.requests = s.requests[1:]
+	return request, nil
+}
+
+func (s *hostUpgradeArtifactServerStream) SendAndClose(response *agentapi.HostUpgradeArtifactStaged) error {
+	s.response = response
+	return nil
+}
+
+func (s *hostUpgradeArtifactServerStream) Context() context.Context {
+	return s.ctx
 }
 
 func newWatchStream(ctx context.Context) *watchStream {

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -1813,6 +1813,158 @@ func (x *HostUpgradeOperationRequest) GetCandidateGenerationId() string {
 	return ""
 }
 
+type StageHostUpgradeArtifactRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion        string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind              string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor             string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	Sha256            string                 `protobuf:"bytes,5,opt,name=sha256,proto3" json:"sha256,omitempty"`
+	SizeBytes         uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Chunk             []byte                 `protobuf:"bytes,7,opt,name=chunk,proto3" json:"chunk,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *StageHostUpgradeArtifactRequest) Reset() {
+	*x = StageHostUpgradeArtifactRequest{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StageHostUpgradeArtifactRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StageHostUpgradeArtifactRequest) ProtoMessage() {}
+
+func (x *StageHostUpgradeArtifactRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StageHostUpgradeArtifactRequest.ProtoReflect.Descriptor instead.
+func (*StageHostUpgradeArtifactRequest) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetApiVersion() string {
+	if x != nil {
+		return x.ApiVersion
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetExpectedMachineId() string {
+	if x != nil {
+		return x.ExpectedMachineId
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetSha256() string {
+	if x != nil {
+		return x.Sha256
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetSizeBytes() uint64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetChunk() []byte {
+	if x != nil {
+		return x.Chunk
+	}
+	return nil
+}
+
+type HostUpgradeArtifactStaged struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	LocalRef      string                 `protobuf:"bytes,1,opt,name=local_ref,json=localRef,proto3" json:"local_ref,omitempty"`
+	Sha256        string                 `protobuf:"bytes,2,opt,name=sha256,proto3" json:"sha256,omitempty"`
+	SizeBytes     uint64                 `protobuf:"varint,3,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HostUpgradeArtifactStaged) Reset() {
+	*x = HostUpgradeArtifactStaged{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HostUpgradeArtifactStaged) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HostUpgradeArtifactStaged) ProtoMessage() {}
+
+func (x *HostUpgradeArtifactStaged) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HostUpgradeArtifactStaged.ProtoReflect.Descriptor instead.
+func (*HostUpgradeArtifactStaged) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *HostUpgradeArtifactStaged) GetLocalRef() string {
+	if x != nil {
+		return x.LocalRef
+	}
+	return ""
+}
+
+func (x *HostUpgradeArtifactStaged) GetSha256() string {
+	if x != nil {
+		return x.Sha256
+	}
+	return ""
+}
+
+func (x *HostUpgradeArtifactStaged) GetSizeBytes() uint64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
 type CreateWorkerJoinMaterialRequest struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	ApiVersion        string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
@@ -1827,7 +1979,7 @@ type CreateWorkerJoinMaterialRequest struct {
 
 func (x *CreateWorkerJoinMaterialRequest) Reset() {
 	*x = CreateWorkerJoinMaterialRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1839,7 +1991,7 @@ func (x *CreateWorkerJoinMaterialRequest) String() string {
 func (*CreateWorkerJoinMaterialRequest) ProtoMessage() {}
 
 func (x *CreateWorkerJoinMaterialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1852,7 +2004,7 @@ func (x *CreateWorkerJoinMaterialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerJoinMaterialRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkerJoinMaterialRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{16}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *CreateWorkerJoinMaterialRequest) GetApiVersion() string {
@@ -1908,7 +2060,7 @@ type CreateWorkerJoinMaterialResponse struct {
 
 func (x *CreateWorkerJoinMaterialResponse) Reset() {
 	*x = CreateWorkerJoinMaterialResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1920,7 +2072,7 @@ func (x *CreateWorkerJoinMaterialResponse) String() string {
 func (*CreateWorkerJoinMaterialResponse) ProtoMessage() {}
 
 func (x *CreateWorkerJoinMaterialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1933,7 +2085,7 @@ func (x *CreateWorkerJoinMaterialResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerJoinMaterialResponse.ProtoReflect.Descriptor instead.
 func (*CreateWorkerJoinMaterialResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *CreateWorkerJoinMaterialResponse) GetMaterialRef() string {
@@ -1971,7 +2123,7 @@ type OperationAccepted struct {
 
 func (x *OperationAccepted) Reset() {
 	*x = OperationAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1983,7 +2135,7 @@ func (x *OperationAccepted) String() string {
 func (*OperationAccepted) ProtoMessage() {}
 
 func (x *OperationAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1996,7 +2148,7 @@ func (x *OperationAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationAccepted.ProtoReflect.Descriptor instead.
 func (*OperationAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *OperationAccepted) GetOperationId() string {
@@ -2052,7 +2204,7 @@ type GetOperationRequest struct {
 
 func (x *GetOperationRequest) Reset() {
 	*x = GetOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2064,7 +2216,7 @@ func (x *GetOperationRequest) String() string {
 func (*GetOperationRequest) ProtoMessage() {}
 
 func (x *GetOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2077,7 +2229,7 @@ func (x *GetOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetOperationRequest) GetOperationId() string {
@@ -2112,7 +2264,7 @@ type ListOperationsRequest struct {
 
 func (x *ListOperationsRequest) Reset() {
 	*x = ListOperationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2124,7 +2276,7 @@ func (x *ListOperationsRequest) String() string {
 func (*ListOperationsRequest) ProtoMessage() {}
 
 func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2137,7 +2289,7 @@ func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListOperationsRequest) GetActiveOnly() bool {
@@ -2170,7 +2322,7 @@ type ListOperationsResponse struct {
 
 func (x *ListOperationsResponse) Reset() {
 	*x = ListOperationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2182,7 +2334,7 @@ func (x *ListOperationsResponse) String() string {
 func (*ListOperationsResponse) ProtoMessage() {}
 
 func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2195,7 +2347,7 @@ func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListOperationsResponse) GetOperations() []*OperationStatus {
@@ -2242,7 +2394,7 @@ type OperationStatus struct {
 
 func (x *OperationStatus) Reset() {
 	*x = OperationStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2254,7 +2406,7 @@ func (x *OperationStatus) String() string {
 func (*OperationStatus) ProtoMessage() {}
 
 func (x *OperationStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2267,7 +2419,7 @@ func (x *OperationStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationStatus.ProtoReflect.Descriptor instead.
 func (*OperationStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *OperationStatus) GetOperationId() string {
@@ -2486,7 +2638,7 @@ type DiagnosticArtifact struct {
 
 func (x *DiagnosticArtifact) Reset() {
 	*x = DiagnosticArtifact{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2498,7 +2650,7 @@ func (x *DiagnosticArtifact) String() string {
 func (*DiagnosticArtifact) ProtoMessage() {}
 
 func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2511,7 +2663,7 @@ func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiagnosticArtifact.ProtoReflect.Descriptor instead.
 func (*DiagnosticArtifact) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DiagnosticArtifact) GetArtifactId() string {
@@ -2566,7 +2718,7 @@ type OperationInvocation struct {
 
 func (x *OperationInvocation) Reset() {
 	*x = OperationInvocation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2578,7 +2730,7 @@ func (x *OperationInvocation) String() string {
 func (*OperationInvocation) ProtoMessage() {}
 
 func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2591,7 +2743,7 @@ func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationInvocation.ProtoReflect.Descriptor instead.
 func (*OperationInvocation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *OperationInvocation) GetInvocationId() string {
@@ -2670,7 +2822,7 @@ type WatchOperationRequest struct {
 
 func (x *WatchOperationRequest) Reset() {
 	*x = WatchOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2682,7 +2834,7 @@ func (x *WatchOperationRequest) String() string {
 func (*WatchOperationRequest) ProtoMessage() {}
 
 func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2695,7 +2847,7 @@ func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchOperationRequest.ProtoReflect.Descriptor instead.
 func (*WatchOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *WatchOperationRequest) GetOperationId() string {
@@ -2748,7 +2900,7 @@ type OperationEvent struct {
 
 func (x *OperationEvent) Reset() {
 	*x = OperationEvent{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2760,7 +2912,7 @@ func (x *OperationEvent) String() string {
 func (*OperationEvent) ProtoMessage() {}
 
 func (x *OperationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2773,7 +2925,7 @@ func (x *OperationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationEvent.ProtoReflect.Descriptor instead.
 func (*OperationEvent) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *OperationEvent) GetOperationId() string {
@@ -2834,7 +2986,7 @@ type ListGenerationsRequest struct {
 
 func (x *ListGenerationsRequest) Reset() {
 	*x = ListGenerationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +2998,7 @@ func (x *ListGenerationsRequest) String() string {
 func (*ListGenerationsRequest) ProtoMessage() {}
 
 func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2859,7 +3011,7 @@ func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsRequest.ProtoReflect.Descriptor instead.
 func (*ListGenerationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListGenerationsRequest) GetIncludeConfigApply() bool {
@@ -2878,7 +3030,7 @@ type ListGenerationsResponse struct {
 
 func (x *ListGenerationsResponse) Reset() {
 	*x = ListGenerationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2890,7 +3042,7 @@ func (x *ListGenerationsResponse) String() string {
 func (*ListGenerationsResponse) ProtoMessage() {}
 
 func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2903,7 +3055,7 @@ func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsResponse.ProtoReflect.Descriptor instead.
 func (*ListGenerationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListGenerationsResponse) GetGenerations() []*Generation {
@@ -2923,7 +3075,7 @@ type GetGenerationRequest struct {
 
 func (x *GetGenerationRequest) Reset() {
 	*x = GetGenerationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2935,7 +3087,7 @@ func (x *GetGenerationRequest) String() string {
 func (*GetGenerationRequest) ProtoMessage() {}
 
 func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2948,7 +3100,7 @@ func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGenerationRequest.ProtoReflect.Descriptor instead.
 func (*GetGenerationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetGenerationRequest) GetGenerationId() string {
@@ -2986,7 +3138,7 @@ type Generation struct {
 
 func (x *Generation) Reset() {
 	*x = Generation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2998,7 +3150,7 @@ func (x *Generation) String() string {
 func (*Generation) ProtoMessage() {}
 
 func (x *Generation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3011,7 +3163,7 @@ func (x *Generation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Generation.ProtoReflect.Descriptor instead.
 func (*Generation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *Generation) GetGenerationId() string {
@@ -3120,7 +3272,7 @@ type ExtensionRef struct {
 
 func (x *ExtensionRef) Reset() {
 	*x = ExtensionRef{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3132,7 +3284,7 @@ func (x *ExtensionRef) String() string {
 func (*ExtensionRef) ProtoMessage() {}
 
 func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3145,7 +3297,7 @@ func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionRef.ProtoReflect.Descriptor instead.
 func (*ExtensionRef) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ExtensionRef) GetName() string {
@@ -3209,7 +3361,7 @@ type GeneratedConfext struct {
 
 func (x *GeneratedConfext) Reset() {
 	*x = GeneratedConfext{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3221,7 +3373,7 @@ func (x *GeneratedConfext) String() string {
 func (*GeneratedConfext) ProtoMessage() {}
 
 func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3234,7 +3386,7 @@ func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeneratedConfext.ProtoReflect.Descriptor instead.
 func (*GeneratedConfext) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GeneratedConfext) GetName() string {
@@ -3281,7 +3433,7 @@ type ConfigApplyStatus struct {
 
 func (x *ConfigApplyStatus) Reset() {
 	*x = ConfigApplyStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3293,7 +3445,7 @@ func (x *ConfigApplyStatus) String() string {
 func (*ConfigApplyStatus) ProtoMessage() {}
 
 func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3306,7 +3458,7 @@ func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyStatus.ProtoReflect.Descriptor instead.
 func (*ConfigApplyStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ConfigApplyStatus) GetPhase() string {
@@ -3378,7 +3530,7 @@ type RebootRequest struct {
 
 func (x *RebootRequest) Reset() {
 	*x = RebootRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3390,7 +3542,7 @@ func (x *RebootRequest) String() string {
 func (*RebootRequest) ProtoMessage() {}
 
 func (x *RebootRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3403,7 +3555,7 @@ func (x *RebootRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebootRequest.ProtoReflect.Descriptor instead.
 func (*RebootRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RebootRequest) GetApiVersion() string {
@@ -3451,7 +3603,7 @@ type RebootAccepted struct {
 
 func (x *RebootAccepted) Reset() {
 	*x = RebootAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3463,7 +3615,7 @@ func (x *RebootAccepted) String() string {
 func (*RebootAccepted) ProtoMessage() {}
 
 func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3476,7 +3628,7 @@ func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebootAccepted.ProtoReflect.Descriptor instead.
 func (*RebootAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{35}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RebootAccepted) GetScheduled() bool {
@@ -3505,7 +3657,7 @@ type ShutdownRequest struct {
 
 func (x *ShutdownRequest) Reset() {
 	*x = ShutdownRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3517,7 +3669,7 @@ func (x *ShutdownRequest) String() string {
 func (*ShutdownRequest) ProtoMessage() {}
 
 func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3530,7 +3682,7 @@ func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{36}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ShutdownRequest) GetApiVersion() string {
@@ -3570,7 +3722,7 @@ type ShutdownAccepted struct {
 
 func (x *ShutdownAccepted) Reset() {
 	*x = ShutdownAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3582,7 +3734,7 @@ func (x *ShutdownAccepted) String() string {
 func (*ShutdownAccepted) ProtoMessage() {}
 
 func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3595,7 +3747,7 @@ func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAccepted.ProtoReflect.Descriptor instead.
 func (*ShutdownAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{37}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ShutdownAccepted) GetScheduled() bool {
@@ -3806,7 +3958,22 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0fimage_local_ref\x18\x02 \x01(\tR\rimageLocalRef\x12!\n" +
 	"\fimage_sha256\x18\x03 \x01(\tR\vimageSha256\x12(\n" +
 	"\x10image_size_bytes\x18\x04 \x01(\x04R\x0eimageSizeBytes\x126\n" +
-	"\x17candidate_generation_id\x18\x05 \x01(\tR\x15candidateGenerationId\"\xcf\x01\n" +
+	"\x17candidate_generation_id\x18\x05 \x01(\tR\x15candidateGenerationId\"\xe9\x01\n" +
+	"\x1fStageHostUpgradeArtifactRequest\x12\x1f\n" +
+	"\vapi_version\x18\x01 \x01(\tR\n" +
+	"apiVersion\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x14\n" +
+	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
+	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\x12\x16\n" +
+	"\x06sha256\x18\x05 \x01(\tR\x06sha256\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x06 \x01(\x04R\tsizeBytes\x12\x14\n" +
+	"\x05chunk\x18\a \x01(\fR\x05chunk\"o\n" +
+	"\x19HostUpgradeArtifactStaged\x12\x1b\n" +
+	"\tlocal_ref\x18\x01 \x01(\tR\blocalRef\x12\x16\n" +
+	"\x06sha256\x18\x02 \x01(\tR\x06sha256\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"\xcf\x01\n" +
 	"\x1fCreateWorkerJoinMaterialRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -3980,7 +4147,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
 	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\"0\n" +
 	"\x10ShutdownAccepted\x12\x1c\n" +
-	"\tscheduled\x18\x01 \x01(\bR\tscheduled2\xa0\t\n" +
+	"\tscheduled\x18\x01 \x01(\bR\tscheduled2\x98\n" +
+	"\n" +
 	"\n" +
 	"KatlcAgent\x12O\n" +
 	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12E\n" +
@@ -3988,7 +4156,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\bShutdown\x12\x1e.katl.agent.v1.ShutdownRequest\x1a\x1f.katl.agent.v1.ShutdownAccepted\x12]\n" +
 	"\x0eValidateConfig\x12$.katl.agent.v1.ValidateConfigRequest\x1a%.katl.agent.v1.ConfigValidationResult\x12Z\n" +
 	"\x0fApplyGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
-	"\x0fStageGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12Z\n" +
+	"\x0fStageGeneration\x12%.katl.agent.v1.GenerationApplyRequest\x1a .katl.agent.v1.OperationAccepted\x12v\n" +
+	"\x18StageHostUpgradeArtifact\x12..katl.agent.v1.StageHostUpgradeArtifactRequest\x1a(.katl.agent.v1.HostUpgradeArtifactStaged(\x01\x12Z\n" +
 	"\x0fSubmitOperation\x12%.katl.agent.v1.SubmitOperationRequest\x1a .katl.agent.v1.OperationAccepted\x12{\n" +
 	"\x18CreateWorkerJoinMaterial\x12..katl.agent.v1.CreateWorkerJoinMaterialRequest\x1a/.katl.agent.v1.CreateWorkerJoinMaterialResponse\x12R\n" +
 	"\fGetOperation\x12\".katl.agent.v1.GetOperationRequest\x1a\x1e.katl.agent.v1.OperationStatus\x12]\n" +
@@ -4009,7 +4178,7 @@ func file_internal_katlc_agentapi_agent_proto_rawDescGZIP() []byte {
 	return file_internal_katlc_agentapi_agent_proto_rawDescData
 }
 
-var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*GetNodeStatusRequest)(nil),                      // 0: katl.agent.v1.GetNodeStatusRequest
 	(*NodeStatus)(nil),                                // 1: katl.agent.v1.NodeStatus
@@ -4027,28 +4196,30 @@ var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*KubernetesSysextUpdateOperationRequest)(nil),    // 13: katl.agent.v1.KubernetesSysextUpdateOperationRequest
 	(*DestructiveResetOperationRequest)(nil),          // 14: katl.agent.v1.DestructiveResetOperationRequest
 	(*HostUpgradeOperationRequest)(nil),               // 15: katl.agent.v1.HostUpgradeOperationRequest
-	(*CreateWorkerJoinMaterialRequest)(nil),           // 16: katl.agent.v1.CreateWorkerJoinMaterialRequest
-	(*CreateWorkerJoinMaterialResponse)(nil),          // 17: katl.agent.v1.CreateWorkerJoinMaterialResponse
-	(*OperationAccepted)(nil),                         // 18: katl.agent.v1.OperationAccepted
-	(*GetOperationRequest)(nil),                       // 19: katl.agent.v1.GetOperationRequest
-	(*ListOperationsRequest)(nil),                     // 20: katl.agent.v1.ListOperationsRequest
-	(*ListOperationsResponse)(nil),                    // 21: katl.agent.v1.ListOperationsResponse
-	(*OperationStatus)(nil),                           // 22: katl.agent.v1.OperationStatus
-	(*DiagnosticArtifact)(nil),                        // 23: katl.agent.v1.DiagnosticArtifact
-	(*OperationInvocation)(nil),                       // 24: katl.agent.v1.OperationInvocation
-	(*WatchOperationRequest)(nil),                     // 25: katl.agent.v1.WatchOperationRequest
-	(*OperationEvent)(nil),                            // 26: katl.agent.v1.OperationEvent
-	(*ListGenerationsRequest)(nil),                    // 27: katl.agent.v1.ListGenerationsRequest
-	(*ListGenerationsResponse)(nil),                   // 28: katl.agent.v1.ListGenerationsResponse
-	(*GetGenerationRequest)(nil),                      // 29: katl.agent.v1.GetGenerationRequest
-	(*Generation)(nil),                                // 30: katl.agent.v1.Generation
-	(*ExtensionRef)(nil),                              // 31: katl.agent.v1.ExtensionRef
-	(*GeneratedConfext)(nil),                          // 32: katl.agent.v1.GeneratedConfext
-	(*ConfigApplyStatus)(nil),                         // 33: katl.agent.v1.ConfigApplyStatus
-	(*RebootRequest)(nil),                             // 34: katl.agent.v1.RebootRequest
-	(*RebootAccepted)(nil),                            // 35: katl.agent.v1.RebootAccepted
-	(*ShutdownRequest)(nil),                           // 36: katl.agent.v1.ShutdownRequest
-	(*ShutdownAccepted)(nil),                          // 37: katl.agent.v1.ShutdownAccepted
+	(*StageHostUpgradeArtifactRequest)(nil),           // 16: katl.agent.v1.StageHostUpgradeArtifactRequest
+	(*HostUpgradeArtifactStaged)(nil),                 // 17: katl.agent.v1.HostUpgradeArtifactStaged
+	(*CreateWorkerJoinMaterialRequest)(nil),           // 18: katl.agent.v1.CreateWorkerJoinMaterialRequest
+	(*CreateWorkerJoinMaterialResponse)(nil),          // 19: katl.agent.v1.CreateWorkerJoinMaterialResponse
+	(*OperationAccepted)(nil),                         // 20: katl.agent.v1.OperationAccepted
+	(*GetOperationRequest)(nil),                       // 21: katl.agent.v1.GetOperationRequest
+	(*ListOperationsRequest)(nil),                     // 22: katl.agent.v1.ListOperationsRequest
+	(*ListOperationsResponse)(nil),                    // 23: katl.agent.v1.ListOperationsResponse
+	(*OperationStatus)(nil),                           // 24: katl.agent.v1.OperationStatus
+	(*DiagnosticArtifact)(nil),                        // 25: katl.agent.v1.DiagnosticArtifact
+	(*OperationInvocation)(nil),                       // 26: katl.agent.v1.OperationInvocation
+	(*WatchOperationRequest)(nil),                     // 27: katl.agent.v1.WatchOperationRequest
+	(*OperationEvent)(nil),                            // 28: katl.agent.v1.OperationEvent
+	(*ListGenerationsRequest)(nil),                    // 29: katl.agent.v1.ListGenerationsRequest
+	(*ListGenerationsResponse)(nil),                   // 30: katl.agent.v1.ListGenerationsResponse
+	(*GetGenerationRequest)(nil),                      // 31: katl.agent.v1.GetGenerationRequest
+	(*Generation)(nil),                                // 32: katl.agent.v1.Generation
+	(*ExtensionRef)(nil),                              // 33: katl.agent.v1.ExtensionRef
+	(*GeneratedConfext)(nil),                          // 34: katl.agent.v1.GeneratedConfext
+	(*ConfigApplyStatus)(nil),                         // 35: katl.agent.v1.ConfigApplyStatus
+	(*RebootRequest)(nil),                             // 36: katl.agent.v1.RebootRequest
+	(*RebootAccepted)(nil),                            // 37: katl.agent.v1.RebootAccepted
+	(*ShutdownRequest)(nil),                           // 38: katl.agent.v1.ShutdownRequest
+	(*ShutdownAccepted)(nil),                          // 39: katl.agent.v1.ShutdownAccepted
 }
 var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	2,  // 0: katl.agent.v1.NodeStatus.control_plane_endpoint:type_name -> katl.agent.v1.ControlPlaneEndpointStatus
@@ -4062,44 +4233,46 @@ var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	12, // 8: katl.agent.v1.SubmitOperationRequest.kubeadm_control_plane_config:type_name -> katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
 	7,  // 9: katl.agent.v1.BootstrapOperationRequest.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
 	7,  // 10: katl.agent.v1.CreateWorkerJoinMaterialResponse.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
-	22, // 11: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
-	22, // 12: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
-	23, // 13: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	24, // 14: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
-	22, // 15: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
-	23, // 16: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	30, // 17: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
-	31, // 18: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
-	32, // 19: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
-	33, // 20: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
+	24, // 11: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
+	24, // 12: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
+	25, // 13: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	26, // 14: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
+	24, // 15: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
+	25, // 16: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	32, // 17: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
+	33, // 18: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
+	34, // 19: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
+	35, // 20: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
 	0,  // 21: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
-	34, // 22: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
-	36, // 23: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
+	36, // 22: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
+	38, // 23: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
 	8,  // 24: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
 	10, // 25: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
 	10, // 26: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	5,  // 27: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
-	16, // 28: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
-	19, // 29: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
-	20, // 30: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
-	25, // 31: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
-	27, // 32: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
-	29, // 33: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
-	1,  // 34: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
-	35, // 35: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
-	37, // 36: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
-	9,  // 37: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
-	18, // 38: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
-	18, // 39: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
-	18, // 40: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
-	17, // 41: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
-	22, // 42: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
-	21, // 43: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
-	26, // 44: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
-	28, // 45: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
-	30, // 46: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
-	34, // [34:47] is the sub-list for method output_type
-	21, // [21:34] is the sub-list for method input_type
+	16, // 27: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:input_type -> katl.agent.v1.StageHostUpgradeArtifactRequest
+	5,  // 28: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
+	18, // 29: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
+	21, // 30: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
+	22, // 31: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
+	27, // 32: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
+	29, // 33: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
+	31, // 34: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
+	1,  // 35: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
+	37, // 36: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
+	39, // 37: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
+	9,  // 38: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
+	20, // 39: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
+	20, // 40: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
+	17, // 41: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:output_type -> katl.agent.v1.HostUpgradeArtifactStaged
+	20, // 42: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
+	19, // 43: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
+	24, // 44: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
+	23, // 45: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
+	28, // 46: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
+	30, // 47: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
+	32, // 48: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
+	35, // [35:49] is the sub-list for method output_type
+	21, // [21:35] is the sub-list for method input_type
 	21, // [21:21] is the sub-list for extension type_name
 	21, // [21:21] is the sub-list for extension extendee
 	0,  // [0:21] is the sub-list for field type_name
@@ -4116,7 +4289,7 @@ func file_internal_katlc_agentapi_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_katlc_agentapi_agent_proto_rawDesc), len(file_internal_katlc_agentapi_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   38,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -11,6 +11,7 @@ service KatlcAgent {
   rpc ValidateConfig(ValidateConfigRequest) returns (ConfigValidationResult);
   rpc ApplyGeneration(GenerationApplyRequest) returns (OperationAccepted);
   rpc StageGeneration(GenerationApplyRequest) returns (OperationAccepted);
+  rpc StageHostUpgradeArtifact(stream StageHostUpgradeArtifactRequest) returns (HostUpgradeArtifactStaged);
   rpc SubmitOperation(SubmitOperationRequest) returns (OperationAccepted);
   rpc CreateWorkerJoinMaterial(CreateWorkerJoinMaterialRequest) returns (CreateWorkerJoinMaterialResponse);
   rpc GetOperation(GetOperationRequest) returns (OperationStatus);
@@ -217,6 +218,22 @@ message HostUpgradeOperationRequest {
   string image_sha256 = 3;
   uint64 image_size_bytes = 4;
   string candidate_generation_id = 5;
+}
+
+message StageHostUpgradeArtifactRequest {
+  string api_version = 1;
+  string kind = 2;
+  string actor = 3;
+  string expected_machine_id = 4;
+  string sha256 = 5;
+  uint64 size_bytes = 6;
+  bytes chunk = 7;
+}
+
+message HostUpgradeArtifactStaged {
+  string local_ref = 1;
+  string sha256 = 2;
+  uint64 size_bytes = 3;
 }
 
 message CreateWorkerJoinMaterialRequest {

--- a/internal/katlc/agentapi/agent_grpc.pb.go
+++ b/internal/katlc/agentapi/agent_grpc.pb.go
@@ -25,6 +25,7 @@ const (
 	KatlcAgent_ValidateConfig_FullMethodName           = "/katl.agent.v1.KatlcAgent/ValidateConfig"
 	KatlcAgent_ApplyGeneration_FullMethodName          = "/katl.agent.v1.KatlcAgent/ApplyGeneration"
 	KatlcAgent_StageGeneration_FullMethodName          = "/katl.agent.v1.KatlcAgent/StageGeneration"
+	KatlcAgent_StageHostUpgradeArtifact_FullMethodName = "/katl.agent.v1.KatlcAgent/StageHostUpgradeArtifact"
 	KatlcAgent_SubmitOperation_FullMethodName          = "/katl.agent.v1.KatlcAgent/SubmitOperation"
 	KatlcAgent_CreateWorkerJoinMaterial_FullMethodName = "/katl.agent.v1.KatlcAgent/CreateWorkerJoinMaterial"
 	KatlcAgent_GetOperation_FullMethodName             = "/katl.agent.v1.KatlcAgent/GetOperation"
@@ -44,6 +45,7 @@ type KatlcAgentClient interface {
 	ValidateConfig(ctx context.Context, in *ValidateConfigRequest, opts ...grpc.CallOption) (*ConfigValidationResult, error)
 	ApplyGeneration(ctx context.Context, in *GenerationApplyRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
 	StageGeneration(ctx context.Context, in *GenerationApplyRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
+	StageHostUpgradeArtifact(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged], error)
 	SubmitOperation(ctx context.Context, in *SubmitOperationRequest, opts ...grpc.CallOption) (*OperationAccepted, error)
 	CreateWorkerJoinMaterial(ctx context.Context, in *CreateWorkerJoinMaterialRequest, opts ...grpc.CallOption) (*CreateWorkerJoinMaterialResponse, error)
 	GetOperation(ctx context.Context, in *GetOperationRequest, opts ...grpc.CallOption) (*OperationStatus, error)
@@ -121,6 +123,19 @@ func (c *katlcAgentClient) StageGeneration(ctx context.Context, in *GenerationAp
 	return out, nil
 }
 
+func (c *katlcAgentClient) StageHostUpgradeArtifact(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &KatlcAgent_ServiceDesc.Streams[0], KatlcAgent_StageHostUpgradeArtifact_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type KatlcAgent_StageHostUpgradeArtifactClient = grpc.ClientStreamingClient[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged]
+
 func (c *katlcAgentClient) SubmitOperation(ctx context.Context, in *SubmitOperationRequest, opts ...grpc.CallOption) (*OperationAccepted, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(OperationAccepted)
@@ -163,7 +178,7 @@ func (c *katlcAgentClient) ListOperations(ctx context.Context, in *ListOperation
 
 func (c *katlcAgentClient) WatchOperation(ctx context.Context, in *WatchOperationRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[OperationEvent], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &KatlcAgent_ServiceDesc.Streams[0], KatlcAgent_WatchOperation_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &KatlcAgent_ServiceDesc.Streams[1], KatlcAgent_WatchOperation_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -210,6 +225,7 @@ type KatlcAgentServer interface {
 	ValidateConfig(context.Context, *ValidateConfigRequest) (*ConfigValidationResult, error)
 	ApplyGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error)
 	StageGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error)
+	StageHostUpgradeArtifact(grpc.ClientStreamingServer[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged]) error
 	SubmitOperation(context.Context, *SubmitOperationRequest) (*OperationAccepted, error)
 	CreateWorkerJoinMaterial(context.Context, *CreateWorkerJoinMaterialRequest) (*CreateWorkerJoinMaterialResponse, error)
 	GetOperation(context.Context, *GetOperationRequest) (*OperationStatus, error)
@@ -244,6 +260,9 @@ func (UnimplementedKatlcAgentServer) ApplyGeneration(context.Context, *Generatio
 }
 func (UnimplementedKatlcAgentServer) StageGeneration(context.Context, *GenerationApplyRequest) (*OperationAccepted, error) {
 	return nil, status.Error(codes.Unimplemented, "method StageGeneration not implemented")
+}
+func (UnimplementedKatlcAgentServer) StageHostUpgradeArtifact(grpc.ClientStreamingServer[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged]) error {
+	return status.Error(codes.Unimplemented, "method StageHostUpgradeArtifact not implemented")
 }
 func (UnimplementedKatlcAgentServer) SubmitOperation(context.Context, *SubmitOperationRequest) (*OperationAccepted, error) {
 	return nil, status.Error(codes.Unimplemented, "method SubmitOperation not implemented")
@@ -394,6 +413,13 @@ func _KatlcAgent_StageGeneration_Handler(srv interface{}, ctx context.Context, d
 	}
 	return interceptor(ctx, in, info, handler)
 }
+
+func _KatlcAgent_StageHostUpgradeArtifact_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(KatlcAgentServer).StageHostUpgradeArtifact(&grpc.GenericServerStream[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type KatlcAgent_StageHostUpgradeArtifactServer = grpc.ClientStreamingServer[StageHostUpgradeArtifactRequest, HostUpgradeArtifactStaged]
 
 func _KatlcAgent_SubmitOperation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SubmitOperationRequest)
@@ -571,6 +597,11 @@ var KatlcAgent_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "StageHostUpgradeArtifact",
+			Handler:       _KatlcAgent_StageHostUpgradeArtifact_Handler,
+			ClientStreams: true,
+		},
 		{
 			StreamName:    "WatchOperation",
 			Handler:       _KatlcAgent_WatchOperation_Handler,

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -106,8 +106,6 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 	writeGuestFile(t, ctx, guest, stateMarker, []byte("state-survives-host-upgrade-and-rollback\n"), 0o600)
 
 	upgrade := discoverBuiltUpgradeImage(t, previousSpec.RuntimeVersion)
-	localRef := filepath.ToSlash(filepath.Join("updates", filepath.Base(upgrade.Path)))
-	uploadGuestFile(t, ctx, guest, upgrade.Path, "/var/lib/katl/artifacts/"+localRef, 4<<20)
 	endpoint := katlcEndpoint(t, node, "")
 	candidateGeneration := "host-upgrade-" + strings.ReplaceAll(upgrade.Version, ".", "-")
 	conn, katlc := dialKatlcAgentForVMTest(t, ctx, endpoint)
@@ -117,10 +115,12 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 		t.Fatalf("read node status before host upgrade: %v", err)
 	}
 	conn.Close()
-	operationID, status := submitHostUpgradeAndWait(t, ctx, endpoint, nodeStatus.GetMachineId(), previousGeneration, candidateGeneration, localRef)
+	localRef := stageHostUpgradeArtifactForVMTest(t, ctx, endpoint, nodeStatus.GetMachineId(), upgrade)
+	operationID, status := submitHostUpgradeAndWait(t, ctx, endpoint, nodeStatus.GetMachineId(), previousGeneration, candidateGeneration, localRef, upgrade)
 	if status.GetResult() != operation.ResultSucceeded || !status.GetBootHealthPending() || status.GetCandidateGenerationId() != candidateGeneration {
 		t.Fatalf("host upgrade operation status = %+v", status)
 	}
+	assertGuestMissing(t, ctx, guest, "/var/lib/katl/artifacts/"+localRef)
 	recordData := readGuestFile(t, ctx, guest, "/var/lib/katl/operations/"+operationID+"/record.json")
 	envelope, err := persistedrecord.DecodeEnvelope([]byte(recordData))
 	if err != nil {
@@ -176,7 +176,8 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 		t.Fatalf("upgrade did not produce distinct version, root slot, and UKI identities: previous=%#v candidate=%#v", previousSpec, candidateSpec)
 	}
 	repeatedGeneration := candidateGeneration + "-repeat"
-	_, repeatedStatus := submitHostUpgradeAndWait(t, ctx, endpoint, nodeStatus.GetMachineId(), previousGeneration, repeatedGeneration, localRef)
+	localRef = stageHostUpgradeArtifactForVMTest(t, ctx, endpoint, nodeStatus.GetMachineId(), upgrade)
+	_, repeatedStatus := submitHostUpgradeAndWait(t, ctx, endpoint, nodeStatus.GetMachineId(), previousGeneration, repeatedGeneration, localRef, upgrade)
 	if repeatedStatus.GetResult() != operation.ResultSucceeded || !repeatedStatus.GetBootHealthPending() || repeatedStatus.GetCandidateGenerationId() != repeatedGeneration {
 		t.Fatalf("repeated host upgrade operation status = %+v", repeatedStatus)
 	}
@@ -205,7 +206,7 @@ func TestInstalledRuntimeSysupdateRootUKITransfer(t *testing.T) {
 	}
 }
 
-func submitHostUpgradeAndWait(t *testing.T, ctx context.Context, endpoint, machineID, currentGeneration, candidateGeneration, localRef string) (string, *agentapi.OperationStatus) {
+func submitHostUpgradeAndWait(t *testing.T, ctx context.Context, endpoint, machineID, currentGeneration, candidateGeneration, localRef string, upgrade builtUpgradeImage) (string, *agentapi.OperationStatus) {
 	t.Helper()
 	conn, katlc := dialKatlcAgentForVMTest(t, ctx, endpoint)
 	accepted, err := katlc.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
@@ -218,6 +219,8 @@ func submitHostUpgradeAndWait(t *testing.T, ctx context.Context, endpoint, machi
 		ExpectedCurrentGenerationId: currentGeneration,
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
 			ImageLocalRef:         localRef,
+			ImageSha256:           upgrade.SHA256,
+			ImageSizeBytes:        upgrade.SizeBytes,
 			CandidateGenerationId: candidateGeneration,
 		},
 	})
@@ -226,6 +229,56 @@ func submitHostUpgradeAndWait(t *testing.T, ctx context.Context, endpoint, machi
 		t.Fatalf("submit host upgrade operation: %v", err)
 	}
 	return accepted.GetOperationId(), waitKatlcOperationTerminal(t, ctx, endpoint, accepted.GetOperationId())
+}
+
+func stageHostUpgradeArtifactForVMTest(t *testing.T, ctx context.Context, endpoint, machineID string, upgrade builtUpgradeImage) string {
+	t.Helper()
+	conn, katlc := dialKatlcAgentForVMTest(t, ctx, endpoint)
+	defer conn.Close()
+	stream, err := katlc.StageHostUpgradeArtifact(ctx)
+	if err != nil {
+		t.Fatalf("start host upgrade artifact staging: %v", err)
+	}
+	file, err := os.Open(upgrade.Path)
+	if err != nil {
+		t.Fatalf("open host upgrade artifact: %v", err)
+	}
+	defer file.Close()
+	buffer := make([]byte, 1<<20)
+	first := true
+	for {
+		n, readErr := file.Read(buffer)
+		if n > 0 {
+			request := &agentapi.StageHostUpgradeArtifactRequest{Chunk: append([]byte(nil), buffer[:n]...)}
+			if first {
+				request.ApiVersion = operation.APIVersion
+				request.Kind = agent.StageHostUpgradeArtifactRequestKind
+				request.Actor = "installed runtime host upgrade vmtest"
+				request.ExpectedMachineId = machineID
+				request.Sha256 = upgrade.SHA256
+				request.SizeBytes = upgrade.SizeBytes
+				first = false
+			}
+			if err := stream.Send(request); err != nil {
+				t.Fatalf("send host upgrade artifact: %v", err)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			t.Fatalf("read host upgrade artifact: %v", readErr)
+		}
+	}
+	staged, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("finish host upgrade artifact staging: %v", err)
+	}
+	wantRef := "host-upgrade/uploads/" + upgrade.SHA256 + ".squashfs"
+	if staged.GetLocalRef() != wantRef || staged.GetSha256() != upgrade.SHA256 || staged.GetSizeBytes() != upgrade.SizeBytes {
+		t.Fatalf("staged host upgrade artifact = %#v", staged)
+	}
+	return staged.GetLocalRef()
 }
 
 type builtUpgradeImage struct {
@@ -298,40 +351,6 @@ func discoverBuiltUpgradeImage(t *testing.T, baseVersion string) builtUpgradeIma
 		t.Fatalf("KatlOS upgrade image SHA-256 = %s, metadata = %s", digest, metadata.SHA256)
 	}
 	return builtUpgradeImage{Path: path, Version: metadata.Version, SHA256: metadata.SHA256, SizeBytes: metadata.SizeBytes}
-}
-
-func uploadGuestFile(t *testing.T, ctx context.Context, guest *GuestControl, source, target string, chunkSize int) {
-	t.Helper()
-	file, err := os.Open(source)
-	if err != nil {
-		t.Fatalf("open guest upload source: %v", err)
-	}
-	defer file.Close()
-	buffer := make([]byte, chunkSize)
-	var offset uint64
-	for {
-		n, readErr := io.ReadFull(file, buffer)
-		if readErr != nil && readErr != io.ErrUnexpectedEOF && readErr != io.EOF {
-			t.Fatalf("read guest upload source at %d: %v", offset, readErr)
-		}
-		if n > 0 {
-			if _, err := guest.WriteFile(ctx, GuestFileRequest{
-				Name:     fmt.Sprintf("host-upgrade-image-%08d", offset),
-				Path:     target,
-				Content:  buffer[:n],
-				Mode:     0o600,
-				Timeout:  30 * time.Second,
-				Offset:   offset,
-				Truncate: offset == 0,
-			}); err != nil {
-				t.Fatalf("upload guest file %s at %d: %v", target, offset, err)
-			}
-			offset += uint64(n)
-		}
-		if readErr == io.ErrUnexpectedEOF || readErr == io.EOF {
-			break
-		}
-	}
 }
 
 func assertBootedGenerationIdentity(t *testing.T, ctx context.Context, guest *GuestControl, spec generation.GenerationSpec) {


### PR DESCRIPTION
## What changed

- add `katldev build upgrade --version` for verified images from the current checkout
- let `katlctl node upgrade --artifact` validate and stream a local image to the node
- keep transfer integrity internal and remove Katl-managed uploads after use
- preserve the existing published-version upgrade path

## Why

Development upgrades required publishing a release or manually staging an image over SSH even though the node operation already understood local artifacts. This makes local builds a supported operator-facing workflow and keeps plan mode complete without uploading.

The focused installed-runtime VM journey covers upload, upgrade, reboot, promotion, rollback, cleanup, re-upload, and repeated staging. The full Go suite also passes.
