### PR TITLE
routing: withdraw workload paths before power loss

### DIFF
--- a/internal/katlc/agent/endpoint_lifecycle.go
+++ b/internal/katlc/agent/endpoint_lifecycle.go
@@ -19,11 +19,44 @@ import (
 
 const (
 	endpointAdvertiserUnit    = "katl-app-bgp-api-vip.service"
+	endpointRoutingUnit       = "katl-app-bird.service"
 	endpointAdvertiserCommand = "/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser"
 	managedEndpointInterface  = "/usr/bin/networkctl"
 	managedEndpointIP         = "/usr/bin/ip"
 	managedEndpointKubectl    = "/usr/bin/kubectl"
 )
+
+// pauseManagedRoutingForPowerTransition withdraws both the API VIP and routes
+// learned from local route-exchange peers before the node loses power. Stopping
+// only the endpoint advertiser leaves BIRD's fabric session established, so a
+// router can retain a dead ECMP path to workload VIPs while the node reboots.
+func pauseManagedRoutingForPowerTransition(ctx context.Context, root string, run ToolRunner) (bool, error) {
+	paused, err := pauseManagedEndpoint(ctx, root, run)
+	if err != nil || !paused {
+		return paused, err
+	}
+	result := run(ctx, []string{"systemctl", "stop", endpointRoutingUnit}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		resumeErr := resumeManagedRoutingAfterFailedPowerTransition(context.Background(), root, run)
+		return false, errors.Join(fmt.Errorf("stop managed route exports: %s", toolFailure(result)), resumeErr)
+	}
+	return true, nil
+}
+
+func resumeManagedRoutingAfterFailedPowerTransition(ctx context.Context, root string, run ToolRunner) error {
+	configured, err := managedEndpointConfigured(root)
+	if err != nil || !configured {
+		return err
+	}
+	if run == nil {
+		return fmt.Errorf("endpoint lifecycle runner is not configured")
+	}
+	result := run(ctx, []string{"systemctl", "start", endpointRoutingUnit}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return fmt.Errorf("resume managed route exports: %s", toolFailure(result))
+	}
+	return resumeManagedEndpoint(ctx, root, run)
+}
 
 type managedJoinEndpoint struct {
 	VIP       string

--- a/internal/katlc/agent/endpoint_lifecycle_test.go
+++ b/internal/katlc/agent/endpoint_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
@@ -44,6 +45,59 @@ func TestManagedEndpointLifecycleFollowsGeneratedEnablement(t *testing.T) {
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("endpoint lifecycle commands = %#v, want %#v", calls, want)
+	}
+}
+
+func TestPowerTransitionLifecycleWithdrawsAndRestoresAllManagedRoutes(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	var calls [][]string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		calls = append(calls, append([]string(nil), argv...))
+		return ToolResult{}
+	}
+
+	paused, err := pauseManagedRoutingForPowerTransition(context.Background(), root, run)
+	if err != nil || !paused {
+		t.Fatalf("pause managed routing = %v, %v", paused, err)
+	}
+	if err := resumeManagedRoutingAfterFailedPowerTransition(context.Background(), root, run); err != nil {
+		t.Fatalf("resume managed routing: %v", err)
+	}
+	want := [][]string{
+		{"systemctl", "stop", endpointAdvertiserUnit},
+		{endpointAdvertiserCommand, "withdraw"},
+		{"systemctl", "stop", endpointRoutingUnit},
+		{"systemctl", "start", endpointRoutingUnit},
+		{"systemctl", "start", endpointAdvertiserUnit},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("power transition lifecycle commands = %#v, want %#v", calls, want)
+	}
+}
+
+func TestPowerTransitionPauseRestoresRoutingWhenFabricWithdrawalFails(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	var calls [][]string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		calls = append(calls, append([]string(nil), argv...))
+		if reflect.DeepEqual(argv, []string{"systemctl", "stop", endpointRoutingUnit}) {
+			return ToolResult{Err: errors.New("bird stop failed"), ExitStatus: 1}
+		}
+		return ToolResult{}
+	}
+
+	paused, err := pauseManagedRoutingForPowerTransition(context.Background(), root, run)
+	if err == nil || paused || !strings.Contains(err.Error(), "stop managed route exports") {
+		t.Fatalf("pause managed routing = %v, %v", paused, err)
+	}
+	wantTail := [][]string{
+		{"systemctl", "start", endpointRoutingUnit},
+		{"systemctl", "start", endpointAdvertiserUnit},
+	}
+	if !reflect.DeepEqual(calls[len(calls)-2:], wantTail) {
+		t.Fatalf("routing restore commands = %#v, want tail %#v", calls, wantTail)
 	}
 }
 

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -145,15 +145,15 @@ func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agen
 	if s.RunReboot == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node reboot runner is not configured")
 	}
-	endpointPaused, err := pauseManagedEndpoint(ctx, s.Root, s.RunEndpointLifecycle)
+	routingPaused, err := pauseManagedRoutingForPowerTransition(ctx, s.Root, s.RunEndpointLifecycle)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "prepare control-plane endpoint for reboot: %s", inventory.Redact(err.Error()))
+		return nil, status.Errorf(codes.Internal, "prepare node routing for reboot: %s", inventory.Redact(err.Error()))
 	}
 	result := s.RunReboot(ctx, []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
 		var resumeErr error
-		if endpointPaused {
-			resumeErr = resumeManagedEndpoint(context.Background(), s.Root, s.RunEndpointLifecycle)
+		if routingPaused {
+			resumeErr = resumeManagedRoutingAfterFailedPowerTransition(context.Background(), s.Root, s.RunEndpointLifecycle)
 		}
 		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(errors.Join(errors.New(toolFailure(result)), resumeErr).Error()))
 	}
@@ -190,15 +190,15 @@ func (s *Server) Shutdown(ctx context.Context, req *agentapi.ShutdownRequest) (*
 	if s.RunShutdown == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node shutdown runner is not configured")
 	}
-	endpointPaused, err := pauseManagedEndpoint(ctx, s.Root, s.RunEndpointLifecycle)
+	routingPaused, err := pauseManagedRoutingForPowerTransition(ctx, s.Root, s.RunEndpointLifecycle)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "prepare control-plane endpoint for shutdown: %s", inventory.Redact(err.Error()))
+		return nil, status.Errorf(codes.Internal, "prepare node routing for shutdown: %s", inventory.Redact(err.Error()))
 	}
 	result := s.RunShutdown(ctx, []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
 		var resumeErr error
-		if endpointPaused {
-			resumeErr = resumeManagedEndpoint(context.Background(), s.Root, s.RunEndpointLifecycle)
+		if routingPaused {
+			resumeErr = resumeManagedRoutingAfterFailedPowerTransition(context.Background(), s.Root, s.RunEndpointLifecycle)
 		}
 		return nil, status.Errorf(codes.Internal, "schedule shutdown: %s", inventory.Redact(errors.Join(errors.New(toolFailure(result)), resumeErr).Error()))
 	}

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -216,7 +216,7 @@ func TestRebootSchedulesCommittedSelectedGeneration(t *testing.T) {
 	}
 }
 
-func TestRebootWithdrawsManagedEndpointBeforeScheduling(t *testing.T) {
+func TestRebootWithdrawsManagedRoutesBeforeScheduling(t *testing.T) {
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
 	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
@@ -243,6 +243,7 @@ func TestRebootWithdrawsManagedEndpointBeforeScheduling(t *testing.T) {
 	want := []string{
 		"systemctl stop " + endpointAdvertiserUnit,
 		endpointAdvertiserCommand + " withdraw",
+		"systemctl stop " + endpointRoutingUnit,
 		"systemd-run --unit=katl-reboot --collect --on-active=2s systemctl reboot",
 	}
 	if !reflect.DeepEqual(actions, want) {
@@ -270,11 +271,48 @@ func TestRebootRefusesWhenManagedEndpointCannotWithdraw(t *testing.T) {
 		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
 		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
 	})
-	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "prepare control-plane endpoint for reboot") {
+	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "prepare node routing for reboot") {
 		t.Fatalf("Reboot() error = %v", err)
 	}
 	if rebootCalled {
 		t.Fatal("reboot was scheduled without withdrawing the managed endpoint")
+	}
+}
+
+func TestRebootRestoresManagedRoutingWhenSchedulingFails(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
+	var actions []string
+	server.RunEndpointLifecycle = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		actions = append(actions, strings.Join(got, " "))
+		return ToolResult{}
+	}
+	server.RunReboot = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		actions = append(actions, strings.Join(got, " "))
+		return ToolResult{Err: errors.New("systemd-run failed"), ExitStatus: 1}
+	}
+	machineID, err := server.machineID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.Reboot(context.Background(), &agentapi.RebootRequest{
+		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
+		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
+	})
+	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "schedule reboot") {
+		t.Fatalf("Reboot() error = %v", err)
+	}
+	want := []string{
+		"systemctl stop " + endpointAdvertiserUnit,
+		endpointAdvertiserCommand + " withdraw",
+		"systemctl stop " + endpointRoutingUnit,
+		"systemd-run --unit=katl-reboot --collect --on-active=2s systemctl reboot",
+		"systemctl start " + endpointRoutingUnit,
+		"systemctl start " + endpointAdvertiserUnit,
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("reboot recovery actions = %#v, want %#v", actions, want)
 	}
 }
 
@@ -305,7 +343,7 @@ func TestShutdownSchedulesPoweroff(t *testing.T) {
 	}
 }
 
-func TestShutdownWithdrawsManagedEndpointBeforeScheduling(t *testing.T) {
+func TestShutdownWithdrawsManagedRoutesBeforeScheduling(t *testing.T) {
 	server := newTestServer(t)
 	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
 	var actions []string
@@ -331,6 +369,7 @@ func TestShutdownWithdrawsManagedEndpointBeforeScheduling(t *testing.T) {
 	want := []string{
 		"systemctl stop " + endpointAdvertiserUnit,
 		endpointAdvertiserCommand + " withdraw",
+		"systemctl stop " + endpointRoutingUnit,
 		"systemd-run --unit=katl-shutdown --collect --on-active=2s systemctl poweroff",
 	}
 	if !reflect.DeepEqual(actions, want) {

--- a/internal/vmtest/runner_scripts_test.go
+++ b/internal/vmtest/runner_scripts_test.go
@@ -219,8 +219,17 @@ func TestVMTestRunHonorsPackageParallelismOverride(t *testing.T) {
 		t.Fatalf("vmtest-run failed: %v\n%s", err, output)
 	}
 	goArgs := readLines(t, goArgsPath)
-	joined := "\n" + strings.Join(goArgs, "\n") + "\n"
-	if strings.Count(joined, "-p") != 1 || !strings.Contains(joined, "\n-p=3\n") {
+	parallelismArgs := 0
+	foundOverride := false
+	for _, arg := range goArgs {
+		if arg == "-p" || strings.HasPrefix(arg, "-p=") {
+			parallelismArgs++
+		}
+		if arg == "-p=3" {
+			foundOverride = true
+		}
+	}
+	if parallelismArgs != 1 || !foundOverride {
 		t.Fatalf("go args do not preserve the sole caller parallelism override: %#v", goArgs)
 	}
 }


### PR DESCRIPTION
Stops the managed BIRD fabric session before reboot or shutdown, after withdrawing the API VIP, and restores routing when power scheduling fails. This prevents stale ECMP paths to route-exchange workload VIPs while a node is offline. The defect was found during a live three-node upgrade: stopping only the endpoint advertiser left BIRD exporting Cilium service routes. Also makes the VM-runner parallelism assertion count exact arguments so repository paths containing `-p` do not cause false failures.