### PR TITLE
release: build and maintain all supported Kubernetes bundles

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -7,23 +7,31 @@ on:
     paths:
       - .github/workflows/kubernetes-bundles.yml
       - Containerfile.mkosi
+      - cmd/katl-boot-health/**
+      - "!cmd/katl-boot-health/**/*_test.go"
+      - cmd/katl-console/**
+      - "!cmd/katl-console/**/*_test.go"
+      - cmd/katl-generation-activate/**
+      - "!cmd/katl-generation-activate/**/*_test.go"
       - cmd/katl-kubernetes-release/**
       - "!cmd/katl-kubernetes-release/**/*_test.go"
       - cmd/katl-mkosi-artifacts/**
       - "!cmd/katl-mkosi-artifacts/**/*_test.go"
       - cmd/katl-publish-kubernetes-sysext/**
       - "!cmd/katl-publish-kubernetes-sysext/**/*_test.go"
+      - cmd/katl-runtime-status/**
+      - "!cmd/katl-runtime-status/**/*_test.go"
+      - cmd/katlc/**
+      - "!cmd/katlc/**/*_test.go"
       - containers-policy.json
       - go.mod
       - go.sum
-      - internal/installer/artifact/**
-      - "!internal/installer/artifact/**/*_test.go"
-      - internal/installer/kubernetesbundle/**
-      - "!internal/installer/kubernetesbundle/**/*_test.go"
-      - internal/installer/manifest/**
-      - "!internal/installer/manifest/**/*_test.go"
-      - internal/installer/sysextcatalog/**
-      - "!internal/installer/sysextcatalog/**/*_test.go"
+      - internal/**
+      - "!internal/**/*_test.go"
+      - "!internal/**/testdata/**"
+      - "!internal/installer/kubernetescompat/catalog.json"
+      - "!internal/resourcetest/**"
+      - "!internal/vmtest/**"
       - internal/kubernetesrelease/supported-versions.json
       - mkosi.conf
       - mkosi.profiles/kubernetes-sysext/**
@@ -37,10 +45,6 @@ on:
         description: Exact supported Kubernetes payload; empty builds every supported version
         required: false
         type: string
-      artifact_version:
-        description: Optional immutable Katl build identity for a single selected payload
-        required: false
-        type: string
       publish:
         description: Publish verified OCI artifacts to ghcr.io/katl-dev/kubernetes
         required: true
@@ -51,7 +55,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.artifact_version || github.ref }}-x86_64
+  group: ${{ github.workflow }}-${{ github.ref }}-x86_64
   cancel-in-progress: false
 
 jobs:
@@ -64,7 +68,6 @@ jobs:
       build: ${{ steps.plan.outputs.build }}
       publish: ${{ steps.plan.outputs.publish }}
     env:
-      DISPATCH_ARTIFACT_VERSION: ${{ inputs.artifact_version }}
       DISPATCH_PAYLOAD_VERSION: ${{ inputs.payload_version }}
       DISPATCH_PUBLISH: ${{ inputs.publish }}
       GOTOOLCHAIN: auto
@@ -72,7 +75,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -93,24 +96,33 @@ jobs:
           fi
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             previous="$RUNNER_TEMP/previous-supported-versions.json"
-            if git show "${{ github.event.before }}:internal/kubernetesrelease/supported-versions.json" > "$previous" &&
-              jq -e '.recipeDigest and (.versions | type == "array")' "$previous" >/dev/null; then
-              args+=(--previous-supported-versions "$previous")
+            previous_commit="${{ github.event.before }}"
+            previous_ref="${previous_commit}:internal/kubernetesrelease/supported-versions.json"
+            if ! git cat-file -e "${previous_commit}^{commit}"; then
+              echo "error: previous main commit is unavailable: $previous_commit" >&2
+              exit 1
+            fi
+            if git cat-file -e "$previous_ref"; then
+              git show "$previous_ref" > "$previous"
+              if jq -e '
+                .apiVersion == "katl.dev/v1alpha1" and
+                .kind == "KubernetesSupportedVersions" and
+                (.recipeDigest | type == "string") and
+                (.versions | type == "array")
+              ' "$previous" >/dev/null; then
+                args+=(--previous-supported-versions "$previous")
+              elif ! jq -e '
+                .apiVersion == "katl.dev/v1alpha1" and
+                .kind == "KubernetesSupportedVersions" and
+                (.versions | type == "array") and
+                all(.versions[]; type == "string")
+              ' "$previous" >/dev/null; then
+                echo "error: previous supported-version policy is malformed" >&2
+                exit 1
+              fi
             fi
           fi
           matrix="$(go run ./cmd/katl-kubernetes-release "${args[@]}")"
-
-          if [[ -n "$DISPATCH_ARTIFACT_VERSION" ]]; then
-            if [[ -z "$DISPATCH_PAYLOAD_VERSION" ]]; then
-              echo "error: artifact_version requires payload_version" >&2
-              exit 1
-            fi
-            if [[ ! "$DISPATCH_ARTIFACT_VERSION" =~ ^${DISPATCH_PAYLOAD_VERSION}-katl\.[0-9]+$ ]]; then
-              echo "error: artifact_version must look like ${DISPATCH_PAYLOAD_VERSION}-katl.1" >&2
-              exit 1
-            fi
-            matrix="$(jq -c --arg artifact "$DISPATCH_ARTIFACT_VERSION" '.include[0].artifactVersion = $artifact' <<<"$matrix")"
-          fi
 
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             publish=true
@@ -175,6 +187,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Set reproducible build timestamp
+        shell: bash
+        run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")" >> "$GITHUB_ENV"
 
       - name: Set up ORAS
         shell: bash
@@ -295,6 +311,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Validate OCI artifact layout
+        id: oci-layout
         shell: bash
         env:
           BUNDLE_DIR: ${{ steps.bundle.outputs.bundle-dir }}
@@ -311,6 +328,7 @@ jobs:
             --annotation "org.opencontainers.image.documentation=https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_SHA}/docs/installing.md" \
             --annotation "org.opencontainers.image.revision=${GITHUB_SHA}" \
             --annotation "org.opencontainers.image.version=${ARTIFACT_VERSION}" \
+            --annotation "dev.katl.bundle.kind=kubernetes" \
             "${RAW}:application/vnd.katl.sysext.raw.v1" \
             "${BUNDLE_DIR}/metadata.json:application/vnd.katl.kubernetes.sysext.metadata.v1+json" \
             "${BUNDLE_DIR}/package-provenance.json:application/vnd.katl.package-provenance.v1+json" \
@@ -327,6 +345,12 @@ jobs:
             .annotations["org.opencontainers.image.licenses"] == $licenses and
             .annotations["org.opencontainers.image.source"] == $source
           ' _build/oci-manifest.json >/dev/null
+          manifest_digest="$(oras resolve --oci-layout "_build/oci-layout:${VERSION_TAG}")"
+          if [[ ! "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "error: invalid local OCI manifest digest: $manifest_digest" >&2
+            exit 1
+          fi
+          echo "manifest-digest=$manifest_digest" >> "$GITHUB_OUTPUT"
 
       - name: Upload inspected bundle artifact
         uses: actions/upload-artifact@v7
@@ -351,44 +375,71 @@ jobs:
         env:
           BUNDLE_DIR: ${{ steps.bundle.outputs.bundle-dir }}
           DIGEST_TAG: ${{ steps.bundle.outputs.digest-tag }}
+          LOCAL_MANIFEST_DIGEST: ${{ steps.oci-layout.outputs.manifest-digest }}
           RAW: ${{ steps.bundle.outputs.raw }}
           VERSION_TAG: ${{ steps.bundle.outputs.version-tag }}
         run: |
-          for tag in "$VERSION_TAG" "$DIGEST_TAG"; do
+          resolve_remote_tag() {
+            local tag="$1"
+            local error_file
+            local digest
             error_file="$(mktemp)"
-            if oras manifest fetch "${OCI_REPOSITORY}:${tag}" >/dev/null 2>"$error_file"; then
-              echo "error: immutable OCI tag already exists: ${OCI_REPOSITORY}:${tag}" >&2
-              exit 1
+            if digest="$(oras resolve "${OCI_REPOSITORY}:${tag}" 2>"$error_file")"; then
+              rm -f "$error_file"
+              printf '%s\n' "$digest"
+              return
             fi
             if ! grep -Eqi 'MANIFEST_UNKNOWN|NAME_UNKNOWN|not found|status code: 404' "$error_file"; then
-              echo "error: could not prove immutable OCI tag is absent: ${OCI_REPOSITORY}:${tag}" >&2
+              echo "error: could not resolve immutable OCI tag ${OCI_REPOSITORY}:${tag}" >&2
               cat "$error_file" >&2
+              rm -f "$error_file"
               exit 1
             fi
             rm -f "$error_file"
+          }
+
+          version_digest="$(resolve_remote_tag "$VERSION_TAG")"
+          bundle_digest="$(resolve_remote_tag "$DIGEST_TAG")"
+          for existing_digest in "$version_digest" "$bundle_digest"; do
+            if [[ -n "$existing_digest" && "$existing_digest" != "$LOCAL_MANIFEST_DIGEST" ]]; then
+              echo "error: immutable OCI tag resolves to $existing_digest, want $LOCAL_MANIFEST_DIGEST" >&2
+              exit 1
+            fi
           done
 
-          oras push "${OCI_REPOSITORY}:${VERSION_TAG},${DIGEST_TAG}" \
-            --artifact-type application/vnd.katl.kubernetes.payload.bundle.v1 \
-            --config "${BUNDLE_DIR}/bundle.json:application/vnd.katl.kubernetes.payload.bundle.v1+json" \
-            --annotation "org.opencontainers.image.title=${OCI_TITLE}" \
-            --annotation "org.opencontainers.image.description=${OCI_DESCRIPTION}" \
-            --annotation "org.opencontainers.image.licenses=${OCI_LICENSES}" \
-            --annotation "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
-            --annotation "org.opencontainers.image.documentation=https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_SHA}/docs/installing.md" \
-            --annotation "org.opencontainers.image.revision=${GITHUB_SHA}" \
-            --annotation "org.opencontainers.image.version=${ARTIFACT_VERSION}" \
-            --annotation "dev.katl.bundle.kind=kubernetes" \
-            "${RAW}:application/vnd.katl.sysext.raw.v1" \
-            "${BUNDLE_DIR}/metadata.json:application/vnd.katl.kubernetes.sysext.metadata.v1+json" \
-            "${BUNDLE_DIR}/package-provenance.json:application/vnd.katl.package-provenance.v1+json" \
-            "${BUNDLE_DIR}/catalog-entry.json:application/vnd.katl.kubernetes.catalog.entry.v1+json" \
-            --format json > _build/oras-push.json
+          if [[ -n "$version_digest" || -n "$bundle_digest" ]]; then
+            manifest_digest="$LOCAL_MANIFEST_DIGEST"
+            missing_tags=()
+            [[ -n "$version_digest" ]] || missing_tags+=("$VERSION_TAG")
+            [[ -n "$bundle_digest" ]] || missing_tags+=("$DIGEST_TAG")
+            if [[ "${#missing_tags[@]}" -gt 0 ]]; then
+              oras tag "${OCI_REPOSITORY}@${manifest_digest}" "${missing_tags[@]}"
+            fi
+            publication="Reused"
+          else
+            oras push "${OCI_REPOSITORY}:${VERSION_TAG},${DIGEST_TAG}" \
+              --artifact-type application/vnd.katl.kubernetes.payload.bundle.v1 \
+              --config "${BUNDLE_DIR}/bundle.json:application/vnd.katl.kubernetes.payload.bundle.v1+json" \
+              --annotation "org.opencontainers.image.title=${OCI_TITLE}" \
+              --annotation "org.opencontainers.image.description=${OCI_DESCRIPTION}" \
+              --annotation "org.opencontainers.image.licenses=${OCI_LICENSES}" \
+              --annotation "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+              --annotation "org.opencontainers.image.documentation=https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_SHA}/docs/installing.md" \
+              --annotation "org.opencontainers.image.revision=${GITHUB_SHA}" \
+              --annotation "org.opencontainers.image.version=${ARTIFACT_VERSION}" \
+              --annotation "dev.katl.bundle.kind=kubernetes" \
+              "${RAW}:application/vnd.katl.sysext.raw.v1" \
+              "${BUNDLE_DIR}/metadata.json:application/vnd.katl.kubernetes.sysext.metadata.v1+json" \
+              "${BUNDLE_DIR}/package-provenance.json:application/vnd.katl.package-provenance.v1+json" \
+              "${BUNDLE_DIR}/catalog-entry.json:application/vnd.katl.kubernetes.catalog.entry.v1+json" \
+              --format json > _build/oras-push.json
 
-          manifest_digest="$(jq -r '.digest' _build/oras-push.json)"
-          if [[ ! "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "error: ORAS returned invalid manifest digest: $manifest_digest" >&2
-            exit 1
+            manifest_digest="$(jq -r '.digest' _build/oras-push.json)"
+            if [[ "$manifest_digest" != "$LOCAL_MANIFEST_DIGEST" ]]; then
+              echo "error: published OCI manifest digest $manifest_digest does not match local digest $LOCAL_MANIFEST_DIGEST" >&2
+              exit 1
+            fi
+            publication="Published"
           fi
           oras manifest fetch --output _build/remote-manifest.json "${OCI_REPOSITORY}@${manifest_digest}"
           oras manifest fetch-config --output _build/remote-bundle.json "${OCI_REPOSITORY}@${manifest_digest}"
@@ -404,7 +455,7 @@ jobs:
 
           echo "manifest-digest=$manifest_digest" >> "$GITHUB_OUTPUT"
           {
-            echo "### Published Kubernetes bundle"
+            echo "### ${publication} Kubernetes bundle"
             echo
             echo "- OCI: \`${OCI_REPOSITORY}@${manifest_digest}\`"
             echo "- Kubernetes bundle: \`${OCI_REPOSITORY}:${VERSION_TAG}@${manifest_digest}\`"

--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -5,19 +5,44 @@ on:
     branches:
       - main
     paths:
-      - mkosi.profiles/kubernetes-sysext/kubernetes.env
+      - .github/workflows/kubernetes-bundles.yml
+      - Containerfile.mkosi
+      - cmd/katl-kubernetes-release/**
+      - "!cmd/katl-kubernetes-release/**/*_test.go"
+      - cmd/katl-mkosi-artifacts/**
+      - "!cmd/katl-mkosi-artifacts/**/*_test.go"
+      - cmd/katl-publish-kubernetes-sysext/**
+      - "!cmd/katl-publish-kubernetes-sysext/**/*_test.go"
+      - containers-policy.json
+      - go.mod
+      - go.sum
+      - internal/installer/artifact/**
+      - "!internal/installer/artifact/**/*_test.go"
+      - internal/installer/kubernetesbundle/**
+      - "!internal/installer/kubernetesbundle/**/*_test.go"
+      - internal/installer/manifest/**
+      - "!internal/installer/manifest/**/*_test.go"
+      - internal/installer/sysextcatalog/**
+      - "!internal/installer/sysextcatalog/**/*_test.go"
+      - internal/kubernetesrelease/supported-versions.json
+      - mkosi.conf
+      - mkosi.profiles/kubernetes-sysext/**
+      - mkosi.profiles/runtime/**
+      - scripts/build-kubernetes-sysext
+      - scripts/check-kubernetes-sysext
+      - scripts/mkosi
   workflow_dispatch:
     inputs:
       payload_version:
-        description: Exact Kubernetes payload version; empty uses the committed release manifest
+        description: Exact supported Kubernetes payload; empty builds every supported version
         required: false
         type: string
       artifact_version:
-        description: Immutable Katl bundle build version; empty derives it from the committed release manifest
+        description: Optional immutable Katl build identity for a single selected payload
         required: false
         type: string
       publish:
-        description: Publish the verified OCI artifact to ghcr.io/katl-dev/kubernetes
+        description: Publish verified OCI artifacts to ghcr.io/katl-dev/kubernetes
         required: true
         default: false
         type: boolean
@@ -30,31 +55,116 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build And Publish Kubernetes Bundle
+  plan:
+    name: Plan Supported Bundles
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
-    permissions:
-      actions: write
-      artifact-metadata: write
-      attestations: write
-      contents: write
-      id-token: write
-      packages: write
-      pull-requests: write
-
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      build: ${{ steps.plan.outputs.build }}
+      publish: ${{ steps.plan.outputs.publish }}
     env:
       DISPATCH_ARTIFACT_VERSION: ${{ inputs.artifact_version }}
       DISPATCH_PAYLOAD_VERSION: ${{ inputs.payload_version }}
       DISPATCH_PUBLISH: ${{ inputs.publish }}
       GOTOOLCHAIN: auto
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify bundle recipe revisions
+        run: go run ./cmd/katl-kubernetes-release verify-recipe
+
+      - name: Resolve supported release matrix
+        id: plan
+        shell: bash
+        run: |
+          args=(matrix)
+          if [[ -n "$DISPATCH_PAYLOAD_VERSION" ]]; then
+            args+=(--payload-version "$DISPATCH_PAYLOAD_VERSION")
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            previous="$RUNNER_TEMP/previous-supported-versions.json"
+            if git show "${{ github.event.before }}:internal/kubernetesrelease/supported-versions.json" > "$previous" &&
+              jq -e '.recipeDigest and (.versions | type == "array")' "$previous" >/dev/null; then
+              args+=(--previous-supported-versions "$previous")
+            fi
+          fi
+          matrix="$(go run ./cmd/katl-kubernetes-release "${args[@]}")"
+
+          if [[ -n "$DISPATCH_ARTIFACT_VERSION" ]]; then
+            if [[ -z "$DISPATCH_PAYLOAD_VERSION" ]]; then
+              echo "error: artifact_version requires payload_version" >&2
+              exit 1
+            fi
+            if [[ ! "$DISPATCH_ARTIFACT_VERSION" =~ ^${DISPATCH_PAYLOAD_VERSION}-katl\.[0-9]+$ ]]; then
+              echo "error: artifact_version must look like ${DISPATCH_PAYLOAD_VERSION}-katl.1" >&2
+              exit 1
+            fi
+            matrix="$(jq -c --arg artifact "$DISPATCH_ARTIFACT_VERSION" '.include[0].artifactVersion = $artifact' <<<"$matrix")"
+          fi
+
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            publish=true
+          else
+            publish="$DISPATCH_PUBLISH"
+          fi
+          if [[ "$publish" != "true" && "$publish" != "false" ]]; then
+            echo "error: publish must be true or false" >&2
+            exit 1
+          fi
+
+          {
+            echo "matrix=$(jq -c . <<<"$matrix")"
+            echo "build=$(jq -r '.include | length > 0' <<<"$matrix")"
+            echo "publish=$publish"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.release.payloadVersion }}
+    if: ${{ needs.plan.outputs.build == 'true' }}
+    needs: plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ${{ fromJSON(needs.plan.outputs.matrix).include }}
+    permissions:
+      actions: write
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    env:
+      ARTIFACT_VERSION: ${{ matrix.release.artifactVersion }}
+      GOTOOLCHAIN: auto
       KATL_ARCHITECTURE: x86_64
+      KATL_BUILD_COMMIT: ${{ matrix.release.artifactVersion }}
       KATL_CONTAINER_RUNTIME: docker
+      KATL_KUBERNETES_ARTIFACT_REVISION: ${{ matrix.release.artifactRevision }}
+      KATL_KUBERNETES_CRITOOLS_VERSION: ${{ matrix.release.criToolsVersion }}
+      KATL_KUBERNETES_KUBEADM_VERSION: ${{ matrix.release.kubeadmVersion }}
+      KATL_KUBERNETES_KUBECTL_VERSION: ${{ matrix.release.kubectlVersion }}
+      KATL_KUBERNETES_KUBELET_VERSION: ${{ matrix.release.kubeletVersion }}
+      KATL_KUBERNETES_MINOR: ${{ matrix.release.minor }}
+      KATL_KUBERNETES_PAYLOAD_VERSION: ${{ matrix.release.payloadVersion }}
       KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
       OCI_REPOSITORY: ghcr.io/katl-dev/kubernetes
       OCI_DESCRIPTION: Kubernetes system extension bundle for KatlOS nodes
       OCI_LICENSES: MIT
       OCI_TITLE: KatlOS Kubernetes system extension
+      PAYLOAD_VERSION: ${{ matrix.release.payloadVersion }}
+      PUBLISH: ${{ needs.plan.outputs.publish }}
 
     steps:
       - name: Check out repository
@@ -80,48 +190,6 @@ jobs:
           echo "$install_dir" >> "$GITHUB_PATH"
           "$install_dir/oras" version
 
-      - name: Resolve and validate release identity
-        shell: bash
-        run: |
-          # shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
-          source mkosi.profiles/kubernetes-sysext/kubernetes.env
-          if [[ "$GITHUB_EVENT_NAME" == "push" || -z "$DISPATCH_PAYLOAD_VERSION" ]]; then
-            PAYLOAD_VERSION="$KATL_KUBERNETES_PAYLOAD_VERSION"
-          else
-            PAYLOAD_VERSION="$DISPATCH_PAYLOAD_VERSION"
-          fi
-          if [[ "$GITHUB_EVENT_NAME" == "push" || -z "$DISPATCH_ARTIFACT_VERSION" ]]; then
-            ARTIFACT_VERSION="${PAYLOAD_VERSION}-katl.${KATL_KUBERNETES_ARTIFACT_REVISION}"
-          else
-            ARTIFACT_VERSION="$DISPATCH_ARTIFACT_VERSION"
-          fi
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            PUBLISH=true
-          else
-            PUBLISH="$DISPATCH_PUBLISH"
-          fi
-
-          if [[ ! "$PAYLOAD_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "error: payload_version must look like v1.36.1" >&2
-            exit 1
-          fi
-          if [[ ! "$ARTIFACT_VERSION" =~ ^${PAYLOAD_VERSION}-katl\.[0-9]+$ ]]; then
-            echo "error: artifact_version must look like ${PAYLOAD_VERSION}-katl.1" >&2
-            exit 1
-          fi
-          if [[ "$PUBLISH" != "true" && "$PUBLISH" != "false" ]]; then
-            echo "error: publish must be true or false" >&2
-            exit 1
-          fi
-
-          {
-            echo "ARTIFACT_VERSION=$ARTIFACT_VERSION"
-            echo "KATL_BUILD_COMMIT=$ARTIFACT_VERSION"
-            echo "KATL_KUBERNETES_PAYLOAD_VERSION=$PAYLOAD_VERSION"
-            echo "PAYLOAD_VERSION=$PAYLOAD_VERSION"
-            echo "PUBLISH=$PUBLISH"
-          } >> "$GITHUB_ENV"
-
       - name: Restore Katl Go build caches
         uses: actions/cache@v6
         with:
@@ -132,25 +200,11 @@ jobs:
           restore-keys: |
             katl-go-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-
 
-      - name: Resolve mkosi cache identity
-        id: mkosi-cache
-        shell: bash
-        run: |
-          digest="$({
-            sha256sum \
-              Containerfile.mkosi \
-              mkosi.conf \
-              mkosi.profiles/kubernetes-sysext/kubernetes.env \
-              mkosi.profiles/kubernetes-sysext/mkosi.conf \
-              mkosi.profiles/runtime/mkosi.conf
-          } | sha256sum | cut -d ' ' -f 1)"
-          echo "key=$digest" >> "$GITHUB_OUTPUT"
-
       - name: Restore mkosi package cache
         uses: actions/cache@v6
         with:
           path: _build/mkosi/package-cache
-          key: katl-kubernetes-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-${{ steps.mkosi-cache.outputs.key }}
+          key: katl-kubernetes-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-${{ hashFiles('Containerfile.mkosi', 'mkosi.conf', 'mkosi.profiles/kubernetes-sysext/**', 'mkosi.profiles/runtime/**') }}
           restore-keys: |
             katl-kubernetes-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
             katl-mkosi-packages-${{ runner.os }}-${{ env.KATL_ARCHITECTURE }}-fedora-44-
@@ -160,6 +214,7 @@ jobs:
           go test ./cmd/katl-publish-kubernetes-sysext \
             ./internal/installer/kubernetesbundle \
             ./internal/installer/sysextcatalog \
+            ./internal/kubernetesrelease \
             -count=1
 
       - name: Build compatible runtime and Kubernetes sysext
@@ -176,6 +231,12 @@ jobs:
             --workdir /work \
             --env KATL_REPO_ROOT=/work \
             --env KATL_ARCHITECTURE \
+            --env KATL_KUBERNETES_ARTIFACT_REVISION \
+            --env KATL_KUBERNETES_CRITOOLS_VERSION \
+            --env KATL_KUBERNETES_KUBEADM_VERSION \
+            --env KATL_KUBERNETES_KUBECTL_VERSION \
+            --env KATL_KUBERNETES_KUBELET_VERSION \
+            --env KATL_KUBERNETES_MINOR \
             --env KATL_KUBERNETES_PAYLOAD_VERSION \
             "$KATL_MKOSI_IMAGE" \
             bash -euo pipefail -c '
@@ -288,7 +349,6 @@ jobs:
         id: publish
         shell: bash
         env:
-          BUNDLE_DIGEST: ${{ steps.bundle.outputs.bundle-digest }}
           BUNDLE_DIR: ${{ steps.bundle.outputs.bundle-dir }}
           DIGEST_TAG: ${{ steps.bundle.outputs.digest-tag }}
           RAW: ${{ steps.bundle.outputs.raw }}
@@ -350,8 +410,6 @@ jobs:
             echo "- Kubernetes bundle: \`${OCI_REPOSITORY}:${VERSION_TAG}@${manifest_digest}\`"
             echo "- Version tag: \`${OCI_REPOSITORY}:${VERSION_TAG}\`"
             echo "- Digest tag: \`${OCI_REPOSITORY}:${DIGEST_TAG}\`"
-            echo
-            echo "This development bundle is digest-verified but remains unsigned until katl-dty.9.35.6 lands."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Attest published OCI manifest
@@ -362,21 +420,89 @@ jobs:
           subject-digest: ${{ steps.publish.outputs.manifest-digest }}
           push-to-registry: true
 
-      - name: Record published compatibility
+      - name: Write compatibility record
         if: ${{ env.PUBLISH == 'true' }}
-        id: compatibility
-        shell: bash
         env:
           BUNDLE_DIR: ${{ steps.bundle.outputs.bundle-dir }}
           MANIFEST_DIGEST: ${{ steps.publish.outputs.manifest-digest }}
+        shell: bash
         run: |
-          runtime_interfaces="$(jq -r '.supportedRuntimeInterfaces | join(",")' "${BUNDLE_DIR}/catalog-entry.json")"
-          go run ./cmd/katl-kubernetes-release record-compatibility \
-            --payload-version "$PAYLOAD_VERSION" \
-            --artifact-version "$ARTIFACT_VERSION" \
-            --manifest-digest "$MANIFEST_DIGEST" \
-            --architecture "$KATL_ARCHITECTURE" \
-            --runtime-interfaces "$runtime_interfaces"
+          mkdir -p _build/compatibility
+          runtime_interfaces="$(jq -c '.supportedRuntimeInterfaces' "${BUNDLE_DIR}/catalog-entry.json")"
+          jq -n \
+            --arg architecture "$KATL_ARCHITECTURE" \
+            --arg artifactVersion "$ARTIFACT_VERSION" \
+            --arg manifestDigest "$MANIFEST_DIGEST" \
+            --arg payloadVersion "$PAYLOAD_VERSION" \
+            --argjson runtimeInterfaces "$runtime_interfaces" \
+            '{
+              architecture: $architecture,
+              artifactVersion: $artifactVersion,
+              manifestDigest: $manifestDigest,
+              payloadVersion: $payloadVersion,
+              runtimeInterfaces: $runtimeInterfaces
+            }' > "_build/compatibility/${PAYLOAD_VERSION}.json"
+
+      - name: Upload compatibility record
+        if: ${{ env.PUBLISH == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: kubernetes-compatibility-${{ env.PAYLOAD_VERSION }}
+          path: _build/compatibility/*.json
+          if-no-files-found: error
+
+  compatibility:
+    name: Record Published Compatibility
+    if: ${{ always() && needs.plan.outputs.build == 'true' && needs.plan.outputs.publish == 'true' && needs.build.result == 'success' }}
+    needs:
+      - plan
+      - build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download compatibility records
+        uses: actions/download-artifact@v8
+        with:
+          pattern: kubernetes-compatibility-*
+          path: _build/compatibility
+          merge-multiple: true
+
+      - name: Record published compatibility
+        id: compatibility
+        shell: bash
+        run: |
+          shopt -s nullglob
+          records=(_build/compatibility/*.json)
+          if [[ "${#records[@]}" -eq 0 ]]; then
+            echo "error: no Kubernetes compatibility records were downloaded" >&2
+            exit 1
+          fi
+          for record in "${records[@]}"; do
+            payload_version="$(jq -r '.payloadVersion' "$record")"
+            artifact_version="$(jq -r '.artifactVersion' "$record")"
+            manifest_digest="$(jq -r '.manifestDigest' "$record")"
+            architecture="$(jq -r '.architecture' "$record")"
+            runtime_interfaces="$(jq -r '.runtimeInterfaces | join(",")' "$record")"
+            go run ./cmd/katl-kubernetes-release record-compatibility \
+              --payload-version "$payload_version" \
+              --artifact-version "$artifact_version" \
+              --manifest-digest "$manifest_digest" \
+              --architecture "$architecture" \
+              --runtime-interfaces "$runtime_interfaces"
+          done
           if git diff --quiet -- internal/installer/kubernetescompat/catalog.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -393,7 +519,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"
           git add internal/installer/kubernetescompat/catalog.json
-          git commit -m "release: record Kubernetes ${PAYLOAD_VERSION} compatibility"
+          git commit -m "release: record supported Kubernetes compatibility"
           git push --set-upstream origin "$branch"
           echo "name=$branch" >> "$GITHUB_OUTPUT"
 
@@ -409,8 +535,8 @@ jobs:
               repo: context.repo.repo,
               base: "main",
               head: process.env.HEAD_BRANCH,
-              title: `release: select Kubernetes ${process.env.PAYLOAD_VERSION}`,
-              body: "Selects the newly published immutable Kubernetes bundle and records its KatlOS runtime compatibility for version-only install and upgrade resolution.",
+              title: "release: record supported Kubernetes compatibility",
+              body: "Records the newly published immutable bundles for every supported Kubernetes payload built by the producer.",
               draft: false,
             });
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/public-kubernetes-bundle.yml
+++ b/.github/workflows/public-kubernetes-bundle.yml
@@ -1,4 +1,4 @@
-name: Public Kubernetes Bundle
+name: Public Kubernetes Bundles
 
 on:
   schedule:
@@ -10,22 +10,48 @@ permissions:
   packages: read
 
 jobs:
-  verify:
-    name: Anonymous Pull And Verify
+  plan:
+    name: Plan Supported Bundles
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      - name: Resolve and verify selected bundle anonymously
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Resolve supported release matrix
+        id: plan
+        run: |
+          go run ./cmd/katl-kubernetes-release verify-recipe
+          echo "matrix=$(go run ./cmd/katl-kubernetes-release matrix)" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Verify ${{ matrix.release.payloadVersion }}
+    needs: plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ${{ fromJSON(needs.plan.outputs.matrix).include }}
+    env:
+      ARTIFACT_VERSION: ${{ matrix.release.artifactVersion }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Resolve and verify bundle anonymously
         id: bundle
         shell: bash
         run: |
-          # shellcheck source=mkosi.profiles/kubernetes-sysext/kubernetes.env
-          source mkosi.profiles/kubernetes-sysext/kubernetes.env
-          artifact_version="${KATL_KUBERNETES_PAYLOAD_VERSION}-katl.${KATL_KUBERNETES_ARTIFACT_REVISION}"
-          image="ghcr.io/katl-dev/kubernetes:${artifact_version}"
+          image="ghcr.io/katl-dev/kubernetes:${ARTIFACT_VERSION}"
           verification="$(scripts/check-public-kubernetes-bundle "$image")"
           printf '%s\n' "$verification"
           digest="${verification##*@}"

--- a/cmd/katl-kubernetes-release/main.go
+++ b/cmd/katl-kubernetes-release/main.go
@@ -24,7 +24,10 @@ const (
 	defaultSupportedVersions    = "internal/kubernetesrelease/supported-versions.json"
 )
 
-var payloadPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+var (
+	payloadPattern  = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+	artifactPattern = regexp.MustCompile(`^(v[0-9]+\.[0-9]+\.[0-9]+)-katl\.([1-9][0-9]*)$`)
+)
 
 type releaseIdentity struct {
 	PayloadVersion  string `json:"payloadVersion"`
@@ -245,9 +248,11 @@ func runRecordCompatibility(args []string, stdout, stderr io.Writer) error {
 	if payloadPattern.FindStringSubmatch(strings.TrimSpace(*payload)) == nil {
 		return fmt.Errorf("--payload-version must look like v1.36.1")
 	}
-	wantArtifactPrefix := strings.TrimSpace(*payload) + "-katl."
-	if !strings.HasPrefix(strings.TrimSpace(*artifact), wantArtifactPrefix) {
-		return fmt.Errorf("--artifact-version must look like %s1", wantArtifactPrefix)
+	payloadVersion := strings.TrimSpace(*payload)
+	artifactVersion := strings.TrimSpace(*artifact)
+	artifactMatch := artifactPattern.FindStringSubmatch(artifactVersion)
+	if artifactMatch == nil || artifactMatch[1] != payloadVersion {
+		return fmt.Errorf("--artifact-version must look like %s-katl.1", payloadVersion)
 	}
 	if !regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(strings.TrimSpace(*manifestDigest)) {
 		return fmt.Errorf("--manifest-digest must be a sha256 OCI manifest digest")
@@ -265,8 +270,8 @@ func runRecordCompatibility(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	entry := kubernetescompat.Entry{
-		KubernetesVersion: strings.TrimSpace(*payload),
-		Bundle:            "ghcr.io/katl-dev/kubernetes:" + strings.TrimSpace(*artifact) + "@" + strings.TrimSpace(*manifestDigest),
+		KubernetesVersion: payloadVersion,
+		Bundle:            "ghcr.io/katl-dev/kubernetes:" + artifactVersion + "@" + strings.TrimSpace(*manifestDigest),
 		Architectures:     []string{strings.TrimSpace(*architecture)},
 		RuntimeInterfaces: interfaces,
 	}

--- a/cmd/katl-kubernetes-release/main.go
+++ b/cmd/katl-kubernetes-release/main.go
@@ -15,11 +15,13 @@ import (
 	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/kubernetescompat"
+	"github.com/katl-dev/katl/internal/kubernetesrelease"
 )
 
 const (
 	defaultManifest             = "mkosi.profiles/kubernetes-sysext/kubernetes.env"
 	defaultCompatibilityCatalog = "internal/installer/kubernetescompat/catalog.json"
+	defaultSupportedVersions    = "internal/kubernetesrelease/supported-versions.json"
 )
 
 var payloadPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
@@ -41,18 +43,188 @@ func main() {
 
 func run(args []string, stdout, stderr io.Writer, query packageQuery) error {
 	if len(args) == 0 {
-		return errors.New("command is required: identity, prepare, or record-compatibility")
+		return errors.New("command is required: identity, matrix, prepare, prepare-supported, recipe-digest, record-compatibility, refresh-rebuilds, or verify-recipe")
 	}
 	switch args[0] {
 	case "identity":
 		return runIdentity(args[1:], stdout, stderr)
+	case "matrix":
+		return runMatrix(args[1:], stdout, stderr)
 	case "prepare":
 		return runPrepare(args[1:], stdout, stderr, query)
+	case "prepare-supported":
+		return runPrepareSupported(args[1:], stdout, stderr, query)
+	case "recipe-digest":
+		return runRecipeDigest(args[1:], stdout, stderr)
 	case "record-compatibility":
 		return runRecordCompatibility(args[1:], stdout, stderr)
+	case "refresh-rebuilds":
+		return runRefreshRebuilds(args[1:], stdout, stderr)
+	case "verify-recipe":
+		return runVerifyRecipe(args[1:], stdout, stderr)
 	default:
 		return fmt.Errorf("unsupported command %q", args[0])
 	}
+}
+
+type releaseMatrix struct {
+	Include []releaseMatrixEntry `json:"include"`
+}
+
+type releaseMatrixEntry struct {
+	PayloadVersion   string `json:"payloadVersion"`
+	ArtifactRevision int    `json:"artifactRevision"`
+	ArtifactVersion  string `json:"artifactVersion"`
+	Minor            string `json:"minor"`
+	KubeadmVersion   string `json:"kubeadmVersion"`
+	KubeletVersion   string `json:"kubeletVersion"`
+	KubectlVersion   string `json:"kubectlVersion"`
+	CRIToolsVersion  string `json:"criToolsVersion"`
+}
+
+func runMatrix(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release matrix", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	path := flags.String("supported-versions", defaultSupportedVersions, "supported Kubernetes versions manifest")
+	payload := flags.String("payload-version", "", "optional exact supported payload to select")
+	previousPath := flags.String("previous-supported-versions", "", "optional previous manifest used to select changed releases")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	supported, err := readSupportedVersions(*path)
+	if err != nil {
+		return err
+	}
+	versions, err := supported.Select(strings.TrimSpace(*payload))
+	if err != nil {
+		return err
+	}
+	if *previousPath != "" {
+		if strings.TrimSpace(*payload) != "" {
+			return fmt.Errorf("--previous-supported-versions cannot be combined with --payload-version")
+		}
+		previous, err := readSupportedVersions(*previousPath)
+		if err != nil {
+			return err
+		}
+		versions, err = supported.ChangedSince(previous)
+		if err != nil {
+			return err
+		}
+	}
+	matrix := releaseMatrix{Include: make([]releaseMatrixEntry, 0, len(versions))}
+	for _, version := range versions {
+		match := payloadPattern.FindStringSubmatch(version.PayloadVersion)
+		matrix.Include = append(matrix.Include, releaseMatrixEntry{
+			PayloadVersion:   version.PayloadVersion,
+			ArtifactRevision: version.ArtifactRevision,
+			ArtifactVersion:  version.ArtifactVersion(),
+			Minor:            "v" + match[1] + "." + match[2],
+			KubeadmVersion:   version.Packages.Kubeadm,
+			KubeletVersion:   version.Packages.Kubelet,
+			KubectlVersion:   version.Packages.Kubectl,
+			CRIToolsVersion:  version.Packages.CRITools,
+		})
+	}
+	data, err := json.Marshal(matrix)
+	if err != nil {
+		return fmt.Errorf("marshal Kubernetes release matrix: %w", err)
+	}
+	fmt.Fprintln(stdout, string(data))
+	return nil
+}
+
+func runRecipeDigest(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release recipe-digest", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("repo-root", ".", "repository root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	digest, err := kubernetesrelease.RecipeDigest(*root)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, digest)
+	return nil
+}
+
+func runRefreshRebuilds(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release refresh-rebuilds", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	path := flags.String("supported-versions", defaultSupportedVersions, "supported Kubernetes versions manifest")
+	root := flags.String("repo-root", ".", "repository root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	supported, err := readSupportedVersions(*path)
+	if err != nil {
+		return err
+	}
+	updated, changed, err := kubernetesrelease.RefreshRecipe(*root, supported)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		fmt.Fprintln(stdout, "Kubernetes bundle recipe is current")
+		return nil
+	}
+	data, err := kubernetesrelease.MarshalSupportedVersions(updated)
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(*path, data); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "updated Kubernetes bundle recipe to %s and advanced %d artifact revisions\n", updated.RecipeDigest, len(updated.Versions))
+	return nil
+}
+
+func runVerifyRecipe(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release verify-recipe", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	path := flags.String("supported-versions", defaultSupportedVersions, "supported Kubernetes versions manifest")
+	root := flags.String("repo-root", ".", "repository root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	supported, err := readSupportedVersions(*path)
+	if err != nil {
+		return err
+	}
+	digest, err := kubernetesrelease.RecipeDigest(*root)
+	if err != nil {
+		return err
+	}
+	if supported.RecipeDigest != digest {
+		return fmt.Errorf("Kubernetes bundle recipe changed: manifest has %s, current inputs are %s; run `go run ./cmd/katl-kubernetes-release refresh-rebuilds`", supported.RecipeDigest, digest)
+	}
+	fmt.Fprintln(stdout, "Kubernetes bundle recipe is current")
+	return nil
+}
+
+func readSupportedVersions(path string) (kubernetesrelease.SupportedVersions, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return kubernetesrelease.SupportedVersions{}, fmt.Errorf("read supported Kubernetes versions: %w", err)
+	}
+	supported, err := kubernetesrelease.DecodeSupportedVersions(data)
+	if err != nil {
+		return kubernetesrelease.SupportedVersions{}, err
+	}
+	return supported, nil
 }
 
 func runRecordCompatibility(args []string, stdout, stderr io.Writer) error {
@@ -152,6 +324,31 @@ func splitNonEmpty(value string) []string {
 	return out
 }
 
+func writeAtomic(path string, data []byte) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".katl-kubernetes-release-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
 func runIdentity(args []string, stdout, stderr io.Writer) error {
 	flags := flag.NewFlagSet("katl-kubernetes-release identity", flag.ContinueOnError)
 	flags.SetOutput(stderr)
@@ -203,69 +400,123 @@ func runPrepare(args []string, stdout, stderr io.Writer, query packageQuery) err
 	if minor != state.minor {
 		return fmt.Errorf("payload minor %s does not match selected release line %s", minor, state.minor)
 	}
-	baseURL := "https://pkgs.k8s.io/core:/stable:/" + minor + "/rpm/"
-	upstream := strings.TrimPrefix(*payload, "v")
-	versions := make(map[string]string, 4)
-	for _, name := range []string{"kubeadm", "kubelet", "kubectl"} {
-		version, err := query(name, name+"-"+upstream, baseURL, *repoquery)
-		if err != nil {
-			return err
-		}
-		if packageUpstream(version) != upstream {
-			return fmt.Errorf("%s resolved to %s, want Kubernetes %s", name, version, upstream)
-		}
-		versions[name] = version
-	}
-	cri, err := query("cri-tools", "cri-tools-"+match[1]+"."+match[2]+".*", baseURL, *repoquery)
+	versions, err := resolvePackageVersions(*payload, *repoquery, query)
 	if err != nil {
 		return err
 	}
-	if err := validateCRITools(cri, match); err != nil {
-		return err
-	}
-	versions["cri-tools"] = cri
-
 	replacements := map[string]string{
 		"KATL_KUBERNETES_PAYLOAD_DEFAULT":           *payload,
 		"KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT": "1",
-		"KATL_KUBERNETES_KUBEADM_VERSION":           versions["kubeadm"],
-		"KATL_KUBERNETES_KUBELET_VERSION":           versions["kubelet"],
-		"KATL_KUBERNETES_KUBECTL_VERSION":           versions["kubectl"],
-		"KATL_KUBERNETES_CRITOOLS_VERSION":          versions["cri-tools"],
+		"KATL_KUBERNETES_KUBEADM_VERSION":           versions.Kubeadm,
+		"KATL_KUBERNETES_KUBELET_VERSION":           versions.Kubelet,
+		"KATL_KUBERNETES_KUBECTL_VERSION":           versions.Kubectl,
+		"KATL_KUBERNETES_CRITOOLS_VERSION":          versions.CRITools,
 	}
 	updated, err := replaceManifestValues(data, replacements)
 	if err != nil {
 		return err
 	}
-	info, err := os.Stat(*manifest)
-	if err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(*manifest), ".kubernetes-release-*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
-	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
-		tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(updated); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpName, *manifest); err != nil {
+	if err := writeAtomic(*manifest, updated); err != nil {
 		return err
 	}
 	fmt.Fprintf(stdout, "prepared %s-katl.1\n", *payload)
-	for _, name := range []string{"kubeadm", "kubelet", "kubectl", "cri-tools"} {
-		fmt.Fprintf(stdout, "%s=%s\n", name, versions[name])
+	for _, item := range []struct {
+		name    string
+		version string
+	}{
+		{name: "kubeadm", version: versions.Kubeadm},
+		{name: "kubelet", version: versions.Kubelet},
+		{name: "kubectl", version: versions.Kubectl},
+		{name: "cri-tools", version: versions.CRITools},
+	} {
+		fmt.Fprintf(stdout, "%s=%s\n", item.name, item.version)
 	}
 	return nil
+}
+
+func runPrepareSupported(args []string, stdout, stderr io.Writer, query packageQuery) error {
+	flags := flag.NewFlagSet("katl-kubernetes-release prepare-supported", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	path := flags.String("supported-versions", defaultSupportedVersions, "supported Kubernetes versions manifest")
+	payload := flags.String("payload-version", "", "exact Kubernetes payload version, for example v1.36.3")
+	repoquery := flags.String("repoquery", "dnf", "dnf-compatible repository query command")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	payloadVersion := strings.TrimSpace(*payload)
+	versions, err := resolvePackageVersions(payloadVersion, *repoquery, query)
+	if err != nil {
+		return err
+	}
+	supported, err := readSupportedVersions(*path)
+	if err != nil {
+		return err
+	}
+	revision := 1
+	if existing, selectErr := supported.Select(payloadVersion); selectErr == nil {
+		revision = existing[0].ArtifactRevision
+		if existing[0].Packages != versions {
+			revision++
+		}
+	}
+	updated, changed, err := supported.Upsert(kubernetesrelease.SupportedVersion{
+		PayloadVersion:   payloadVersion,
+		ArtifactRevision: revision,
+		Packages:         versions,
+	})
+	if err != nil {
+		return err
+	}
+	if !changed {
+		fmt.Fprintf(stdout, "supported Kubernetes %s is current at %s-katl.%d\n", payloadVersion, payloadVersion, revision)
+		return nil
+	}
+	data, err := kubernetesrelease.MarshalSupportedVersions(updated)
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(*path, data); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "prepared supported Kubernetes %s-katl.%d\n", payloadVersion, revision)
+	return nil
+}
+
+func resolvePackageVersions(payloadVersion, repoquery string, query packageQuery) (kubernetesrelease.PackageVersions, error) {
+	match := payloadPattern.FindStringSubmatch(payloadVersion)
+	if match == nil {
+		return kubernetesrelease.PackageVersions{}, fmt.Errorf("--payload-version must look like v1.36.1")
+	}
+	minor := "v" + match[1] + "." + match[2]
+	baseURL := "https://pkgs.k8s.io/core:/stable:/" + minor + "/rpm/"
+	upstream := strings.TrimPrefix(payloadVersion, "v")
+	versions := make(map[string]string, 4)
+	for _, name := range []string{"kubeadm", "kubelet", "kubectl"} {
+		version, err := query(name, name+"-"+upstream, baseURL, repoquery)
+		if err != nil {
+			return kubernetesrelease.PackageVersions{}, err
+		}
+		if packageUpstream(version) != upstream {
+			return kubernetesrelease.PackageVersions{}, fmt.Errorf("%s resolved to %s, want Kubernetes %s", name, version, upstream)
+		}
+		versions[name] = version
+	}
+	cri, err := query("cri-tools", "cri-tools-"+match[1]+"."+match[2]+".*", baseURL, repoquery)
+	if err != nil {
+		return kubernetesrelease.PackageVersions{}, err
+	}
+	if err := validateCRITools(cri, match); err != nil {
+		return kubernetesrelease.PackageVersions{}, err
+	}
+	return kubernetesrelease.PackageVersions{
+		Kubeadm:  versions["kubeadm"],
+		Kubelet:  versions["kubelet"],
+		Kubectl:  versions["kubectl"],
+		CRITools: cri,
+	}, nil
 }
 
 type releaseState struct {

--- a/cmd/katl-kubernetes-release/main_test.go
+++ b/cmd/katl-kubernetes-release/main_test.go
@@ -258,6 +258,39 @@ func TestRecordCompatibility(t *testing.T) {
 	}
 }
 
+func TestRecordCompatibilityRejectsMalformedArtifactVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.json")
+	if err := os.WriteFile(path, []byte(`{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesCompatibilityCatalog",
+  "entries": []
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, artifact := range []string{
+		"v1x36x3-katl.2",
+		"v1.36.3-katl.0",
+		"v1.36.3-katl.one",
+		"v1.36.3-katl.2-extra",
+		"v1.36.4-katl.2",
+	} {
+		t.Run(artifact, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			err := run([]string{
+				"record-compatibility",
+				"--catalog", path,
+				"--payload-version", "v1.36.3",
+				"--artifact-version", artifact,
+				"--manifest-digest", "sha256:" + strings.Repeat("a", 64),
+			}, &stdout, &stderr, nil)
+			if err == nil || !strings.Contains(err.Error(), "artifact-version") {
+				t.Fatalf("run() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestPrepareRejectsPackageMismatch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "kubernetes.env")
 	if err := os.WriteFile(path, []byte(testManifest), 0o644); err != nil {

--- a/cmd/katl-kubernetes-release/main_test.go
+++ b/cmd/katl-kubernetes-release/main_test.go
@@ -54,6 +54,55 @@ func TestPrepare(t *testing.T) {
 	}
 }
 
+func TestPrepareSupportedAddsPayload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "supported-versions.json")
+	if err := os.WriteFile(path, []byte(`{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesSupportedVersions",
+  "recipeDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "versions": [{
+    "payloadVersion": "v1.36.0",
+    "artifactRevision": 3,
+    "packages": {
+      "kubeadm": "0:1.36.0-1",
+      "kubelet": "0:1.36.0-1",
+      "kubectl": "0:1.36.0-1",
+      "criTools": "0:1.36.0-1"
+    }
+  }]
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	versions := map[string]string{
+		"kubeadm":   "0:1.36.1-150500.1.1",
+		"kubelet":   "0:1.36.1-150500.1.1",
+		"kubectl":   "0:1.36.1-150500.1.1",
+		"cri-tools": "0:1.36.0-150500.1.1",
+	}
+	query := func(name, selector, baseURL, command string) (string, error) {
+		return versions[name], nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"prepare-supported", "--supported-versions", path, "--payload-version", "v1.36.1"}, &stdout, &stderr, query); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"payloadVersion": "v1.36.0"`,
+		`"payloadVersion": "v1.36.1"`,
+		`"artifactRevision": 1`,
+		`"kubeadm": "0:1.36.1-150500.1.1"`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("updated supported versions missing %q:\n%s", want, data)
+		}
+	}
+}
+
 func TestIdentity(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "kubernetes.env")
 	if err := os.WriteFile(path, []byte(testManifest), 0o644); err != nil {
@@ -66,6 +115,102 @@ func TestIdentity(t *testing.T) {
 	want := `{"payloadVersion":"v1.36.0","artifactVersion":"v1.36.0-katl.4","image":"ghcr.io/katl-dev/kubernetes:v1.36.0-katl.4"}`
 	if strings.TrimSpace(stdout.String()) != want {
 		t.Fatalf("identity = %s, want %s", stdout.String(), want)
+	}
+}
+
+func TestMatrixSelectsSupportedPayload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "supported-versions.json")
+	if err := os.WriteFile(path, []byte(`{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesSupportedVersions",
+  "recipeDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "versions": [{
+    "payloadVersion": "v1.35.9",
+    "artifactRevision": 3,
+    "packages": {
+      "kubeadm": "0:1.35.9-1",
+      "kubelet": "0:1.35.9-1",
+      "kubectl": "0:1.35.9-1",
+      "criTools": "0:1.35.0-1"
+    }
+  }, {
+    "payloadVersion": "v1.36.3",
+    "artifactRevision": 2,
+    "packages": {
+      "kubeadm": "0:1.36.3-2",
+      "kubelet": "0:1.36.3-2",
+      "kubectl": "0:1.36.3-2",
+      "criTools": "0:1.36.0-1"
+    }
+  }]
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"matrix", "--supported-versions", path, "--payload-version", "v1.36.3"}, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{
+		`"payloadVersion":"v1.36.3"`,
+		`"artifactVersion":"v1.36.3-katl.2"`,
+		`"minor":"v1.36"`,
+		`"kubeadmVersion":"0:1.36.3-2"`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("matrix missing %q: %s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "v1.35.9") {
+		t.Fatalf("matrix included unselected payload: %s", stdout.String())
+	}
+}
+
+func TestMatrixSelectsChangedPayloads(t *testing.T) {
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "current.json")
+	previousPath := filepath.Join(dir, "previous.json")
+	current := `{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesSupportedVersions",
+  "recipeDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "versions": [{
+    "payloadVersion": "v1.36.0",
+    "artifactRevision": 2,
+    "packages": {
+      "kubeadm": "0:1.36.0-1",
+      "kubelet": "0:1.36.0-1",
+      "kubectl": "0:1.36.0-1",
+      "criTools": "0:1.36.0-1"
+    }
+  }, {
+    "payloadVersion": "v1.36.1",
+    "artifactRevision": 1,
+    "packages": {
+      "kubeadm": "0:1.36.1-1",
+      "kubelet": "0:1.36.1-1",
+      "kubectl": "0:1.36.1-1",
+      "criTools": "0:1.36.0-1"
+    }
+  }]
+}
+`
+	previous := strings.Replace(current, `"artifactRevision": 2`, `"artifactRevision": 1`, 1)
+	if err := os.WriteFile(currentPath, []byte(current), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(previousPath, []byte(previous), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"matrix", "--supported-versions", currentPath, "--previous-supported-versions", previousPath}, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"payloadVersion":"v1.36.0"`) {
+		t.Fatalf("matrix missing changed payload: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "v1.36.1") {
+		t.Fatalf("matrix included unchanged payload: %s", stdout.String())
 	}
 }
 

--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,7 +45,10 @@ func run(args []string, stdout, stderr io.Writer, environ []string) error {
 	if err != nil {
 		return err
 	}
-	cfg := configFromEnv(envMap(environ), repoRoot)
+	cfg, err := configFromEnv(envMap(environ), repoRoot)
+	if err != nil {
+		return err
+	}
 
 	switch command {
 	case "write":
@@ -170,12 +174,17 @@ type config struct {
 	Version              string
 	Architecture         string
 	InstallerInterface   string
+	CreatedAt            string
 }
 
-func configFromEnv(env map[string]string, repo string) config {
+func configFromEnv(env map[string]string, repo string) (config, error) {
 	buildDir := filepath.Join(repo, "_build", "mkosi")
 	version := envDefault(env, "KATL_VERSION", defaultVersion)
 	architecture := envDefaultFunc(env, "KATL_ARCHITECTURE", hostArchitecture)
+	createdAt, err := buildTimestamp(env)
+	if err != nil {
+		return config{}, err
+	}
 	katlosDefault := filepath.Join(buildDir, "katlos-install-"+version+"-"+architecture+".squashfs")
 	installerISO, installerISOExplicit := envPathExplicit(env, repo, "KATL_INSTALLER_ISO", filepath.Join(buildDir, "katl-installer.iso"))
 	runtimeUKI := envPath(env, repo, "KATL_RUNTIME_UKI", filepath.Join(buildDir, "katl-runtime.efi"))
@@ -204,7 +213,20 @@ func configFromEnv(env map[string]string, repo string) config {
 		Version:              version,
 		Architecture:         architecture,
 		InstallerInterface:   envDefault(env, "KATL_INSTALLER_INTERFACE", defaultInstallerInterface),
+		CreatedAt:            createdAt,
+	}, nil
+}
+
+func buildTimestamp(env map[string]string) (string, error) {
+	value := strings.TrimSpace(env["SOURCE_DATE_EPOCH"])
+	if value == "" {
+		return time.Now().UTC().Format(time.RFC3339), nil
 	}
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds < 0 {
+		return "", fmt.Errorf("SOURCE_DATE_EPOCH must be a non-negative Unix timestamp")
+	}
+	return time.Unix(seconds, 0).UTC().Format(time.RFC3339), nil
 }
 
 type artifactIndex struct {
@@ -379,7 +401,7 @@ func runWriteRuntimeRoot(args []string, stdout, stderr io.Writer, cfg config) er
 			RuntimeInterface:  "katl-runtime-1",
 			KernelCommandLine: runtimeKernelCommandLine(),
 		},
-		Created: time.Now().UTC().Format(time.RFC3339),
+		Created: cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
 		return err
@@ -434,7 +456,7 @@ func runWriteRuntimeUKI(args []string, stdout, stderr io.Writer, cfg config) err
 		},
 		KernelVersion:     *kernelVersion,
 		KernelCommandLine: runtimeKernelCommandLine(),
-		Created:           time.Now().UTC().Format(time.RFC3339),
+		Created:           cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
 		return err
@@ -643,7 +665,7 @@ func writeKubernetesSysextMetadata(req kubernetesSysextRequest, cfg config) (str
 			ArtifactPath:   filepath.Base(req.RuntimePath),
 			ArtifactSHA256: sha,
 		},
-		Created: time.Now().UTC().Format(time.RFC3339),
+		Created: cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(req.ArtifactPath), metadata, cfg.RepoRoot); err != nil {
 		return "", err
@@ -700,7 +722,7 @@ func runWriteEndpointAdvertiserSysext(args []string, stdout, stderr io.Writer, c
 			ArtifactPath:   filepath.Base(absPath(cfg.RepoRoot, *runtimeArtifact)),
 			ArtifactSHA256: runtimeSHA,
 		},
-		Created: time.Now().UTC().Format(time.RFC3339),
+		Created: cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
 		return err
@@ -877,7 +899,7 @@ func runWriteKatlOSIndex(args []string, stdout, stderr io.Writer, cfg config) er
 		BuildID:          *buildID,
 		Architecture:     *architecture,
 		RuntimeInterface: *runtimeInterface,
-		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:        cfg.CreatedAt,
 		Components: []katlosComponent{
 			{
 				Name:         "runtime-root",
@@ -988,7 +1010,7 @@ func runWriteKatlOSArtifact(args []string, stdout, stderr io.Writer, cfg config)
 		SHA256:            digest,
 		ChecksumPath:      filepath.Base(artifactPath) + ".sha256",
 		EmbeddedIndexPath: *embeddedIndexPath,
-		CreatedAt:         time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:         cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
 		return err
@@ -1138,7 +1160,7 @@ func writeIndex(indexPath string, cfg config) error {
 		return err
 	}
 
-	created := time.Now().UTC().Format(time.RFC3339)
+	created := cfg.CreatedAt
 	entries := []artifactEntry{}
 	indexedArtifacts := []struct {
 		kind     string
@@ -1220,7 +1242,7 @@ func writeInstallerArtifacts(cfg config) error {
 			return err
 		}
 	}
-	created := time.Now().UTC().Format(time.RFC3339)
+	created := cfg.CreatedAt
 	for _, artifact := range artifacts {
 		if err := writeChecksum(artifact.path); err != nil {
 			return err
@@ -1282,7 +1304,7 @@ func writeRuntimeIndex(indexPath string, cfg config) error {
 			entries = append(entries, entry)
 		}
 	}
-	index.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	index.GeneratedAt = cfg.CreatedAt
 	index.Generation = cfg.Generation
 	index.Artifacts = append(entries, runtimeEntries...)
 	return writeJSON(indexPath, index, cfg.RepoRoot)

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
+func TestBuildTimestamp(t *testing.T) {
+	got, err := buildTimestamp(map[string]string{"SOURCE_DATE_EPOCH": "0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "1970-01-01T00:00:00Z" {
+		t.Fatalf("buildTimestamp() = %q", got)
+	}
+	if _, err := buildTimestamp(map[string]string{"SOURCE_DATE_EPOCH": "invalid"}); err == nil {
+		t.Fatal("buildTimestamp() accepted invalid SOURCE_DATE_EPOCH")
+	}
+}
+
 func TestWriteAndPath(t *testing.T) {
 	repo := testRepoRoot(t)
 	workDir := testWorkDir(t, repo)
@@ -288,7 +301,11 @@ func TestKubernetesSysextFromLog(t *testing.T) {
 		"--repo-minor", "v1.36",
 		"--expected-payload-version", "v1.36.0",
 		"--expected-kubeadm-version", "1.36.0-1",
-	}, &stdout, &bytes.Buffer{}, []string{"KATL_BUILD_COMMIT=test-build", "KATL_ARCHITECTURE=x86_64"})
+	}, &stdout, &bytes.Buffer{}, []string{
+		"KATL_BUILD_COMMIT=test-build",
+		"KATL_ARCHITECTURE=x86_64",
+		"SOURCE_DATE_EPOCH=0",
+	})
 	if err != nil {
 		t.Fatalf("write-kubernetes-sysext-from-log error = %v", err)
 	}
@@ -296,6 +313,9 @@ func TestKubernetesSysextFromLog(t *testing.T) {
 	readTestJSON(t, sysext+".json", &metadata)
 	if metadata.PayloadVersion != "v1.36.0" || metadata.PackageVersions["kubeadm"] != "1.36.0-1" {
 		t.Fatalf("metadata = %#v", metadata)
+	}
+	if metadata.Created != "1970-01-01T00:00:00Z" {
+		t.Fatalf("metadata created = %q", metadata.Created)
 	}
 	if metadata.PackageVersions["ethtool"] != "2:7.0-1.fc44" || metadata.PackageVersions["socat"] != "0:1.8.1.1-1.fc44" {
 		t.Fatalf("helper packageVersions = %#v", metadata.PackageVersions)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -366,13 +366,15 @@ advance existing artifact revisions.
 
 Manual dispatch remains the explicit dry-run path. Dispatch it with empty
 version inputs to build the whole supported matrix, or select one supported
-payload. Keep `publish: false` for build-only verification; an explicit
-artifact identity can be supplied only with one selected payload.
+payload. Keep `publish: false` for build-only verification. Published artifact
+identities always come directly from the reviewed supported-version policy.
 
-Set `publish: true` only for a reviewed bundle identity. The workflow refuses
-to replace either immutable GHCR tag, publishes the Katl custom bundle manifest
-as the OCI config with the sysext and metadata as layers, pulls the config back
-for byte verification, and creates a GitHub build-provenance attestation. It
+Set `publish: true` only for a reviewed bundle identity. The workflow reuses an
+existing tag only when it resolves to the byte-identical OCI manifest produced
+from the same commit, making interrupted publication safe to retry. It
+publishes the Katl custom bundle manifest as the OCI config with the sysext and
+metadata as layers, pulls the config back for byte verification, and creates a
+GitHub build-provenance attestation. It
 then records the exact version, manifest digest, architecture, and runtime
 interfaces in the embedded compatibility catalog through a ready auto-merged
 pull request. Install and upgrade clients consume that mapping; they never

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -331,35 +331,43 @@ future node-side trust-root, revocation, and downgrade policy.
 ## Kubernetes Bundle Artifacts
 
 `.github/workflows/kubernetes-bundles.yml` is the independent Kubernetes
-payload producer. The normal release path is a reviewed Renovate pull request.
-Renovate tracks the selected Kubernetes `v1.36` patch and the exact kubeadm,
-kubelet, kubectl, and cri-tools RPM NEVRAs in
-`mkosi.profiles/kubernetes-sysext/kubernetes.env`. Merging that lock update to
-`main` builds, verifies, publishes, and attests the corresponding immutable
-`vMAJOR.MINOR.PATCH-katl.1` GHCR artifact. Earlier patch releases and digests
+payload producer. `internal/kubernetesrelease/supported-versions.json` declares
+every maintained payload, its exact kubeadm, kubelet, kubectl, and cri-tools RPM
+NEVRAs, and its next immutable Katl artifact revision. Merging a reviewed policy
+update to `main` builds, verifies, publishes, and attests each new or
+revision-advanced entry in parallel, then opens one compatibility-catalog pull
+request with the published digests. Earlier artifact identities and digests
 remain addressable.
 
-Prepare or complete that reviewed update with one command on a capable build
-host:
+Add a released Kubernetes patch to the supported matrix with:
 
 ```sh
-scripts/prepare-kubernetes-release v1.36.2
+go run ./cmd/katl-kubernetes-release prepare-supported \
+  --payload-version v1.36.3
 ```
 
 The command resolves the exact x86_64 RPMs from the selected official
 Kubernetes repository, requires kubeadm, kubelet, and kubectl to match the
-payload patch, selects the newest compatible cri-tools patch, resets the Katl
-artifact revision to `1`, builds the runtime and sysext, refreshes the resource
-lock, and runs the producer checks. Review the resulting release manifest and
-resource-lock diff, then submit them as a normal ready pull request. The merge
-is the release event; no tag or manual workflow dispatch is required.
+payload patch, selects the newest compatible cri-tools patch, and starts a new
+payload at artifact revision `1`. Review the policy diff and submit it as a
+normal ready pull request.
 
-Manual dispatch remains the explicit rebuild and dry-run path. Dispatch it with
-empty version inputs to rebuild the committed release manifest, or provide an
-exact Kubernetes payload and immutable Katl build identity to inspect another
-candidate. Keep `publish: false` for a build-only verification run. A
-successful build uploads the complete staged bundle as a GitHub Actions
-artifact.
+Changes to bundle-producing code, profiles, or workflows must rebuild every
+supported payload. Refresh the recipe fingerprint and advance all immutable
+artifact revisions in the same pull request:
+
+```sh
+go run ./cmd/katl-kubernetes-release refresh-rebuilds
+```
+
+The Go baseline rejects a changed bundle recipe until this command has updated
+the supported-version policy. Changes that only add a supported payload do not
+advance existing artifact revisions.
+
+Manual dispatch remains the explicit dry-run path. Dispatch it with empty
+version inputs to build the whole supported matrix, or select one supported
+payload. Keep `publish: false` for build-only verification; an explicit
+artifact identity can be supplied only with one selected payload.
 
 Set `publish: true` only for a reviewed bundle identity. The workflow refuses
 to replace either immutable GHCR tag, publishes the Katl custom bundle manifest
@@ -386,11 +394,10 @@ development bundles remain unsigned until the signing policy lands; the GitHub
 attestation records build provenance but is not yet a trust decision enforced
 by `katlc`.
 
-The scheduled public-bundle workflow derives the selected readable tag from
-the same committed release manifest, resolves its immutable digest
-anonymously, verifies every OCI blob, and verifies the GitHub attestation. A
-patch release therefore does not require a second commit just to update a
-hard-coded verifier digest.
+The scheduled public-bundle workflow derives every supported readable tag from
+the committed policy, resolves each immutable digest anonymously, verifies
+every OCI blob, and verifies each GitHub attestation. A patch release therefore
+does not require a second commit just to update hard-coded verifier digests.
 
 ## VM Tests on a Capable Host
 

--- a/docs/internal/kubernetes-sysext-delivery.md
+++ b/docs/internal/kubernetes-sysext-delivery.md
@@ -900,6 +900,12 @@ catalog entry. A successful `v1.36.1` publication does not replace `v1.36.0`;
 both remain addressable by exact payload version and digest until retention
 policy removes or deprecates them.
 
+`internal/kubernetesrelease/supported-versions.json` declares the exact
+upstream Kubernetes releases that Katl intends to build and maintain. Support
+intent is separate from artifact availability: a version becomes installable
+only after its immutable bundle is published and recorded in the compatibility
+catalog. The initial policy lists the GA releases `v1.36.0` through `v1.36.3`.
+
 The checked-in release lock carries an artifact revision in addition to the
 payload and exact RPM NEVRAs. A Renovate patch update resets that revision to
 `1`. A reviewed rebuild of unchanged Kubernetes package inputs increments the

--- a/docs/internal/kubernetes-sysext-delivery.md
+++ b/docs/internal/kubernetes-sysext-delivery.md
@@ -493,12 +493,13 @@ complete Kubernetes provisioning story.
 The in-repository workflow is narrow:
 
 ```text
-Renovate updates mkosi.profiles/kubernetes-sysext/kubernetes.env
+reviewed policy updates internal/kubernetesrelease/supported-versions.json
   -> GitHub Actions builds the runtime base needed for compatibility metadata
-  -> GitHub Actions builds the Kubernetes sysext for the exact target version
+  -> GitHub Actions builds each new or revision-advanced Kubernetes sysext in parallel
   -> checks verify sysext contents, coherent package versions, and checksums
   -> katl-publish-kubernetes-sysext stages the OCI bundle manifest, layers, and catalog data
-  -> the custom OCI artifact is published immutably to ghcr.io/katl-dev/kubernetes
+  -> custom OCI artifacts are published immutably to ghcr.io/katl-dev/kubernetes
+  -> one follow-up PR records all published compatibility digests
 ```
 
 The producer consumes Katl runtime compatibility as data, even while it lives in
@@ -868,12 +869,11 @@ explicit reference. `katlc` requires the Katl bundle manifest to be the resolved
 config. GitHub Releases or a static HTTPS layout may mirror the same bytes
 later, but they are not the primary store.
 
-The readable tag deliberately retains the exact Kubernetes patch version.
-Renovate's Docker datasource preserves tag precision and treats the hyphenated
-suffix as compatibility, so `v1.36.0-katl.1` can advance to
-`v1.36.1-katl.1`. The release catalog pairs that readable identity with its
-digest pin. Katl separately verifies and records the custom bundle manifest
-digest.
+The readable tag deliberately retains the exact Kubernetes patch version and
+an immutable Katl artifact revision, such as `v1.36.1-katl.2`. The supported
+version policy advances that revision when package or bundle-recipe inputs
+change. The release catalog pairs that readable identity with its digest pin.
+Katl separately verifies and records the custom bundle manifest digest.
 
 The OCI manifest digest is the distribution digest. The sysext payload digest is
 still recorded as the activation digest in bundle metadata, catalog data, and
@@ -893,24 +893,20 @@ verify the catalog or artifact signatures before staging or activation.
 ## Version Bumps
 
 Kubernetes patch updates should be ordinary reviewed dependency updates.
-Renovate should update the declared target payload and package expectations in
-`mkosi.profiles/kubernetes-sysext/kubernetes.env` or its successor. That change
-triggers the producer workflow, which builds a new immutable sysext artifact and
-catalog entry. A successful `v1.36.1` publication does not replace `v1.36.0`;
-both remain addressable by exact payload version and digest until retention
-policy removes or deprecates them.
-
 `internal/kubernetesrelease/supported-versions.json` declares the exact
-upstream Kubernetes releases that Katl intends to build and maintain. Support
-intent is separate from artifact availability: a version becomes installable
-only after its immutable bundle is published and recorded in the compatibility
-catalog. The initial policy lists the GA releases `v1.36.0` through `v1.36.3`.
+upstream Kubernetes releases that Katl intends to build and maintain, their
+exact RPM NEVRAs, and their immutable artifact revisions. Support intent is
+separate from artifact availability: a version becomes installable only after
+its immutable bundle is published and recorded in the compatibility catalog.
+The initial policy lists the GA releases `v1.36.0` through `v1.36.3`.
 
-The checked-in release lock carries an artifact revision in addition to the
-payload and exact RPM NEVRAs. A Renovate patch update resets that revision to
-`1`. A reviewed rebuild of unchanged Kubernetes package inputs increments the
-revision manually. The main-branch producer trigger consumes only this lock;
-unrelated Katl source changes do not mint a new Kubernetes bundle.
+Adding a payload starts its artifact revision at `1`. The policy also records a
+fingerprint of every bundle-producing input. A change to those inputs must
+refresh the fingerprint and increment every supported payload's revision, so
+the main-branch producer rebuilds the entire supported matrix without replacing
+an immutable tag. Package changes for an existing payload increment only that
+payload's revision. A successful rebuild updates the catalog mapping but does
+not remove older exact artifact identities or digests.
 
 Minor updates, such as `v1.36` to `v1.37`, require the same artifact production
 mechanics plus Kubernetes version-skew policy review. Katl should continue to

--- a/internal/kubernetesrelease/recipe.go
+++ b/internal/kubernetesrelease/recipe.go
@@ -1,29 +1,32 @@
 package kubernetesrelease
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 )
 
-var recipeInputs = []string{
+var recipeRoots = []string{
 	".github/workflows/kubernetes-bundles.yml",
 	"Containerfile.mkosi",
+	"cmd/katl-boot-health",
+	"cmd/katl-console",
+	"cmd/katl-generation-activate",
 	"cmd/katl-kubernetes-release",
 	"cmd/katl-mkosi-artifacts",
 	"cmd/katl-publish-kubernetes-sysext",
+	"cmd/katl-runtime-status",
+	"cmd/katlc",
 	"containers-policy.json",
 	"go.mod",
 	"go.sum",
-	"internal/installer/artifact",
-	"internal/installer/kubernetesbundle",
-	"internal/installer/manifest",
-	"internal/installer/sysextcatalog",
+	"internal",
 	"mkosi.conf",
 	"mkosi.profiles/kubernetes-sysext",
 	"mkosi.profiles/runtime",
@@ -32,16 +35,9 @@ var recipeInputs = []string{
 	"scripts/mkosi",
 }
 
-var recipeDirectories = map[string]bool{
-	"cmd/katl-kubernetes-release":         true,
-	"cmd/katl-mkosi-artifacts":            true,
-	"cmd/katl-publish-kubernetes-sysext":  true,
-	"internal/installer/artifact":         true,
-	"internal/installer/kubernetesbundle": true,
-	"internal/installer/manifest":         true,
-	"internal/installer/sysextcatalog":    true,
-	"mkosi.profiles/kubernetes-sysext":    true,
-	"mkosi.profiles/runtime":              true,
+var recipeExcludedPaths = map[string]bool{
+	"internal/installer/kubernetescompat/catalog.json":   true,
+	"internal/kubernetesrelease/supported-versions.json": true,
 }
 
 func RecipeDigest(root string) (string, error) {
@@ -50,28 +46,21 @@ func RecipeDigest(root string) (string, error) {
 		return "", err
 	}
 	digest := sha256.New()
-	for _, path := range paths {
-		relative, err := filepath.Rel(root, path)
-		if err != nil {
-			return "", fmt.Errorf("resolve Kubernetes bundle recipe path %s: %w", path, err)
-		}
-		if _, err := io.WriteString(digest, filepath.ToSlash(relative)); err != nil {
+	for _, file := range paths {
+		if _, err := io.WriteString(digest, file.mode); err != nil {
 			return "", err
 		}
 		if _, err := digest.Write([]byte{0}); err != nil {
 			return "", err
 		}
-		file, err := os.Open(path)
-		if err != nil {
-			return "", fmt.Errorf("open Kubernetes bundle recipe input %s: %w", path, err)
+		if _, err := io.WriteString(digest, file.path); err != nil {
+			return "", err
 		}
-		_, copyErr := io.Copy(digest, file)
-		closeErr := file.Close()
-		if copyErr != nil {
-			return "", fmt.Errorf("hash Kubernetes bundle recipe input %s: %w", path, copyErr)
+		if _, err := digest.Write([]byte{0}); err != nil {
+			return "", err
 		}
-		if closeErr != nil {
-			return "", fmt.Errorf("close Kubernetes bundle recipe input %s: %w", path, closeErr)
+		if _, err := digest.Write(file.content); err != nil {
+			return "", err
 		}
 		if _, err := digest.Write([]byte{0}); err != nil {
 			return "", err
@@ -99,34 +88,76 @@ func RefreshRecipe(root string, supported SupportedVersions) (SupportedVersions,
 	return supported, true, nil
 }
 
-func recipeFiles(root string) ([]string, error) {
-	var paths []string
-	for _, input := range recipeInputs {
-		path := filepath.Join(root, filepath.FromSlash(input))
-		info, err := os.Stat(path)
-		if err != nil {
-			return nil, fmt.Errorf("inspect Kubernetes bundle recipe input %s: %w", input, err)
-		}
-		if !info.IsDir() {
-			paths = append(paths, path)
+type recipeFile struct {
+	path    string
+	mode    string
+	content []byte
+}
+
+func recipeFiles(root string) ([]recipeFile, error) {
+	args := append([]string{"-C", root, "ls-files", "-z", "--"}, recipeRoots...)
+	output, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("list tracked Kubernetes bundle recipe inputs: %w", err)
+	}
+	var files []recipeFile
+	for _, rawPath := range bytes.Split(output, []byte{0}) {
+		if len(rawPath) == 0 {
 			continue
 		}
-		if err := filepath.WalkDir(path, func(path string, entry fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
+		relative := filepath.ToSlash(string(rawPath))
+		if recipePathExcluded(relative) {
+			continue
+		}
+		path := filepath.Join(root, filepath.FromSlash(relative))
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, fmt.Errorf("inspect Kubernetes bundle recipe input %s: %w", relative, err)
+		}
+		file := recipeFile{path: relative}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			file.mode = "120000"
+			target, err := os.Readlink(path)
+			if err != nil {
+				return nil, fmt.Errorf("read Kubernetes bundle recipe symlink %s: %w", relative, err)
 			}
-			if entry.IsDir() {
-				return nil
+			file.content = []byte(target)
+		case info.Mode().IsRegular():
+			file.mode = "100644"
+			if info.Mode().Perm()&0o111 != 0 {
+				file.mode = "100755"
 			}
-			if !entry.Type().IsRegular() || strings.HasSuffix(entry.Name(), "_test.go") {
-				return nil
+			file.content, err = os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("read Kubernetes bundle recipe input %s: %w", relative, err)
 			}
-			paths = append(paths, path)
-			return nil
-		}); err != nil {
-			return nil, fmt.Errorf("walk Kubernetes bundle recipe input %s: %w", input, err)
+		default:
+			return nil, fmt.Errorf("unsupported Kubernetes bundle recipe input type %s", relative)
+		}
+		files = append(files, file)
+	}
+	sort.Slice(files, func(left, right int) bool {
+		return files[left].path < files[right].path
+	})
+	if len(files) == 0 {
+		return nil, fmt.Errorf("Kubernetes bundle recipe has no tracked inputs")
+	}
+	return files, nil
+}
+
+func recipePathExcluded(path string) bool {
+	if recipeExcludedPaths[path] || strings.HasSuffix(path, "_test.go") {
+		return true
+	}
+	for _, excluded := range []string{
+		"/testdata/",
+		"internal/resourcetest/",
+		"internal/vmtest/",
+	} {
+		if strings.Contains(path, excluded) || strings.HasPrefix(path, strings.TrimPrefix(excluded, "/")) {
+			return true
 		}
 	}
-	sort.Strings(paths)
-	return paths, nil
+	return false
 }

--- a/internal/kubernetesrelease/recipe.go
+++ b/internal/kubernetesrelease/recipe.go
@@ -1,0 +1,132 @@
+package kubernetesrelease
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var recipeInputs = []string{
+	".github/workflows/kubernetes-bundles.yml",
+	"Containerfile.mkosi",
+	"cmd/katl-kubernetes-release",
+	"cmd/katl-mkosi-artifacts",
+	"cmd/katl-publish-kubernetes-sysext",
+	"containers-policy.json",
+	"go.mod",
+	"go.sum",
+	"internal/installer/artifact",
+	"internal/installer/kubernetesbundle",
+	"internal/installer/manifest",
+	"internal/installer/sysextcatalog",
+	"mkosi.conf",
+	"mkosi.profiles/kubernetes-sysext",
+	"mkosi.profiles/runtime",
+	"scripts/build-kubernetes-sysext",
+	"scripts/check-kubernetes-sysext",
+	"scripts/mkosi",
+}
+
+var recipeDirectories = map[string]bool{
+	"cmd/katl-kubernetes-release":         true,
+	"cmd/katl-mkosi-artifacts":            true,
+	"cmd/katl-publish-kubernetes-sysext":  true,
+	"internal/installer/artifact":         true,
+	"internal/installer/kubernetesbundle": true,
+	"internal/installer/manifest":         true,
+	"internal/installer/sysextcatalog":    true,
+	"mkosi.profiles/kubernetes-sysext":    true,
+	"mkosi.profiles/runtime":              true,
+}
+
+func RecipeDigest(root string) (string, error) {
+	paths, err := recipeFiles(root)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.New()
+	for _, path := range paths {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return "", fmt.Errorf("resolve Kubernetes bundle recipe path %s: %w", path, err)
+		}
+		if _, err := io.WriteString(digest, filepath.ToSlash(relative)); err != nil {
+			return "", err
+		}
+		if _, err := digest.Write([]byte{0}); err != nil {
+			return "", err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return "", fmt.Errorf("open Kubernetes bundle recipe input %s: %w", path, err)
+		}
+		_, copyErr := io.Copy(digest, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return "", fmt.Errorf("hash Kubernetes bundle recipe input %s: %w", path, copyErr)
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf("close Kubernetes bundle recipe input %s: %w", path, closeErr)
+		}
+		if _, err := digest.Write([]byte{0}); err != nil {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("sha256:%x", digest.Sum(nil)), nil
+}
+
+func RefreshRecipe(root string, supported SupportedVersions) (SupportedVersions, bool, error) {
+	digest, err := RecipeDigest(root)
+	if err != nil {
+		return SupportedVersions{}, false, err
+	}
+	if supported.RecipeDigest == digest {
+		return supported, false, nil
+	}
+	supported.Versions = copyVersions(supported.Versions)
+	supported.RecipeDigest = digest
+	for index := range supported.Versions {
+		supported.Versions[index].ArtifactRevision++
+	}
+	if err := validateSupportedVersions(supported); err != nil {
+		return SupportedVersions{}, false, err
+	}
+	return supported, true, nil
+}
+
+func recipeFiles(root string) ([]string, error) {
+	var paths []string
+	for _, input := range recipeInputs {
+		path := filepath.Join(root, filepath.FromSlash(input))
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("inspect Kubernetes bundle recipe input %s: %w", input, err)
+		}
+		if !info.IsDir() {
+			paths = append(paths, path)
+			continue
+		}
+		if err := filepath.WalkDir(path, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			if !entry.Type().IsRegular() || strings.HasSuffix(entry.Name(), "_test.go") {
+				return nil
+			}
+			paths = append(paths, path)
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("walk Kubernetes bundle recipe input %s: %w", input, err)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}

--- a/internal/kubernetesrelease/recipe_test.go
+++ b/internal/kubernetesrelease/recipe_test.go
@@ -2,6 +2,7 @@ package kubernetesrelease
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,9 +30,6 @@ func TestRecipeDigestChangesWithProductionInput(t *testing.T) {
 func TestRecipeDigestIgnoresTests(t *testing.T) {
 	root := writeRecipeFixture(t)
 	path := filepath.Join(root, "cmd", "katl-mkosi-artifacts", "main_test.go")
-	if err := os.WriteFile(path, []byte("first"), 0o644); err != nil {
-		t.Fatal(err)
-	}
 	first, err := RecipeDigest(root)
 	if err != nil {
 		t.Fatal(err)
@@ -45,6 +43,74 @@ func TestRecipeDigestIgnoresTests(t *testing.T) {
 	}
 	if first != second {
 		t.Fatal("test-only change affected recipe digest")
+	}
+}
+
+func TestRecipeDigestTracksControllerAndRuntimeSources(t *testing.T) {
+	for _, relative := range []string{
+		"internal/kubernetesrelease/input.go",
+		"internal/operatorconsole/input.go",
+		"cmd/katlc/input.go",
+	} {
+		t.Run(relative, func(t *testing.T) {
+			root := writeRecipeFixture(t)
+			first, err := RecipeDigest(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, filepath.FromSlash(relative))
+			if err := os.WriteFile(path, []byte("changed"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			second, err := RecipeDigest(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first == second {
+				t.Fatalf("%s did not affect recipe digest", relative)
+			}
+		})
+	}
+}
+
+func TestRecipeDigestTracksSymlinkTarget(t *testing.T) {
+	root := writeRecipeFixture(t)
+	path := filepath.Join(root, "mkosi.profiles", "runtime", "input.link")
+	first, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target-b", path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("symlink target did not affect recipe digest")
+	}
+}
+
+func TestRecipeDigestTracksExecutableMode(t *testing.T) {
+	root := writeRecipeFixture(t)
+	path := filepath.Join(root, "scripts", "mkosi")
+	first, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	second, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("executable mode did not affect recipe digest")
 	}
 }
 
@@ -107,13 +173,26 @@ func testSupportedVersion(payload string, revision int) SupportedVersion {
 func writeRecipeFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
-	for _, input := range recipeInputs {
+	directories := map[string]bool{
+		"cmd/katl-boot-health":               true,
+		"cmd/katl-console":                   true,
+		"cmd/katl-generation-activate":       true,
+		"cmd/katl-kubernetes-release":        true,
+		"cmd/katl-mkosi-artifacts":           true,
+		"cmd/katl-publish-kubernetes-sysext": true,
+		"cmd/katl-runtime-status":            true,
+		"cmd/katlc":                          true,
+		"internal":                           true,
+		"mkosi.profiles/kubernetes-sysext":   true,
+		"mkosi.profiles/runtime":             true,
+	}
+	for _, input := range recipeRoots {
 		path := filepath.Join(root, filepath.FromSlash(input))
-		if recipeDirectories[input] {
+		if directories[input] {
 			if err := os.MkdirAll(path, 0o755); err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(filepath.Join(path, "input"), []byte(input), 0o644); err != nil {
+			if err := os.WriteFile(filepath.Join(path, "input.go"), []byte(input), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			continue
@@ -125,5 +204,32 @@ func writeRecipeFixture(t *testing.T) string {
 			t.Fatal(err)
 		}
 	}
+	for relative, content := range map[string]string{
+		"cmd/katl-mkosi-artifacts/main_test.go": "test",
+		"internal/kubernetesrelease/input.go":   "controller",
+		"internal/operatorconsole/input.go":     "runtime",
+	} {
+		path := filepath.Join(root, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(root, "mkosi.profiles", "runtime", "input.link")
+	if err := os.Symlink("target-a", link); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "init", "--quiet")
+	runGit(t, root, "add", ".")
 	return root
+}
+
+func runGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
 }

--- a/internal/kubernetesrelease/recipe_test.go
+++ b/internal/kubernetesrelease/recipe_test.go
@@ -1,0 +1,129 @@
+package kubernetesrelease
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecipeDigestChangesWithProductionInput(t *testing.T) {
+	root := writeRecipeFixture(t)
+	first, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatalf("RecipeDigest() error = %v", err)
+	}
+	path := filepath.Join(root, "scripts", "mkosi")
+	if err := os.WriteFile(path, []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatalf("RecipeDigest() error = %v", err)
+	}
+	if first == second {
+		t.Fatal("recipe digest did not change")
+	}
+}
+
+func TestRecipeDigestIgnoresTests(t *testing.T) {
+	root := writeRecipeFixture(t)
+	path := filepath.Join(root, "cmd", "katl-mkosi-artifacts", "main_test.go")
+	if err := os.WriteFile(path, []byte("first"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	first, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("second"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second, err := RecipeDigest(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("test-only change affected recipe digest")
+	}
+}
+
+func TestRefreshRecipeAdvancesEverySupportedArtifact(t *testing.T) {
+	root := writeRecipeFixture(t)
+	supported := SupportedVersions{
+		APIVersion:   APIVersion,
+		Kind:         Kind,
+		RecipeDigest: "sha256:" + strings.Repeat("a", 64),
+		Versions: []SupportedVersion{
+			testSupportedVersion("v1.35.9", 2),
+			testSupportedVersion("v1.36.3", 1),
+		},
+	}
+	updated, changed, err := RefreshRecipe(root, supported)
+	if err != nil {
+		t.Fatalf("RefreshRecipe() error = %v", err)
+	}
+	if !changed || updated.Versions[0].ArtifactRevision != 3 || updated.Versions[1].ArtifactRevision != 2 {
+		t.Fatalf("updated = %#v, changed = %t", updated, changed)
+	}
+	again, changed, err := RefreshRecipe(root, updated)
+	if err != nil {
+		t.Fatalf("RefreshRecipe() error = %v", err)
+	}
+	if changed || again.Versions[0].ArtifactRevision != 3 || again.Versions[1].ArtifactRevision != 2 {
+		t.Fatalf("second refresh = %#v, changed = %t", again, changed)
+	}
+}
+
+func TestDefaultRecipeDigestMatchesRepository(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := RecipeDigest(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if supported.RecipeDigest != digest {
+		t.Fatalf("recipe digest = %s, want %s; run go run ./cmd/katl-kubernetes-release refresh-rebuilds", supported.RecipeDigest, digest)
+	}
+}
+
+func testSupportedVersion(payload string, revision int) SupportedVersion {
+	numeric := strings.TrimPrefix(payload, "v")
+	minor := numeric[:strings.LastIndex(numeric, ".")]
+	return SupportedVersion{
+		PayloadVersion:   payload,
+		ArtifactRevision: revision,
+		Packages: PackageVersions{
+			Kubeadm:  "0:" + numeric + "-1",
+			Kubelet:  "0:" + numeric + "-1",
+			Kubectl:  "0:" + numeric + "-1",
+			CRITools: "0:" + minor + ".0-1",
+		},
+	}
+}
+
+func writeRecipeFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, input := range recipeInputs {
+		path := filepath.Join(root, filepath.FromSlash(input))
+		if recipeDirectories[input] {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(path, "input"), []byte(input), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:05fefc5c231545cd2d3bc47b8a748ce256024c7f7619a2c1672805d76a2ab6c0",
+  "recipeDigest": "sha256:d08e76f58eb9246b30e66193b8b2684516b84dc62b5b9508c6f5dd7e03b8dba9",
   "versions": [
     {
       "payloadVersion": "v1.36.0",

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "katl.dev/v1alpha1",
+  "kind": "KubernetesSupportedVersions",
+  "versions": [
+    "v1.36.0",
+    "v1.36.1",
+    "v1.36.2",
+    "v1.36.3"
+  ]
+}

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,10 +1,47 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
+  "recipeDigest": "sha256:05fefc5c231545cd2d3bc47b8a748ce256024c7f7619a2c1672805d76a2ab6c0",
   "versions": [
-    "v1.36.0",
-    "v1.36.1",
-    "v1.36.2",
-    "v1.36.3"
+    {
+      "payloadVersion": "v1.36.0",
+      "artifactRevision": 4,
+      "packages": {
+        "kubeadm": "0:1.36.0-150500.1.1",
+        "kubelet": "0:1.36.0-150500.1.1",
+        "kubectl": "0:1.36.0-150500.1.1",
+        "criTools": "0:1.36.0-150500.1.1"
+      }
+    },
+    {
+      "payloadVersion": "v1.36.1",
+      "artifactRevision": 2,
+      "packages": {
+        "kubeadm": "0:1.36.1-150500.1.1",
+        "kubelet": "0:1.36.1-150500.1.1",
+        "kubectl": "0:1.36.1-150500.1.1",
+        "criTools": "0:1.36.0-150500.1.1"
+      }
+    },
+    {
+      "payloadVersion": "v1.36.2",
+      "artifactRevision": 1,
+      "packages": {
+        "kubeadm": "0:1.36.2-150500.2.1",
+        "kubelet": "0:1.36.2-150500.2.1",
+        "kubectl": "0:1.36.2-150500.2.1",
+        "criTools": "0:1.36.0-150500.1.1"
+      }
+    },
+    {
+      "payloadVersion": "v1.36.3",
+      "artifactRevision": 1,
+      "packages": {
+        "kubeadm": "0:1.36.3-150500.1.1",
+        "kubelet": "0:1.36.3-150500.1.1",
+        "kubectl": "0:1.36.3-150500.1.1",
+        "criTools": "0:1.36.0-150500.1.1"
+      }
+    }
   ]
 }

--- a/internal/kubernetesrelease/supported_versions.go
+++ b/internal/kubernetesrelease/supported_versions.go
@@ -1,0 +1,120 @@
+package kubernetesrelease
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+)
+
+const (
+	APIVersion = "katl.dev/v1alpha1"
+	Kind       = "KubernetesSupportedVersions"
+)
+
+//go:embed supported-versions.json
+var defaultSupportedVersions []byte
+
+var versionPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+
+type SupportedVersions struct {
+	APIVersion string   `json:"apiVersion"`
+	Kind       string   `json:"kind"`
+	Versions   []string `json:"versions"`
+}
+
+func DefaultSupportedVersions() (SupportedVersions, error) {
+	return DecodeSupportedVersions(defaultSupportedVersions)
+}
+
+func DecodeSupportedVersions(data []byte) (SupportedVersions, error) {
+	var supported SupportedVersions
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&supported); err != nil {
+		return SupportedVersions{}, fmt.Errorf("decode supported Kubernetes versions: %w", err)
+	}
+	if err := rejectTrailingJSON(decoder); err != nil {
+		return SupportedVersions{}, err
+	}
+	if err := validateSupportedVersions(supported); err != nil {
+		return SupportedVersions{}, err
+	}
+	supported.Versions = append([]string(nil), supported.Versions...)
+	return supported, nil
+}
+
+func rejectTrailingJSON(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode supported Kubernetes versions: unexpected trailing JSON")
+		}
+		return fmt.Errorf("decode supported Kubernetes versions: %w", err)
+	}
+	return nil
+}
+
+func validateSupportedVersions(supported SupportedVersions) error {
+	if supported.APIVersion != APIVersion {
+		return fmt.Errorf("supported Kubernetes versions apiVersion must be %s", APIVersion)
+	}
+	if supported.Kind != Kind {
+		return fmt.Errorf("supported Kubernetes versions kind must be %s", Kind)
+	}
+	if len(supported.Versions) == 0 {
+		return fmt.Errorf("supported Kubernetes versions must not be empty")
+	}
+	seen := make(map[string]bool, len(supported.Versions))
+	var previous [3]int
+	for index, version := range supported.Versions {
+		parsed, err := parseVersion(version)
+		if err != nil {
+			return fmt.Errorf("supported Kubernetes version %d: %w", index, err)
+		}
+		if seen[version] {
+			return fmt.Errorf("supported Kubernetes version %q is duplicated", version)
+		}
+		seen[version] = true
+		if index == 0 {
+			previous = parsed
+			continue
+		}
+		if compareVersions(previous, parsed) >= 0 {
+			return fmt.Errorf("supported Kubernetes versions must be ordered from oldest to newest")
+		}
+		previous = parsed
+	}
+	return nil
+}
+
+func parseVersion(version string) ([3]int, error) {
+	match := versionPattern.FindStringSubmatch(version)
+	if match == nil {
+		return [3]int{}, fmt.Errorf("%q must look like v1.36.0", version)
+	}
+	var parsed [3]int
+	for index := range parsed {
+		value, err := strconv.Atoi(match[index+1])
+		if err != nil {
+			return [3]int{}, fmt.Errorf("parse %q: %w", version, err)
+		}
+		parsed[index] = value
+	}
+	return parsed, nil
+}
+
+func compareVersions(left, right [3]int) int {
+	for index := range left {
+		switch {
+		case left[index] < right[index]:
+			return -1
+		case left[index] > right[index]:
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/kubernetesrelease/supported_versions.go
+++ b/internal/kubernetesrelease/supported_versions.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strconv"
 )
 
@@ -18,12 +19,34 @@ const (
 //go:embed supported-versions.json
 var defaultSupportedVersions []byte
 
-var versionPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+var (
+	versionPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+	packagePattern = regexp.MustCompile(`^0:([0-9]+)\.([0-9]+)\.([0-9]+)-[A-Za-z0-9._+~-]+$`)
+	digestPattern  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+)
 
 type SupportedVersions struct {
-	APIVersion string   `json:"apiVersion"`
-	Kind       string   `json:"kind"`
-	Versions   []string `json:"versions"`
+	APIVersion   string             `json:"apiVersion"`
+	Kind         string             `json:"kind"`
+	RecipeDigest string             `json:"recipeDigest"`
+	Versions     []SupportedVersion `json:"versions"`
+}
+
+type SupportedVersion struct {
+	PayloadVersion   string          `json:"payloadVersion"`
+	ArtifactRevision int             `json:"artifactRevision"`
+	Packages         PackageVersions `json:"packages"`
+}
+
+type PackageVersions struct {
+	Kubeadm  string `json:"kubeadm"`
+	Kubelet  string `json:"kubelet"`
+	Kubectl  string `json:"kubectl"`
+	CRITools string `json:"criTools"`
+}
+
+func (version SupportedVersion) ArtifactVersion() string {
+	return fmt.Sprintf("%s-katl.%d", version.PayloadVersion, version.ArtifactRevision)
 }
 
 func DefaultSupportedVersions() (SupportedVersions, error) {
@@ -43,8 +66,85 @@ func DecodeSupportedVersions(data []byte) (SupportedVersions, error) {
 	if err := validateSupportedVersions(supported); err != nil {
 		return SupportedVersions{}, err
 	}
-	supported.Versions = append([]string(nil), supported.Versions...)
+	supported.Versions = copyVersions(supported.Versions)
 	return supported, nil
+}
+
+func MarshalSupportedVersions(supported SupportedVersions) ([]byte, error) {
+	if err := validateSupportedVersions(supported); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(supported, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal supported Kubernetes versions: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func (supported SupportedVersions) Select(payloadVersion string) ([]SupportedVersion, error) {
+	if payloadVersion == "" {
+		return copyVersions(supported.Versions), nil
+	}
+	for _, version := range supported.Versions {
+		if version.PayloadVersion == payloadVersion {
+			return []SupportedVersion{version}, nil
+		}
+	}
+	return nil, fmt.Errorf("Kubernetes %s is not declared as supported", payloadVersion)
+}
+
+func (supported SupportedVersions) ChangedSince(previous SupportedVersions) ([]SupportedVersion, error) {
+	previousByPayload := make(map[string]SupportedVersion, len(previous.Versions))
+	for _, version := range previous.Versions {
+		previousByPayload[version.PayloadVersion] = version
+	}
+	var changed []SupportedVersion
+	for _, version := range supported.Versions {
+		old, exists := previousByPayload[version.PayloadVersion]
+		if !exists {
+			changed = append(changed, version)
+			continue
+		}
+		if old == version {
+			if supported.RecipeDigest != previous.RecipeDigest {
+				return nil, fmt.Errorf("Kubernetes bundle recipe changed without advancing %s artifactRevision", version.PayloadVersion)
+			}
+			continue
+		}
+		if version.ArtifactRevision <= old.ArtifactRevision {
+			return nil, fmt.Errorf("supported Kubernetes %s changed without advancing artifactRevision beyond %d", version.PayloadVersion, old.ArtifactRevision)
+		}
+		changed = append(changed, version)
+	}
+	return changed, nil
+}
+
+func (supported SupportedVersions) Upsert(version SupportedVersion) (SupportedVersions, bool, error) {
+	supported.Versions = copyVersions(supported.Versions)
+	found := false
+	for index, existing := range supported.Versions {
+		if existing.PayloadVersion != version.PayloadVersion {
+			continue
+		}
+		if existing == version {
+			return supported, false, nil
+		}
+		supported.Versions[index] = version
+		found = true
+		break
+	}
+	if !found {
+		supported.Versions = append(supported.Versions, version)
+	}
+	sort.Slice(supported.Versions, func(left, right int) bool {
+		leftVersion, _ := parseVersion(supported.Versions[left].PayloadVersion)
+		rightVersion, _ := parseVersion(supported.Versions[right].PayloadVersion)
+		return compareVersions(leftVersion, rightVersion) < 0
+	})
+	if err := validateSupportedVersions(supported); err != nil {
+		return SupportedVersions{}, false, err
+	}
+	return supported, true, nil
 }
 
 func rejectTrailingJSON(decoder *json.Decoder) error {
@@ -65,44 +165,81 @@ func validateSupportedVersions(supported SupportedVersions) error {
 	if supported.Kind != Kind {
 		return fmt.Errorf("supported Kubernetes versions kind must be %s", Kind)
 	}
+	if !digestPattern.MatchString(supported.RecipeDigest) {
+		return fmt.Errorf("supported Kubernetes versions recipeDigest must be a sha256 digest")
+	}
 	if len(supported.Versions) == 0 {
 		return fmt.Errorf("supported Kubernetes versions must not be empty")
 	}
 	seen := make(map[string]bool, len(supported.Versions))
 	var previous [3]int
 	for index, version := range supported.Versions {
-		parsed, err := parseVersion(version)
+		parsed, err := parseVersion(version.PayloadVersion)
 		if err != nil {
 			return fmt.Errorf("supported Kubernetes version %d: %w", index, err)
 		}
-		if seen[version] {
-			return fmt.Errorf("supported Kubernetes version %q is duplicated", version)
+		if seen[version.PayloadVersion] {
+			return fmt.Errorf("supported Kubernetes version %q is duplicated", version.PayloadVersion)
 		}
-		seen[version] = true
-		if index == 0 {
-			previous = parsed
-			continue
-		}
-		if compareVersions(previous, parsed) >= 0 {
+		seen[version.PayloadVersion] = true
+		if index > 0 && compareVersions(previous, parsed) >= 0 {
 			return fmt.Errorf("supported Kubernetes versions must be ordered from oldest to newest")
 		}
 		previous = parsed
+		if version.ArtifactRevision < 1 {
+			return fmt.Errorf("supported Kubernetes version %s artifactRevision must be at least 1", version.PayloadVersion)
+		}
+		if err := validatePackages(version, parsed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePackages(version SupportedVersion, payload [3]int) error {
+	for _, item := range []struct {
+		name  string
+		value string
+		exact bool
+	}{
+		{name: "kubeadm", value: version.Packages.Kubeadm, exact: true},
+		{name: "kubelet", value: version.Packages.Kubelet, exact: true},
+		{name: "kubectl", value: version.Packages.Kubectl, exact: true},
+		{name: "criTools", value: version.Packages.CRITools},
+	} {
+		parsed, err := parsePackageVersion(item.value)
+		if err != nil {
+			return fmt.Errorf("supported Kubernetes version %s package %s: %w", version.PayloadVersion, item.name, err)
+		}
+		if item.exact && parsed != payload {
+			return fmt.Errorf("supported Kubernetes version %s package %s does not match its payload", version.PayloadVersion, item.name)
+		}
+		if !item.exact && (parsed[0] != payload[0] || parsed[1] != payload[1]) {
+			return fmt.Errorf("supported Kubernetes version %s package %s does not match its minor", version.PayloadVersion, item.name)
+		}
 	}
 	return nil
 }
 
 func parseVersion(version string) ([3]int, error) {
-	match := versionPattern.FindStringSubmatch(version)
+	return parseNumericVersion(versionPattern.FindStringSubmatch(version), version, "v1.36.0")
+}
+
+func parsePackageVersion(version string) ([3]int, error) {
+	return parseNumericVersion(packagePattern.FindStringSubmatch(version), version, "0:1.36.0-150500.1.1")
+}
+
+func parseNumericVersion(match []string, value, example string) ([3]int, error) {
 	if match == nil {
-		return [3]int{}, fmt.Errorf("%q must look like v1.36.0", version)
+		return [3]int{}, fmt.Errorf("%q must look like %s", value, example)
 	}
 	var parsed [3]int
 	for index := range parsed {
-		value, err := strconv.Atoi(match[index+1])
+		number, err := strconv.Atoi(match[index+1])
 		if err != nil {
-			return [3]int{}, fmt.Errorf("parse %q: %w", version, err)
+			return [3]int{}, fmt.Errorf("parse %q: %w", value, err)
 		}
-		parsed[index] = value
+		parsed[index] = number
 	}
 	return parsed, nil
 }
@@ -117,4 +254,8 @@ func compareVersions(left, right [3]int) int {
 		}
 	}
 	return 0
+}
+
+func copyVersions(versions []SupportedVersion) []SupportedVersion {
+	return append([]SupportedVersion(nil), versions...)
 }

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -1,0 +1,46 @@
+package kubernetesrelease
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDefaultSupportedVersions(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatalf("DefaultSupportedVersions() error = %v", err)
+	}
+	want := []string{"v1.36.0", "v1.36.1", "v1.36.2", "v1.36.3"}
+	if !reflect.DeepEqual(supported.Versions, want) {
+		t.Fatalf("versions = %v, want %v", supported.Versions, want)
+	}
+}
+
+func TestDecodeSupportedVersionsRejectsInvalidPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions string
+		extra    string
+		want     string
+	}{
+		{name: "empty", versions: "", want: "must not be empty"},
+		{name: "malformed", versions: `"1.36.0"`, want: "must look like"},
+		{name: "duplicate", versions: `"v1.36.0", "v1.36.0"`, want: "duplicated"},
+		{name: "unordered", versions: `"v1.36.1", "v1.36.0"`, want: "ordered from oldest to newest"},
+		{name: "unknown field", versions: `"v1.36.0"`, extra: `, "unknown": true`, want: "unknown field"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := `{
+				"apiVersion": "katl.dev/v1alpha1",
+				"kind": "KubernetesSupportedVersions",
+				"versions": [` + test.versions + `]` + test.extra + `
+			}`
+			_, err := DecodeSupportedVersions([]byte(data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodeSupportedVersions() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -11,30 +11,111 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultSupportedVersions() error = %v", err)
 	}
+	var got []string
+	for _, version := range supported.Versions {
+		got = append(got, version.PayloadVersion)
+	}
 	want := []string{"v1.36.0", "v1.36.1", "v1.36.2", "v1.36.3"}
-	if !reflect.DeepEqual(supported.Versions, want) {
-		t.Fatalf("versions = %v, want %v", supported.Versions, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("versions = %v, want %v", got, want)
+	}
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.1" {
+		t.Fatalf("artifact version = %q", got)
+	}
+}
+
+func TestSupportedVersionsSelect(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected, err := supported.Select("v1.36.2")
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if len(selected) != 1 || selected[0].PayloadVersion != "v1.36.2" {
+		t.Fatalf("selected = %#v", selected)
+	}
+	if _, err := supported.Select("v1.35.0"); err == nil || !strings.Contains(err.Error(), "not declared as supported") {
+		t.Fatalf("Select() error = %v", err)
+	}
+}
+
+func TestSupportedVersionsChangedSince(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := supported
+	previous.Versions = copyVersions(supported.Versions[:3])
+	previous.Versions[1].ArtifactRevision--
+
+	changed, err := supported.ChangedSince(previous)
+	if err != nil {
+		t.Fatalf("ChangedSince() error = %v", err)
+	}
+	var got []string
+	for _, version := range changed {
+		got = append(got, version.PayloadVersion)
+	}
+	want := []string{"v1.36.1", "v1.36.3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("changed = %v, want %v", got, want)
+	}
+}
+
+func TestSupportedVersionsChangedSinceRequiresRevision(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := supported
+	previous.Versions = copyVersions(supported.Versions)
+	previous.Versions[0].Packages.Kubeadm = "0:1.36.0-previous"
+
+	if _, err := supported.ChangedSince(previous); err == nil || !strings.Contains(err.Error(), "without advancing artifactRevision") {
+		t.Fatalf("ChangedSince() error = %v", err)
 	}
 }
 
 func TestDecodeSupportedVersionsRejectsInvalidPolicy(t *testing.T) {
+	validVersion := `{
+		"payloadVersion": "v1.36.0",
+		"artifactRevision": 1,
+		"packages": {
+			"kubeadm": "0:1.36.0-1",
+			"kubelet": "0:1.36.0-1",
+			"kubectl": "0:1.36.0-1",
+			"criTools": "0:1.36.0-1"
+		}
+	}`
+	nextVersion := strings.ReplaceAll(validVersion, "1.36.0", "1.36.1")
 	tests := []struct {
 		name     string
 		versions string
+		digest   string
 		extra    string
 		want     string
 	}{
 		{name: "empty", versions: "", want: "must not be empty"},
-		{name: "malformed", versions: `"1.36.0"`, want: "must look like"},
-		{name: "duplicate", versions: `"v1.36.0", "v1.36.0"`, want: "duplicated"},
-		{name: "unordered", versions: `"v1.36.1", "v1.36.0"`, want: "ordered from oldest to newest"},
-		{name: "unknown field", versions: `"v1.36.0"`, extra: `, "unknown": true`, want: "unknown field"},
+		{name: "malformed", versions: strings.Replace(validVersion, "v1.36.0", "1.36.0", 1), want: "must look like"},
+		{name: "duplicate", versions: validVersion + ", " + validVersion, want: "duplicated"},
+		{name: "unordered", versions: nextVersion + ", " + validVersion, want: "ordered from oldest to newest"},
+		{name: "zero revision", versions: strings.Replace(validVersion, `"artifactRevision": 1`, `"artifactRevision": 0`, 1), want: "at least 1"},
+		{name: "package mismatch", versions: strings.Replace(validVersion, `"kubeadm": "0:1.36.0-1"`, `"kubeadm": "0:1.36.1-1"`, 1), want: "does not match its payload"},
+		{name: "bad digest", versions: validVersion, digest: "sha256:nope", want: "recipeDigest"},
+		{name: "unknown field", versions: validVersion, extra: `, "unknown": true`, want: "unknown field"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			digest := test.digest
+			if digest == "" {
+				digest = "sha256:" + strings.Repeat("a", 64)
+			}
 			data := `{
 				"apiVersion": "katl.dev/v1alpha1",
 				"kind": "KubernetesSupportedVersions",
+				"recipeDigest": "` + digest + `",
 				"versions": [` + test.versions + `]` + test.extra + `
 			}`
 			_, err := DecodeSupportedVersions([]byte(data))

--- a/mkosi.profiles/kubernetes-sysext/kubernetes.env
+++ b/mkosi.profiles/kubernetes-sysext/kubernetes.env
@@ -15,16 +15,16 @@ fi
 # patch and exact RPM NEVRAs in one reviewed pull request; merging that change
 # publishes the corresponding immutable -katl.1 bundle.
 # renovate: datasource=github-releases depName=kubernetes/kubernetes versioning=semver
-KATL_KUBERNETES_PAYLOAD_DEFAULT=v1.36.1
+KATL_KUBERNETES_PAYLOAD_DEFAULT=v1.36.2
 KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=1
 : "${KATL_KUBERNETES_PAYLOAD_VERSION:=$KATL_KUBERNETES_PAYLOAD_DEFAULT}"
 : "${KATL_KUBERNETES_ARTIFACT_REVISION:=$KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT}"
 # renovate: datasource=rpm depName=kubeadm versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
-: "${KATL_KUBERNETES_KUBEADM_VERSION:=0:1.36.1-150500.1.1}"
+: "${KATL_KUBERNETES_KUBEADM_VERSION:=0:1.36.2-150500.2.1}"
 # renovate: datasource=rpm depName=kubelet versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
-: "${KATL_KUBERNETES_KUBELET_VERSION:=0:1.36.1-150500.1.1}"
+: "${KATL_KUBERNETES_KUBELET_VERSION:=0:1.36.2-150500.2.1}"
 # renovate: datasource=rpm depName=kubectl versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
-: "${KATL_KUBERNETES_KUBECTL_VERSION:=0:1.36.1-150500.1.1}"
+: "${KATL_KUBERNETES_KUBECTL_VERSION:=0:1.36.2-150500.2.1}"
 # renovate: datasource=rpm depName=cri-tools versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
 : "${KATL_KUBERNETES_CRITOOLS_VERSION:=0:1.36.0-150500.1.1}"
 : "${KATL_KUBERNETES_ETHTOOL_VERSION:=}"

--- a/mkosi.profiles/kubernetes-sysext/kubernetes.env
+++ b/mkosi.profiles/kubernetes-sysext/kubernetes.env
@@ -11,21 +11,16 @@ fi
 : "${KATL_KUBERNETES_REPO_BASEURL:=https://pkgs.k8s.io/core:/stable:/${KATL_KUBERNETES_MINOR}/rpm/}"
 : "${KATL_KUBERNETES_REPO_GPGKEY:=${KATL_KUBERNETES_REPO_BASEURL%/}/repodata/repomd.xml.key}"
 
-# The release producer treats these as one lock. Renovate updates the selected
-# patch and exact RPM NEVRAs in one reviewed pull request; merging that change
-# publishes the corresponding immutable -katl.1 bundle.
-# renovate: datasource=github-releases depName=kubernetes/kubernetes versioning=semver
+# These values select the default payload for direct development builds.
+# Published support policy and per-version package locks live in
+# internal/kubernetesrelease/supported-versions.json.
 KATL_KUBERNETES_PAYLOAD_DEFAULT=v1.36.2
 KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=1
 : "${KATL_KUBERNETES_PAYLOAD_VERSION:=$KATL_KUBERNETES_PAYLOAD_DEFAULT}"
 : "${KATL_KUBERNETES_ARTIFACT_REVISION:=$KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT}"
-# renovate: datasource=rpm depName=kubeadm versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
 : "${KATL_KUBERNETES_KUBEADM_VERSION:=0:1.36.2-150500.2.1}"
-# renovate: datasource=rpm depName=kubelet versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
 : "${KATL_KUBERNETES_KUBELET_VERSION:=0:1.36.2-150500.2.1}"
-# renovate: datasource=rpm depName=kubectl versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
 : "${KATL_KUBERNETES_KUBECTL_VERSION:=0:1.36.2-150500.2.1}"
-# renovate: datasource=rpm depName=cri-tools versioning=rpm registryUrl=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/
 : "${KATL_KUBERNETES_CRITOOLS_VERSION:=0:1.36.0-150500.1.1}"
 : "${KATL_KUBERNETES_ETHTOOL_VERSION:=}"
 : "${KATL_KUBERNETES_SOCAT_VERSION:=}"

--- a/renovate.json
+++ b/renovate.json
@@ -2,57 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track the selected Kubernetes patch release",
-      "managerFilePatterns": [
-        "/^mkosi\\.profiles/kubernetes-sysext/kubernetes\\.env$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>github-releases) depName=(?<depName>\\S+) versioning=(?<versioning>semver)\\nKATL_KUBERNETES_PAYLOAD_DEFAULT=(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\nKATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=\\d+"
-      ],
-      "autoReplaceStringTemplate": "# renovate: datasource=github-releases depName=kubernetes/kubernetes versioning=semver\\nKATL_KUBERNETES_PAYLOAD_DEFAULT={{{newValue}}}\\nKATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=1"
-    },
-    {
-      "customType": "regex",
-      "description": "Lock Kubernetes RPM package versions",
-      "managerFilePatterns": [
-        "/^mkosi\\.profiles/kubernetes-sysext/kubernetes\\.env$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>rpm) depName=(?<depName>\\S+) versioning=(?<versioning>rpm) registryUrl=(?<registryUrl>\\S+)\\n: \\\"\\$\\{KATL_KUBERNETES_[A-Z]+_VERSION:=0:(?<currentValue>[^}]+)\\}\\\""
-      ]
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Keep the producer on the reviewed Kubernetes v1.36 release line",
-      "matchDatasources": [
-        "github-releases"
-      ],
-      "matchPackageNames": [
-        "kubernetes/kubernetes"
-      ],
-      "allowedVersions": "/^v1\\.36\\.\\d+$/",
-      "groupName": "Kubernetes v1.36 bundle",
-      "automerge": false
-    },
-    {
-      "description": "Update the exact v1.36 RPM locks with the payload declaration",
-      "matchDatasources": [
-        "rpm"
-      ],
-      "matchPackageNames": [
-        "kubeadm",
-        "kubelet",
-        "kubectl",
-        "cri-tools"
-      ],
-      "allowedVersions": "/^1\\.36\\.\\d+-/",
-      "groupName": "Kubernetes v1.36 bundle",
-      "automerge": false
-    }
   ]
 }

--- a/scripts/build-kubernetes-sysext
+++ b/scripts/build-kubernetes-sysext
@@ -110,6 +110,7 @@ cache_fingerprint() {
         printf 'builder-image=%s\n' "${KATL_MKOSI_IMAGE:-localhost/katl-mkosi-builder:fedora-44-go-squashfs}"
         printf 'builder-image-identity=%s\n' "$(builder_image_identity)"
         printf 'KATL_BUILD_COMMIT=%s\n' "$build_commit"
+        printf 'SOURCE_DATE_EPOCH=%s\n' "${SOURCE_DATE_EPOCH:-}"
         printf 'KATL_VERSION=%s\n' "${KATL_VERSION:-}"
         printf 'KATL_ARCHITECTURE=%s\n' "$architecture"
         printf 'KATL_KUBERNETES_MINOR=%s\n' "$KATL_KUBERNETES_MINOR"

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -32,6 +32,9 @@ mkosi_env=(--environment "KATL_BUILD_COMMIT=$build_commit")
 if [[ -n "${KATL_VERSION:-}" ]]; then
     mkosi_env+=(--environment "KATL_VERSION=$KATL_VERSION")
 fi
+if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
+    mkosi_env+=(--environment "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH")
+fi
 vmtest_image_support="${KATL_VMTEST_IMAGE_SUPPORT:-0}"
 case "$vmtest_image_support" in
     0|1) ;;
@@ -229,6 +232,7 @@ cache_fingerprint() {
             printf 'builder-image=%s\n' "$image"
             printf 'builder-image-identity=%s\n' "$(builder_image_identity)"
             printf 'KATL_BUILD_COMMIT=%s\n' "$build_commit"
+            printf 'SOURCE_DATE_EPOCH=%s\n' "${SOURCE_DATE_EPOCH:-}"
             printf 'KATL_VERSION=%s\n' "${KATL_VERSION:-}"
             printf 'KATL_ARCHITECTURE=%s\n' "${KATL_ARCHITECTURE:-$(uname -m)}"
             printf 'KATL_KATLOS_IMAGE_ROLE=%s\n' "${KATL_KATLOS_IMAGE_ROLE:-install}"
@@ -561,6 +565,17 @@ else
     esac
 fi
 
+if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
+    seed_hex="$(
+        printf 'katl-mkosi-v1\0%s\0%s\0' "$build_commit" "$*" |
+            sha256sum
+    )"
+    seed_hex="${seed_hex%% *}"
+    seed_hex="${seed_hex:0:12}5${seed_hex:13:3}8${seed_hex:17:15}"
+    mkosi_seed="${seed_hex:0:8}-${seed_hex:8:4}-${seed_hex:12:4}-${seed_hex:16:4}-${seed_hex:20:12}"
+    mkosi_env+=(--seed "$mkosi_seed")
+fi
+
 run_flags=(
     run
     --rm
@@ -575,6 +590,9 @@ run_flags=(
     --env "KATL_EMIT_INSTALLER_ISO=$emit_installer_iso"
     --env "KATL_VMTEST_IMAGE_SUPPORT=$vmtest_image_support"
 )
+if [[ -n "${SOURCE_DATE_EPOCH:-}" ]]; then
+    run_flags+=(--env "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH")
+fi
 chown_build=1
 
 direct_tool_search_path() {


### PR DESCRIPTION
## Summary

- make the supported-version manifest authoritative for exact payload, package, and immutable artifact identities
- build and attest new or revision-advanced supported entries in parallel, then record their digests in one compatibility PR
- fingerprint tracked bundle inputs, including executable modes and symlink targets, so recipe changes require every supported artifact revision to advance
- make interrupted matrix publication retry-safe with reproducible builds and byte-identical immutable-tag reuse
- keep Renovate enabled for ordinary dependencies while Kubernetes support policy remains an explicit reviewed decision

## Why

The previous single-value release lock could select one patch, but it could not preserve and rebuild the full supported set. This gives the producer an explicit supported matrix, prevents out-of-policy publication identities, and provides a recoverable update path for future patch and minor policy changes.