### PR TITLE
agents: require katldev UX journeys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ Katl produces KatlOS, an installable, upgradeable, systemd-native Kubernetes nod
 - Verify generated systemd units with `systemd-analyze verify` where practical. Risky boot, disk, update, security, or kubeadm changes also require focused review.
 - Use delete-on-success retention for routine VM gates. Keep large run output only while debugging and remove it afterwards.
 - A release should exercise the same artifacts and supported journeys users receive. Do not infer release readiness solely from unit tests or a successful artifact build.
-- Use `katldev` for hands-on UX verification of operator journeys through the public `katlctl` interface. Exercise representative happy paths, repeat applies, online configuration changes, and safe failure or recovery paths without relying on internal shortcuts. Judge the journey as a user would: verify useful progress, actionable errors, expected end state, and the absence of surprising disruption; record product gaps discovered along the way.
+- Use `katldev` for hands-on user-journey and UX verification when operator-facing behavior changes or automated gates expose usability concerns. Exercise representative happy paths, repeat applies, online configuration changes, and safe failure or recovery paths through the public `katlctl` interface without relying on internal shortcuts. Judge the journey as a user would: verify useful progress, actionable errors, expected end state, and the absence of surprising disruption; record product gaps discovered along the way.
+- Treat Katldev journey testing as exploratory product evidence, not a ritual duplicate gate. Reuse a recent, relevant completed journey when later work has not changed the exercised behavior or artifact; rerun only the portions invalidated by subsequent changes or needed to verify a discovered fix.
 
 ## Task and Delivery Workflow
 


### PR DESCRIPTION
Updates the agent guidance so operator-facing UX changes are exercised through public katlctl journeys in katldev. This makes repeat applies, live updates, and safe recovery behavior explicit release-confidence expectations instead of relying on implementation-level checks.