### PR TITLE
upgrade: wait for Kubernetes recovery

### DIFF
--- a/cmd/katlctl/cluster_status.go
+++ b/cmd/katlctl/cluster_status.go
@@ -36,6 +36,7 @@ type clusterNodeStatus struct {
 	Generation           string                      `json:"generation,omitempty"`
 	Activity             string                      `json:"activity,omitempty"`
 	Error                string                      `json:"error,omitempty"`
+	Kubernetes           *kubernetesStatusReport     `json:"kubernetes,omitempty"`
 	ControlPlaneEndpoint *controlPlaneEndpointReport `json:"controlPlaneEndpoint,omitempty"`
 }
 
@@ -125,6 +126,7 @@ func runClusterStatus(ctx context.Context, opts clusterStatusOptions, stdout io.
 			result.KatlOSVersion = host.KatlOSVersion
 			result.Generation = host.Generation
 			result.Activity = host.Activity
+			result.Kubernetes = host.Kubernetes
 			result.ControlPlaneEndpoint = host.ControlPlaneEndpoint
 			report.Nodes[i] = result
 		}(i, node)
@@ -143,17 +145,23 @@ func runClusterStatus(ctx context.Context, opts clusterStatusOptions, stdout io.
 		}
 		fmt.Fprintln(w)
 	}
-	fmt.Fprintln(w, "NODE\tROLE\tREACHABLE\tHEALTH\tKATLOS\tGENERATION\tACTIVITY")
+	fmt.Fprintln(w, "NODE\tROLE\tREACHABLE\tHEALTH\tKUBERNETES\tKATLOS\tGENERATION\tACTIVITY")
 	for _, node := range report.Nodes {
 		reachable := "no"
-		health, version, generation, activity := "-", "-", "-", "-"
+		health, kubernetes, version, generation, activity := "-", "-", "-", "-", "-"
 		if node.Reachable {
 			reachable = "yes"
 			health, version, generation, activity = node.Health, node.KatlOSVersion, node.Generation, node.Activity
+			if node.Kubernetes != nil {
+				kubernetes = firstNonEmpty(strings.TrimSpace(node.Kubernetes.State), "unknown")
+			}
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", node.Node, node.Role, reachable, health, version, generation, activity)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", node.Node, node.Role, reachable, health, kubernetes, version, generation, activity)
 		if node.Error != "" {
 			fmt.Fprintf(w, "\t\t\t%s\n", node.Error)
+		}
+		if node.Kubernetes != nil && node.Kubernetes.FailureReason != "" {
+			fmt.Fprintf(w, "\t\t\t\t%s\n", node.Kubernetes.FailureReason)
 		}
 		if node.ControlPlaneEndpoint != nil && node.ControlPlaneEndpoint.FailureReason != "" {
 			fmt.Fprintf(w, "\t\t\tcontrol-plane endpoint: %s\n", node.ControlPlaneEndpoint.FailureReason)

--- a/cmd/katlctl/cluster_status_test.go
+++ b/cmd/katlctl/cluster_status_test.go
@@ -29,7 +29,10 @@ clusters:
     systemRole: worker
 `)
 	client := &fakeKatlcAgentClient{
-		nodeStatus: &agentapi.NodeStatus{CurrentGenerationId: "generation-1"},
+		nodeStatus: &agentapi.NodeStatus{
+			CurrentGenerationId: "generation-1",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "ready", Role: "control-plane", NodeName: "cp-1", KubeletActive: true, NodeReady: true, ControlPlaneComponentsReady: true},
+		},
 		generation: &agentapi.Generation{GenerationId: "generation-1", RuntimeVersion: "2026.7.0-alpha.15", CommitState: generation.CommitStateCommitted, BootState: generation.BootStateGood, HealthState: generation.HealthStateHealthy},
 	}
 	oldDial := dialKatlcAgent
@@ -51,6 +54,9 @@ clusters:
 	}
 	if len(report.Nodes) != 2 || !report.Nodes[0].Reachable || report.Nodes[0].Health != "OK" || report.Nodes[1].Reachable || !strings.Contains(report.Nodes[1].Error, "connection refused") {
 		t.Fatalf("report = %#v", report)
+	}
+	if report.Nodes[0].Kubernetes == nil || report.Nodes[0].Kubernetes.State != "ready" || !report.Nodes[0].Kubernetes.NodeReady {
+		t.Fatalf("Kubernetes report = %#v", report.Nodes[0].Kubernetes)
 	}
 }
 

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -46,7 +46,18 @@ type hostStatusReport struct {
 	KatlOSVersion        string                      `json:"katlosVersion,omitempty"`
 	NextBoot             string                      `json:"nextBoot,omitempty"`
 	Activity             string                      `json:"activity"`
+	Kubernetes           *kubernetesStatusReport     `json:"kubernetes,omitempty"`
 	ControlPlaneEndpoint *controlPlaneEndpointReport `json:"controlPlaneEndpoint,omitempty"`
+}
+
+type kubernetesStatusReport struct {
+	State                       string `json:"state"`
+	Role                        string `json:"role"`
+	NodeName                    string `json:"nodeName"`
+	KubeletActive               bool   `json:"kubeletActive"`
+	NodeReady                   bool   `json:"nodeReady"`
+	ControlPlaneComponentsReady bool   `json:"controlPlaneComponentsReady,omitempty"`
+	FailureReason               string `json:"failureReason,omitempty"`
 }
 
 type controlPlaneEndpointReport struct {
@@ -356,12 +367,28 @@ func newHostStatusReport(node, endpoint string, status *agentapi.NodeStatus, cur
 		Generation:           current.GetGenerationId(),
 		KatlOSVersion:        strings.TrimSpace(current.GetRuntimeVersion()),
 		Activity:             activity,
+		Kubernetes:           newKubernetesStatusReport(status.GetKubernetes()),
 		ControlPlaneEndpoint: newControlPlaneEndpointReport(status.GetControlPlaneEndpoint()),
 	}
 	if target := strings.TrimSpace(status.GetBootTargetGenerationId()); target != "" && target != current.GetGenerationId() {
 		report.NextBoot = target
 	}
 	return report
+}
+
+func newKubernetesStatusReport(status *agentapi.KubernetesStatus) *kubernetesStatusReport {
+	if status == nil {
+		return nil
+	}
+	return &kubernetesStatusReport{
+		State:                       status.GetState(),
+		Role:                        status.GetRole(),
+		NodeName:                    status.GetNodeName(),
+		KubeletActive:               status.GetKubeletActive(),
+		NodeReady:                   status.GetNodeReady(),
+		ControlPlaneComponentsReady: status.GetControlPlaneComponentsReady(),
+		FailureReason:               status.GetFailureReason(),
+	}
 }
 
 func newControlPlaneEndpointReport(status *agentapi.ControlPlaneEndpointStatus) *controlPlaneEndpointReport {
@@ -407,7 +434,7 @@ func writeHostStatus(stdout io.Writer, output string, report hostStatusReport) e
 		return writeJSON(stdout, report)
 	}
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-	if _, err := fmt.Fprintln(w, "NODE\tHEALTH\tKATLOS\tGENERATION\tNEXT BOOT\tACTIVITY"); err != nil {
+	if _, err := fmt.Fprintln(w, "NODE\tHEALTH\tKUBERNETES\tKATLOS\tGENERATION\tNEXT BOOT\tACTIVITY"); err != nil {
 		return err
 	}
 	version := report.KatlOSVersion
@@ -418,8 +445,17 @@ func writeHostStatus(stdout io.Writer, output string, report hostStatusReport) e
 	if nextBoot == "" {
 		nextBoot = "-"
 	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", report.Node, report.Health, version, report.Generation, nextBoot, report.Activity); err != nil {
+	kubernetes := "-"
+	if report.Kubernetes != nil {
+		kubernetes = firstNonEmpty(strings.TrimSpace(report.Kubernetes.State), "unknown")
+	}
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", report.Node, report.Health, kubernetes, version, report.Generation, nextBoot, report.Activity); err != nil {
 		return err
+	}
+	if report.Kubernetes != nil && report.Kubernetes.FailureReason != "" {
+		if _, err := fmt.Fprintf(w, "\t\t%s\n", report.Kubernetes.FailureReason); err != nil {
+			return err
+		}
 	}
 	if err := w.Flush(); err != nil {
 		return err

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -28,6 +28,10 @@ clusters:
 	fake.nodeStatus.OperationLockHeld = true
 	fake.nodeStatus.ActiveOperationIds = []string{"operation-secret"}
 	fake.nodeStatus.BootTargetGenerationId = "generation-staged"
+	fake.nodeStatus.Kubernetes = &agentapi.KubernetesStatus{
+		State: "waiting-for-node", Role: "control-plane", NodeName: "cp-1", KubeletActive: true,
+		FailureReason: "Kubernetes node cp-1 is not Ready",
+	}
 	fake.nodeStatus.ControlPlaneEndpoint = &agentapi.ControlPlaneEndpointStatus{
 		Endpoint: "api.home.example:6443", Vip: "10.40.0.10/32", State: "failed", FailureReason: "endpoint routing control socket unavailable",
 		Peers: []*agentapi.ControlPlaneEndpointPeerStatus{{Address: "10.0.0.1", Asn: 64500, State: "established", RouteExported: true}},
@@ -44,7 +48,7 @@ clusters:
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	output := stdout.String()
-	for _, want := range []string{"NODE", "HEALTH", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy", "CONTROL PLANE ENDPOINT", "api.home.example:6443", "10.40.0.10/32", "failed", "1/1", "endpoint routing control socket unavailable"} {
+	for _, want := range []string{"NODE", "HEALTH", "KUBERNETES", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "waiting-for-node", "Kubernetes node cp-1 is not Ready", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy", "CONTROL PLANE ENDPOINT", "api.home.example:6443", "10.40.0.10/32", "failed", "1/1", "endpoint routing control socket unavailable"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}
@@ -212,6 +216,7 @@ func healthyHostClient(machineID, agentStartID, generationID string) *fakeKatlcA
 			MachineId:           machineID,
 			AgentStartId:        agentStartID,
 			CurrentGenerationId: generationID,
+			Kubernetes:          &agentapi.KubernetesStatus{State: "not-configured"},
 		},
 		generation: &agentapi.Generation{
 			GenerationId: generationID,

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -259,6 +259,7 @@ type hostUpgradeReport struct {
 	Result     string `json:"result"`
 	Rebooted   bool   `json:"rebooted"`
 	BootHealth string `json:"bootHealth"`
+	Kubernetes string `json:"kubernetes,omitempty"`
 }
 
 type hostUpgradeArtifact struct {
@@ -276,7 +277,7 @@ func newHostUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobra
 	cmd := &cobra.Command{
 		Use:   "upgrade [VERSION] [NODE]",
 		Short: "Upgrade one KatlOS node and verify its next boot",
-		Long: `Upgrade one KatlOS node to a published KatlOS release or a locally built image, reboot it, and verify that it returns healthy.
+		Long: `Upgrade one KatlOS node to a published KatlOS release or a locally built image, reboot it, and verify that KatlOS and any existing Kubernetes role return healthy.
 
 Use the same ClusterConfig used to install the node. --artifact accepts an upgrade image and its generated .json metadata without requiring a published release. --endpoint can override the node's recorded address when DHCP or local routing changed. A saved katlctl context is optional shorthand for repeated commands.`,
 		Args: cobra.MaximumNArgs(2),
@@ -388,7 +389,18 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		if node == "" {
 			node = target.endpoint
 		}
-		return writeHostUpgradeReport(stdout, opts.output, hostUpgradeReport{Node: node, Version: opts.version, Image: image, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy})
+		recovery := nodeUpgradeRecovery(status)
+		if !recovery.Ready {
+			recoveryCtx, cancel := context.WithTimeout(ctx, opts.waitTimeout)
+			recoveryConn, recoveredStatus, recoveryErr := waitNodeKubernetesRecovery(recoveryCtx, node, target.endpoint, stderr)
+			cancel()
+			if recoveryErr != nil {
+				return recoveryErr
+			}
+			recovery = nodeUpgradeRecovery(recoveredStatus)
+			_ = recoveryConn.Close()
+		}
+		return writeHostUpgradeReport(stdout, opts.output, hostUpgradeReport{Node: node, Version: opts.version, Image: image, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy, Kubernetes: recovery.State})
 	}
 	if localArtifact != nil && !opts.plan {
 		localRef, err := stageHostUpgradeArtifact(ctx, conn.Client, strings.TrimSpace(opts.actor), status.GetMachineId(), *localArtifact, target.nodeName, stderr)
@@ -446,7 +458,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	}
 	_ = conn.Close()
 	bootCtx, cancel := context.WithTimeout(ctx, opts.waitTimeout)
-	verifiedConn, _, err := waitNodeBootHealth(bootCtx, report.Node, target.endpoint, agentStart, request.CandidateGenerationID, stderr)
+	verifiedConn, verified, err := waitNodeBootHealth(bootCtx, report.Node, target.endpoint, agentStart, request.CandidateGenerationID, stderr)
 	cancel()
 	if err != nil {
 		report.Result = "failed"
@@ -455,10 +467,12 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		_ = writeHostUpgradeReport(stdout, opts.output, report)
 		return err
 	}
+	recovery := nodeUpgradeRecovery(verified.Status)
 	_ = verifiedConn.Close()
 	report.Result = operation.ResultSucceeded
 	report.Rebooted = true
 	report.BootHealth = generation.HealthStateHealthy
+	report.Kubernetes = recovery.State
 	return writeHostUpgradeReport(stdout, opts.output, report)
 }
 
@@ -471,7 +485,11 @@ func writeHostUpgradeReport(stdout io.Writer, output string, report hostUpgradeR
 		return err
 	}
 	if report.Result == operation.ResultSucceeded {
-		_, err := fmt.Fprintf(stdout, "%s runs KatlOS %s; health %s\n", report.Node, report.Version, report.BootHealth)
+		kubernetes := ""
+		if report.Kubernetes != "" {
+			kubernetes = "; Kubernetes " + report.Kubernetes
+		}
+		_, err := fmt.Fprintf(stdout, "%s runs KatlOS %s; health %s%s\n", report.Node, report.Version, report.BootHealth, kubernetes)
 		return err
 	}
 	_, err := fmt.Fprintf(stdout, "%s KatlOS %s upgrade result: %s\n", report.Node, report.Version, report.Result)

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -1940,7 +1940,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 
 func TestHostUpgradeVersionStagesRebootsAndVerifiesHealth(t *testing.T) {
 	fake := &fakeKatlcAgentClient{
-		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current"},
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
 		generation:      &agentapi.Generation{GenerationId: "generation-current", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", Architecture: "x86_64"}}},
 		submitAccepted:  &agentapi.OperationAccepted{OperationId: "host-upgrade-01", OperationKind: "host-upgrade"},
 		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "arm-trial-boot"},
@@ -2092,7 +2092,7 @@ func TestHostUpgradeLocalArtifactRejectsRedundantVersion(t *testing.T) {
 
 func readyHostUpgradeClient() *fakeKatlcAgentClient {
 	fake := &fakeKatlcAgentClient{
-		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current"},
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
 		generation:      &agentapi.Generation{GenerationId: "generation-current", RuntimeArchitecture: "x86_64"},
 		submitAccepted:  &agentapi.OperationAccepted{OperationId: "host-upgrade-01", OperationKind: "host-upgrade"},
 		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "arm-trial-boot"},
@@ -2507,6 +2507,7 @@ type fakeKatlcAgentClient struct {
 	submitAccepted          *agentapi.OperationAccepted
 	nodeStatus              *agentapi.NodeStatus
 	nodeStatusErr           error
+	onGetNodeStatus         func()
 	generation              *agentapi.Generation
 	generationRequest       *agentapi.GetGenerationRequest
 	operationStatus         *agentapi.OperationStatus
@@ -2589,6 +2590,9 @@ func readyWipeClusterClient(machineID string) *fakeKatlcAgentClient {
 }
 
 func (c *fakeKatlcAgentClient) GetNodeStatus(context.Context, *agentapi.GetNodeStatusRequest, ...grpc.CallOption) (*agentapi.NodeStatus, error) {
+	if c.onGetNodeStatus != nil {
+		c.onGetNodeStatus()
+	}
 	return c.nodeStatus, c.nodeStatusErr
 }
 

--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -18,6 +18,12 @@ type verifiedNodeBoot struct {
 	Generation *agentapi.Generation
 }
 
+type nodeRecovery struct {
+	State  string
+	Reason string
+	Ready  bool
+}
+
 func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, actor, machineID, targetGeneration string) error {
 	accepted, err := client.Reboot(ctx, &agentapi.RebootRequest{
 		ApiVersion:         generation.APIVersion,
@@ -37,6 +43,7 @@ func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, ac
 
 func waitNodeBootHealth(ctx context.Context, nodeName, endpoint, previousAgentStart, targetGeneration string, stderr io.Writer) (katlcAgentConnection, verifiedNodeBoot, error) {
 	lastState := ""
+	lastRecovery := nodeRecovery{}
 	for {
 		conn, err := dialKatlcAgent(ctx, endpoint)
 		if err == nil {
@@ -58,7 +65,16 @@ func waitNodeBootHealth(ctx context.Context, nodeName, endpoint, previousAgentSt
 							return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s reported generation %s unhealthy after reboot", nodeName, targetGeneration)
 						}
 						if status.GetCurrentGenerationId() == targetGeneration && candidate.GetCommitState() == generation.CommitStateCommitted && candidate.GetBootState() == generation.BootStateGood && candidate.GetHealthState() == generation.HealthStateHealthy {
-							return conn, verifiedNodeBoot{Status: status, Generation: candidate}, nil
+							recovery := nodeUpgradeRecovery(status)
+							if recovery != lastRecovery {
+								lastRecovery = recovery
+								if !recovery.Ready {
+									_, _ = fmt.Fprintf(stderr, "upgrade node=%s waiting-for-kubernetes state=%s reason=%s\n", nodeName, recovery.State, recovery.Reason)
+								}
+							}
+							if recovery.Ready {
+								return conn, verifiedNodeBoot{Status: status, Generation: candidate}, nil
+							}
 						}
 					}
 				}
@@ -70,8 +86,106 @@ func waitNodeBootHealth(ctx context.Context, nodeName, endpoint, previousAgentSt
 		select {
 		case <-ctx.Done():
 			timer.Stop()
+			if lastRecovery.Reason != "" {
+				return katlcAgentConnection{}, verifiedNodeBoot{}, nodeKubernetesRecoveryTimeoutError(nodeName, targetGeneration, lastRecovery.Reason, ctx.Err())
+			}
 			return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s did not return healthy on generation %s: %w", nodeName, targetGeneration, ctx.Err())
 		case <-timer.C:
 		}
 	}
+}
+
+func waitNodeKubernetesRecovery(ctx context.Context, nodeName, endpoint string, stderr io.Writer) (katlcAgentConnection, *agentapi.NodeStatus, error) {
+	lastRecovery := nodeRecovery{}
+	for {
+		conn, err := dialKatlcAgent(ctx, endpoint)
+		if err == nil {
+			status, statusErr := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+			if statusErr == nil {
+				recovery := nodeUpgradeRecovery(status)
+				if recovery != lastRecovery {
+					lastRecovery = recovery
+					if !recovery.Ready {
+						_, _ = fmt.Fprintf(stderr, "upgrade node=%s waiting-for-kubernetes state=%s reason=%s\n", nodeName, recovery.State, recovery.Reason)
+					}
+				}
+				if recovery.Ready {
+					return conn, status, nil
+				}
+			}
+			_ = conn.Close()
+		}
+		timer := time.NewTimer(upgradeRebootPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return katlcAgentConnection{}, nil, nodeKubernetesRecoveryTimeoutError(nodeName, "", lastRecovery.Reason, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func nodeKubernetesRecoveryTimeoutError(nodeName, generationID, reason string, err error) error {
+	generationText := ""
+	if generationID = strings.TrimSpace(generationID); generationID != "" {
+		generationText = " on generation " + generationID
+	}
+	if reason = strings.TrimSpace(reason); reason == "" {
+		reason = "Kubernetes readiness was not reported"
+	}
+	return fmt.Errorf("node %s did not recover Kubernetes%s: %s: %w; do not schedule workloads on the node, and inspect it with 'katlctl node status'", nodeName, generationText, reason, err)
+}
+
+func nodeUpgradeRecovery(status *agentapi.NodeStatus) nodeRecovery {
+	kubernetes := status.GetKubernetes()
+	if kubernetes == nil {
+		return nodeRecovery{
+			State:  "unknown",
+			Reason: "Kubernetes status is not reported by the node agent",
+		}
+	}
+	recovery := nodeRecovery{State: strings.TrimSpace(kubernetes.GetState()), Reason: strings.TrimSpace(kubernetes.GetFailureReason())}
+	if recovery.State == "" {
+		recovery.State = "unknown"
+	}
+	if recovery.State == "not-configured" {
+		recovery.Ready = true
+		return recovery
+	}
+	if !kubernetes.GetKubeletActive() {
+		if recovery.Reason == "" {
+			recovery.Reason = "kubelet is not active"
+		}
+		return recovery
+	}
+	if strings.EqualFold(kubernetes.GetRole(), "control-plane") && !kubernetes.GetControlPlaneComponentsReady() {
+		if recovery.Reason == "" {
+			recovery.Reason = "local control-plane components are not ready"
+		}
+		return recovery
+	}
+	if !kubernetes.GetNodeReady() {
+		if recovery.Reason == "" {
+			recovery.Reason = "Kubernetes node is not Ready"
+		}
+		return recovery
+	}
+	if endpoint := status.GetControlPlaneEndpoint(); endpoint != nil {
+		if !endpoint.GetLocalApiReady() || !endpoint.GetRouteOriginated() || !strings.EqualFold(endpoint.GetState(), "advertised") {
+			recovery.State = "waiting-for-managed-endpoint"
+			recovery.Reason = "managed API endpoint is " + firstNonEmpty(strings.TrimSpace(endpoint.GetState()), "not ready")
+			return recovery
+		}
+		for _, exchange := range endpoint.GetRouteExchange() {
+			if !strings.EqualFold(exchange.GetState(), "established") {
+				recovery.State = "waiting-for-route-exchange"
+				recovery.Reason = fmt.Sprintf("route exchange %s is %s", exchange.GetName(), firstNonEmpty(strings.TrimSpace(exchange.GetState()), "not established"))
+				return recovery
+			}
+		}
+	}
+	recovery.State = "ready"
+	recovery.Reason = ""
+	recovery.Ready = true
+	return recovery
 }

--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -176,13 +176,6 @@ func nodeUpgradeRecovery(status *agentapi.NodeStatus) nodeRecovery {
 			recovery.Reason = "managed API endpoint is " + firstNonEmpty(strings.TrimSpace(endpoint.GetState()), "not ready")
 			return recovery
 		}
-		for _, exchange := range endpoint.GetRouteExchange() {
-			if !strings.EqualFold(exchange.GetState(), "established") {
-				recovery.State = "waiting-for-route-exchange"
-				recovery.Reason = fmt.Sprintf("route exchange %s is %s", exchange.GetName(), firstNonEmpty(strings.TrimSpace(exchange.GetState()), "not established"))
-				return recovery
-			}
-		}
 	}
 	recovery.State = "ready"
 	recovery.Reason = ""

--- a/cmd/katlctl/upgrade_reboot_test.go
+++ b/cmd/katlctl/upgrade_reboot_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+func TestNodeUpgradeRecoveryRequiresKubernetesAndManagedRouting(t *testing.T) {
+	readyKubernetes := &agentapi.KubernetesStatus{
+		State:                       "ready",
+		Role:                        "control-plane",
+		NodeName:                    "cp-1",
+		KubeletActive:               true,
+		NodeReady:                   true,
+		ControlPlaneComponentsReady: true,
+	}
+	tests := []struct {
+		name   string
+		status *agentapi.NodeStatus
+		state  string
+		reason string
+		ready  bool
+	}{
+		{
+			name: "status unsupported", status: &agentapi.NodeStatus{},
+			state: "unknown", reason: "Kubernetes status is not reported by the node agent",
+		},
+		{
+			name: "not bootstrapped", status: &agentapi.NodeStatus{Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
+			state: "not-configured", ready: true,
+		},
+		{
+			name:   "node not ready",
+			status: &agentapi.NodeStatus{Kubernetes: &agentapi.KubernetesStatus{State: "waiting-for-node", Role: "worker", KubeletActive: true, FailureReason: "Kubernetes node worker-1 is not Ready"}},
+			state:  "waiting-for-node", reason: "Kubernetes node worker-1 is not Ready",
+		},
+		{
+			name: "managed endpoint not ready",
+			status: &agentapi.NodeStatus{
+				Kubernetes:           readyKubernetes,
+				ControlPlaneEndpoint: &agentapi.ControlPlaneEndpointStatus{State: "waiting-for-apiserver"},
+			},
+			state: "waiting-for-managed-endpoint", reason: "managed API endpoint is waiting-for-apiserver",
+		},
+		{
+			name: "route exchange not ready",
+			status: &agentapi.NodeStatus{
+				Kubernetes: readyKubernetes,
+				ControlPlaneEndpoint: &agentapi.ControlPlaneEndpointStatus{
+					State: "advertised", LocalApiReady: true, RouteOriginated: true,
+					RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "passive"}},
+				},
+			},
+			state: "waiting-for-route-exchange", reason: "route exchange cilium is passive",
+		},
+		{
+			name: "ready",
+			status: &agentapi.NodeStatus{
+				Kubernetes: readyKubernetes,
+				ControlPlaneEndpoint: &agentapi.ControlPlaneEndpointStatus{
+					State: "advertised", LocalApiReady: true, RouteOriginated: true,
+					RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "established"}},
+				},
+			},
+			state: "ready", ready: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := nodeUpgradeRecovery(test.status)
+			if got.State != test.state || got.Reason != test.reason || got.Ready != test.ready {
+				t.Fatalf("recovery = %#v", got)
+			}
+		})
+	}
+}
+
+func TestWaitNodeBootHealthWaitsForKubernetesRecovery(t *testing.T) {
+	fake := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			AgentStartId:        "after",
+			CurrentGenerationId: "katlos-next",
+			Kubernetes: &agentapi.KubernetesStatus{
+				State:         "waiting-for-node",
+				Role:          "control-plane",
+				NodeName:      "cp-1",
+				KubeletActive: true,
+				FailureReason: "Kubernetes node cp-1 is not Ready",
+			},
+		},
+		generation: &agentapi.Generation{
+			GenerationId: "katlos-next",
+			CommitState:  generation.CommitStateCommitted,
+			BootState:    generation.BootStateGood,
+			HealthState:  generation.HealthStateHealthy,
+		},
+	}
+	polls := 0
+	fake.onGetNodeStatus = func() {
+		polls++
+		if polls < 3 {
+			return
+		}
+		fake.nodeStatus.Kubernetes = &agentapi.KubernetesStatus{
+			State:                       "ready",
+			Role:                        "control-plane",
+			NodeName:                    "cp-1",
+			KubeletActive:               true,
+			NodeReady:                   true,
+			ControlPlaneComponentsReady: true,
+		}
+		fake.nodeStatus.ControlPlaneEndpoint = &agentapi.ControlPlaneEndpointStatus{
+			State: "advertised", LocalApiReady: true, RouteOriginated: true,
+			RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "established"}},
+		}
+	}
+	installKatlcDial(t, func(endpoint string) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("endpoint = %q", endpoint)
+		}
+	}, fake)
+	previousPollInterval := upgradeRebootPollInterval
+	upgradeRebootPollInterval = time.Millisecond
+	t.Cleanup(func() { upgradeRebootPollInterval = previousPollInterval })
+
+	var progress bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, verified, err := waitNodeBootHealth(ctx, "cp-1", "10.0.0.11:9443", "before", "katlos-next", &progress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	if polls < 3 || !nodeUpgradeRecovery(verified.Status).Ready {
+		t.Fatalf("polls = %d, status = %#v", polls, verified.Status)
+	}
+	if output := progress.String(); !strings.Contains(output, "waiting-for-kubernetes state=waiting-for-node") || !strings.Contains(output, "Kubernetes node cp-1 is not Ready") {
+		t.Fatalf("progress = %q", output)
+	}
+}
+
+func TestCurrentHostUpgradeWaitsForKubernetesRecovery(t *testing.T) {
+	const generationID = "katlos-2026.7.0-alpha.9"
+	fake := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			CurrentGenerationId: generationID,
+			Kubernetes: &agentapi.KubernetesStatus{
+				State:         "waiting-for-node",
+				Role:          "worker",
+				NodeName:      "cp-1",
+				KubeletActive: true,
+				FailureReason: "Kubernetes node cp-1 is not Ready",
+			},
+		},
+		generation: &agentapi.Generation{
+			GenerationId:        generationID,
+			RuntimeArchitecture: "x86_64",
+			CommitState:         generation.CommitStateCommitted,
+			BootState:           generation.BootStateGood,
+			HealthState:         generation.HealthStateHealthy,
+		},
+	}
+	polls := 0
+	fake.onGetNodeStatus = func() {
+		polls++
+		if polls >= 3 {
+			fake.nodeStatus.Kubernetes.State = "ready"
+			fake.nodeStatus.Kubernetes.NodeReady = true
+			fake.nodeStatus.Kubernetes.FailureReason = ""
+		}
+	}
+	installKatlcDial(t, nil, fake)
+	previousPollInterval := upgradeRebootPollInterval
+	upgradeRebootPollInterval = time.Millisecond
+	t.Cleanup(func() { upgradeRebootPollInterval = previousPollInterval })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"node", "upgrade", "2026.7.0-alpha.9", "cp-1", "--config", writeClusterConfig(t), "--timeout", "1s"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.submitRequest != nil || len(fake.rebootRequests) != 0 {
+		t.Fatalf("submitted = %#v, reboots = %d", fake.submitRequest, len(fake.rebootRequests))
+	}
+	if polls < 3 || !strings.Contains(stdout.String(), "Kubernetes ready") || !strings.Contains(stderr.String(), "waiting-for-kubernetes") {
+		t.Fatalf("polls = %d, stdout = %q, stderr = %q", polls, stdout.String(), stderr.String())
+	}
+}
+
+func TestWaitNodeKubernetesRecoveryTimeoutIsActionable(t *testing.T) {
+	fake := &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{Kubernetes: &agentapi.KubernetesStatus{
+		State: "waiting-for-control-plane", Role: "control-plane", KubeletActive: true, NodeReady: true,
+		FailureReason: "local etcd component is not running",
+	}}}
+	installKatlcDial(t, nil, fake)
+	previousPollInterval := upgradeRebootPollInterval
+	upgradeRebootPollInterval = time.Millisecond
+	t.Cleanup(func() { upgradeRebootPollInterval = previousPollInterval })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, _, err := waitNodeKubernetesRecovery(ctx, "cp-1", "10.0.0.11:9443", &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "local etcd component is not running") || !strings.Contains(err.Error(), "do not schedule workloads") || !strings.Contains(err.Error(), "katlctl node status") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/cmd/katlctl/upgrade_reboot_test.go
+++ b/cmd/katlctl/upgrade_reboot_test.go
@@ -49,7 +49,7 @@ func TestNodeUpgradeRecoveryRequiresKubernetesAndManagedRouting(t *testing.T) {
 			state: "waiting-for-managed-endpoint", reason: "managed API endpoint is waiting-for-apiserver",
 		},
 		{
-			name: "route exchange not ready",
+			name: "passive optional route exchange",
 			status: &agentapi.NodeStatus{
 				Kubernetes: readyKubernetes,
 				ControlPlaneEndpoint: &agentapi.ControlPlaneEndpointStatus{
@@ -57,7 +57,7 @@ func TestNodeUpgradeRecoveryRequiresKubernetesAndManagedRouting(t *testing.T) {
 					RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "passive"}},
 				},
 			},
-			state: "waiting-for-route-exchange", reason: "route exchange cilium is passive",
+			state: "ready", ready: true,
 		},
 		{
 			name: "ready",

--- a/docs/operations/upgrade-host.md
+++ b/docs/operations/upgrade-host.md
@@ -2,8 +2,9 @@
 
 KatlOS host upgrades are one-node-at-a-time operations. The normal command
 resolves a release, stages its root and UKI into the inactive slot, reboots into
-a bounded trial, and waits for boot health. It does not upgrade Kubernetes or
-orchestrate availability across several hosts.
+a bounded trial, and waits for both boot health and recovery of any existing
+Kubernetes role. It does not upgrade Kubernetes, drain the node, or orchestrate
+availability across several hosts.
 
 ## Preconditions
 
@@ -41,11 +42,13 @@ For repeated day-two commands, `katlctl context save --config ./cluster.yaml`
 can save this topology locally. That context is optional; it is not a second
 cluster configuration operators must maintain.
 
-`katlctl` follows staging progress, asks the node agent to reboot,
-waits for the agent to restart, and requires the selected generation to be
-committed, booted, and healthy. The default result is concise text; use
-`--output json` when automation needs the structured `rebooted` and
-`bootHealth` fields. Check workload availability before upgrading another host.
+`katlctl` follows staging progress, asks the node agent to reboot, waits for the
+agent to restart, and requires the selected generation to be committed, booted,
+and healthy. On a bootstrapped node it also waits for kubelet, Node Ready, local
+control-plane components where applicable, and the managed API and route
+exchange paths. The default result is concise text; use `--output json` when
+automation needs the structured `rebooted`, `bootHealth`, and `kubernetes`
+fields. Check workload availability before upgrading another host.
 
 During the reboot, the console may show a containerd stop-job
 countdown after the containerd daemon has exited. Containerd deliberately keeps
@@ -62,3 +65,6 @@ reports that rollback and stops. It does not
 undo Kubernetes, etcd, workload, or external-infrastructure changes. If the
 operation record says `recoveryRequired: true`, or the node fails to return,
 stop the rollout and collect the evidence in [Troubleshoot KatlOS](troubleshoot.md).
+If KatlOS returns but Kubernetes does not recover before the timeout, do not
+schedule workloads on that node. `katlctl node status` reports whether kubelet,
+Node Ready, local control-plane components, or managed routing is still waiting.

--- a/internal/katlc/agent/kubernetes_status.go
+++ b/internal/katlc/agent/kubernetes_status.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+const kubernetesStatusProbeTimeout = 5 * time.Second
+
+func nodeKubernetesStatus(ctx context.Context, root string, run ToolRunner) (*agentapi.KubernetesStatus, error) {
+	kubeletConfig := rootedRuntimePath(root, "/etc/kubernetes/kubelet.conf")
+	if _, err := os.Stat(kubeletConfig); errors.Is(err, os.ErrNotExist) {
+		return &agentapi.KubernetesStatus{State: "not-configured"}, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("inspect kubelet configuration: %w", err)
+	}
+
+	nodeName, err := kubernetesNodeName(root)
+	if err != nil {
+		return nil, err
+	}
+	report := &agentapi.KubernetesStatus{
+		State:    "waiting-for-kubelet",
+		Role:     "worker",
+		NodeName: nodeName,
+	}
+	adminConfig := rootedRuntimePath(root, "/etc/kubernetes/admin.conf")
+	if info, statErr := os.Stat(adminConfig); statErr == nil && !info.IsDir() {
+		report.Role = "control-plane"
+	} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect control-plane configuration: %w", statErr)
+	}
+
+	if run == nil {
+		return nil, fmt.Errorf("Kubernetes status runner is not configured")
+	}
+	if _, ok := kubernetesStatusCommand(ctx, run, []string{"/usr/bin/systemctl", "is-active", "--quiet", "kubelet.service"}, false); !ok {
+		report.FailureReason = "kubelet is not active"
+		return report, nil
+	}
+	report.KubeletActive = true
+
+	if report.Role == "control-plane" {
+		for _, component := range []string{"etcd", "kube-apiserver", "kube-controller-manager", "kube-scheduler"} {
+			if _, ok := kubernetesStatusCommand(ctx, run, []string{"/usr/bin/crictl", "ps", "--state", "Running", "--name", component, "-q"}, true); !ok {
+				report.State = "waiting-for-control-plane"
+				report.FailureReason = "local " + component + " component is not running"
+				return report, nil
+			}
+		}
+		report.ControlPlaneComponentsReady = true
+	}
+
+	readConfig := kubeletConfig
+	if report.Role == "control-plane" {
+		readConfig = adminConfig
+	}
+	readyState, ok := kubernetesStatusCommand(ctx, run, []string{
+		"/usr/bin/kubectl", "--kubeconfig", readConfig,
+		"get", "node", nodeName,
+		"-o", `jsonpath={.status.conditions[?(@.type=="Ready")].status}`,
+	}, true)
+	if !ok || !strings.EqualFold(strings.TrimSpace(readyState), "true") {
+		report.State = "waiting-for-node"
+		report.FailureReason = "Kubernetes node " + nodeName + " is not Ready"
+		return report, nil
+	}
+	report.NodeReady = true
+	report.State = "ready"
+	return report, nil
+}
+
+func kubernetesNodeName(root string) (string, error) {
+	data, err := os.ReadFile(rootedRuntimePath(root, "/etc/hostname"))
+	if err == nil {
+		if name := strings.TrimSpace(string(data)); name != "" {
+			return name, nil
+		}
+	}
+	if strings.TrimSpace(root) != "" && filepath.Clean(root) != "/" {
+		if err != nil {
+			return "", fmt.Errorf("read Kubernetes node name: %w", err)
+		}
+		return "", fmt.Errorf("read Kubernetes node name: /etc/hostname is empty")
+	}
+	name, hostnameErr := os.Hostname()
+	if hostnameErr != nil {
+		return "", fmt.Errorf("read Kubernetes node name: %w", errors.Join(err, hostnameErr))
+	}
+	if name = strings.TrimSpace(name); name == "" {
+		return "", fmt.Errorf("read Kubernetes node name: hostname is empty")
+	}
+	return name, nil
+}
+
+func kubernetesStatusCommand(ctx context.Context, run ToolRunner, argv []string, requireOutput bool) (string, bool) {
+	probeCtx, cancel := context.WithTimeout(ctx, kubernetesStatusProbeTimeout)
+	defer cancel()
+	result := run(probeCtx, argv, func(int) {})
+	if result.Err != nil || result.ExitStatus != 0 {
+		return "", false
+	}
+	output := strings.TrimSpace(string(result.Stdout))
+	return output, !requireOutput || output != ""
+}

--- a/internal/katlc/agent/kubernetes_status_test.go
+++ b/internal/katlc/agent/kubernetes_status_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNodeKubernetesStatusReportsNotConfiguredBeforeBootstrap(t *testing.T) {
+	called := false
+	status, err := nodeKubernetesStatus(context.Background(), t.TempDir(), func(context.Context, []string, func(int)) ToolResult {
+		called = true
+		return ToolResult{}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.GetState() != "not-configured" || called {
+		t.Fatalf("status = %#v, runner called = %t", status, called)
+	}
+}
+
+func TestNodeKubernetesStatusReportsReadyControlPlane(t *testing.T) {
+	root := t.TempDir()
+	writeKubernetesStatusFile(t, root, "etc/hostname", "cp-1\n")
+	writeKubernetesStatusFile(t, root, "etc/kubernetes/kubelet.conf", "kubelet\n")
+	writeKubernetesStatusFile(t, root, "etc/kubernetes/admin.conf", "admin\n")
+
+	var commands [][]string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		commands = append(commands, append([]string(nil), argv...))
+		switch argv[0] {
+		case "/usr/bin/systemctl":
+			return ToolResult{}
+		case "/usr/bin/crictl":
+			return ToolResult{Stdout: []byte("container-id\n")}
+		case "/usr/bin/kubectl":
+			return ToolResult{Stdout: []byte("True")}
+		default:
+			return ToolResult{Err: errors.New("unexpected command"), ExitStatus: 1}
+		}
+	}
+	status, err := nodeKubernetesStatus(context.Background(), root, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.GetState() != "ready" || status.GetRole() != "control-plane" || status.GetNodeName() != "cp-1" || !status.GetKubeletActive() || !status.GetNodeReady() || !status.GetControlPlaneComponentsReady() || status.GetFailureReason() != "" {
+		t.Fatalf("status = %#v", status)
+	}
+	if len(commands) != 6 {
+		t.Fatalf("commands = %#v, want kubelet, four components, and Node Ready", commands)
+	}
+	wantKubeconfig := filepath.Join(root, "etc/kubernetes/admin.conf")
+	if got := commands[5]; len(got) < 3 || got[2] != wantKubeconfig {
+		t.Fatalf("Node Ready command = %#v, want kubeconfig %s", got, wantKubeconfig)
+	}
+}
+
+func TestNodeKubernetesStatusExplainsUnreadyNode(t *testing.T) {
+	root := t.TempDir()
+	writeKubernetesStatusFile(t, root, "etc/hostname", "worker-1\n")
+	writeKubernetesStatusFile(t, root, "etc/kubernetes/kubelet.conf", "kubelet\n")
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		if argv[0] == "/usr/bin/kubectl" {
+			return ToolResult{Stdout: []byte("False")}
+		}
+		return ToolResult{}
+	}
+	status, err := nodeKubernetesStatus(context.Background(), root, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.GetState() != "waiting-for-node" || status.GetRole() != "worker" || !status.GetKubeletActive() || status.GetNodeReady() || !strings.Contains(status.GetFailureReason(), "worker-1 is not Ready") {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestNodeKubernetesStatusStopsAtMissingControlPlaneComponent(t *testing.T) {
+	root := t.TempDir()
+	writeKubernetesStatusFile(t, root, "etc/hostname", "cp-1\n")
+	writeKubernetesStatusFile(t, root, "etc/kubernetes/kubelet.conf", "kubelet\n")
+	writeKubernetesStatusFile(t, root, "etc/kubernetes/admin.conf", "admin\n")
+	var components []string
+	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		if argv[0] != "/usr/bin/crictl" {
+			return ToolResult{}
+		}
+		components = append(components, argv[5])
+		if argv[5] == "kube-apiserver" {
+			return ToolResult{ExitStatus: 1}
+		}
+		return ToolResult{Stdout: []byte("container-id\n")}
+	}
+	status, err := nodeKubernetesStatus(context.Background(), root, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.GetState() != "waiting-for-control-plane" || status.GetControlPlaneComponentsReady() || status.GetFailureReason() != "local kube-apiserver component is not running" {
+		t.Fatalf("status = %#v", status)
+	}
+	if !reflect.DeepEqual(components, []string{"etcd", "kube-apiserver"}) {
+		t.Fatalf("components = %#v", components)
+	}
+}
+
+func writeKubernetesStatusFile(t *testing.T, root, relative, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -72,6 +72,7 @@ type Server struct {
 	Dispatcher              Dispatcher
 	RunJoinMaterial         ToolRunner
 	RunEndpointLifecycle    ToolRunner
+	RunKubernetesStatus     ToolRunner
 	RunReboot               ToolRunner
 	RunShutdown             ToolRunner
 	Now                     func() time.Time
@@ -90,6 +91,7 @@ func NewServer(root string, store operation.Store) *Server {
 		SupportedOperationKinds: append([]string(nil), bootstrapOperationKinds...),
 		RunJoinMaterial:         runChildProcess,
 		RunEndpointLifecycle:    runChildProcess,
+		RunKubernetesStatus:     runChildProcess,
 		RunReboot:               runChildProcess,
 		RunShutdown:             runChildProcess,
 		Now:                     func() time.Time { return time.Now().UTC() },
@@ -222,6 +224,10 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "read control-plane endpoint status: %v", err)
 	}
+	kubernetesStatus, err := nodeKubernetesStatus(ctx, s.Root, s.RunKubernetesStatus)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "read Kubernetes status: %v", err)
+	}
 	bootTargetGenerationID := currentGenerationID
 	if selection, selectionErr := generation.ReadBootSelection(s.Root); selectionErr == nil {
 		if target := strings.TrimSpace(selection.TargetBootGenerationID); target != "" {
@@ -242,6 +248,7 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 		CurrentGenerationId:     currentGenerationID,
 		BootTargetGenerationId:  bootTargetGenerationID,
 		ControlPlaneEndpoint:    endpointStatus,
+		Kubernetes:              kubernetesStatus,
 	}, nil
 }
 

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -70,6 +70,7 @@ type NodeStatus struct {
 	CurrentGenerationId     string                      `protobuf:"bytes,9,opt,name=current_generation_id,json=currentGenerationId,proto3" json:"current_generation_id,omitempty"`
 	BootTargetGenerationId  string                      `protobuf:"bytes,10,opt,name=boot_target_generation_id,json=bootTargetGenerationId,proto3" json:"boot_target_generation_id,omitempty"`
 	ControlPlaneEndpoint    *ControlPlaneEndpointStatus `protobuf:"bytes,11,opt,name=control_plane_endpoint,json=controlPlaneEndpoint,proto3" json:"control_plane_endpoint,omitempty"`
+	Kubernetes              *KubernetesStatus           `protobuf:"bytes,12,opt,name=kubernetes,proto3" json:"kubernetes,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -181,6 +182,105 @@ func (x *NodeStatus) GetControlPlaneEndpoint() *ControlPlaneEndpointStatus {
 	return nil
 }
 
+func (x *NodeStatus) GetKubernetes() *KubernetesStatus {
+	if x != nil {
+		return x.Kubernetes
+	}
+	return nil
+}
+
+type KubernetesStatus struct {
+	state                       protoimpl.MessageState `protogen:"open.v1"`
+	State                       string                 `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	Role                        string                 `protobuf:"bytes,2,opt,name=role,proto3" json:"role,omitempty"`
+	NodeName                    string                 `protobuf:"bytes,3,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	KubeletActive               bool                   `protobuf:"varint,4,opt,name=kubelet_active,json=kubeletActive,proto3" json:"kubelet_active,omitempty"`
+	NodeReady                   bool                   `protobuf:"varint,5,opt,name=node_ready,json=nodeReady,proto3" json:"node_ready,omitempty"`
+	ControlPlaneComponentsReady bool                   `protobuf:"varint,6,opt,name=control_plane_components_ready,json=controlPlaneComponentsReady,proto3" json:"control_plane_components_ready,omitempty"`
+	FailureReason               string                 `protobuf:"bytes,7,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
+}
+
+func (x *KubernetesStatus) Reset() {
+	*x = KubernetesStatus{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubernetesStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubernetesStatus) ProtoMessage() {}
+
+func (x *KubernetesStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KubernetesStatus.ProtoReflect.Descriptor instead.
+func (*KubernetesStatus) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *KubernetesStatus) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+func (x *KubernetesStatus) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *KubernetesStatus) GetNodeName() string {
+	if x != nil {
+		return x.NodeName
+	}
+	return ""
+}
+
+func (x *KubernetesStatus) GetKubeletActive() bool {
+	if x != nil {
+		return x.KubeletActive
+	}
+	return false
+}
+
+func (x *KubernetesStatus) GetNodeReady() bool {
+	if x != nil {
+		return x.NodeReady
+	}
+	return false
+}
+
+func (x *KubernetesStatus) GetControlPlaneComponentsReady() bool {
+	if x != nil {
+		return x.ControlPlaneComponentsReady
+	}
+	return false
+}
+
+func (x *KubernetesStatus) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
 type ControlPlaneEndpointStatus struct {
 	state                 protoimpl.MessageState                     `protogen:"open.v1"`
 	Endpoint              string                                     `protobuf:"bytes,1,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
@@ -200,7 +300,7 @@ type ControlPlaneEndpointStatus struct {
 
 func (x *ControlPlaneEndpointStatus) Reset() {
 	*x = ControlPlaneEndpointStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[2]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -212,7 +312,7 @@ func (x *ControlPlaneEndpointStatus) String() string {
 func (*ControlPlaneEndpointStatus) ProtoMessage() {}
 
 func (x *ControlPlaneEndpointStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[2]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -225,7 +325,7 @@ func (x *ControlPlaneEndpointStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlPlaneEndpointStatus.ProtoReflect.Descriptor instead.
 func (*ControlPlaneEndpointStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{2}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ControlPlaneEndpointStatus) GetEndpoint() string {
@@ -317,7 +417,7 @@ type ControlPlaneEndpointPeerStatus struct {
 
 func (x *ControlPlaneEndpointPeerStatus) Reset() {
 	*x = ControlPlaneEndpointPeerStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[3]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -329,7 +429,7 @@ func (x *ControlPlaneEndpointPeerStatus) String() string {
 func (*ControlPlaneEndpointPeerStatus) ProtoMessage() {}
 
 func (x *ControlPlaneEndpointPeerStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[3]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -342,7 +442,7 @@ func (x *ControlPlaneEndpointPeerStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlPlaneEndpointPeerStatus.ProtoReflect.Descriptor instead.
 func (*ControlPlaneEndpointPeerStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{3}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ControlPlaneEndpointPeerStatus) GetAddress() string {
@@ -388,7 +488,7 @@ type ControlPlaneEndpointRouteExchangeStatus struct {
 
 func (x *ControlPlaneEndpointRouteExchangeStatus) Reset() {
 	*x = ControlPlaneEndpointRouteExchangeStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[4]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -400,7 +500,7 @@ func (x *ControlPlaneEndpointRouteExchangeStatus) String() string {
 func (*ControlPlaneEndpointRouteExchangeStatus) ProtoMessage() {}
 
 func (x *ControlPlaneEndpointRouteExchangeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[4]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -413,7 +513,7 @@ func (x *ControlPlaneEndpointRouteExchangeStatus) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use ControlPlaneEndpointRouteExchangeStatus.ProtoReflect.Descriptor instead.
 func (*ControlPlaneEndpointRouteExchangeStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{4}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ControlPlaneEndpointRouteExchangeStatus) GetName() string {
@@ -490,7 +590,7 @@ type SubmitOperationRequest struct {
 
 func (x *SubmitOperationRequest) Reset() {
 	*x = SubmitOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[5]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -502,7 +602,7 @@ func (x *SubmitOperationRequest) String() string {
 func (*SubmitOperationRequest) ProtoMessage() {}
 
 func (x *SubmitOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[5]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -515,7 +615,7 @@ func (x *SubmitOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitOperationRequest.ProtoReflect.Descriptor instead.
 func (*SubmitOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{5}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SubmitOperationRequest) GetApiVersion() string {
@@ -657,7 +757,7 @@ type BootstrapOperationRequest struct {
 
 func (x *BootstrapOperationRequest) Reset() {
 	*x = BootstrapOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[6]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -669,7 +769,7 @@ func (x *BootstrapOperationRequest) String() string {
 func (*BootstrapOperationRequest) ProtoMessage() {}
 
 func (x *BootstrapOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[6]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -682,7 +782,7 @@ func (x *BootstrapOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootstrapOperationRequest.ProtoReflect.Descriptor instead.
 func (*BootstrapOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{6}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *BootstrapOperationRequest) GetInventoryNodeName() string {
@@ -780,7 +880,7 @@ type WorkerJoinMaterial struct {
 
 func (x *WorkerJoinMaterial) Reset() {
 	*x = WorkerJoinMaterial{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[7]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -792,7 +892,7 @@ func (x *WorkerJoinMaterial) String() string {
 func (*WorkerJoinMaterial) ProtoMessage() {}
 
 func (x *WorkerJoinMaterial) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[7]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -805,7 +905,7 @@ func (x *WorkerJoinMaterial) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkerJoinMaterial.ProtoReflect.Descriptor instead.
 func (*WorkerJoinMaterial) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{7}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *WorkerJoinMaterial) GetJoinArgv() []string {
@@ -848,7 +948,7 @@ type ValidateConfigRequest struct {
 
 func (x *ValidateConfigRequest) Reset() {
 	*x = ValidateConfigRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[8]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -860,7 +960,7 @@ func (x *ValidateConfigRequest) String() string {
 func (*ValidateConfigRequest) ProtoMessage() {}
 
 func (x *ValidateConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[8]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -873,7 +973,7 @@ func (x *ValidateConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateConfigRequest.ProtoReflect.Descriptor instead.
 func (*ValidateConfigRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{8}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ValidateConfigRequest) GetApiVersion() string {
@@ -972,7 +1072,7 @@ type ConfigValidationResult struct {
 
 func (x *ConfigValidationResult) Reset() {
 	*x = ConfigValidationResult{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -984,7 +1084,7 @@ func (x *ConfigValidationResult) String() string {
 func (*ConfigValidationResult) ProtoMessage() {}
 
 func (x *ConfigValidationResult) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -997,7 +1097,7 @@ func (x *ConfigValidationResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigValidationResult.ProtoReflect.Descriptor instead.
 func (*ConfigValidationResult) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{9}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ConfigValidationResult) GetApiVersion() string {
@@ -1096,7 +1196,7 @@ type GenerationApplyRequest struct {
 
 func (x *GenerationApplyRequest) Reset() {
 	*x = GenerationApplyRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1108,7 +1208,7 @@ func (x *GenerationApplyRequest) String() string {
 func (*GenerationApplyRequest) ProtoMessage() {}
 
 func (x *GenerationApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1121,7 +1221,7 @@ func (x *GenerationApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerationApplyRequest.ProtoReflect.Descriptor instead.
 func (*GenerationApplyRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{10}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GenerationApplyRequest) GetApiVersion() string {
@@ -1213,7 +1313,7 @@ type ConfigApplyOperationRequest struct {
 
 func (x *ConfigApplyOperationRequest) Reset() {
 	*x = ConfigApplyOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1225,7 +1325,7 @@ func (x *ConfigApplyOperationRequest) String() string {
 func (*ConfigApplyOperationRequest) ProtoMessage() {}
 
 func (x *ConfigApplyOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1238,7 +1338,7 @@ func (x *ConfigApplyOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyOperationRequest.ProtoReflect.Descriptor instead.
 func (*ConfigApplyOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{11}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ConfigApplyOperationRequest) GetCandidateGenerationId() string {
@@ -1298,7 +1398,7 @@ type KubeadmControlPlaneConfigOperationRequest struct {
 
 func (x *KubeadmControlPlaneConfigOperationRequest) Reset() {
 	*x = KubeadmControlPlaneConfigOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1310,7 +1410,7 @@ func (x *KubeadmControlPlaneConfigOperationRequest) String() string {
 func (*KubeadmControlPlaneConfigOperationRequest) ProtoMessage() {}
 
 func (x *KubeadmControlPlaneConfigOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1323,7 +1423,7 @@ func (x *KubeadmControlPlaneConfigOperationRequest) ProtoReflect() protoreflect.
 
 // Deprecated: Use KubeadmControlPlaneConfigOperationRequest.ProtoReflect.Descriptor instead.
 func (*KubeadmControlPlaneConfigOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{12}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *KubeadmControlPlaneConfigOperationRequest) GetRolloutId() string {
@@ -1500,7 +1600,7 @@ type KubernetesSysextUpdateOperationRequest struct {
 
 func (x *KubernetesSysextUpdateOperationRequest) Reset() {
 	*x = KubernetesSysextUpdateOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1512,7 +1612,7 @@ func (x *KubernetesSysextUpdateOperationRequest) String() string {
 func (*KubernetesSysextUpdateOperationRequest) ProtoMessage() {}
 
 func (x *KubernetesSysextUpdateOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1525,7 +1625,7 @@ func (x *KubernetesSysextUpdateOperationRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use KubernetesSysextUpdateOperationRequest.ProtoReflect.Descriptor instead.
 func (*KubernetesSysextUpdateOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{13}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *KubernetesSysextUpdateOperationRequest) GetTargetPayloadVersion() string {
@@ -1674,7 +1774,7 @@ type DestructiveResetOperationRequest struct {
 
 func (x *DestructiveResetOperationRequest) Reset() {
 	*x = DestructiveResetOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1686,7 +1786,7 @@ func (x *DestructiveResetOperationRequest) String() string {
 func (*DestructiveResetOperationRequest) ProtoMessage() {}
 
 func (x *DestructiveResetOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1699,7 +1799,7 @@ func (x *DestructiveResetOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestructiveResetOperationRequest.ProtoReflect.Descriptor instead.
 func (*DestructiveResetOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{14}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *DestructiveResetOperationRequest) GetInventoryNodeName() string {
@@ -1750,7 +1850,7 @@ type HostUpgradeOperationRequest struct {
 
 func (x *HostUpgradeOperationRequest) Reset() {
 	*x = HostUpgradeOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1762,7 +1862,7 @@ func (x *HostUpgradeOperationRequest) String() string {
 func (*HostUpgradeOperationRequest) ProtoMessage() {}
 
 func (x *HostUpgradeOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1775,7 +1875,7 @@ func (x *HostUpgradeOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostUpgradeOperationRequest.ProtoReflect.Descriptor instead.
 func (*HostUpgradeOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{15}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *HostUpgradeOperationRequest) GetImageUrl() string {
@@ -1828,7 +1928,7 @@ type StageHostUpgradeArtifactRequest struct {
 
 func (x *StageHostUpgradeArtifactRequest) Reset() {
 	*x = StageHostUpgradeArtifactRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1840,7 +1940,7 @@ func (x *StageHostUpgradeArtifactRequest) String() string {
 func (*StageHostUpgradeArtifactRequest) ProtoMessage() {}
 
 func (x *StageHostUpgradeArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1853,7 +1953,7 @@ func (x *StageHostUpgradeArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StageHostUpgradeArtifactRequest.ProtoReflect.Descriptor instead.
 func (*StageHostUpgradeArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{16}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *StageHostUpgradeArtifactRequest) GetApiVersion() string {
@@ -1916,7 +2016,7 @@ type HostUpgradeArtifactStaged struct {
 
 func (x *HostUpgradeArtifactStaged) Reset() {
 	*x = HostUpgradeArtifactStaged{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1928,7 +2028,7 @@ func (x *HostUpgradeArtifactStaged) String() string {
 func (*HostUpgradeArtifactStaged) ProtoMessage() {}
 
 func (x *HostUpgradeArtifactStaged) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1941,7 +2041,7 @@ func (x *HostUpgradeArtifactStaged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostUpgradeArtifactStaged.ProtoReflect.Descriptor instead.
 func (*HostUpgradeArtifactStaged) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *HostUpgradeArtifactStaged) GetLocalRef() string {
@@ -1979,7 +2079,7 @@ type CreateWorkerJoinMaterialRequest struct {
 
 func (x *CreateWorkerJoinMaterialRequest) Reset() {
 	*x = CreateWorkerJoinMaterialRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1991,7 +2091,7 @@ func (x *CreateWorkerJoinMaterialRequest) String() string {
 func (*CreateWorkerJoinMaterialRequest) ProtoMessage() {}
 
 func (x *CreateWorkerJoinMaterialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2004,7 +2104,7 @@ func (x *CreateWorkerJoinMaterialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerJoinMaterialRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkerJoinMaterialRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *CreateWorkerJoinMaterialRequest) GetApiVersion() string {
@@ -2060,7 +2160,7 @@ type CreateWorkerJoinMaterialResponse struct {
 
 func (x *CreateWorkerJoinMaterialResponse) Reset() {
 	*x = CreateWorkerJoinMaterialResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2072,7 +2172,7 @@ func (x *CreateWorkerJoinMaterialResponse) String() string {
 func (*CreateWorkerJoinMaterialResponse) ProtoMessage() {}
 
 func (x *CreateWorkerJoinMaterialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2085,7 +2185,7 @@ func (x *CreateWorkerJoinMaterialResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerJoinMaterialResponse.ProtoReflect.Descriptor instead.
 func (*CreateWorkerJoinMaterialResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CreateWorkerJoinMaterialResponse) GetMaterialRef() string {
@@ -2123,7 +2223,7 @@ type OperationAccepted struct {
 
 func (x *OperationAccepted) Reset() {
 	*x = OperationAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2135,7 +2235,7 @@ func (x *OperationAccepted) String() string {
 func (*OperationAccepted) ProtoMessage() {}
 
 func (x *OperationAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2148,7 +2248,7 @@ func (x *OperationAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationAccepted.ProtoReflect.Descriptor instead.
 func (*OperationAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *OperationAccepted) GetOperationId() string {
@@ -2204,7 +2304,7 @@ type GetOperationRequest struct {
 
 func (x *GetOperationRequest) Reset() {
 	*x = GetOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2216,7 +2316,7 @@ func (x *GetOperationRequest) String() string {
 func (*GetOperationRequest) ProtoMessage() {}
 
 func (x *GetOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2229,7 +2329,7 @@ func (x *GetOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetOperationRequest) GetOperationId() string {
@@ -2264,7 +2364,7 @@ type ListOperationsRequest struct {
 
 func (x *ListOperationsRequest) Reset() {
 	*x = ListOperationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2276,7 +2376,7 @@ func (x *ListOperationsRequest) String() string {
 func (*ListOperationsRequest) ProtoMessage() {}
 
 func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2289,7 +2389,7 @@ func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListOperationsRequest) GetActiveOnly() bool {
@@ -2322,7 +2422,7 @@ type ListOperationsResponse struct {
 
 func (x *ListOperationsResponse) Reset() {
 	*x = ListOperationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2334,7 +2434,7 @@ func (x *ListOperationsResponse) String() string {
 func (*ListOperationsResponse) ProtoMessage() {}
 
 func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2347,7 +2447,7 @@ func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ListOperationsResponse) GetOperations() []*OperationStatus {
@@ -2394,7 +2494,7 @@ type OperationStatus struct {
 
 func (x *OperationStatus) Reset() {
 	*x = OperationStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2406,7 +2506,7 @@ func (x *OperationStatus) String() string {
 func (*OperationStatus) ProtoMessage() {}
 
 func (x *OperationStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2419,7 +2519,7 @@ func (x *OperationStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationStatus.ProtoReflect.Descriptor instead.
 func (*OperationStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *OperationStatus) GetOperationId() string {
@@ -2638,7 +2738,7 @@ type DiagnosticArtifact struct {
 
 func (x *DiagnosticArtifact) Reset() {
 	*x = DiagnosticArtifact{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2650,7 +2750,7 @@ func (x *DiagnosticArtifact) String() string {
 func (*DiagnosticArtifact) ProtoMessage() {}
 
 func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2663,7 +2763,7 @@ func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiagnosticArtifact.ProtoReflect.Descriptor instead.
 func (*DiagnosticArtifact) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DiagnosticArtifact) GetArtifactId() string {
@@ -2718,7 +2818,7 @@ type OperationInvocation struct {
 
 func (x *OperationInvocation) Reset() {
 	*x = OperationInvocation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2730,7 +2830,7 @@ func (x *OperationInvocation) String() string {
 func (*OperationInvocation) ProtoMessage() {}
 
 func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2743,7 +2843,7 @@ func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationInvocation.ProtoReflect.Descriptor instead.
 func (*OperationInvocation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *OperationInvocation) GetInvocationId() string {
@@ -2822,7 +2922,7 @@ type WatchOperationRequest struct {
 
 func (x *WatchOperationRequest) Reset() {
 	*x = WatchOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2834,7 +2934,7 @@ func (x *WatchOperationRequest) String() string {
 func (*WatchOperationRequest) ProtoMessage() {}
 
 func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2847,7 +2947,7 @@ func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchOperationRequest.ProtoReflect.Descriptor instead.
 func (*WatchOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *WatchOperationRequest) GetOperationId() string {
@@ -2900,7 +3000,7 @@ type OperationEvent struct {
 
 func (x *OperationEvent) Reset() {
 	*x = OperationEvent{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2912,7 +3012,7 @@ func (x *OperationEvent) String() string {
 func (*OperationEvent) ProtoMessage() {}
 
 func (x *OperationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2925,7 +3025,7 @@ func (x *OperationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationEvent.ProtoReflect.Descriptor instead.
 func (*OperationEvent) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *OperationEvent) GetOperationId() string {
@@ -2986,7 +3086,7 @@ type ListGenerationsRequest struct {
 
 func (x *ListGenerationsRequest) Reset() {
 	*x = ListGenerationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2998,7 +3098,7 @@ func (x *ListGenerationsRequest) String() string {
 func (*ListGenerationsRequest) ProtoMessage() {}
 
 func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3011,7 +3111,7 @@ func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsRequest.ProtoReflect.Descriptor instead.
 func (*ListGenerationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListGenerationsRequest) GetIncludeConfigApply() bool {
@@ -3030,7 +3130,7 @@ type ListGenerationsResponse struct {
 
 func (x *ListGenerationsResponse) Reset() {
 	*x = ListGenerationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3042,7 +3142,7 @@ func (x *ListGenerationsResponse) String() string {
 func (*ListGenerationsResponse) ProtoMessage() {}
 
 func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3055,7 +3155,7 @@ func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsResponse.ProtoReflect.Descriptor instead.
 func (*ListGenerationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListGenerationsResponse) GetGenerations() []*Generation {
@@ -3075,7 +3175,7 @@ type GetGenerationRequest struct {
 
 func (x *GetGenerationRequest) Reset() {
 	*x = GetGenerationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3087,7 +3187,7 @@ func (x *GetGenerationRequest) String() string {
 func (*GetGenerationRequest) ProtoMessage() {}
 
 func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3100,7 +3200,7 @@ func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGenerationRequest.ProtoReflect.Descriptor instead.
 func (*GetGenerationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetGenerationRequest) GetGenerationId() string {
@@ -3138,7 +3238,7 @@ type Generation struct {
 
 func (x *Generation) Reset() {
 	*x = Generation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3150,7 +3250,7 @@ func (x *Generation) String() string {
 func (*Generation) ProtoMessage() {}
 
 func (x *Generation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3163,7 +3263,7 @@ func (x *Generation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Generation.ProtoReflect.Descriptor instead.
 func (*Generation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Generation) GetGenerationId() string {
@@ -3272,7 +3372,7 @@ type ExtensionRef struct {
 
 func (x *ExtensionRef) Reset() {
 	*x = ExtensionRef{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3284,7 +3384,7 @@ func (x *ExtensionRef) String() string {
 func (*ExtensionRef) ProtoMessage() {}
 
 func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3297,7 +3397,7 @@ func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionRef.ProtoReflect.Descriptor instead.
 func (*ExtensionRef) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ExtensionRef) GetName() string {
@@ -3361,7 +3461,7 @@ type GeneratedConfext struct {
 
 func (x *GeneratedConfext) Reset() {
 	*x = GeneratedConfext{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3373,7 +3473,7 @@ func (x *GeneratedConfext) String() string {
 func (*GeneratedConfext) ProtoMessage() {}
 
 func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3386,7 +3486,7 @@ func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeneratedConfext.ProtoReflect.Descriptor instead.
 func (*GeneratedConfext) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GeneratedConfext) GetName() string {
@@ -3433,7 +3533,7 @@ type ConfigApplyStatus struct {
 
 func (x *ConfigApplyStatus) Reset() {
 	*x = ConfigApplyStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3445,7 +3545,7 @@ func (x *ConfigApplyStatus) String() string {
 func (*ConfigApplyStatus) ProtoMessage() {}
 
 func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3458,7 +3558,7 @@ func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyStatus.ProtoReflect.Descriptor instead.
 func (*ConfigApplyStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{35}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ConfigApplyStatus) GetPhase() string {
@@ -3530,7 +3630,7 @@ type RebootRequest struct {
 
 func (x *RebootRequest) Reset() {
 	*x = RebootRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3542,7 +3642,7 @@ func (x *RebootRequest) String() string {
 func (*RebootRequest) ProtoMessage() {}
 
 func (x *RebootRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3555,7 +3655,7 @@ func (x *RebootRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebootRequest.ProtoReflect.Descriptor instead.
 func (*RebootRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{36}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RebootRequest) GetApiVersion() string {
@@ -3603,7 +3703,7 @@ type RebootAccepted struct {
 
 func (x *RebootAccepted) Reset() {
 	*x = RebootAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3615,7 +3715,7 @@ func (x *RebootAccepted) String() string {
 func (*RebootAccepted) ProtoMessage() {}
 
 func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3628,7 +3728,7 @@ func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebootAccepted.ProtoReflect.Descriptor instead.
 func (*RebootAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{37}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *RebootAccepted) GetScheduled() bool {
@@ -3657,7 +3757,7 @@ type ShutdownRequest struct {
 
 func (x *ShutdownRequest) Reset() {
 	*x = ShutdownRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3669,7 +3769,7 @@ func (x *ShutdownRequest) String() string {
 func (*ShutdownRequest) ProtoMessage() {}
 
 func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3682,7 +3782,7 @@ func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{38}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ShutdownRequest) GetApiVersion() string {
@@ -3722,7 +3822,7 @@ type ShutdownAccepted struct {
 
 func (x *ShutdownAccepted) Reset() {
 	*x = ShutdownAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3734,7 +3834,7 @@ func (x *ShutdownAccepted) String() string {
 func (*ShutdownAccepted) ProtoMessage() {}
 
 func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3747,7 +3847,7 @@ func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAccepted.ProtoReflect.Descriptor instead.
 func (*ShutdownAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{39}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ShutdownAccepted) GetScheduled() bool {
@@ -3762,7 +3862,7 @@ var File_internal_katlc_agentapi_agent_proto protoreflect.FileDescriptor
 const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\n" +
 	"#internal/katlc/agentapi/agent.proto\x12\rkatl.agent.v1\"\x16\n" +
-	"\x14GetNodeStatusRequest\"\xc0\x04\n" +
+	"\x14GetNodeStatusRequest\"\x81\x05\n" +
 	"\n" +
 	"NodeStatus\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
@@ -3778,7 +3878,19 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x15current_generation_id\x18\t \x01(\tR\x13currentGenerationId\x129\n" +
 	"\x19boot_target_generation_id\x18\n" +
 	" \x01(\tR\x16bootTargetGenerationId\x12_\n" +
-	"\x16control_plane_endpoint\x18\v \x01(\v2).katl.agent.v1.ControlPlaneEndpointStatusR\x14controlPlaneEndpoint\"\x85\x04\n" +
+	"\x16control_plane_endpoint\x18\v \x01(\v2).katl.agent.v1.ControlPlaneEndpointStatusR\x14controlPlaneEndpoint\x12?\n" +
+	"\n" +
+	"kubernetes\x18\f \x01(\v2\x1f.katl.agent.v1.KubernetesStatusR\n" +
+	"kubernetes\"\x8b\x02\n" +
+	"\x10KubernetesStatus\x12\x14\n" +
+	"\x05state\x18\x01 \x01(\tR\x05state\x12\x12\n" +
+	"\x04role\x18\x02 \x01(\tR\x04role\x12\x1b\n" +
+	"\tnode_name\x18\x03 \x01(\tR\bnodeName\x12%\n" +
+	"\x0ekubelet_active\x18\x04 \x01(\bR\rkubeletActive\x12\x1d\n" +
+	"\n" +
+	"node_ready\x18\x05 \x01(\bR\tnodeReady\x12C\n" +
+	"\x1econtrol_plane_components_ready\x18\x06 \x01(\bR\x1bcontrolPlaneComponentsReady\x12%\n" +
+	"\x0efailure_reason\x18\a \x01(\tR\rfailureReason\"\x85\x04\n" +
 	"\x1aControlPlaneEndpointStatus\x12\x1a\n" +
 	"\bendpoint\x18\x01 \x01(\tR\bendpoint\x12\x10\n" +
 	"\x03vip\x18\x02 \x01(\tR\x03vip\x12\x14\n" +
@@ -4178,104 +4290,106 @@ func file_internal_katlc_agentapi_agent_proto_rawDescGZIP() []byte {
 	return file_internal_katlc_agentapi_agent_proto_rawDescData
 }
 
-var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*GetNodeStatusRequest)(nil),                      // 0: katl.agent.v1.GetNodeStatusRequest
 	(*NodeStatus)(nil),                                // 1: katl.agent.v1.NodeStatus
-	(*ControlPlaneEndpointStatus)(nil),                // 2: katl.agent.v1.ControlPlaneEndpointStatus
-	(*ControlPlaneEndpointPeerStatus)(nil),            // 3: katl.agent.v1.ControlPlaneEndpointPeerStatus
-	(*ControlPlaneEndpointRouteExchangeStatus)(nil),   // 4: katl.agent.v1.ControlPlaneEndpointRouteExchangeStatus
-	(*SubmitOperationRequest)(nil),                    // 5: katl.agent.v1.SubmitOperationRequest
-	(*BootstrapOperationRequest)(nil),                 // 6: katl.agent.v1.BootstrapOperationRequest
-	(*WorkerJoinMaterial)(nil),                        // 7: katl.agent.v1.WorkerJoinMaterial
-	(*ValidateConfigRequest)(nil),                     // 8: katl.agent.v1.ValidateConfigRequest
-	(*ConfigValidationResult)(nil),                    // 9: katl.agent.v1.ConfigValidationResult
-	(*GenerationApplyRequest)(nil),                    // 10: katl.agent.v1.GenerationApplyRequest
-	(*ConfigApplyOperationRequest)(nil),               // 11: katl.agent.v1.ConfigApplyOperationRequest
-	(*KubeadmControlPlaneConfigOperationRequest)(nil), // 12: katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
-	(*KubernetesSysextUpdateOperationRequest)(nil),    // 13: katl.agent.v1.KubernetesSysextUpdateOperationRequest
-	(*DestructiveResetOperationRequest)(nil),          // 14: katl.agent.v1.DestructiveResetOperationRequest
-	(*HostUpgradeOperationRequest)(nil),               // 15: katl.agent.v1.HostUpgradeOperationRequest
-	(*StageHostUpgradeArtifactRequest)(nil),           // 16: katl.agent.v1.StageHostUpgradeArtifactRequest
-	(*HostUpgradeArtifactStaged)(nil),                 // 17: katl.agent.v1.HostUpgradeArtifactStaged
-	(*CreateWorkerJoinMaterialRequest)(nil),           // 18: katl.agent.v1.CreateWorkerJoinMaterialRequest
-	(*CreateWorkerJoinMaterialResponse)(nil),          // 19: katl.agent.v1.CreateWorkerJoinMaterialResponse
-	(*OperationAccepted)(nil),                         // 20: katl.agent.v1.OperationAccepted
-	(*GetOperationRequest)(nil),                       // 21: katl.agent.v1.GetOperationRequest
-	(*ListOperationsRequest)(nil),                     // 22: katl.agent.v1.ListOperationsRequest
-	(*ListOperationsResponse)(nil),                    // 23: katl.agent.v1.ListOperationsResponse
-	(*OperationStatus)(nil),                           // 24: katl.agent.v1.OperationStatus
-	(*DiagnosticArtifact)(nil),                        // 25: katl.agent.v1.DiagnosticArtifact
-	(*OperationInvocation)(nil),                       // 26: katl.agent.v1.OperationInvocation
-	(*WatchOperationRequest)(nil),                     // 27: katl.agent.v1.WatchOperationRequest
-	(*OperationEvent)(nil),                            // 28: katl.agent.v1.OperationEvent
-	(*ListGenerationsRequest)(nil),                    // 29: katl.agent.v1.ListGenerationsRequest
-	(*ListGenerationsResponse)(nil),                   // 30: katl.agent.v1.ListGenerationsResponse
-	(*GetGenerationRequest)(nil),                      // 31: katl.agent.v1.GetGenerationRequest
-	(*Generation)(nil),                                // 32: katl.agent.v1.Generation
-	(*ExtensionRef)(nil),                              // 33: katl.agent.v1.ExtensionRef
-	(*GeneratedConfext)(nil),                          // 34: katl.agent.v1.GeneratedConfext
-	(*ConfigApplyStatus)(nil),                         // 35: katl.agent.v1.ConfigApplyStatus
-	(*RebootRequest)(nil),                             // 36: katl.agent.v1.RebootRequest
-	(*RebootAccepted)(nil),                            // 37: katl.agent.v1.RebootAccepted
-	(*ShutdownRequest)(nil),                           // 38: katl.agent.v1.ShutdownRequest
-	(*ShutdownAccepted)(nil),                          // 39: katl.agent.v1.ShutdownAccepted
+	(*KubernetesStatus)(nil),                          // 2: katl.agent.v1.KubernetesStatus
+	(*ControlPlaneEndpointStatus)(nil),                // 3: katl.agent.v1.ControlPlaneEndpointStatus
+	(*ControlPlaneEndpointPeerStatus)(nil),            // 4: katl.agent.v1.ControlPlaneEndpointPeerStatus
+	(*ControlPlaneEndpointRouteExchangeStatus)(nil),   // 5: katl.agent.v1.ControlPlaneEndpointRouteExchangeStatus
+	(*SubmitOperationRequest)(nil),                    // 6: katl.agent.v1.SubmitOperationRequest
+	(*BootstrapOperationRequest)(nil),                 // 7: katl.agent.v1.BootstrapOperationRequest
+	(*WorkerJoinMaterial)(nil),                        // 8: katl.agent.v1.WorkerJoinMaterial
+	(*ValidateConfigRequest)(nil),                     // 9: katl.agent.v1.ValidateConfigRequest
+	(*ConfigValidationResult)(nil),                    // 10: katl.agent.v1.ConfigValidationResult
+	(*GenerationApplyRequest)(nil),                    // 11: katl.agent.v1.GenerationApplyRequest
+	(*ConfigApplyOperationRequest)(nil),               // 12: katl.agent.v1.ConfigApplyOperationRequest
+	(*KubeadmControlPlaneConfigOperationRequest)(nil), // 13: katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
+	(*KubernetesSysextUpdateOperationRequest)(nil),    // 14: katl.agent.v1.KubernetesSysextUpdateOperationRequest
+	(*DestructiveResetOperationRequest)(nil),          // 15: katl.agent.v1.DestructiveResetOperationRequest
+	(*HostUpgradeOperationRequest)(nil),               // 16: katl.agent.v1.HostUpgradeOperationRequest
+	(*StageHostUpgradeArtifactRequest)(nil),           // 17: katl.agent.v1.StageHostUpgradeArtifactRequest
+	(*HostUpgradeArtifactStaged)(nil),                 // 18: katl.agent.v1.HostUpgradeArtifactStaged
+	(*CreateWorkerJoinMaterialRequest)(nil),           // 19: katl.agent.v1.CreateWorkerJoinMaterialRequest
+	(*CreateWorkerJoinMaterialResponse)(nil),          // 20: katl.agent.v1.CreateWorkerJoinMaterialResponse
+	(*OperationAccepted)(nil),                         // 21: katl.agent.v1.OperationAccepted
+	(*GetOperationRequest)(nil),                       // 22: katl.agent.v1.GetOperationRequest
+	(*ListOperationsRequest)(nil),                     // 23: katl.agent.v1.ListOperationsRequest
+	(*ListOperationsResponse)(nil),                    // 24: katl.agent.v1.ListOperationsResponse
+	(*OperationStatus)(nil),                           // 25: katl.agent.v1.OperationStatus
+	(*DiagnosticArtifact)(nil),                        // 26: katl.agent.v1.DiagnosticArtifact
+	(*OperationInvocation)(nil),                       // 27: katl.agent.v1.OperationInvocation
+	(*WatchOperationRequest)(nil),                     // 28: katl.agent.v1.WatchOperationRequest
+	(*OperationEvent)(nil),                            // 29: katl.agent.v1.OperationEvent
+	(*ListGenerationsRequest)(nil),                    // 30: katl.agent.v1.ListGenerationsRequest
+	(*ListGenerationsResponse)(nil),                   // 31: katl.agent.v1.ListGenerationsResponse
+	(*GetGenerationRequest)(nil),                      // 32: katl.agent.v1.GetGenerationRequest
+	(*Generation)(nil),                                // 33: katl.agent.v1.Generation
+	(*ExtensionRef)(nil),                              // 34: katl.agent.v1.ExtensionRef
+	(*GeneratedConfext)(nil),                          // 35: katl.agent.v1.GeneratedConfext
+	(*ConfigApplyStatus)(nil),                         // 36: katl.agent.v1.ConfigApplyStatus
+	(*RebootRequest)(nil),                             // 37: katl.agent.v1.RebootRequest
+	(*RebootAccepted)(nil),                            // 38: katl.agent.v1.RebootAccepted
+	(*ShutdownRequest)(nil),                           // 39: katl.agent.v1.ShutdownRequest
+	(*ShutdownAccepted)(nil),                          // 40: katl.agent.v1.ShutdownAccepted
 }
 var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
-	2,  // 0: katl.agent.v1.NodeStatus.control_plane_endpoint:type_name -> katl.agent.v1.ControlPlaneEndpointStatus
-	3,  // 1: katl.agent.v1.ControlPlaneEndpointStatus.peers:type_name -> katl.agent.v1.ControlPlaneEndpointPeerStatus
-	4,  // 2: katl.agent.v1.ControlPlaneEndpointStatus.route_exchange:type_name -> katl.agent.v1.ControlPlaneEndpointRouteExchangeStatus
-	6,  // 3: katl.agent.v1.SubmitOperationRequest.bootstrap:type_name -> katl.agent.v1.BootstrapOperationRequest
-	11, // 4: katl.agent.v1.SubmitOperationRequest.config_apply:type_name -> katl.agent.v1.ConfigApplyOperationRequest
-	13, // 5: katl.agent.v1.SubmitOperationRequest.kubernetes_sysext_update:type_name -> katl.agent.v1.KubernetesSysextUpdateOperationRequest
-	14, // 6: katl.agent.v1.SubmitOperationRequest.destructive_reset:type_name -> katl.agent.v1.DestructiveResetOperationRequest
-	15, // 7: katl.agent.v1.SubmitOperationRequest.host_upgrade:type_name -> katl.agent.v1.HostUpgradeOperationRequest
-	12, // 8: katl.agent.v1.SubmitOperationRequest.kubeadm_control_plane_config:type_name -> katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
-	7,  // 9: katl.agent.v1.BootstrapOperationRequest.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
-	7,  // 10: katl.agent.v1.CreateWorkerJoinMaterialResponse.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
-	24, // 11: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
-	24, // 12: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
-	25, // 13: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	26, // 14: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
-	24, // 15: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
-	25, // 16: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	32, // 17: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
-	33, // 18: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
-	34, // 19: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
-	35, // 20: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
-	0,  // 21: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
-	36, // 22: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
-	38, // 23: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
-	8,  // 24: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
-	10, // 25: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	10, // 26: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	16, // 27: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:input_type -> katl.agent.v1.StageHostUpgradeArtifactRequest
-	5,  // 28: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
-	18, // 29: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
-	21, // 30: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
-	22, // 31: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
-	27, // 32: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
-	29, // 33: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
-	31, // 34: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
-	1,  // 35: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
-	37, // 36: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
-	39, // 37: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
-	9,  // 38: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
-	20, // 39: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
-	20, // 40: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
-	17, // 41: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:output_type -> katl.agent.v1.HostUpgradeArtifactStaged
-	20, // 42: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
-	19, // 43: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
-	24, // 44: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
-	23, // 45: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
-	28, // 46: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
-	30, // 47: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
-	32, // 48: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
-	35, // [35:49] is the sub-list for method output_type
-	21, // [21:35] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	3,  // 0: katl.agent.v1.NodeStatus.control_plane_endpoint:type_name -> katl.agent.v1.ControlPlaneEndpointStatus
+	2,  // 1: katl.agent.v1.NodeStatus.kubernetes:type_name -> katl.agent.v1.KubernetesStatus
+	4,  // 2: katl.agent.v1.ControlPlaneEndpointStatus.peers:type_name -> katl.agent.v1.ControlPlaneEndpointPeerStatus
+	5,  // 3: katl.agent.v1.ControlPlaneEndpointStatus.route_exchange:type_name -> katl.agent.v1.ControlPlaneEndpointRouteExchangeStatus
+	7,  // 4: katl.agent.v1.SubmitOperationRequest.bootstrap:type_name -> katl.agent.v1.BootstrapOperationRequest
+	12, // 5: katl.agent.v1.SubmitOperationRequest.config_apply:type_name -> katl.agent.v1.ConfigApplyOperationRequest
+	14, // 6: katl.agent.v1.SubmitOperationRequest.kubernetes_sysext_update:type_name -> katl.agent.v1.KubernetesSysextUpdateOperationRequest
+	15, // 7: katl.agent.v1.SubmitOperationRequest.destructive_reset:type_name -> katl.agent.v1.DestructiveResetOperationRequest
+	16, // 8: katl.agent.v1.SubmitOperationRequest.host_upgrade:type_name -> katl.agent.v1.HostUpgradeOperationRequest
+	13, // 9: katl.agent.v1.SubmitOperationRequest.kubeadm_control_plane_config:type_name -> katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
+	8,  // 10: katl.agent.v1.BootstrapOperationRequest.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
+	8,  // 11: katl.agent.v1.CreateWorkerJoinMaterialResponse.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
+	25, // 12: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
+	25, // 13: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
+	26, // 14: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	27, // 15: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
+	25, // 16: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
+	26, // 17: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	33, // 18: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
+	34, // 19: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
+	35, // 20: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
+	36, // 21: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
+	0,  // 22: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
+	37, // 23: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
+	39, // 24: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
+	9,  // 25: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
+	11, // 26: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	11, // 27: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	17, // 28: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:input_type -> katl.agent.v1.StageHostUpgradeArtifactRequest
+	6,  // 29: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
+	19, // 30: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
+	22, // 31: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
+	23, // 32: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
+	28, // 33: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
+	30, // 34: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
+	32, // 35: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
+	1,  // 36: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
+	38, // 37: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
+	40, // 38: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
+	10, // 39: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
+	21, // 40: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
+	21, // 41: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
+	18, // 42: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:output_type -> katl.agent.v1.HostUpgradeArtifactStaged
+	21, // 43: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
+	20, // 44: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
+	25, // 45: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
+	24, // 46: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
+	29, // 47: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
+	31, // 48: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
+	33, // 49: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
+	36, // [36:50] is the sub-list for method output_type
+	22, // [22:36] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_internal_katlc_agentapi_agent_proto_init() }
@@ -4289,7 +4403,7 @@ func file_internal_katlc_agentapi_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_katlc_agentapi_agent_proto_rawDesc), len(file_internal_katlc_agentapi_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   40,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -35,6 +35,17 @@ message NodeStatus {
   string current_generation_id = 9;
   string boot_target_generation_id = 10;
   ControlPlaneEndpointStatus control_plane_endpoint = 11;
+  KubernetesStatus kubernetes = 12;
+}
+
+message KubernetesStatus {
+  string state = 1;
+  string role = 2;
+  string node_name = 3;
+  bool kubelet_active = 4;
+  bool node_ready = 5;
+  bool control_plane_components_ready = 6;
+  string failure_reason = 7;
 }
 
 message ControlPlaneEndpointStatus {

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:87607894139a65e202ed159c2334bf14962aa9f3d485b30c54e53aac294180bb",
+  "recipeDigest": "sha256:d17bf8e2702951a0bf8c572de631eab8bcdf79cb6c66fc8d750df8e7423776fc",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 7,
+      "artifactRevision": 8,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 5,
+      "artifactRevision": 6,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 4,
+      "artifactRevision": 5,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 4,
+      "artifactRevision": 5,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,7 +19,7 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
-	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.4" {
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.5" {
 		t.Fatalf("artifact version = %q", got)
 	}
 }

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -343,6 +343,12 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("wait for kubectl nodes failed: %v\n%s", err, output)
 	}
+	if err := waitForAgentKubernetesReady(ctx, nodes, addresses, 3*time.Minute); err != nil {
+		collectKubectlDiagnostics(kubeconfigPath, result.RunDir)
+		collectTwoNodeDiagnostics("", nodes...)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("wait for agent Kubernetes readiness failed: %v", err)
+	}
 	collectKubectlDiagnostics(kubeconfigPath, result.RunDir)
 	for _, node := range nodes {
 		if _, err := collectKubernetesVersionEvidence(ctx, node, filepath.Join(versionEvidenceDir, node.Name), kubernetesBundle.PayloadVersion); err != nil {
@@ -400,6 +406,45 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 		}
 	}
 	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
+}
+
+func waitForAgentKubernetesReady(ctx context.Context, nodes []vmtest.RunningInstalledRuntimeNode, addresses map[string]string, timeout time.Duration) error {
+	for _, node := range nodes {
+		deadline := time.Now().Add(timeout)
+		last := "Kubernetes status was not reported"
+		for {
+			connector := cluster.TCPAgentConnector{DialTimeout: 5 * time.Second}
+			connection, err := connector.Connect(ctx, inventory.PlannedNode{
+				Name: node.Name, Address: addresses[node.Name], Access: inventory.Access{Method: "agent"},
+			})
+			if err == nil {
+				status, statusErr := connection.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+				_ = connection.Close()
+				if statusErr == nil {
+					kubernetes := status.GetKubernetes()
+					if kubernetes != nil && kubernetes.GetState() == "ready" && kubernetes.GetKubeletActive() && kubernetes.GetNodeReady() && kubernetes.GetControlPlaneComponentsReady() {
+						break
+					}
+					if kubernetes != nil {
+						last = firstString(kubernetes.GetFailureReason(), kubernetes.GetState())
+					}
+				} else {
+					last = statusErr.Error()
+				}
+			} else {
+				last = err.Error()
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("%s did not report ready Kubernetes state: %s", node.Name, last)
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+	return nil
 }
 
 func assertCNISysctls(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) error {


### PR DESCRIPTION
Make host upgrades wait until the node's Kubernetes role, local control-plane components, Node Ready condition, and managed API route have recovered. Expose that recovery state through node and cluster status and provide actionable timeout guidance. The root cause was treating successful KatlOS boot health as proof that Kubernetes was usable; live validation also found that an optional passive Cilium route exchange must not block an otherwise healthy node.