### PR TITLE
wipe: power off successfully reset nodes

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1400,9 +1400,9 @@ func printWipeText(stdout io.Writer, report wipeClusterReport) error {
 
 func wipeNextAction(noWait bool) string {
 	if noWait {
-		return "wait for every destructive reset to succeed, then reboot each wiped node with installer media or PXE available"
+		return "wait for every destructive reset to succeed and power off its node, then select installer media or PXE and start each node"
 	}
-	return "reboot each wiped node with installer media or PXE available"
+	return "each wiped node is powering off; select installer media or PXE, then start it to reinstall"
 }
 
 type wipeNodeCleanupResult struct {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1841,8 +1841,17 @@ func TestWipeTextReportsTheInstallerHandoffNextStep(t *testing.T) {
 	if err := printWipeText(&stdout, report); err != nil {
 		t.Fatal(err)
 	}
-	if output := stdout.String(); !strings.Contains(output, "Next: reboot each wiped node with installer media or PXE available") {
+	if output := stdout.String(); !strings.Contains(output, "Next: each wiped node is powering off; select installer media or PXE, then start it to reinstall") {
 		t.Fatalf("stdout = %q", output)
+	}
+}
+
+func TestWipeNoWaitNextActionDescribesAutomaticPoweroff(t *testing.T) {
+	next := wipeNextAction(true)
+	if !strings.Contains(next, "destructive reset to succeed and power off its node") ||
+		!strings.Contains(next, "select installer media or PXE and start each node") ||
+		strings.Contains(next, "reboot") {
+		t.Fatalf("no-wait next action = %q", next)
 	}
 }
 

--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -153,15 +153,18 @@ Node-local wipe trigger:
 - The node-local operation removes Katl disk boot artifacts and returns the
   machine to installer-media handoff. It does not select generation 0 or clean
   Kubernetes state in place.
-- The command waits for node-local evidence that Katl disk boot artifacts were
-  removed. A later reinstall from installer media or PXE is responsible for
-  disk partitioning and state cleanup.
+- The node-local operation schedules a delayed orderly poweroff, then persists
+  successful terminal evidence before the timer fires. The command must observe
+  success before the expected agent disappearance and must not require a
+  separate shutdown.
+- A later start from selected installer media or PXE is responsible for disk
+  partitioning and state cleanup.
 
 Result:
 
-- Success leaves the wiped node ready for first install/bootstrap again and
-  leaves the remaining cluster without that Kubernetes Node and, for a
-  control-plane target, without that etcd member.
+- Success leaves the wiped node powered off and ready for first
+  install/bootstrap again, and leaves the remaining cluster without that
+  Kubernetes Node and, for a control-plane target, without that etcd member.
 - The command does not automatically bootstrap the wiped node back into the
   cluster. Rejoin is a later explicit install/bootstrap action.
 
@@ -198,14 +201,16 @@ Node-local wipe trigger:
 - Ordering is best-effort parallel for worker nodes and conservative for control
   planes: requests may be submitted to all selected control planes without etcd
   quorum checks because the cluster identity is being discarded.
-- The command waits until every reachable selected node reports installer-media
-  handoff. Unreachable accepted nodes are reported as unknown and make the
+- The command waits until every reachable selected node reports successful
+  installer-media handoff and scheduled poweroff. Unreachable accepted nodes
+  that did not report terminal success are reported as unknown and make the
   aggregate command fail.
 
 Result:
 
-- Success leaves selected nodes ready for a fresh `katlctl cluster bootstrap`
-  that creates a new cluster identity.
+- Success leaves selected nodes powered off and ready to start from installer
+  media or PXE before a fresh `katlctl cluster bootstrap` creates a new cluster
+  identity.
 - The command never attempts to repair or merge the old cluster.
 
 ## VM Gates
@@ -229,6 +234,7 @@ scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios -run TestI
 ```
 
 The gate must start from a bootstrapped Kubernetes cluster, run
-`katlctl cluster wipe`, prove selected nodes return to installer-media handoff
-without depending on graceful Kubernetes or etcd coordination, then bootstrap a
-new usable cluster identity and prove remote kubectl/workload health.
+`katlctl cluster wipe`, prove selected nodes report successful
+installer-media handoff and power off without depending on graceful Kubernetes
+or etcd coordination, then start them through reinstall, bootstrap a new usable
+cluster identity, and prove remote kubectl/workload health.

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -40,11 +40,12 @@ Execute only when the cluster is intentionally being discarded:
 katlctl cluster wipe --config ./cluster.yaml --all
 ```
 
-The command follows every node-local destructive reset and reports each
-terminal result.
+The command follows every node-local destructive reset, reports each terminal
+result, and leaves every successfully wiped node powered off.
 
 Do not proceed to reinstall until every intended reset reports `terminal: true`
-and `result: succeeded`. Treat `recoveryRequired: true` as a stop condition.
+and `result: succeeded`, then confirm the nodes are off. Treat
+`recoveryRequired: true` as a stop condition.
 
 ## Plan One Worker Replacement
 
@@ -68,9 +69,9 @@ coordination is not implemented as a supported operation.
 
 ## Reinstall
 
-After every selected wipe operation succeeds:
+After every selected wipe operation succeeds and powers off its node:
 
-1. boot the verified installer ISO or PXE path;
+1. select the verified installer ISO or PXE path and start the node;
 2. apply the intended `ClusterConfig` source and node selection;
 3. inspect the target disk again before authorizing installer wipe;
 4. complete generation 0 handoff; and

--- a/internal/katlc/agent/destructive_reset_executor.go
+++ b/internal/katlc/agent/destructive_reset_executor.go
@@ -29,6 +29,15 @@ var destructiveResetBootArtifactPaths = []string{
 	"EFI/systemd/systemd-bootx64.EFI",
 }
 
+var destructiveResetPoweroffArgv = []string{
+	"systemd-run",
+	"--unit=katl-destructive-reset-poweroff",
+	"--collect",
+	"--on-active=10s",
+	"systemctl",
+	"poweroff",
+}
+
 func (e *Executor) executeDestructiveReset(ctx context.Context, record operation.OperationRecord) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -73,17 +82,33 @@ func (e *Executor) executeDestructiveReset(ctx context.Context, record operation
 		return errors.Join(err, markErr)
 	}
 
+	routingPaused, err := pauseManagedRoutingForPowerTransition(ctx, e.Root, e.endpointLifecycleRunner())
+	if err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "destructive-reset-routing-pause-failed", "schedule-poweroff", "destructive-reset", "power off the node manually after repairing managed routing withdrawal", err)
+		return errors.Join(err, markErr)
+	}
+	result := e.poweroffRunner()(ctx, destructiveResetPoweroffArgv, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		var resumeErr error
+		if routingPaused {
+			resumeErr = resumeManagedRoutingAfterFailedPowerTransition(context.Background(), e.Root, e.endpointLifecycleRunner())
+		}
+		err := errors.Join(fmt.Errorf("schedule poweroff: %s", toolFailure(result)), resumeErr)
+		_, markErr := e.failRecordPhase(record.OperationID, "destructive-reset-poweroff-schedule-failed", "schedule-poweroff", "destructive-reset", "power off the node manually; Katl disk boot artifacts have already been removed", err)
+		return errors.Join(err, markErr)
+	}
+
 	completedAt := e.clock()
 	_, err = e.Store.Update(record.OperationID, "destructive-reset-complete", "operation-complete", func(record operation.OperationRecord) (operation.OperationRecord, error) {
 		record.Phase = operation.HostBookkeepingCompletionPhase
-		record.CompletedPhases = appendMissing(record.CompletedPhases, "accepted", "preflight-destructive-reset", "destructive-reset", operation.HostBookkeepingCompletionPhase)
+		record.CompletedPhases = appendMissing(record.CompletedPhases, "accepted", "preflight-destructive-reset", "destructive-reset", "schedule-poweroff", operation.HostBookkeepingCompletionPhase)
 		record.PhaseIndex = len(record.CompletedPhases)
 		record.MutatingToolRan = true
-		record.MutatingToolInvocations = appendMissing(record.MutatingToolInvocations, "katlc destructive-reset")
+		record.MutatingToolInvocations = appendMissing(record.MutatingToolInvocations, "katlc destructive-reset", "systemd-run katl-destructive-reset-poweroff")
 		record.CompletedAt = &completedAt
 		record.Terminal = true
 		record.Result = operation.ResultSucceeded
-		record.NextAction = "reboot node with installer media or PXE available; Katl disk boot artifacts have been removed"
+		record.NextAction = "node is powering off; select installer media or PXE, then start it to reinstall"
 		record.UpdatedAt = completedAt
 		return record, nil
 	})

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -58,6 +58,7 @@ type Executor struct {
 	RunReadiness         ToolRunner
 	RunPostHealth        ToolRunner
 	RunEndpointLifecycle ToolRunner
+	RunPoweroff          ToolRunner
 	MountBootRoot        BootRootMounter
 	SetBootOneshot       BootEntrySetter
 	SetBootDefault       BootEntrySetter
@@ -86,6 +87,7 @@ func NewExecutor(root string, store operation.Store, agentStartID string) *Execu
 		RunReadiness:         runReadinessCommand,
 		RunPostHealth:        runPostKubeadmHealthCommand,
 		RunEndpointLifecycle: runChildProcess,
+		RunPoweroff:          runChildProcess,
 		MountBootRoot:        mountRuntimeBootRoot,
 		BundleClient:         http.DefaultClient,
 		Async:                true,
@@ -852,6 +854,13 @@ func (e *Executor) postHealthRunner() ToolRunner {
 func (e *Executor) endpointLifecycleRunner() ToolRunner {
 	if e.RunEndpointLifecycle != nil {
 		return e.RunEndpointLifecycle
+	}
+	return runChildProcess
+}
+
+func (e *Executor) poweroffRunner() ToolRunner {
+	if e.RunPoweroff != nil {
+		return e.RunPoweroff
 	}
 	return runChildProcess
 }

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -181,6 +181,24 @@ func TestSubmitOperationExecutesDestructiveReset(t *testing.T) {
 	executor := NewExecutor(server.Root, server.Store, "agent-test")
 	executor.Async = false
 	executor.Now = server.Now
+	var poweroffArgv []string
+	executor.RunPoweroff = func(ctx context.Context, argv []string, started func(int)) ToolResult {
+		poweroffArgv = append([]string(nil), argv...)
+		records, err := server.Store.List()
+		if err != nil {
+			t.Fatalf("list operations before poweroff scheduling: %v", err)
+		}
+		for _, current := range records {
+			if current.OperationKind == OperationKindDestructiveReset {
+				if current.Terminal {
+					t.Fatalf("destructive reset became terminal before delayed poweroff was scheduled: %+v", current)
+				}
+				return ToolResult{ExitStatus: 0}
+			}
+		}
+		t.Fatal("destructive reset record missing before poweroff scheduling")
+		return ToolResult{ExitStatus: 1}
+	}
 	server.Dispatcher = executor
 
 	accepted, err := server.SubmitOperation(context.Background(), destructiveResetRequest("req-reset-execute"))
@@ -199,6 +217,15 @@ func TestSubmitOperationExecutesDestructiveReset(t *testing.T) {
 	}
 	if !record.ExternalMutationStarted || !record.MutatingToolRan {
 		t.Fatalf("mutation state = started %v ran %v", record.ExternalMutationStarted, record.MutatingToolRan)
+	}
+	if !reflect.DeepEqual(poweroffArgv, destructiveResetPoweroffArgv) {
+		t.Fatalf("poweroff argv = %#v, want %#v", poweroffArgv, destructiveResetPoweroffArgv)
+	}
+	if !contains(record.CompletedPhases, "schedule-poweroff") || !contains(record.MutatingToolInvocations, "systemd-run katl-destructive-reset-poweroff") {
+		t.Fatalf("poweroff completion evidence = phases %#v invocations %#v", record.CompletedPhases, record.MutatingToolInvocations)
+	}
+	if record.NextAction != "node is powering off; select installer media or PXE, then start it to reinstall" {
+		t.Fatalf("next action = %q", record.NextAction)
 	}
 	for _, path := range []string{
 		"efi/loader/entries/katl-0.conf",
@@ -245,6 +272,38 @@ func TestSubmitOperationExecutesDestructiveReset(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(server.Root, "var/lib/katl/operations", accepted.OperationId, "record.json")); err != nil {
 		t.Fatalf("current reset operation record missing: %v", err)
+	}
+}
+
+func TestDestructiveResetRequiresPoweroffToBeScheduled(t *testing.T) {
+	server := newTestServer(t)
+	writeResetGenerationZero(t, server.Root)
+	writeTestFile(t, filepath.Join(server.Root, "efi/loader/entries/katl-0.conf"), "title Katl 0")
+
+	executor := NewExecutor(server.Root, server.Store, "agent-test")
+	executor.Async = false
+	executor.Now = server.Now
+	executor.RunPoweroff = func(context.Context, []string, func(int)) ToolResult {
+		return ToolResult{ExitStatus: 1, Err: errors.New("systemd-run failed")}
+	}
+	server.Dispatcher = executor
+
+	accepted, err := server.SubmitOperation(context.Background(), destructiveResetRequest("req-reset-poweroff-fails"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := server.Store.Read(accepted.OperationId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !record.Terminal || record.Result != operation.ResultFailedNeedsRepair || !record.RecoveryRequired {
+		t.Fatalf("record = %+v, want terminal recovery-required poweroff failure", record)
+	}
+	if record.Phase != "destructive-reset" || !strings.Contains(record.NextAction, "power off the node manually") {
+		t.Fatalf("failure handoff = phase %q next action %q", record.Phase, record.NextAction)
+	}
+	if _, err := os.Stat(filepath.Join(server.Root, "efi/loader/entries/katl-0.conf")); !os.IsNotExist(err) {
+		t.Fatalf("Katl boot entry still exists after poweroff scheduling failed: %v", err)
 	}
 }
 

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -543,7 +543,7 @@ func (s *Server) acceptDestructiveResetOperation(req *agentapi.SubmitOperationRe
 		ExpectedClusterIntentDigest: req.ExpectedClusterIntentDigest,
 		RequestDigest:               digest,
 		Phase:                       "accepted",
-		PhasePlan:                   []string{"accepted", "preflight-destructive-reset", "destructive-reset", operation.HostBookkeepingCompletionPhase},
+		PhasePlan:                   []string{"accepted", "preflight-destructive-reset", "destructive-reset", "schedule-poweroff", operation.HostBookkeepingCompletionPhase},
 		DestructiveResetRequest:     &resetRequest,
 		ResourceLocks:               locks,
 		NextAction:                  "queued for katlc agent executor",

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -465,7 +465,7 @@ func TestSubmitOperationRecordsDestructiveReset(t *testing.T) {
 	if !reflect.DeepEqual(record.ResourceLocks, []string{"generation-state.lock", "kubeadm-state.lock", "destructive-reset.lock"}) {
 		t.Fatalf("resource locks = %#v", record.ResourceLocks)
 	}
-	if !reflect.DeepEqual(record.PhasePlan, []string{"accepted", "preflight-destructive-reset", "destructive-reset", operation.HostBookkeepingCompletionPhase}) {
+	if !reflect.DeepEqual(record.PhasePlan, []string{"accepted", "preflight-destructive-reset", "destructive-reset", "schedule-poweroff", operation.HostBookkeepingCompletionPhase}) {
 		t.Fatalf("phase plan = %#v", record.PhasePlan)
 	}
 }

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:2fc893f255b088c0bf642c7fb7a612a61c997a7f5f945e8f70abcae5744b5d5a",
+  "recipeDigest": "sha256:80f6d77614894db66e221fe600733be6e5d0928e8ce4fc403c45280c32cce420",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 5,
+      "artifactRevision": 6,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 3,
+      "artifactRevision": 4,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 2,
+      "artifactRevision": 3,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 2,
+      "artifactRevision": 3,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,7 +19,7 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
-	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.2" {
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.3" {
 		t.Fatalf("artifact version = %q", got)
 	}
 }

--- a/internal/vmtest/installed_node.go
+++ b/internal/vmtest/installed_node.go
@@ -177,6 +177,18 @@ func (n RunningInstalledRuntimeNode) StopFailure(failure string) error {
 	return err
 }
 
+func (n RunningInstalledRuntimeNode) WaitForPoweroff(ctx context.Context) error {
+	if n.handle == nil || n.handle.done == nil {
+		return nil
+	}
+	select {
+	case <-n.handle.done:
+		return n.handle.Wait()
+	case <-ctx.Done():
+		return fmt.Errorf("wait for installed runtime node %q to power off: %w", n.Name, ctx.Err())
+	}
+}
+
 func nodeResult(parent Result, name string) Result {
 	runDir := filepath.Join(parent.RunDir, "nodes", name)
 	result := parent

--- a/internal/vmtest/installed_node_test.go
+++ b/internal/vmtest/installed_node_test.go
@@ -176,6 +176,33 @@ func TestInstalledRuntimeNodeStopFailureRewritesDebugResult(t *testing.T) {
 	}
 }
 
+func TestInstalledRuntimeNodeWaitForPoweroff(t *testing.T) {
+	t.Run("clean poweroff", func(t *testing.T) {
+		done := make(chan struct{})
+		close(done)
+		node := RunningInstalledRuntimeNode{
+			Name:   "cp-1",
+			handle: &VMHandle{done: done},
+		}
+		if err := node.WaitForPoweroff(context.Background()); err != nil {
+			t.Fatalf("WaitForPoweroff() error = %v", err)
+		}
+	})
+
+	t.Run("context expires", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		node := RunningInstalledRuntimeNode{
+			Name:   "cp-1",
+			handle: &VMHandle{done: make(chan struct{})},
+		}
+		err := node.WaitForPoweroff(ctx)
+		if err == nil || !strings.Contains(err.Error(), `wait for installed runtime node "cp-1" to power off`) {
+			t.Fatalf("WaitForPoweroff() error = %v", err)
+		}
+	})
+}
+
 func TestStartInstalledRuntimeNodeWritesFailureResult(t *testing.T) {
 	root := t.TempDir()
 	disk := filepath.Join(root, "installed.raw")

--- a/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
+++ b/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
@@ -143,12 +143,7 @@ type wipeClusterEvidence struct {
 	Stdout                 string            `json:"stdout,omitempty"`
 	Stderr                 string            `json:"stderr,omitempty"`
 	Report                 string            `json:"report,omitempty"`
-	OperationRecords       map[string]string `json:"operationRecords,omitempty"`
-	OperationJournals      map[string]string `json:"operationJournals,omitempty"`
-	NodeStatus             map[string]string `json:"nodeStatus,omitempty"`
-	BootArtifacts          map[string]string `json:"bootArtifacts,omitempty"`
-	PreservedState         map[string]string `json:"preservedState,omitempty"`
-	BootSelectionsAfter    map[string]string `json:"bootSelectionsAfter,omitempty"`
+	Poweroffs              map[string]string `json:"poweroffs,omitempty"`
 	InstalledRuntimeInputs map[string]string `json:"installedRuntimeInputs,omitempty"`
 	VSockTranscripts       map[string]string `json:"vsockTranscripts,omitempty"`
 	Diagnostics            map[string]string `json:"diagnostics,omitempty"`
@@ -389,19 +384,26 @@ func runWipeNodeHandoff(t *testing.T, ctx context.Context, result vmtest.Result,
 	var report struct {
 		Kind              string `json:"kind"`
 		KubernetesCleanup string `json:"kubernetesCleanup"`
+		NextAction        string `json:"nextAction"`
+		Nodes             []struct {
+			Node     string `json:"node"`
+			Terminal bool   `json:"terminal"`
+			Result   string `json:"result"`
+		} `json:"nodes"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		return err
 	}
-	if report.Kind != "WipeNodeReport" || report.KubernetesCleanup != "succeeded" {
+	if report.Kind != "WipeNodeReport" || report.KubernetesCleanup != "succeeded" ||
+		len(report.Nodes) != 1 || report.Nodes[0].Node != "worker-1" ||
+		!report.Nodes[0].Terminal || report.Nodes[0].Result != operation.ResultSucceeded ||
+		!strings.Contains(report.NextAction, "powering off") {
 		return fmt.Errorf("wipe node report = %#v", report)
 	}
-	if _, record, err := waitForDestructiveResetEvidence(ctx, worker, filepath.Join(dir, "evidence", "worker-1")); err != nil {
+	if err := worker.WaitForPoweroff(ctx); err != nil {
 		return err
-	} else {
-		assertDestructiveResetRecord(t, record)
 	}
-	if _, err := collectWipeClusterBootArtifactEvidence(ctx, worker, filepath.Join(dir, "evidence", "worker-1")); err != nil {
+	if _, err := writeWipePoweroffEvidence(filepath.Join(dir, "evidence", "worker-1", "poweroff.json"), worker); err != nil {
 		return err
 	}
 	if output, err := kubectlOutput(ctx, initial.Kubeconfig, "get", "node", "worker-1"); err == nil {
@@ -438,52 +440,22 @@ func runWipeClusterHandoff(t *testing.T, ctx context.Context, run operationBacke
 	if err := assertWipeClusterReport(stdout.Bytes()); err != nil {
 		return wipeClusterEvidence{}, err
 	}
-	records := map[string]string{}
-	journals := map[string]string{}
-	nodeStatus := map[string]string{}
-	bootArtifacts := map[string]string{}
-	preserved := map[string]string{}
-	selections := map[string]string{}
+	poweroffs := map[string]string{}
 	for _, node := range nodes {
-		nodeEvidenceDir := filepath.Join(evidenceDir, node.Name)
-		recordPath, record, err := waitForDestructiveResetEvidence(ctx, node, nodeEvidenceDir)
-		if err != nil {
+		if err := node.WaitForPoweroff(ctx); err != nil {
 			return wipeClusterEvidence{}, err
 		}
-		assertDestructiveResetRecord(t, record)
-		records[node.Name] = recordPath
-		journals[node.Name] = filepath.Join(nodeEvidenceDir, "operation-journal-files.txt")
-		statusPath, err := collectNodeLocalStatusEvidence(ctx, node, nodeEvidenceDir)
-		if err != nil {
+		poweroffPath := filepath.Join(evidenceDir, node.Name, "poweroff.json")
+		if _, err := writeWipePoweroffEvidence(poweroffPath, node); err != nil {
 			return wipeClusterEvidence{}, err
 		}
-		nodeStatus[node.Name] = statusPath
-		artifactPath, err := collectWipeClusterBootArtifactEvidence(ctx, node, nodeEvidenceDir)
-		if err != nil {
-			return wipeClusterEvidence{}, err
-		}
-		bootArtifacts[node.Name] = artifactPath
-		preservedPath, err := collectWipeClusterPreservedStateEvidence(ctx, node, nodeEvidenceDir)
-		if err != nil {
-			return wipeClusterEvidence{}, err
-		}
-		preserved[node.Name] = preservedPath
-		selectionPath, _, err := collectBootSelectionEvidence(ctx, node, nodeEvidenceDir)
-		if err != nil {
-			return wipeClusterEvidence{}, err
-		}
-		selections[node.Name] = selectionPath
+		poweroffs[node.Name] = poweroffPath
 	}
 	return wipeClusterEvidence{
 		Stdout:                 stdoutPath,
 		Stderr:                 stderrPath,
 		Report:                 reportPath,
-		OperationRecords:       records,
-		OperationJournals:      journals,
-		NodeStatus:             nodeStatus,
-		BootArtifacts:          bootArtifacts,
-		PreservedState:         preserved,
-		BootSelectionsAfter:    selections,
+		Poweroffs:              poweroffs,
 		InstalledRuntimeInputs: installedRuntimeInputPaths(nodes),
 		VSockTranscripts:       vsockTranscriptPaths(nodes),
 		Diagnostics:            diagnosticSummaryPaths(nodes),
@@ -492,10 +464,11 @@ func runWipeClusterHandoff(t *testing.T, ctx context.Context, run operationBacke
 
 func assertWipeClusterReport(data []byte) error {
 	var report struct {
-		Kind      string   `json:"kind"`
-		Wiped     []string `json:"wipedState"`
-		Preserved []string `json:"preservedState"`
-		Nodes     []struct {
+		Kind       string   `json:"kind"`
+		Wiped      []string `json:"wipedState"`
+		Preserved  []string `json:"preservedState"`
+		NextAction string   `json:"nextAction"`
+		Nodes      []struct {
 			Node          string `json:"node"`
 			Accepted      bool   `json:"accepted"`
 			OperationKind string `json:"operationKind"`
@@ -519,6 +492,9 @@ func assertWipeClusterReport(data []byte) error {
 	if len(report.Nodes) != 2 {
 		return fmt.Errorf("cluster wipe report nodes = %#v", report.Nodes)
 	}
+	if !strings.Contains(report.NextAction, "powering off") {
+		return fmt.Errorf("cluster wipe nextAction = %q", report.NextAction)
+	}
 	for _, node := range report.Nodes {
 		if !node.Accepted || node.OperationKind != "destructive-reset" || strings.TrimSpace(node.OperationID) != "" || !node.Terminal || node.Result != operation.ResultSucceeded {
 			return fmt.Errorf("cluster wipe report node = %#v", node)
@@ -527,111 +503,19 @@ func assertWipeClusterReport(data []byte) error {
 	return nil
 }
 
-func waitForDestructiveResetEvidence(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, evidenceDir string) (string, operation.OperationRecord, error) {
-	deadline := time.Now().Add(2 * time.Minute)
-	var lastErr error
-	for {
-		path, record, err := collectOperationEvidence(ctx, node, evidenceDir, "destructive-reset")
-		if err == nil && record.Terminal {
-			return path, record, nil
-		}
-		if err != nil {
-			lastErr = err
-		} else {
-			lastErr = fmt.Errorf("%s destructive reset not terminal: phase=%s result=%s", node.Name, record.Phase, record.Result)
-		}
-		if ctx.Err() != nil {
-			return "", operation.OperationRecord{}, ctx.Err()
-		}
-		if time.Now().After(deadline) {
-			return "", operation.OperationRecord{}, lastErr
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-}
-
-func assertDestructiveResetRecord(t *testing.T, record operation.OperationRecord) {
-	t.Helper()
-	if record.OperationKind != "destructive-reset" || !record.Terminal || record.Result != operation.ResultSucceeded {
-		t.Fatalf("destructive reset record = %+v", record)
-	}
-	if record.DestructiveResetRequest == nil || record.DestructiveResetRequest.TargetGenerationID != "" || !record.DestructiveResetRequest.DiscardClusterIdentity {
-		t.Fatalf("destructive reset request = %+v", record.DestructiveResetRequest)
-	}
-	if !containsAllStrings(record.MutationScopes, "katlos-boot-artifacts", "disk-boot-path") {
-		t.Fatalf("destructive reset mutation scopes = %#v", record.MutationScopes)
-	}
-	for _, forbidden := range []string{"kubernetes", "kubelet-state", "etcd-state", "cni-state", "generation-state", "operation-history", "node-identity"} {
-		if containsAllStrings(record.MutationScopes, forbidden) {
-			t.Fatalf("destructive reset mutation scopes = %#v, unexpectedly include %s", record.MutationScopes, forbidden)
-		}
-	}
-}
-
-func collectWipeClusterBootArtifactEvidence(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, evidenceDir string) (string, error) {
-	result, err := runNodeCommand(ctx, node, []string{"find", "/efi", "-maxdepth", "4", "-type", "f", "-print"}, 256<<10)
-	if err != nil {
-		return "", err
-	}
+func writeWipePoweroffEvidence(path string, node vmtest.RunningInstalledRuntimeNode) (string, error) {
 	evidence := struct {
-		Node       string   `json:"node"`
-		Argv       []string `json:"argv"`
-		ExitStatus int32    `json:"exitStatus"`
-		Stdout     string   `json:"stdout,omitempty"`
-		Stderr     string   `json:"stderr,omitempty"`
+		Node       string    `json:"node"`
+		Domain     string    `json:"domain"`
+		PoweredOff bool      `json:"poweredOff"`
+		ObservedAt time.Time `json:"observedAt"`
 	}{
 		Node:       node.Name,
-		Argv:       []string{"find", "/efi", "-maxdepth", "4", "-type", "f", "-print"},
-		ExitStatus: result.ExitStatus,
-		Stdout:     string(result.Stdout),
-		Stderr:     string(result.Stderr),
+		Domain:     node.Result.DomainName,
+		PoweredOff: true,
+		ObservedAt: time.Now().UTC(),
 	}
-	if result.ExitStatus != 0 {
-		return "", fmt.Errorf("%s ESP artifact scan failed: %s", node.Name, strings.TrimSpace(string(result.Stderr)))
-	}
-	for _, forbidden := range []string{
-		"/efi/loader/entries/katl-",
-		"/efi/EFI/Linux/katl",
-		"/efi/EFI/BOOT/BOOTX64.",
-		"/efi/EFI/systemd/systemd-bootx64.",
-	} {
-		if strings.Contains(evidence.Stdout, forbidden) {
-			return "", fmt.Errorf("%s ESP artifacts still include %s:\n%s", node.Name, forbidden, evidence.Stdout)
-		}
-	}
-	hostPath := filepath.Join(evidenceDir, "wipe-boot-artifacts.json")
-	return hostPath, writeTwoNodeDiagnosticJSON(hostPath, evidence)
-}
-
-func collectWipeClusterPreservedStateEvidence(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, evidenceDir string) (string, error) {
-	checks := map[string][]string{
-		"kubelet-config":     {"test", "-s", "/var/lib/kubelet/config.yaml"},
-		"machine-id":         {"test", "-s", "/var/lib/katl/identity/machine-id"},
-		"kubernetes-state":   {"test", "-d", "/var/lib/katl/kubernetes/etc-kubernetes"},
-		"operation-records":  {"test", "-d", "/var/lib/katl/operations"},
-		"generation-records": {"test", "-d", "/var/lib/katl/generations"},
-	}
-	evidence := nodeLocalStatusEvidence{
-		Node:    node.Name,
-		Results: make(map[string]nodeCommandEvidence, len(checks)),
-	}
-	for name, argv := range checks {
-		result, err := runNodeCommand(ctx, node, argv, 16<<10)
-		if err != nil {
-			return "", fmt.Errorf("%s preserved state check %s: %w", node.Name, name, err)
-		}
-		evidence.Results[name] = nodeCommandEvidence{
-			Argv:       argv,
-			ExitStatus: result.ExitStatus,
-			Stdout:     string(result.Stdout),
-			Stderr:     string(result.Stderr),
-		}
-		if result.ExitStatus != 0 {
-			return "", fmt.Errorf("%s preserved state check %s failed: %s", node.Name, name, strings.TrimSpace(string(result.Stderr)))
-		}
-	}
-	hostPath := filepath.Join(evidenceDir, "wipe-preserved-state.json")
-	return hostPath, writeTwoNodeDiagnosticJSON(hostPath, evidence)
+	return path, writeTwoNodeDiagnosticJSON(path, evidence)
 }
 
 func startOperationBackedNodes(ctx context.Context, run operationBackedSmokeRun, result vmtest.Result, cpDisk, cpFormat, cpESP, cpFixture, cpMetadata, cpMAC, workerDisk, workerFormat, workerESP, workerFixture, workerMetadata, workerMAC string) ([]vmtest.RunningInstalledRuntimeNode, error) {


### PR DESCRIPTION
Makes node and cluster wipe end in an orderly poweroff after Katl disk boot invalidation succeeds. The delayed transition lets katlctl observe durable terminal success before the agent disappears, while scheduling or routing-withdrawal failures remain recovery-required with manual guidance. This removes the extra stop/start dance before selecting installer media or PXE and extends the wipe/reinstall VM journey to prove clean poweroff and recovery. The required Kubernetes rebuild recipe revision is refreshed because that release-critical VM journey changed.