### PR TITLE
wipe: prove pre-bootstrap control-plane reinstall

### DIFF
--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -120,7 +120,7 @@ Failure behavior:
 Command:
 
 ```text
-katlctl node wipe NAME [--config PATH] --kubeconfig PATH
+katlctl node wipe NAME [--config PATH] [--kubeconfig PATH]
 ```
 
 Target selection:
@@ -133,17 +133,21 @@ Target selection:
 
 Graceful Kubernetes cleanup:
 
-- `--kubeconfig` is required for execution. `--plan` may run without contacting
-  the Kubernetes API only if it reports Kubernetes cleanup as `unknown`.
+- `--kubeconfig` is required for an enrolled node. A node that reports
+  Kubernetes state `not-configured` does not require Kubernetes API cleanup and
+  reports that cleanup as `not-needed`.
+- `--plan` may run for an enrolled node without contacting the Kubernetes API
+  only if it reports Kubernetes cleanup as `unknown`.
 - `katlctl` first attempts to cordon the Kubernetes Node.
 - It then attempts a bounded drain that evicts ordinary workload pods and ignores
   DaemonSet-managed pods. Mirror/static pods are not deleted through the API.
 - It deletes the Kubernetes Node object after drain attempts complete or time
   out.
-- For a control-plane node, it removes the matching stacked-etcd member when the
-  remaining control plane has quorum. If quorum cannot be proven, the command is
-  refused before node-local wipe unless the target set is the whole cluster,
-  which belongs to `katlctl cluster wipe`.
+- A pre-bootstrap control-plane node can be reset without choosing an inventory
+  init node, even when the topology contains multiple control planes.
+- A single enrolled control-plane wipe is refused before mutation because
+  stacked-etcd membership coordination is not yet implemented. Discarding the
+  whole cluster belongs to `katlctl cluster wipe`.
 
 Node-local wipe trigger:
 
@@ -163,8 +167,8 @@ Node-local wipe trigger:
 Result:
 
 - Success leaves the wiped node powered off and ready for first
-  install/bootstrap again, and leaves the remaining cluster without that
-  Kubernetes Node and, for a control-plane target, without that etcd member.
+  install/bootstrap again. Enrolled worker replacement also leaves the
+  remaining cluster without that Kubernetes Node.
 - The command does not automatically bootstrap the wiped node back into the
   cluster. Rejoin is a later explicit install/bootstrap action.
 
@@ -215,17 +219,21 @@ Result:
 
 ## VM Gates
 
-Implementation of `katlctl node wipe` must add and pass:
+Implementation of `katlctl node wipe` must add and pass both enrolled-worker
+and pre-bootstrap control-plane journeys:
 
 ```text
 scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios -run TestInstalledRuntimeTwoNodeWipeNodeBootstrapSmoke -count=1
+scripts/vmtest-run --artifact-set=default ./internal/vmtest/scenarios -run TestInstalledRuntimeTwoNodeWipePreBootstrapControlPlaneSmoke -count=1
 ```
 
-The gate must start from a bootstrapped Kubernetes cluster with real Kubernetes
-and etcd state, run `katlctl node wipe` against one node, prove Kubernetes Node
-cleanup and etcd member cleanup when applicable, prove the node reaches
-installer-media handoff, then reinstall/bootstrap the node and prove remote
-kubectl/workload health.
+The worker gate starts from a bootstrapped Kubernetes cluster, proves Kubernetes
+Node cleanup and installer-media handoff, reinstalls the worker, rejoins it, and
+proves remote kubectl health. The control-plane gate starts from a
+multi-control-plane topology before bootstrap, runs without a kubeconfig or
+init-node choice, proves the report and destructive operation identify only the
+selected control plane, observes automatic poweroff, reinstalls it, and proves a
+clean generation 0 with a new node identity.
 
 Implementation of `katlctl cluster wipe` must add and pass:
 

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -47,9 +47,10 @@ Do not proceed to reinstall until every intended reset reports `terminal: true`
 and `result: succeeded`, then confirm the nodes are off. Treat
 `recoveryRequired: true` as a stop condition.
 
-## Plan One Worker Replacement
+## Plan One Node Replacement
 
-Single-node wipe coordinates Kubernetes Node cleanup before the node-local reset:
+For an enrolled worker, single-node wipe coordinates Kubernetes Node cleanup
+before the node-local reset:
 
 ```sh
 katlctl node wipe worker-1 --config ./cluster.yaml --plan
@@ -62,10 +63,22 @@ the source can be omitted:
 katlctl node wipe worker-1 --config ./cluster.yaml --kubeconfig ./kubeconfig
 ```
 
-Execution requires `--kubeconfig` so Katl can remove the Kubernetes Node first.
-If Kubernetes cleanup fails, Katl reports recovery required and refuses the
-node-local wipe. Single control-plane wipe is refused because etcd membership
-coordination is not implemented as a supported operation.
+Execution requires `--kubeconfig` for an enrolled node so Katl can remove the
+Kubernetes Node first. If Kubernetes cleanup fails, Katl reports recovery
+required and refuses the node-local wipe.
+
+A control-plane node that has not joined Kubernetes can be reset without a
+kubeconfig or an init-node choice, including from a configuration containing
+multiple control planes:
+
+```sh
+katlctl node wipe cp-1 --config ./cluster.yaml --plan
+katlctl node wipe cp-1 --config ./cluster.yaml
+```
+
+The report identifies the single control-plane target and says
+`kubernetesCleanup: not-needed`. A single enrolled control-plane wipe remains
+refused because supported etcd membership coordination is not implemented.
 
 ## Reinstall
 

--- a/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
+++ b/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
@@ -43,6 +43,19 @@ func TestInstalledRuntimeTwoNodeWipeNodeBootstrapSmoke(t *testing.T) {
 	_ = vmtest.RequireWorld(t)
 }
 
+func TestInstalledRuntimeTwoNodeWipePreBootstrapControlPlaneSmoke(t *testing.T) {
+	if run, ok := wipePreBootstrapControlPlaneWorldSmokeRun(t); ok {
+		runWipePreBootstrapControlPlaneSmoke(t, run)
+		return
+	}
+
+	options := vmtest.DefaultOptions()
+	if !options.Enabled {
+		t.Skip("set -katl.vmtest.run or KATL_VMTEST_RUN=1 to run pre-bootstrap control-plane wipe smoke")
+	}
+	_ = vmtest.RequireWorld(t)
+}
+
 func TestInstalledRuntimeTwoNodeWipeReinstallBootstrapSmoke(t *testing.T) {
 	if run, ok := wipeReinstallWorldSmokeRun(t); ok {
 		runWipeReinstallBootstrapSmoke(t, run)
@@ -64,6 +77,11 @@ func wipeClusterWorldSmokeRun(t *testing.T) (operationBackedSmokeRun, bool) {
 func wipeNodeWorldSmokeRun(t *testing.T) (operationBackedSmokeRun, bool) {
 	t.Helper()
 	return wipeReinstallWorldSmokeRunNamed(t, "installed-runtime-two-node-wipe-node-bootstrap")
+}
+
+func wipePreBootstrapControlPlaneWorldSmokeRun(t *testing.T) (operationBackedSmokeRun, bool) {
+	t.Helper()
+	return wipeReinstallWorldSmokeRunNamed(t, "installed-runtime-two-node-wipe-pre-bootstrap-control-plane")
 }
 
 func wipeReinstallWorldSmokeRun(t *testing.T) (operationBackedSmokeRun, bool) {
@@ -328,6 +346,161 @@ func runWipeNodeBootstrapSmoke(t *testing.T, run operationBackedSmokeRun) {
 		t.Fatal(err)
 	}
 	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
+}
+
+func runWipePreBootstrapControlPlaneSmoke(t *testing.T, run operationBackedSmokeRun) {
+	t.Helper()
+	runner, scenario, result, inputs := run.Runner, run.Scenario, run.Result, run.Inputs
+	requireVMHost(t, runner, scenario, result, vmtest.HostRequirements{Libvirt: true, OVMF: true, KVM: run.Options.KVM})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	liveNodes := []vmtest.RunningInstalledRuntimeNode{}
+	defer func() {
+		for _, node := range liveNodes {
+			stopNode(t, node)
+		}
+	}()
+	nodes, err := startOperationBackedNodes(ctx, run, result, inputs.ControlPlaneDisk, inputs.ControlPlaneDiskFormat, inputs.ControlPlaneESP, inputs.ControlPlaneFixture, inputs.ControlPlaneMetadata, inputs.ControlPlaneMAC, inputs.WorkerDisk, inputs.WorkerDiskFormat, inputs.WorkerESP, inputs.WorkerFixture, inputs.WorkerMetadata, inputs.WorkerMAC)
+	if err != nil {
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatal(err)
+	}
+	liveNodes = nodes
+	cpNode, otherNode := nodeByName(nodes, "cp-1"), nodeByName(nodes, "worker-1")
+	cpAddress, err := liveNodeIPv4Address(ctx, cpNode, inputs.ControlPlaneAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherAddress, err := liveNodeIPv4Address(ctx, otherNode, inputs.WorkerAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventoryPath := filepath.Join(result.RunDir, "pre-bootstrap-control-plane-wipe", "inventory.yaml")
+	if err := writePreBootstrapControlPlaneWipeInventory(inventoryPath, inputs.KubernetesVersion, cpAddress, otherAddress); err != nil {
+		t.Fatal(err)
+	}
+	oldMachineID, err := readNodeFileWithRetry(ctx, cpNode, "/var/lib/katl/identity/machine-id", 4<<10, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cpOverlay, err := bootOverlayPath(cpNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runPreBootstrapControlPlaneWipeHandoff(t, ctx, result, inventoryPath, cpNode); err != nil {
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatal(err)
+	}
+	stopNode(t, cpNode)
+	liveNodes = []vmtest.RunningInstalledRuntimeNode{otherNode}
+
+	reinstallRunner := vmtest.NewRunner(vmtest.Options{Enabled: true, StateRoot: filepath.Join(result.RunDir, "pre-bootstrap-control-plane-reinstall-vm-runs"), Keep: vmtest.KeepAlways, KVM: run.Options.KVM, Missing: vmtest.MissingFails})
+	reinstallResult, err := runWipeReinstallNode(ctx, run, reinstallRunner, "cp-1", cpOverlay, inputs.ControlPlaneInstall, inputs.ControlPlaneMAC)
+	if err != nil {
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatal(err)
+	}
+	cpDisk, err := firstInstallResultDisk(reinstallResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postRunner := vmtest.NewRunner(vmtest.Options{Enabled: true, StateRoot: filepath.Join(result.RunDir, "post-control-plane-reinstall-vm-runs"), Keep: vmtest.KeepFailed, KVM: run.Options.KVM, Missing: vmtest.MissingFails})
+	postResult, err := postRunner.Plan(vmtest.Scenario{Name: "post-control-plane-reinstall"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postResult.Started = time.Now().UTC()
+	reinstalledCP, err := vmtest.StartInstalledRuntimeNode(ctx, postResult, vmtest.InstalledRuntimeNodeConfig{Name: "cp-1", Runtime: vmtest.InstalledRuntimeConfig{Disk: cpDisk, DiskFormat: vmtest.DiskQCOW2, ESPArtifacts: reinstallResult.Artifacts.InstalledESP, NodeMetadata: inputs.ControlPlaneMetadata, VM: operationBackedVMConfigForRun(run, inputs.ControlPlaneMAC, 0)}}, vmtest.VMRunner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveNodes = append(liveNodes, reinstalledCP)
+	if _, err := collectWipeReinstallGeneration0Evidence(ctx, postResult, []vmtest.RunningInstalledRuntimeNode{reinstalledCP}); err != nil {
+		t.Fatal(err)
+	}
+	newMachineID, err := readNodeFileWithRetry(ctx, reinstalledCP, "/var/lib/katl/identity/machine-id", 4<<10, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(newMachineID)) == strings.TrimSpace(string(oldMachineID)) {
+		t.Fatal("control-plane reinstall preserved the old node identity")
+	}
+	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
+}
+
+func writePreBootstrapControlPlaneWipeInventory(path, kubernetesVersion, cpAddress, otherAddress string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data := `controlPlaneEndpoint: ` + cpAddress + `:6443
+kubernetesVersion: ` + kubernetesVersion + `
+nodes:
+- name: cp-1
+  address: ` + cpAddress + `
+  systemRole: control-plane
+  access:
+    method: agent
+  kubeadmConfig:
+    ref: control-plane
+    path: /etc/katl/kubeadm/control-plane/config.yaml
+    intent: control-plane
+  kubernetesVersion: ` + kubernetesVersion + `
+- name: cp-2
+  address: ` + otherAddress + `
+  systemRole: control-plane
+  access:
+    method: agent
+  kubeadmConfig:
+    ref: control-plane
+    path: /etc/katl/kubeadm/control-plane/config.yaml
+    intent: control-plane
+  kubernetesVersion: ` + kubernetesVersion + `
+`
+	return os.WriteFile(path, []byte(data), 0o644)
+}
+
+func runPreBootstrapControlPlaneWipeHandoff(t *testing.T, ctx context.Context, result vmtest.Result, inventoryPath string, cpNode vmtest.RunningInstalledRuntimeNode) error {
+	t.Helper()
+	dir := filepath.Join(result.RunDir, "pre-bootstrap-control-plane-wipe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	var stdout, stderr bytes.Buffer
+	err := runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"node", "wipe", "cp-1", "--inventory", inventoryPath, "--timeout", "10m", "--output", "json"}, &stdout, &stderr)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-wipe-node.stdout"), stdout.Bytes(), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-wipe-node.stderr"), stderr.Bytes(), 0o644)
+	if err != nil {
+		return fmt.Errorf("katlctl pre-bootstrap control-plane wipe failed: %w: %s", err, stderr.String())
+	}
+	var report struct {
+		Kind              string `json:"kind"`
+		KubernetesCleanup string `json:"kubernetesCleanup"`
+		NextAction        string `json:"nextAction"`
+		Targets           []struct {
+			Name       string `json:"name"`
+			SystemRole string `json:"systemRole"`
+		} `json:"targets"`
+		Nodes []struct {
+			Node     string `json:"node"`
+			Terminal bool   `json:"terminal"`
+			Result   string `json:"result"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		return err
+	}
+	if report.Kind != "WipeNodeReport" || report.KubernetesCleanup != "not-needed" ||
+		len(report.Targets) != 1 || report.Targets[0].Name != "cp-1" || report.Targets[0].SystemRole != "control-plane" ||
+		len(report.Nodes) != 1 || report.Nodes[0].Node != "cp-1" ||
+		!report.Nodes[0].Terminal || report.Nodes[0].Result != operation.ResultSucceeded ||
+		!strings.Contains(report.NextAction, "installer media or PXE") {
+		return fmt.Errorf("pre-bootstrap control-plane wipe report = %#v", report)
+	}
+	if err := cpNode.WaitForPoweroff(ctx); err != nil {
+		return err
+	}
+	_, err = writeWipePoweroffEvidence(filepath.Join(dir, "evidence", "cp-1", "poweroff.json"), cpNode)
+	return err
 }
 
 func runReinstalledWorkerJoin(t *testing.T, ctx context.Context, run operationBackedSmokeRun, result vmtest.Result, kubeconfigPath string, bundle threeControlPlaneKubernetesPayloadBundle, nodes []vmtest.RunningInstalledRuntimeNode) error {


### PR DESCRIPTION
Adds an installed-runtime journey for the supported recovery path: wipe one
not-configured control plane from a multi-control-plane topology without a
kubeconfig or init-node choice, observe automatic poweroff, reinstall it, and
verify a clean generation 0 with a new node identity.

The implementation was already present, but coverage stopped at enrolled worker
replacement and the operator/internal docs still described every single
control-plane wipe as refused. The docs now distinguish safe pre-bootstrap reset
from enrolled control planes, which remain refused pending etcd coordination.

The rebuilt public `katlctl` wipe/reinstall VM journey passes.
