### PR TITLE
cluster: skip kubeadm apply before bootstrap

### DIFF
--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -62,6 +62,7 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 		"control-plane": true,
 		"kubelet":       true,
 	}
+	preBootstrap := false
 	if strings.TrimSpace(opts.configPath) != "" {
 		var activated activatedClusterConfig
 		activated, err = activateClusterConfig(ctx, opts, inv.Nodes)
@@ -70,6 +71,7 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 		}
 		generations = activated.generations
 		components = activated.components
+		preBootstrap = activated.preBootstrap
 	} else if strings.TrimSpace(opts.generationID) == "" {
 		return fmt.Errorf("--generation is required with --inventory")
 	}
@@ -77,6 +79,17 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 	results := map[string]any{}
 	for _, component := range []string{"control-plane", "kubelet", "kube-proxy"} {
 		if !components[component] {
+			continue
+		}
+		if preBootstrap {
+			if err := clusterApplyProgress(opts.progress, "component=%s status=skipped reason=kubernetes-not-configured", component); err != nil {
+				return err
+			}
+			results[component] = map[string]string{
+				"component": component,
+				"reason":    "kubernetes-not-configured",
+				"result":    "skipped",
+			}
 			continue
 		}
 		componentOpts := opts
@@ -286,8 +299,9 @@ func kubeadmConfigInventory(opts kubeadmControlPlaneConfigOptions) (inventory.In
 }
 
 type activatedClusterConfig struct {
-	generations map[string]string
-	components  map[string]bool
+	generations  map[string]string
+	components   map[string]bool
+	preBootstrap bool
 }
 
 func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOptions, nodes []inventory.Node) (activatedClusterConfig, error) {
@@ -306,6 +320,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		configYAML        []byte
 		machineID         string
 		currentGeneration string
+		kubernetesState   string
 		noChanges         bool
 	}
 	prepared := make([]preparedInput, 0, len(nodes))
@@ -373,6 +388,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		}
 		input.machineID = status.MachineId
 		input.currentGeneration = status.CurrentGenerationId
+		input.kubernetesState = strings.TrimSpace(status.GetKubernetes().GetState())
 		input.noChanges = validation.NoChanges
 		_ = conn.Close()
 		if validation.NoChanges {
@@ -385,6 +401,22 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		if validation.AcceptedApplyMode != generation.ApplyModeLive {
 			return activatedClusterConfig{}, fmt.Errorf("node %s cannot apply Kubernetes configuration online (accepted mode %s)", node.Name, validation.AcceptedApplyMode)
 		}
+	}
+
+	notConfigured := 0
+	var kubernetesStates []string
+	for _, input := range prepared {
+		if input.kubernetesState == "not-configured" {
+			notConfigured++
+		}
+		kubernetesStates = append(kubernetesStates, input.node.Name+"="+firstNonEmpty(input.kubernetesState, "unknown"))
+	}
+	preBootstrap := len(prepared) > 0 && notConfigured == len(prepared)
+	if notConfigured > 0 && !preBootstrap {
+		return activatedClusterConfig{}, fmt.Errorf(
+			"cluster has mixed Kubernetes lifecycle state (%s); recover or wipe the inconsistent nodes before applying cluster config",
+			strings.Join(kubernetesStates, ", "),
+		)
 	}
 
 	for _, input := range prepared {
@@ -429,7 +461,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		}
 		result[node.Name] = activatedGeneration
 	}
-	return activatedClusterConfig{generations: result, components: components}, nil
+	return activatedClusterConfig{generations: result, components: components, preBootstrap: preBootstrap}, nil
 }
 
 func clusterApplyProgress(w io.Writer, format string, args ...any) error {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -160,6 +160,102 @@ func TestRunClusterApplyReconcilesWholeConfigAndAllKubernetesComponents(t *testi
 	}
 }
 
+func TestRunClusterApplySkipsKubernetesComponentsBeforeBootstrap(t *testing.T) {
+	configPath := writeClusterConfig(t)
+	var stdout, stderr bytes.Buffer
+	client := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-1",
+			CurrentGenerationId: "generation-0",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "not-configured"},
+		},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+	}
+	previousDial := dialKatlcAgent
+	defer func() { dialKatlcAgent = previousDial }()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("endpoint = %q", endpoint)
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		`"result":"succeeded"`,
+		`"control-plane":{"component":"control-plane","reason":"kubernetes-not-configured","result":"skipped"}`,
+		`"kubelet":{"component":"kubelet","reason":"kubernetes-not-configured","result":"skipped"}`,
+	} {
+		if !strings.Contains(stdout.String(), required) {
+			t.Fatalf("stdout = %s, missing %s", stdout.String(), required)
+		}
+	}
+	for _, component := range []string{"control-plane", "kubelet"} {
+		required := "component=" + component + " status=skipped reason=kubernetes-not-configured"
+		if !strings.Contains(stderr.String(), required) {
+			t.Fatalf("stderr = %s, missing %s", stderr.String(), required)
+		}
+	}
+	if strings.Contains(stderr.String(), "component=control-plane status=started") ||
+		strings.Contains(stderr.String(), "component=kubelet status=started") {
+		t.Fatalf("pre-bootstrap apply started Kubernetes reconciliation: %s", stderr.String())
+	}
+	if len(client.submitRequests) != 0 {
+		t.Fatalf("pre-bootstrap no-op submitted mutations: %#v", client.submitRequests)
+	}
+}
+
+func TestActivateClusterConfigRejectsMixedKubernetesStateBeforeMutation(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "cluster.yaml")
+	source := configBundleSource() + `    - name: cp-2
+      controlPlane: true
+      bootstrap:
+        address: 10.0.0.12
+      install:
+        targetDisk:
+          byID: /dev/disk/by-id/ata-cp-2-root
+`
+	if err := os.WriteFile(configPath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-1",
+			CurrentGenerationId: "generation-0",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "not-configured"},
+		},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+	}
+	second := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-2",
+			CurrentGenerationId: "generation-1",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "ready"},
+		},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+	}
+	previousDial := dialKatlcAgent
+	defer func() { dialKatlcAgent = previousDial }()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		clients := map[string]*fakeKatlcAgentClient{"10.0.0.11:9443": first, "10.0.0.12:9443": second}
+		return katlcAgentConnection{Client: clients[endpoint], Close: func() error { return nil }}, nil
+	}
+
+	_, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, []inventory.Node{
+		{Name: "cp-1", Address: "10.0.0.11", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
+		{Name: "cp-2", Address: "10.0.0.12", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "mixed Kubernetes lifecycle state (cp-1=not-configured, cp-2=ready)") {
+		t.Fatalf("activateClusterConfig() error = %v", err)
+	}
+	if len(first.submitRequests) != 0 || len(second.submitRequests) != 0 {
+		t.Fatalf("mutation started with mixed Kubernetes state: first=%#v second=%#v", first.submitRequests, second.submitRequests)
+	}
+}
+
 func TestActivateClusterConfigValidatesEveryNodeBeforeMutation(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")


### PR DESCRIPTION
## What changed

Make `katlctl cluster apply` treat an entirely unconfigured cluster as a valid pre-bootstrap state. It applies or confirms the whole-node configuration, reports kubeadm-produced components as skipped, and rejects mixed Kubernetes lifecycle state before mutation.

## Why

After a clean install, generation 0 intentionally has no Kubernetes payload. The coordinator nevertheless attempted online kubeadm reconciliation and failed before the cluster’s first bootstrap.

The public apply and its immediate repeat now succeed against all three freshly reinstalled lab nodes without starting bootstrap or disrupting them.
