### PR TITLE
upgrade: verify synchronized root slots

### DIFF
--- a/docs/internal/systemd-sysupdate-update-decision.md
+++ b/docs/internal/systemd-sysupdate-update-decision.md
@@ -85,6 +85,13 @@ finalizes transfers alphabetically, and the boot entry is the runtime entry
 point; writing it last avoids exposing a bootable entry before the matching root
 slot has been staged.
 
+Katl leaves sysupdate synchronization enabled and flushes the inactive block
+device buffers before hashing the staged root. Some block-device transfer paths
+can otherwise leave an immediately reopened partition view backed by stale
+cached pages even though the durable partition contains the new bytes. Katl
+must not arm the trial boot until verification observes the synchronized
+partition contents.
+
 Optional verity support adds one earlier transfer:
 
 ```text

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -251,7 +251,7 @@ func (e *Executor) stageHostUpgrade(ctx context.Context, record operation.Operat
 	if err := os.WriteFile(filepath.Join(definitions, "70-katl-uki.transfer"), []byte(ukiTransferDefinition(source)), 0o600); err != nil {
 		return err
 	}
-	argv := []string{"/usr/lib/systemd/systemd-sysupdate", "--no-pager", "--verify=no", "--sync=no", "--definitions=" + definitions}
+	argv := []string{"/usr/lib/systemd/systemd-sysupdate", "--no-pager", "--verify=no", "--definitions=" + definitions}
 	if root != "/" {
 		argv = append(argv, "--root="+root)
 	}
@@ -259,6 +259,9 @@ func (e *Executor) stageHostUpgrade(ctx context.Context, record operation.Operat
 	result := e.toolRunner()(ctx, argv, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
 		return fmt.Errorf("systemd-sysupdate: %s", toolFailure(result))
+	}
+	if err := flushUpgradeDevice(ctx, e.toolRunner(), inactiveDevice); err != nil {
+		return fmt.Errorf("flush staged runtime root: %w", err)
 	}
 	if err := verifyUpgradePrefix(inactiveDevice, payload.Runtime.SHA256, payload.Runtime.SizeBytes); err != nil {
 		return fmt.Errorf("verify staged runtime root: %w", err)
@@ -408,6 +411,14 @@ func copyUpgradeComponent(source, target string) error {
 		return err
 	}
 	return out.Close()
+}
+
+func flushUpgradeDevice(ctx context.Context, run ToolRunner, device string) error {
+	result := run(ctx, []string{"blockdev", "--flushbufs", device}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return fmt.Errorf("blockdev: %s", toolFailure(result))
+	}
+	return nil
 }
 
 func verifyUpgradePrefix(path, want string, size int64) error {

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,6 +145,7 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	}
 	executor.SetBootOneshot = func(_ context.Context, _ string, entry string) error { oneshoot = entry; return nil }
 	var toolCalls []string
+	var stagedRoot []byte
 	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
 		toolCalls = append(toolCalls, strings.Join(argv, " "))
 		switch filepath.Base(argv[0]) {
@@ -175,10 +177,16 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 		case "sfdisk", "partx":
 			return ToolResult{}
 		case "systemd-sysupdate":
-			if err := os.WriteFile(inactiveDevice, append(append([]byte(nil), runtimeBytes...), make([]byte, 32)...), 0o600); err != nil {
+			stagedRoot = append(append([]byte(nil), runtimeBytes...), make([]byte, 32)...)
+			if err := os.WriteFile(filepath.Join(root, "efi/EFI/Linux/katl_2026.7.0-dev.1.efi"), ukiBytes, 0o600); err != nil {
 				return ToolResult{Err: err, ExitStatus: -1}
 			}
-			if err := os.WriteFile(filepath.Join(root, "efi/EFI/Linux/katl_2026.7.0-dev.1.efi"), ukiBytes, 0o600); err != nil {
+			return ToolResult{}
+		case "blockdev":
+			if strings.Join(argv, " ") != "blockdev --flushbufs "+inactiveDevice {
+				return ToolResult{Err: errors.New("unexpected blockdev arguments"), ExitStatus: 1}
+			}
+			if err := os.WriteFile(inactiveDevice, stagedRoot, 0o600); err != nil {
 				return ToolResult{Err: err, ExitStatus: -1}
 			}
 			return ToolResult{}
@@ -191,6 +199,21 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	}
 	if calls := strings.Join(toolCalls, "\n"); strings.Contains(calls, "PARTLABEL=") {
 		t.Fatalf("host upgrade discovered mutable partition labels:\n%s", calls)
+	}
+	if calls := strings.Join(toolCalls, "\n"); strings.Contains(calls, "--sync=no") {
+		t.Fatalf("host upgrade disabled sysupdate durability:\n%s", calls)
+	}
+	sysupdateCall, flushCall := -1, -1
+	for index, call := range toolCalls {
+		switch {
+		case strings.Contains(call, "systemd-sysupdate"):
+			sysupdateCall = index
+		case strings.HasPrefix(call, "blockdev --flushbufs "):
+			flushCall = index
+		}
+	}
+	if sysupdateCall < 0 || flushCall != sysupdateCall+1 {
+		t.Fatalf("host upgrade calls = %#v, want block cache flush immediately after sysupdate", toolCalls)
 	}
 	if oneshoot != "loader/entries/katl-gen1.conf" {
 		t.Fatalf("oneshot entry = %q", oneshoot)

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:d17bf8e2702951a0bf8c572de631eab8bcdf79cb6c66fc8d750df8e7423776fc",
+  "recipeDigest": "sha256:9e5a0bf4710c40a47c7d674ec6ce3bc4321c180b73bf2696a6db2ef4e2664b8e",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 8,
+      "artifactRevision": 9,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 6,
+      "artifactRevision": 7,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 5,
+      "artifactRevision": 6,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 5,
+      "artifactRevision": 6,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,7 +19,7 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
-	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.5" {
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.6" {
 		t.Fatalf("artifact version = %q", got)
 	}
 }

--- a/internal/vmtest/agent_server.go
+++ b/internal/vmtest/agent_server.go
@@ -462,6 +462,7 @@ func defaultAgentCommands() map[string]bool {
 		"bootctl":           true,
 		"crictl":            true,
 		"blkid":             true,
+		"blockdev":          true,
 		"bgp-api-vip-smoke": true,
 		"chmod":             true,
 		"configapply-smoke": true,

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -160,6 +160,7 @@ fi
 
 for path in \
     /usr/lib/os-release \
+    /usr/bin/blockdev \
     /usr/bin/katlc \
     /usr/bin/katl-console \
     /usr/bin/mount.nfs \


### PR DESCRIPTION
## What changed

Host upgrades keep systemd-sysupdate synchronization enabled, flush the inactive root block device before hashing it, and retain strict verification before arming a trial boot. Runtime contracts and release rebuild inputs are updated with the behavior.

## Why

A successful transfer could be followed by a hash read from stale cached block data, falsely marking the operation as repair-required even though offline verification showed the partition was correct.

The fix passed an isolated installed-runtime sequential A/B upgrade and rollback journey, and a fresh local artifact completed the live cp2 upgrade on its first attempt.