### PR TITLE
routing: tolerate transient API probe stalls

### DIFF
--- a/internal/installer/bgpapivip/bgpapivip.go
+++ b/internal/installer/bgpapivip/bgpapivip.go
@@ -33,6 +33,7 @@ const (
 	NetworkPath              = "/etc/systemd/network/05-katl-bgp-api-vip.network"
 	DummyNetDevPath          = "/etc/systemd/network/05-katl-bgp-api-vip.netdev"
 	defaultHealthPath        = "/readyz"
+	defaultHealthTimeout     = "5s"
 )
 
 var (
@@ -522,7 +523,7 @@ func normalizeHealth(health Health, endpoint Endpoint, vip netip.Prefix) (Health
 	health.Host = defaultString(health.Host, vip.Addr().String())
 	health.Path = defaultString(health.Path, defaultHealthPath)
 	health.Interval = defaultString(health.Interval, "2s")
-	health.Timeout = defaultString(health.Timeout, "1s")
+	health.Timeout = defaultString(health.Timeout, defaultHealthTimeout)
 	health.CARef = defaultString(health.CARef, "kube-apiserver-ca")
 	health.TLSServerName = defaultString(health.TLSServerName, endpoint.TLSServerName)
 	if health.Port == 0 {

--- a/internal/installer/bgpapivip/bgpapivip_test.go
+++ b/internal/installer/bgpapivip/bgpapivip_test.go
@@ -131,7 +131,10 @@ func TestRenderNativeEtcFilesMinimalIPv4DummyVIP(t *testing.T) {
 	if plan.Config.Endpoint.Port != 6443 || plan.Config.Endpoint.AddressFamily != "ipv4" {
 		t.Fatalf("normalized endpoint = %#v", plan.Config.Endpoint)
 	}
-	if plan.Config.Health.Path != "/readyz" || plan.Config.Health.TLSServerName != "api.home.example" {
+	if plan.Config.Health.Path != "/readyz" ||
+		plan.Config.Health.Timeout != defaultHealthTimeout ||
+		plan.Config.Health.FailureThreshold != 3 ||
+		plan.Config.Health.TLSServerName != "api.home.example" {
 		t.Fatalf("normalized health = %#v", plan.Config.Health)
 	}
 }

--- a/internal/installer/bgpapivip/controller_test.go
+++ b/internal/installer/bgpapivip/controller_test.go
@@ -74,6 +74,32 @@ func TestControllerWithdrawsAfterHealthFailure(t *testing.T) {
 	}
 }
 
+func TestControllerKeepsAdvertisingThroughTransientHealthFailures(t *testing.T) {
+	bird := &fakeBird{status: readyBirdStatus()}
+	health := &sequenceHealth{results: []HealthResult{
+		{Healthy: true, StatusCode: 200},
+		{Healthy: true, StatusCode: 200},
+		{Healthy: false, Error: "request timed out"},
+		{Healthy: false, Error: "request timed out"},
+		{Healthy: true, StatusCode: 200},
+	}}
+	controller := testController(bird, health)
+	var status Status
+	for range health.results {
+		var err error
+		status, err = controller.RunOnce(context.Background())
+		if err != nil {
+			t.Fatalf("RunOnce() error = %v", err)
+		}
+	}
+	if got, want := bird.advertisements, []bool{false, true}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("advertisements = %#v, want %#v", got, want)
+	}
+	if status.AdvertisementState != AdvertisementAdvertised || status.Withdrawn {
+		t.Fatalf("status advertisement = %#v", status)
+	}
+}
+
 func TestControllerReportsUnavailableAPIAsHealthStateNotRuntimeFailure(t *testing.T) {
 	bird := &fakeBird{status: readyBirdStatus()}
 	controller := testController(bird, fakeHealth{result: HealthResult{Error: "waiting for kubeadm API CA"}})

--- a/internal/installer/bgpapivip/testdata/minimal-ipv4-dummy.golden
+++ b/internal/installer/bgpapivip/testdata/minimal-ipv4-dummy.golden
@@ -51,7 +51,7 @@ spec:
         port: 6443
         path: /readyz
         interval: 2s
-        timeout: 1s
+        timeout: 5s
         successThreshold: 2
         failureThreshold: 3
         caRef: kube-apiserver-ca

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:80f6d77614894db66e221fe600733be6e5d0928e8ce4fc403c45280c32cce420",
+  "recipeDigest": "sha256:87607894139a65e202ed159c2334bf14962aa9f3d485b30c54e53aac294180bb",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 6,
+      "artifactRevision": 7,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 4,
+      "artifactRevision": 5,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 3,
+      "artifactRevision": 4,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 3,
+      "artifactRevision": 4,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,7 +19,7 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
-	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.3" {
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.4" {
 		t.Fatalf("artifact version = %q", got)
 	}
 }


### PR DESCRIPTION
Raises the internal API readiness probe timeout from one second to five seconds while preserving three-failure withdrawal and immediate explicit power-transition withdrawal. The one-second deadline let ordinary kubelet housekeeping stalls flap otherwise healthy BGP API VIP paths and reset operator connections. The controller regression proves transient misses recover without toggling BIRD, the focused BGP VM proof passed, and a replacement-pve live cp-2 drain completed with 240/240 stable-endpoint probes successful and no route transition.