### PR TITLE
vmtest: keep implicit Kubernetes inputs resolvable

### DIFF
--- a/internal/vmtest/first_install_world.go
+++ b/internal/vmtest/first_install_world.go
@@ -16,6 +16,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
+	"github.com/katl-dev/katl/internal/installer/kubernetescompat"
 	installmanifest "github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -1031,21 +1032,9 @@ func writeFirstInstallWorldBundleSource(scenario *WorldScenario, repo string, sp
 	} else if err != nil {
 		return "", "", err
 	}
-	kubernetesVersion := strings.TrimSpace(requestedKubernetesVersion)
-	if kubernetesVersion == "" {
-		kubernetesVersion = metadata.KubernetesPayloadVersion()
-	}
-	if kubernetesVersion == "" {
-		if artifact, ok := index.artifact("kubernetes-sysext"); ok {
-			var err error
-			kubernetesVersion, err = readKubernetesSysextPayloadVersion(artifact)
-			if err != nil {
-				return "", "", err
-			}
-		}
-	}
-	if kubernetesVersion == "" {
-		kubernetesVersion = "v1.36.1"
+	kubernetesVersion, err := resolveFirstInstallWorldKubernetesVersion(requestedKubernetesVersion, metadata, index)
+	if err != nil {
+		return "", "", err
 	}
 
 	nodes := []map[string]any{}
@@ -1275,6 +1264,40 @@ func (metadata katlosImageMetadata) KubernetesPayloadVersion() string {
 		}
 	}
 	return ""
+}
+
+func resolveFirstInstallWorldKubernetesVersion(requested string, metadata katlosImageMetadata, index mkosiArtifactIndex) (string, error) {
+	if requested = strings.TrimSpace(requested); requested != "" {
+		return requested, nil
+	}
+	inferred := metadata.KubernetesPayloadVersion()
+	if inferred == "" {
+		if artifact, ok := index.artifact("kubernetes-sysext"); ok {
+			var err error
+			inferred, err = readKubernetesSysextPayloadVersion(artifact)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	if inferred != "" {
+		if _, err := kubernetescompat.Resolve(kubernetescompat.Request{
+			KubernetesVersion: inferred,
+			Architecture:      metadata.Architecture,
+			RuntimeInterface:  metadata.RuntimeInterface,
+		}); err == nil {
+			return inferred, nil
+		}
+	}
+	fallback := configbundle.DefaultKubernetesVersion
+	if _, err := kubernetescompat.Resolve(kubernetescompat.Request{
+		KubernetesVersion: fallback,
+		Architecture:      metadata.Architecture,
+		RuntimeInterface:  metadata.RuntimeInterface,
+	}); err != nil {
+		return "", fmt.Errorf("resolve default VM fixture Kubernetes version: %w", err)
+	}
+	return fallback, nil
 }
 
 func readKubernetesSysextPayloadVersion(artifact mkosiArtifact) (string, error) {

--- a/internal/vmtest/first_install_world_test.go
+++ b/internal/vmtest/first_install_world_test.go
@@ -527,6 +527,55 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 	if data, err := os.ReadFile(filepath.Join(filepath.Dir(handoff.Config.ManifestPath), "kubeadm", "control-plane.yaml")); err != nil || !strings.Contains(string(data), "kubernetesVersion: v1.36.1") {
 		t.Fatalf("handoff kubeadm version override = %q, err = %v", data, err)
 	}
+
+	_, err = planFirstInstallWorldRun(world, "local mkosi unavailable kubernetes", repo, NodeSpec{Name: "cp-3", Role: ControlPlane}, firstInstallWorldInput{
+		KubernetesVersion: "v1.36.2",
+		TargetDiskSize:    "20G",
+	}, KVMOff)
+	if err == nil || !strings.Contains(err.Error(), `Kubernetes "v1.36.2" is not available`) {
+		t.Fatalf("explicit unavailable Kubernetes version error = %v", err)
+	}
+}
+
+func TestResolveFirstInstallWorldKubernetesVersion(t *testing.T) {
+	metadata := katlosImageMetadata{
+		Architecture:     "x86_64",
+		RuntimeInterface: "katl-runtime-1",
+	}
+	localMetadata := writeFixtureFile(t, filepath.Join(t.TempDir(), "katl-kubernetes.raw.json"), `{"payloadVersion":"v1.36.2"}`)
+	index := mkosiArtifactIndex{Artifacts: []mkosiArtifact{{
+		Kind:         "kubernetes-sysext",
+		MetadataPath: localMetadata,
+	}}}
+
+	got, err := resolveFirstInstallWorldKubernetesVersion("", metadata, index)
+	if err != nil {
+		t.Fatalf("resolveFirstInstallWorldKubernetesVersion() error = %v", err)
+	}
+	if got != configbundle.DefaultKubernetesVersion {
+		t.Fatalf("implicit local Kubernetes version = %q, want supported default %q", got, configbundle.DefaultKubernetesVersion)
+	}
+
+	got, err = resolveFirstInstallWorldKubernetesVersion("v1.36.2", metadata, index)
+	if err != nil {
+		t.Fatalf("resolveFirstInstallWorldKubernetesVersion(explicit) error = %v", err)
+	}
+	if got != "v1.36.2" {
+		t.Fatalf("explicit Kubernetes version = %q, want v1.36.2", got)
+	}
+
+	metadata.Components = []struct {
+		Name           string `json:"name"`
+		Role           string `json:"role"`
+		PayloadVersion string `json:"payloadVersion"`
+	}{{Name: "kubernetes", PayloadVersion: "v1.36.0"}}
+	got, err = resolveFirstInstallWorldKubernetesVersion("", metadata, mkosiArtifactIndex{})
+	if err != nil {
+		t.Fatalf("resolveFirstInstallWorldKubernetesVersion(compatible) error = %v", err)
+	}
+	if got != "v1.36.0" {
+		t.Fatalf("compatible local Kubernetes version = %q, want v1.36.0", got)
+	}
 }
 
 func TestPlanFirstInstallWorldRunSelectsNodesFromSharedConfigBundle(t *testing.T) {


### PR DESCRIPTION
## What changed

Default installed-runtime fixtures now use a locally inferred Kubernetes payload only when the release compatibility catalog can resolve it. Explicit version requests remain authoritative.

## Why

Main builds a local v1.36.2 sysext while the published compatibility catalog currently ends at v1.36.1. Fixture planning inferred v1.36.2 and rejected it before VM boot, preventing local host-lifecycle validation until another bundle release existed. The fallback keeps the local development loop usable without inventing unpublished bundle metadata.

The installed-runtime sequential A/B upgrade and rollback journey now reaches the VM and passes with current main artifacts.