### PR TITLE
bootstrap: reload systemd after extensions

### DIFF
--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -915,9 +915,23 @@ func runReadinessCommand(ctx context.Context, argv []string, started func(int)) 
 	if len(argv) > 1 {
 		configPath = strings.TrimSpace(argv[1])
 	}
-	commands := [][]string{
-		{"/usr/bin/systemctl", "daemon-reload"},
+	commands := bootstrapReadinessCommands(candidate, configPath)
+	var stdout, stderr bytes.Buffer
+	for _, argv := range commands {
+		result := runChildProcess(ctx, argv, started)
+		stdout.Write(result.Stdout)
+		stderr.Write(result.Stderr)
+		if result.Err != nil || result.ExitStatus != 0 {
+			result.Stdout = stdout.Bytes()
+			result.Stderr = stderr.Bytes()
+			return result
+		}
 	}
+	return ToolResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes(), ExitStatus: 0}
+}
+
+func bootstrapReadinessCommands(candidate, configPath string) [][]string {
+	var commands [][]string
 	if candidate != "" {
 		commands = append(commands,
 			[]string{"/usr/lib/katl/runtime/katl-generation-activate", "--root=/", "--generation", candidate},
@@ -931,6 +945,7 @@ func runReadinessCommand(ctx context.Context, argv []string, started func(int)) 
 		)
 	}
 	commands = append(commands,
+		[]string{"/usr/bin/systemctl", "daemon-reload"},
 		[]string{"/usr/bin/test", "-x", "/usr/bin/kubelet"},
 		[]string{"/usr/bin/systemctl", "start", "etc-kubernetes.mount"},
 		[]string{"/usr/bin/systemctl", "start", "containerd.service"},
@@ -944,18 +959,7 @@ func runReadinessCommand(ctx context.Context, argv []string, started func(int)) 
 	if configPath != "" {
 		commands = append(commands, []string{"/usr/bin/test", "-s", configPath})
 	}
-	var stdout, stderr bytes.Buffer
-	for _, argv := range commands {
-		result := runChildProcess(ctx, argv, started)
-		stdout.Write(result.Stdout)
-		stderr.Write(result.Stderr)
-		if result.Err != nil || result.ExitStatus != 0 {
-			result.Stdout = stdout.Bytes()
-			result.Stderr = stderr.Bytes()
-			return result
-		}
-	}
-	return ToolResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes(), ExitStatus: 0}
+	return commands
 }
 
 func runPostKubeadmHealthCommand(ctx context.Context, argv []string, started func(int)) ToolResult {

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -511,6 +511,19 @@ func TestExecutorStopsBeforeKubeadmWhenReadinessFails(t *testing.T) {
 	}
 }
 
+func TestBootstrapReadinessReloadsSystemdAfterExtensionRefresh(t *testing.T) {
+	commands := bootstrapReadinessCommands("candidate-1", "/etc/katl/kubeadm/default/config.yaml")
+	assertCommandOrder(t, commands,
+		"katl-generation-activate --root=/ --generation candidate-1",
+		"systemd-sysext refresh",
+		"systemd-confext refresh",
+		"systemctl daemon-reload",
+		"test -x /usr/bin/kubelet",
+		"systemctl start katl-kubeadm-ready.target",
+		"test -s /etc/katl/kubeadm/default/config.yaml",
+	)
+}
+
 func TestExecutorPostKubeadmHealthFailureRequiresRepair(t *testing.T) {
 	server := newTestServer(t)
 	seedBootstrapRuntimeRoot(t, server.Root)

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:9e5a0bf4710c40a47c7d674ec6ce3bc4321c180b73bf2696a6db2ef4e2664b8e",
+  "recipeDigest": "sha256:0cbbfbcc44fb9b7dd4225304b31ee277eb824080c39288e8300521aafa707667",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 9,
+      "artifactRevision": 10,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 7,
+      "artifactRevision": 8,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 6,
+      "artifactRevision": 7,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 6,
+      "artifactRevision": 7,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,7 +19,7 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
-	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.6" {
+	if got := supported.Versions[3].ArtifactVersion(); got != "v1.36.3-katl.7" {
 		t.Fatalf("artifact version = %q", got)
 	}
 }


### PR DESCRIPTION
Reload systemd after activating and refreshing the operation-scoped Kubernetes extensions, before checking kubelet or starting bootstrap readiness. A clean bootstrap could expose kubelet.service through the sysext while systemd still had a stale unit cache, causing the supported cluster journey to fail even though the unit existed. This restores reliable bootstrap init and worker join from current artifacts and keeps the generated Kubernetes release inputs synchronized.