### PR TITLE
build: snapshot runtime boot artifacts

### DIFF
--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -17,10 +17,34 @@ func TestRuntimeInitrdIncludesLibseccomp(t *testing.T) {
 	for _, want := range []string{
 		`"$root/usr/lib64/libseccomp.so.2"`,
 		"cpio --null --create --append --format=newc",
-		`zstd -q --ultra -22 -f "$initrd_raw" -o "$initrd"`,
+		`zstd -q --ultra -22 -f "$initrd_raw" -o "$runtime_initrd"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("runtime artifact packaging does not append libseccomp to the initrd: missing %q", want)
+		}
+	}
+}
+
+func TestRuntimeBootInputsArePublishedBeforeInitrdPackaging(t *testing.T) {
+	wrapper, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts", "mkosi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(wrapper)
+	publish := `cp --reflink=auto "$kernel_source" "$runtime_kernel"`
+	packageInitrd := `zstd -q -d -c "$runtime_initrd"`
+	publishAt := strings.Index(text, publish)
+	packageAt := strings.Index(text, packageInitrd)
+	if publishAt < 0 || packageAt < 0 || publishAt >= packageAt {
+		t.Fatalf("runtime boot inputs must be copied to durable artifacts before initrd packaging")
+	}
+	for _, want := range []string{
+		`cp --reflink=auto "$initrd_source" "$runtime_initrd"`,
+		`--linux "$runtime_kernel"`,
+		`--initrd "$runtime_initrd"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("runtime UKI packaging does not use published boot input %q", want)
 		}
 	}
 }

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -736,15 +736,19 @@ set +e
                 echo "error: runtime kernel not found under $root/boot" >&2
                 status=1
             else
-                kernel="$kernel_dir/linux"
-                initrd="$kernel_dir/initrd"
+                kernel_source="$kernel_dir/linux"
+                initrd_source="$kernel_dir/initrd"
                 kernel_version="$(basename "$kernel_dir")"
                 os_release="$root/usr/lib/os-release"
-                if [[ ! -f "$initrd" ]]; then
-                    echo "error: runtime initrd not found: $initrd" >&2
+                if [[ ! -f "$initrd_source" ]]; then
+                    echo "error: runtime initrd not found: $initrd_source" >&2
                     status=1
                 elif [[ ! -f "$os_release" ]]; then
                     echo "error: runtime os-release not found: $os_release" >&2
+                    status=1
+                elif ! cp --reflink=auto "$kernel_source" "$runtime_kernel" \
+                    || ! cp --reflink=auto "$initrd_source" "$runtime_initrd"; then
+                    echo "error: publish runtime direct-boot kernel and initrd" >&2
                     status=1
                 else
                     initrd_overlay=$(mktemp -d)
@@ -756,7 +760,7 @@ set +e
                         "$initrd_overlay/usr/lib64/"; then
                         echo "error: stage runtime initrd libseccomp overlay" >&2
                         status=1
-                    elif ! zstd -q -d -c "$initrd" >"$initrd_raw"; then
+                    elif ! zstd -q -d -c "$runtime_initrd" >"$initrd_raw"; then
                         echo "error: decompress runtime initrd" >&2
                         status=1
                     elif ! (
@@ -767,19 +771,15 @@ set +e
                     ); then
                         echo "error: append runtime initrd libseccomp overlay" >&2
                         status=1
-                    elif ! zstd -q --ultra -22 -f "$initrd_raw" -o "$initrd"; then
+                    elif ! zstd -q --ultra -22 -f "$initrd_raw" -o "$runtime_initrd"; then
                         echo "error: recompress runtime initrd" >&2
                         status=1
                     fi
                     rm -rf "$initrd_overlay" "$initrd_raw"
-                    if [[ "$status" -eq 0 ]] && { ! cp --reflink=auto "$kernel" "$runtime_kernel" || ! cp --reflink=auto "$initrd" "$runtime_initrd"; }; then
-                        echo "error: publish runtime direct-boot kernel and initrd" >&2
-                        status=1
-                    fi
                     ukify_args=(
                         build
-                        --linux "$kernel"
-                        --initrd "$initrd"
+                        --linux "$runtime_kernel"
+                        --initrd "$runtime_initrd"
                         --os-release "@$os_release"
                         --cmdline "rootfstype=squashfs ro"
                         --uname "$kernel_version"


### PR DESCRIPTION
## What changed

- snapshot mkosi's kernel and initrd into their published runtime artifact paths immediately
- augment the durable initrd copy and build the runtime UKI from the published copies
- cover the ordering and UKI inputs in the packaging regression

## Why

Runtime packaging kept reading boot files from mkosi's transient output tree while it modified the initrd. The kernel path could disappear before the later copy, causing local KatlOS builds to fail and leaving the split VM boot artifacts unpublished.

The exact failing local upgrade build now succeeds, and the focused direct-runtime libvirt journey boots successfully from the published kernel, initrd, and runtime root.
