### PR TITLE
kubeadm: make online config applies legible

### DIFF
--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -24,13 +24,14 @@ import (
 type kubeadmControlPlaneConfigOptions struct {
 	configPath, inventoryPath, coordinator, generationID, configName string
 	rolloutID, component                                             string
+	progress                                                         io.Writer
 }
 
 var kubeadmConfigNow = func() time.Time { return time.Now().UTC() }
 
 func newClusterApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := kubeadmControlPlaneConfigOptions{}
-	cmd := &cobra.Command{Use: "apply", Short: "Apply the complete ClusterConfig to a running cluster", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runClusterApply(ctx, opts, stdout) }}
+	cmd := &cobra.Command{Use: "apply", Short: "Apply the complete ClusterConfig to a running cluster", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runClusterApply(ctx, opts, stdout, stderr) }}
 	f := cmd.Flags()
 	f.StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	f.StringVar(&opts.inventoryPath, "inventory", "", "advanced cluster inventory")
@@ -41,13 +42,16 @@ func newClusterApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	for _, name := range []string{"inventory", "generation", "config-name", "rollout-id"} {
 		cmd.Flags().Lookup(name).Hidden = true
 	}
-	_ = stderr
 	return cmd
 }
 
-func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout io.Writer) error {
+func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout, stderr io.Writer) error {
+	opts.progress = stderr
 	inv, err := kubeadmConfigInventory(opts)
 	if err != nil {
+		return err
+	}
+	if err := clusterApplyProgress(opts.progress, "phase=configuration status=started nodes=%d", len(inv.Nodes)); err != nil {
 		return err
 	}
 	if strings.TrimSpace(opts.rolloutID) == "" {
@@ -78,11 +82,17 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 		componentOpts := opts
 		componentOpts.component = component
 		componentOpts.rolloutID = opts.rolloutID + "-" + component
+		if err := clusterApplyProgress(opts.progress, "component=%s status=started", component); err != nil {
+			return err
+		}
 		summary, err := runKubeadmConfigComponent(ctx, componentOpts, inv, generations)
 		if err != nil {
 			return err
 		}
 		results[component] = summary
+		if err := clusterApplyProgress(opts.progress, "component=%s status=succeeded", component); err != nil {
+			return err
+		}
 	}
 	return json.NewEncoder(stdout).Encode(map[string]any{
 		"nodes":      len(inv.Nodes),
@@ -220,18 +230,27 @@ func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConf
 			return nil, fmt.Errorf("node %s did not confirm kubeadm rollout dry-run", t.node.Name)
 		}
 	}
+	if err := clusterApplyProgress(opts.progress, "component=%s phase=preflight status=succeeded nodes=%d", opts.component, len(targets)); err != nil {
+		return nil, err
+	}
 	for i, t := range targets {
 		body := kubeadmControlPlaneConfigBody(opts, t.node, t.generation, uint32(i+1), uint32(len(targets)))
+		if err := clusterApplyProgress(opts.progress, "component=%s node=%s phase=apply status=started", opts.component, t.node.Name); err != nil {
+			return nil, err
+		}
 		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, KubeadmControlPlaneConfig: body})
 		if err != nil {
 			return nil, fmt.Errorf("submit %s: %w", t.node.Name, err)
 		}
-		terminal, err := waitKubeadmControlPlaneConfig(ctx, t.conn.Client, accepted.OperationId)
+		terminal, err := waitKubeadmControlPlaneConfig(ctx, t.conn.Client, accepted.OperationId, opts.component, t.node.Name, opts.progress)
 		if err != nil {
 			return nil, fmt.Errorf("node %s: %w", t.node.Name, err)
 		}
 		if terminal.Result != operation.ResultSucceeded {
 			return nil, fmt.Errorf("node %s stopped rollout: %s: %s", t.node.Name, terminal.Phase, terminal.FailureReason)
+		}
+		if err := clusterApplyProgress(opts.progress, "component=%s node=%s phase=%s status=succeeded", opts.component, t.node.Name, firstNonEmpty(terminal.Phase, "complete")); err != nil {
+			return nil, err
 		}
 		summary = append(summary, map[string]string{"node": t.node.Name, "result": terminal.Result})
 	}
@@ -292,6 +311,9 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 	prepared := make([]preparedInput, 0, len(nodes))
 	components := map[string]bool{}
 	for _, node := range nodes {
+		if err := clusterApplyProgress(opts.progress, "phase=config-validation node=%s status=started", node.Name); err != nil {
+			return activatedClusterConfig{}, err
+		}
 		selected, err := configbundle.ReadSelectedNode(bytes.NewReader(loaded.Archive), configbundle.ReadOptions{NodeName: node.Name, AllowMissingKatlosImage: true})
 		if err != nil {
 			return activatedClusterConfig{}, fmt.Errorf("select cluster config for %s: %w", node.Name, err)
@@ -345,12 +367,19 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			_ = conn.Close()
 			return activatedClusterConfig{}, fmt.Errorf("node %s rejected cluster config: %s", node.Name, firstNonEmpty(validation.FailureReason, strings.Join(validation.Diagnostics, "; ")))
 		}
+		if err := clusterApplyProgress(opts.progress, "phase=config-validation node=%s status=succeeded", node.Name); err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, err
+		}
 		input.machineID = status.MachineId
 		input.currentGeneration = status.CurrentGenerationId
 		input.noChanges = validation.NoChanges
 		_ = conn.Close()
 		if validation.NoChanges {
 			result[node.Name] = status.CurrentGenerationId
+			if err := clusterApplyProgress(opts.progress, "phase=node-config node=%s status=unchanged", node.Name); err != nil {
+				return activatedClusterConfig{}, err
+			}
 			continue
 		}
 		if validation.AcceptedApplyMode != generation.ApplyModeLive {
@@ -367,6 +396,10 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		if err != nil {
 			return activatedClusterConfig{}, fmt.Errorf("connect %s to apply cluster config: %w", node.Name, err)
 		}
+		if err := clusterApplyProgress(opts.progress, "phase=node-config node=%s status=started", node.Name); err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, err
+		}
 		accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
 			OperationKind: "generation-apply", Actor: "katlctl cluster apply", ExpectedMachineId: input.machineID, ExpectedCurrentGenerationId: input.currentGeneration,
@@ -376,13 +409,16 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			_ = conn.Close()
 			return activatedClusterConfig{}, fmt.Errorf("apply cluster config on %s: %w", node.Name, err)
 		}
-		terminal, err := waitAcceptedOperationStatus(ctx, conn.Client, accepted, 30*time.Minute, io.Discard)
+		terminal, err := waitClusterApplyNodeConfig(ctx, conn.Client, accepted, node.Name, opts.progress)
 		if err == nil {
 			err = operationResultError(terminal)
 		}
 		_ = conn.Close()
 		if err != nil {
 			return activatedClusterConfig{}, fmt.Errorf("apply cluster config on %s: %w", node.Name, err)
+		}
+		if err := clusterApplyProgress(opts.progress, "phase=node-config node=%s status=succeeded", node.Name); err != nil {
+			return activatedClusterConfig{}, err
 		}
 		activatedGeneration := strings.TrimSpace(terminal.GetCandidateGenerationId())
 		if activatedGeneration == "" {
@@ -394,6 +430,51 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		result[node.Name] = activatedGeneration
 	}
 	return activatedClusterConfig{generations: result, components: components}, nil
+}
+
+func clusterApplyProgress(w io.Writer, format string, args ...any) error {
+	if w == nil {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "cluster apply "+format+"\n", args...)
+	return err
+}
+
+func waitClusterApplyNodeConfig(ctx context.Context, client agentapi.KatlcAgentClient, accepted *agentapi.OperationAccepted, node string, progress io.Writer) (*agentapi.OperationStatus, error) {
+	if accepted == nil || strings.TrimSpace(accepted.OperationId) == "" {
+		return nil, fmt.Errorf("agent returned an empty operation acceptance")
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	status := accepted.InitialStatus
+	lastPhase := ""
+	for {
+		if status == nil {
+			var err error
+			status, err = client.GetOperation(waitCtx, &agentapi.GetOperationRequest{OperationId: accepted.OperationId, IncludeDiagnostics: "normal"})
+			if err != nil {
+				return nil, err
+			}
+		}
+		phase := firstNonEmpty(status.Phase, "pending")
+		if phase != lastPhase {
+			if err := clusterApplyProgress(progress, "phase=node-config node=%s step=%s status=running", node, phase); err != nil {
+				return nil, err
+			}
+			lastPhase = phase
+		}
+		if status.Terminal {
+			return status, nil
+		}
+		status = nil
+		select {
+		case <-waitCtx.Done():
+			return nil, waitCtx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func orderControlPlanes(nodes []inventory.Node, coordinator string) ([]inventory.Node, error) {
@@ -430,13 +511,21 @@ func orderKubeletNodes(nodes, controlPlanes []inventory.Node, coordinator string
 	return append([]inventory.Node{coordinatorNode}, remaining...), nil
 }
 
-func waitKubeadmControlPlaneConfig(ctx context.Context, client agentapi.KatlcAgentClient, id string) (*agentapi.OperationStatus, error) {
+func waitKubeadmControlPlaneConfig(ctx context.Context, client agentapi.KatlcAgentClient, id, component, node string, progress io.Writer) (*agentapi.OperationStatus, error) {
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
+	lastPhase := ""
 	for {
 		status, err := client.GetOperation(ctx, &agentapi.GetOperationRequest{OperationId: id, IncludeDiagnostics: "normal"})
 		if err != nil {
 			return nil, err
+		}
+		phase := firstNonEmpty(status.Phase, "pending")
+		if phase != lastPhase {
+			if err := clusterApplyProgress(progress, "component=%s node=%s phase=%s status=running", component, node, phase); err != nil {
+				return nil, err
+			}
+			lastPhase = phase
 		}
 		if status.Terminal {
 			return status, nil

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -74,6 +74,7 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 
 func TestRunClusterApplyReconcilesWholeConfigAndAllKubernetesComponents(t *testing.T) {
 	configPath := writeClusterConfig(t)
+	var stdout, stderr bytes.Buffer
 	client := &fakeKatlcAgentClient{
 		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
 		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
@@ -86,6 +87,22 @@ func TestRunClusterApplyReconcilesWholeConfigAndAllKubernetesComponents(t *testi
 			ConfigApply:  &agentapi.ConfigApplyStatus{SelectedKubeadmConfigName: "control-plane"},
 			Sysexts:      []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: strings.Repeat("c", 64)}},
 		},
+	}
+	client.onSubmit = func(request *agentapi.SubmitOperationRequest) {
+		if request.DryRun {
+			return
+		}
+		var required string
+		switch request.OperationKind {
+		case "generation-apply":
+			required = "phase=node-config node=cp-1 status=started"
+		case "kubeadm-control-plane-config":
+			component := strings.TrimPrefix(request.KubeadmControlPlaneConfig.SupportedFieldDelta[0], "component/")
+			required = "component=" + component + " node=cp-1 phase=apply status=started"
+		}
+		if required != "" && !strings.Contains(stderr.String(), required) {
+			t.Fatalf("progress before %s submission = %q, missing %q", request.OperationKind, stderr.String(), required)
+		}
 	}
 	previousDial := dialKatlcAgent
 	previousNow := kubeadmConfigNow
@@ -101,14 +118,32 @@ func TestRunClusterApplyReconcilesWholeConfigAndAllKubernetesComponents(t *testi
 	}
 	kubeadmConfigNow = func() time.Time { return time.Unix(0, 42).UTC() }
 
-	var stdout bytes.Buffer
-	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout); err != nil {
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout, &stderr); err != nil {
 		t.Fatal(err)
 	}
 	for _, required := range []string{`"result":"succeeded"`, `"control-plane"`, `"kubelet"`} {
 		if !strings.Contains(stdout.String(), required) {
 			t.Fatalf("stdout = %s, missing %s", stdout.String(), required)
 		}
+	}
+	for _, required := range []string{
+		"phase=configuration status=started nodes=1",
+		"phase=config-validation node=cp-1 status=succeeded",
+		"phase=node-config node=cp-1 step=pending status=running",
+		"phase=node-config node=cp-1 status=succeeded",
+		"component=control-plane phase=preflight status=succeeded nodes=1",
+		"component=control-plane node=cp-1 phase=pending status=running",
+		"component=kubelet node=cp-1 phase=complete status=succeeded",
+	} {
+		if !strings.Contains(stderr.String(), required) {
+			t.Fatalf("stderr = %s, missing %s", stderr.String(), required)
+		}
+	}
+	if strings.Contains(stdout.String(), "cluster apply ") {
+		t.Fatalf("structured stdout contains progress output: %s", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "operation kind=") || strings.Contains(stderr.String(), "operation-id") {
+		t.Fatalf("progress exposed internal operation bookkeeping: %s", stderr.String())
 	}
 	if client.validateRequest == nil || !strings.Contains(client.validateRequest.ConfigYaml, "identity:") || !strings.Contains(client.validateRequest.ConfigYaml, "kubeadmConfigs:") {
 		t.Fatalf("cluster validation did not receive the whole node config: %#v", client.validateRequest)

--- a/internal/installer/kubeadmplan/control_plane_config.go
+++ b/internal/installer/kubeadmplan/control_plane_config.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,7 +19,17 @@ func CanonicalClusterConfigurationSHA256(data []byte) (string, error) {
 }
 
 func CanonicalKubeletConfigurationSHA256(data []byte) (string, error) {
-	return CanonicalDocumentSHA256(data, "kubelet.config.k8s.io/v1beta1", "KubeletConfiguration")
+	config, err := configurationDocument(data, "kubelet.config.k8s.io/v1beta1", "KubeletConfiguration")
+	if err != nil {
+		return "", err
+	}
+	normalizeKubeletDurationValues(config)
+	canonical, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func CanonicalKubeProxyConfigurationSHA256(data []byte) (string, error) {
@@ -60,10 +71,30 @@ func KubeletConfigurationContains(actual, desired []byte) error {
 		delete(actualConfig, "containerRuntimeEndpoint")
 		delete(desiredConfig, "containerRuntimeEndpoint")
 	}
+	normalizeKubeletDurationValues(actualConfig)
+	normalizeKubeletDurationValues(desiredConfig)
 	if !containsValue(actualConfig, desiredConfig) {
 		return fmt.Errorf("live KubeletConfiguration does not contain the desired fields")
 	}
 	return nil
+}
+
+func normalizeKubeletDurationValues(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			typed[key] = normalizeKubeletDurationValues(child)
+		}
+	case []any:
+		for i, child := range typed {
+			typed[i] = normalizeKubeletDurationValues(child)
+		}
+	case string:
+		if duration, err := time.ParseDuration(typed); err == nil {
+			return duration.String()
+		}
+	}
+	return value
 }
 
 func KubeProxyConfigurationContains(actual, desired []byte) error {

--- a/internal/installer/kubeadmplan/control_plane_config_test.go
+++ b/internal/installer/kubeadmplan/control_plane_config_test.go
@@ -61,6 +61,31 @@ func TestKubeletConfigurationContainsAllowsDefaultedLiveFields(t *testing.T) {
 	}
 }
 
+func TestKubeletConfigurationCanonicalizesDurations(t *testing.T) {
+	desired := []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nshutdownGracePeriod: 60s\nshutdownGracePeriodCriticalPods: 20s\n")
+	canonicalized := []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nshutdownGracePeriod: 1m0s\nshutdownGracePeriodCriticalPods: 20s\n")
+
+	desiredDigest, err := CanonicalKubeletConfigurationSHA256(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalDigest, err := CanonicalKubeletConfigurationSHA256(canonicalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if desiredDigest != canonicalDigest {
+		t.Fatalf("canonical kubelet digests differ: desired=%s live=%s", desiredDigest, canonicalDigest)
+	}
+	if err := KubeletConfigurationContains(canonicalized, desired); err != nil {
+		t.Fatalf("KubeletConfigurationContains() rejected equivalent durations: %v", err)
+	}
+
+	different := []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nshutdownGracePeriod: 61s\nshutdownGracePeriodCriticalPods: 20s\n")
+	if err := KubeletConfigurationContains(different, desired); err == nil {
+		t.Fatal("KubeletConfigurationContains() accepted a different shutdown grace period")
+	}
+}
+
 func TestSupportedControlPlaneProfilingDelta(t *testing.T) {
 	live := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\n")
 	desired := []byte("apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nclusterName: katl\nkubernetesVersion: v1.36.1\napiServer:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\nscheduler:\n  extraArgs:\n    - name: profiling\n      value: \"false\"\n")

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:d08e76f58eb9246b30e66193b8b2684516b84dc62b5b9508c6f5dd7e03b8dba9",
+  "recipeDigest": "sha256:2fc893f255b088c0bf642c7fb7a612a61c997a7f5f945e8f70abcae5744b5d5a",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 4,
+      "artifactRevision": 5,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 2,
+      "artifactRevision": 3,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 1,
+      "artifactRevision": 2,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 1,
+      "artifactRevision": 2,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,7 +19,7 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
-	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.1" {
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.2" {
 		t.Fatalf("artifact version = %q", got)
 	}
 }

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -468,7 +468,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("collect live kubelet config: %w", err)
 	}
-	desiredKubeletConfig, err := kubeletMaxPodsConfig(liveKubeletConfig, 120)
+	desiredKubeletConfig, err := kubeletOperationConfig(liveKubeletConfig, 120)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	return nil
 }
 
-func kubeletMaxPodsConfig(live []byte, maxPods int) ([]byte, error) {
+func kubeletOperationConfig(live []byte, maxPods int) ([]byte, error) {
 	var document yaml.Node
 	if err := yaml.Unmarshal(live, &document); err != nil {
 		return nil, err
@@ -572,14 +572,22 @@ func kubeletMaxPodsConfig(live []byte, maxPods int) ([]byte, error) {
 		return nil, errors.New("live KubeletConfiguration must be one YAML mapping")
 	}
 	root := document.Content[0]
-	value := yamlMappingValue(root, "maxPods")
-	if value == nil {
-		value = &yaml.Node{}
-		root.Content = append(root.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "maxPods"}, value)
+	for _, field := range []struct {
+		name, tag, value string
+	}{
+		{name: "maxPods", tag: "!!int", value: strconv.Itoa(maxPods)},
+		{name: "shutdownGracePeriod", tag: "!!str", value: "60s"},
+		{name: "shutdownGracePeriodCriticalPods", tag: "!!str", value: "20s"},
+	} {
+		value := yamlMappingValue(root, field.name)
+		if value == nil {
+			value = &yaml.Node{}
+			root.Content = append(root.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: field.name}, value)
+		}
+		value.Kind = yaml.ScalarNode
+		value.Tag = field.tag
+		value.Value = field.value
 	}
-	value.Kind = yaml.ScalarNode
-	value.Tag = "!!int"
-	value.Value = strconv.Itoa(maxPods)
 	return yaml.Marshal(&document)
 }
 


### PR DESCRIPTION
Reports per-node progress while cluster apply rolls kubeadm-managed configuration across the control plane. It also compares kubelet durations by parsed value, preventing equivalent spellings such as 1m and 60s from producing false configuration changes. The previous path could appear stalled and could plan unnecessary kubelet work from text-only comparisons.