### PR TITLE
upgrade: reject unsafe sources before acceptance

### DIFF
--- a/internal/installer/katlosimage/host_upgrade.go
+++ b/internal/installer/katlosimage/host_upgrade.go
@@ -47,14 +47,8 @@ func (p Payload) HostUpgradePlan(request HostUpgradeRequest) (HostUpgradePlan, e
 	if p.Index.ImageRole != RoleUpgrade {
 		return HostUpgradePlan{}, fmt.Errorf("KatlOS image role must be %s", RoleUpgrade)
 	}
-	if err := generation.ValidateGenerationSpec(request.PreviousSpec); err != nil {
-		return HostUpgradePlan{}, fmt.Errorf("previous generation spec is invalid: %w", err)
-	}
-	if err := generation.ValidateGenerationStatus(request.PreviousSpec, request.PreviousStatus); err != nil {
-		return HostUpgradePlan{}, fmt.Errorf("previous generation status is invalid: %w", err)
-	}
-	if !generation.IsKnownGood(request.PreviousStatus) {
-		return HostUpgradePlan{}, fmt.Errorf("previous generation %q is not known-good", request.PreviousSpec.GenerationID)
+	if err := ValidateHostUpgradeSource(request.PreviousSpec, request.PreviousStatus, request.Bootstrapped); err != nil {
+		return HostUpgradePlan{}, err
 	}
 	generationID := strings.TrimSpace(request.GenerationID)
 	if generationID == "" {
@@ -155,6 +149,24 @@ func (p Payload) HostUpgradePlan(request HostUpgradeRequest) (HostUpgradePlan, e
 		BootSelection:   selection,
 		PreservedAssets: append(sysextAssets, confextAssets...),
 	}, nil
+}
+
+func ValidateHostUpgradeSource(previousSpec generation.GenerationSpec, previousStatus generation.GenerationStatus, bootstrapped bool) error {
+	if err := generation.ValidateGenerationSpec(previousSpec); err != nil {
+		return fmt.Errorf("previous generation spec is invalid: %w", err)
+	}
+	if err := generation.ValidateGenerationStatus(previousSpec, previousStatus); err != nil {
+		return fmt.Errorf("previous generation status is invalid: %w", err)
+	}
+	if !generation.IsKnownGood(previousStatus) {
+		return fmt.Errorf("previous generation %q is not known-good", previousSpec.GenerationID)
+	}
+	if bootstrapped {
+		if _, ok := selectedKubernetes(previousSpec.Sysexts); !ok {
+			return fmt.Errorf("bootstrapped node current generation has no Kubernetes sysext to preserve")
+		}
+	}
+	return nil
 }
 
 func mergeKernelCommandLine(previous, required []string) []string {

--- a/internal/katlc/agent/host_upgrade.go
+++ b/internal/katlc/agent/host_upgrade.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"google.golang.org/grpc/codes"
@@ -33,9 +35,32 @@ func validateHostUpgradeRequest(kind string, req *agentapi.HostUpgradeOperationR
 	return operation.ValidateHostUpgrade(hostUpgradeFromProto(req))
 }
 
+func (s *Server) validateHostUpgradePlan(req *agentapi.HostUpgradeOperationRequest) error {
+	request := hostUpgradeFromProto(req)
+	if err := s.validateCandidateGenerationAvailable(request.CandidateGenerationID); err != nil {
+		return err
+	}
+	currentID, err := currentGenerationID(s.Root)
+	if err != nil {
+		return fmt.Errorf("read current generation: %w", err)
+	}
+	previousSpec, previousStatus, err := generation.ReadGeneration(s.Root, currentID)
+	if err != nil {
+		return fmt.Errorf("read current generation %q: %w", currentID, err)
+	}
+	kubernetesState, err := s.kubernetesNodeState()
+	if err != nil {
+		return fmt.Errorf("inspect Kubernetes node state: %w", err)
+	}
+	if err := katlosimage.ValidateHostUpgradeSource(previousSpec, previousStatus, kubernetesState.bootstrapped); err != nil {
+		return fmt.Errorf("%w; inspect the current generation, then recover it or wipe and reinstall this node before retrying the upgrade", err)
+	}
+	return nil
+}
+
 func (s *Server) acceptHostUpgradeOperation(req *agentapi.SubmitOperationRequest, digest, id string, locks []string, now time.Time) (operation.OperationRecord, *agentapi.OperationAccepted, error) {
 	request := hostUpgradeFromProto(req.GetHostUpgrade())
-	if err := s.validateCandidateGenerationAvailable(request.CandidateGenerationID); err != nil {
+	if err := s.validateHostUpgradePlan(req.GetHostUpgrade()); err != nil {
 		return operation.OperationRecord{}, nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 	record := operation.OperationRecord{

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/katlosimage"
@@ -385,8 +386,31 @@ func (e *Executor) toolOutput(ctx context.Context, name string, args ...string) 
 }
 
 func (e *Executor) failHostUpgrade(record operation.OperationRecord, phase string, cause error) error {
-	_, err := e.failRecord(record.OperationID, "host-upgrade-"+phase+"-failed", phase, "host upgrade failed before candidate activation", cause)
-	return errors.Join(cause, err)
+	now := e.clock()
+	latest, readErr := e.Store.Read(record.OperationID)
+	mutated := record.ExternalMutationStarted
+	if readErr == nil {
+		mutated = latest.ExternalMutationStarted
+	}
+	_, updateErr := e.Store.Update(record.OperationID, "host-upgrade-"+phase+"-failed", phase, func(current operation.OperationRecord) (operation.OperationRecord, error) {
+		current.Phase = phase
+		current.Terminal = true
+		current.CompletedAt = &now
+		current.UpdatedAt = now
+		current.FailureReason = inventory.Redact(cause.Error())
+		current.Result = "failed"
+		current.GenerationCommitState = operation.GenerationCommitAbandoned
+		current.NextAction = "fix the pre-mutation failure and submit a new explicit host upgrade"
+		if mutated {
+			current.RecoveryRequired = true
+			current.Result = operation.ResultFailedNeedsRepair
+			current.GenerationCommitState = operation.GenerationCommitCandidate
+			current.ActivationState = operation.ActivationStateFailed
+			current.NextAction = "inspect host-upgrade diagnostics and repair the staged generation before retrying"
+		}
+		return current, nil
+	})
+	return errors.Join(cause, readErr, updateErr)
 }
 
 func inactiveRoot(current string) (string, error) {

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -42,6 +42,66 @@ func TestCleanupManagedHostUpgradeArtifactRemovesOnlyUploadedImage(t *testing.T)
 	}
 }
 
+func TestExecutorClassifiesHostUpgradeFailureByMutationBoundary(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		mutated    bool
+		wantResult string
+		wantRepair bool
+	}{
+		{name: "pre-mutation", wantResult: "failed"},
+		{name: "post-mutation", mutated: true, wantResult: operation.ResultFailedNeedsRepair, wantRepair: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			now := time.Date(2026, 7, 24, 6, 0, 0, 0, time.UTC)
+			record, err := store.Create(operation.OperationRecord{
+				OperationID:             "host-upgrade-failure",
+				OperationKind:           OperationKindHostUpgrade,
+				Scope:                   "host-generation",
+				RequestDigest:           strings.Repeat("d", 64),
+				Phase:                   "accepted",
+				CandidateGenerationID:   "gen1",
+				ActivationMode:          operation.ActivationModeNextBoot,
+				ActivationState:         operation.ActivationStatePending,
+				GenerationCommitState:   operation.GenerationCommitCandidate,
+				ExternalMutationStarted: test.mutated,
+				HostUpgradeRequest: &operation.HostUpgrade{
+					ImageURL:              "https://updates.example.test/katlos-upgrade.squashfs",
+					CandidateGenerationID: "gen1",
+				},
+			}, "accepted", now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			executor := NewExecutor(root, store, "agent-test")
+			executor.Now = func() time.Time { return now.Add(time.Minute) }
+			cause := errors.New("source generation prerequisite failed")
+			if err := executor.failHostUpgrade(record, "verify-katlos-image", cause); !errors.Is(err, cause) {
+				t.Fatalf("failHostUpgrade() error = %v, want cause", err)
+			}
+			failed, err := store.Read(record.OperationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !failed.Terminal || failed.Result != test.wantResult || failed.RecoveryRequired != test.wantRepair {
+				t.Fatalf("failed record = %+v, want result %q repair=%t", failed, test.wantResult, test.wantRepair)
+			}
+			if test.mutated {
+				if failed.GenerationCommitState != operation.GenerationCommitCandidate || failed.ActivationState != operation.ActivationStateFailed {
+					t.Fatalf("post-mutation lifecycle = %+v", failed)
+				}
+			} else if failed.GenerationCommitState != operation.GenerationCommitAbandoned || !strings.Contains(failed.NextAction, "pre-mutation") {
+				t.Fatalf("pre-mutation lifecycle = %+v", failed)
+			}
+		})
+	}
+}
+
 func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{"etc", "efi/EFI/Linux", "dev/disk/by-partlabel"} {

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -424,6 +424,11 @@ func (s *Server) acceptOperation(req *agentapi.SubmitOperationRequest, digest st
 			}
 			return operation.OperationRecord{}, accepted, nil
 		}
+		if req.GetHostUpgrade() != nil {
+			if err := s.validateHostUpgradePlan(req.GetHostUpgrade()); err != nil {
+				return operation.OperationRecord{}, nil, status.Errorf(codes.FailedPrecondition, "host upgrade preflight: %v", err)
+			}
+		}
 		candidateID := requestCandidateGenerationID(req)
 		return operation.OperationRecord{}, &agentapi.OperationAccepted{
 			OperationKind: req.OperationKind,

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -503,6 +503,7 @@ func TestSubmitOperationRecordsDestructiveReset(t *testing.T) {
 
 func TestSubmitOperationRecordsHostUpgrade(t *testing.T) {
 	server := newTestServer(t)
+	writeKnownGoodHostUpgradeSource(t, server.Root)
 	var dispatched atomic.Int32
 	server.Dispatcher = dispatchFunc(func(context.Context, operation.OperationRecord) error {
 		dispatched.Add(1)
@@ -541,6 +542,91 @@ func TestSubmitOperationRecordsHostUpgrade(t *testing.T) {
 	}
 }
 
+func TestHostUpgradeDryRunRejectsUnknownSourceWithoutRecord(t *testing.T) {
+	server := newTestServer(t)
+	writeKnownGoodHostUpgradeSource(t, server.Root)
+	spec, generationStatus, err := generation.ReadGeneration(server.Root, "generation-0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	generationStatus.HealthState = generation.HealthStateUnhealthy
+	if err := generation.WriteGenerationStatus(server.Root, spec, generationStatus); err != nil {
+		t.Fatal(err)
+	}
+	req := hostUpgradeSubmitRequest("req-host-upgrade-dry-run")
+	req.DryRun = true
+
+	_, err = server.SubmitOperation(context.Background(), req)
+	if status.Code(err) != codes.FailedPrecondition ||
+		!strings.Contains(err.Error(), "not known-good") ||
+		!strings.Contains(err.Error(), "wipe and reinstall") {
+		t.Fatalf("SubmitOperation() error = %v, want actionable source-generation refusal", err)
+	}
+	ids, err := server.Store.OperationIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("operation ids = %v, want no record for dry-run refusal", ids)
+	}
+}
+
+func TestHostUpgradeAcceptanceRejectsBootstrappedSourceWithoutKubernetesSysext(t *testing.T) {
+	server := newTestServer(t)
+	writeKnownGoodHostUpgradeSource(t, server.Root)
+	adminConfig := filepath.Join(server.Root, "etc/kubernetes/admin.conf")
+	if err := os.MkdirAll(filepath.Dir(adminConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(adminConfig, []byte("bootstrapped\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var dispatched atomic.Int32
+	server.Dispatcher = dispatchFunc(func(context.Context, operation.OperationRecord) error {
+		dispatched.Add(1)
+		return nil
+	})
+
+	_, err := server.SubmitOperation(context.Background(), hostUpgradeSubmitRequest("req-host-upgrade-missing-sysext"))
+	if status.Code(err) != codes.FailedPrecondition ||
+		!strings.Contains(err.Error(), "no Kubernetes sysext") ||
+		!strings.Contains(err.Error(), "wipe and reinstall") {
+		t.Fatalf("SubmitOperation() error = %v, want actionable payload refusal", err)
+	}
+	if dispatched.Load() != 0 {
+		t.Fatalf("dispatcher calls = %d, want no operation dispatch", dispatched.Load())
+	}
+	ids, err := server.Store.OperationIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("operation ids = %v, want no record for acceptance refusal", ids)
+	}
+}
+
+func TestHostUpgradeDryRunAllowsHealthySourceBeforeBootstrap(t *testing.T) {
+	server := newTestServer(t)
+	writeKnownGoodHostUpgradeSource(t, server.Root)
+	req := hostUpgradeSubmitRequest("req-host-upgrade-pre-bootstrap")
+	req.DryRun = true
+
+	accepted, err := server.SubmitOperation(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.GetOperationId() != "" || accepted.GetInitialStatus().GetPhase() != "dry-run" {
+		t.Fatalf("accepted = %+v, want non-persistent dry-run", accepted)
+	}
+	ids, err := server.Store.OperationIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("operation ids = %v, want none", ids)
+	}
+}
+
 func TestSubmitOperationRejectsUnsafeHostUpgradeReference(t *testing.T) {
 	server := newTestServer(t)
 	server.Dispatcher = dispatchFunc(func(context.Context, operation.OperationRecord) error { return nil })
@@ -559,6 +645,42 @@ func TestSubmitOperationRejectsUnsafeHostUpgradeReference(t *testing.T) {
 	_, err := server.SubmitOperation(context.Background(), req)
 	if status.Code(err) != codes.InvalidArgument || !strings.Contains(err.Error(), "without credentials, query, or fragment") {
 		t.Fatalf("SubmitOperation() error = %v, want unsafe URL rejection", err)
+	}
+}
+
+func hostUpgradeSubmitRequest(clientRequestID string) *agentapi.SubmitOperationRequest {
+	return &agentapi.SubmitOperationRequest{
+		ApiVersion:      APIVersion,
+		Kind:            RequestKind,
+		ClientRequestId: clientRequestID,
+		OperationKind:   OperationKindHostUpgrade,
+		Actor:           "test-actor",
+		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
+			ImageUrl:              "https://updates.example.test/katlos-upgrade.squashfs",
+			CandidateGenerationId: "gen-upgrade-1",
+		},
+	}
+}
+
+func writeKnownGoodHostUpgradeSource(t *testing.T, root string) {
+	t.Helper()
+	writeCleanGenerationZeroState(t, root)
+	spec, _, err := generation.ReadGeneration(root, "generation-0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	generationStatus, err := generation.NewGenerationStatus(
+		spec,
+		generation.CommitStateCommitted,
+		generation.BootStateGood,
+		generation.HealthStateHealthy,
+		time.Date(2026, 6, 15, 11, 5, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := generation.WriteGenerationStatus(root, spec, generationStatus); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:397337229df895e1e74f4669d685da6baffbf1a064bfc34ffa963171c1a7ebd1",
+  "recipeDigest": "sha256:0e20ae7cb697a1e6c0167f8650f90a508d87fae9953d1d2b68b0f013d2fc7bb5",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 14,
+      "artifactRevision": 15,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 12,
+      "artifactRevision": 13,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 11,
+      "artifactRevision": 12,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 11,
+      "artifactRevision": 12,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",


### PR DESCRIPTION
Host upgrade dry-runs and real submissions now validate the current durable
generation and Kubernetes state before accepting work. Executor failures are
also classified by whether external mutation had begun, so a safe refusal no
longer tells the operator that repair is required.

The root cause was that request planning checked only request shape while the
executor owned source-generation prerequisites. This allowed an unhealthy
generation to pass `--plan`, then fail after acceptance with misleading
recovery status.

The installed-runtime root/UKI upgrade VM journey passes with the rebuilt
artifacts.
