### PR TITLE
release: restore Kubernetes sysext builds

### DIFF
--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:0e20ae7cb697a1e6c0167f8650f90a508d87fae9953d1d2b68b0f013d2fc7bb5",
+  "recipeDigest": "sha256:e9ae48a95a80fd0a5e4377037275cd5b93543c328edaca9b80b98ceabf0358eb",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 15,
+      "artifactRevision": 16,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 13,
+      "artifactRevision": 14,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 12,
+      "artifactRevision": 13,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 12,
+      "artifactRevision": 13,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/kubernetes_sysext_builder_test.go
+++ b/internal/scriptstest/kubernetes_sysext_builder_test.go
@@ -16,7 +16,8 @@ func TestKubernetesSysextBuilderOwnsProfileAndOutputSelection(t *testing.T) {
 	repoFile := filepath.Join(profileDir, "mkosi.sandbox", "etc", "yum.repos.d", "kubernetes.repo")
 	profile := filepath.Join(profileDir, "mkosi.conf")
 	manifest := filepath.Join(profileDir, "kubernetes.env")
-	for _, dir := range []string{filepath.Join(repo, "scripts"), filepath.Dir(repoFile), buildDir} {
+	runtimePackageDB := filepath.Join(buildDir, "katl-runtime-root", "usr", "lib", "sysimage", "rpm")
+	for _, dir := range []string{filepath.Join(repo, "scripts"), filepath.Dir(repoFile), buildDir, runtimePackageDB} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -132,5 +133,19 @@ printf '{"sha256":"%s","sizeBytes":%s}\n' "$digest" "$size" > "$artifact.json"
 	}
 	if got := strings.Join(readLinesForScripts(t, goArgs), " "); !strings.Contains(got, "--artifact "+filepath.Join(buildDir, "katl-kubernetes-upgrade.raw")) {
 		t.Fatalf("metadata command did not receive the explicit output: %s", got)
+	}
+
+	if err := os.RemoveAll(runtimePackageDB); err != nil {
+		t.Fatalf("remove runtime package database: %v", err)
+	}
+	missingDB := exec.Command(filepath.Join(repo, "scripts", "build-kubernetes-sysext"), "--output", "katl-kubernetes-upgrade", "--no-cache")
+	missingDB.Dir = repo
+	missingDB.Env = cmd.Env
+	output, err = missingDB.CombinedOutput()
+	if err == nil {
+		t.Fatalf("build-kubernetes-sysext without the runtime package database unexpectedly passed:\n%s", output)
+	}
+	if !strings.Contains(string(output), "rebuild the runtime with scripts/mkosi build-runtime") {
+		t.Fatalf("missing package database error is not actionable:\n%s", output)
 	}
 }

--- a/scripts/build-kubernetes-sysext
+++ b/scripts/build-kubernetes-sysext
@@ -55,11 +55,18 @@ profile="$repo_root/mkosi.profiles/kubernetes-sysext/mkosi.conf"
 repo_file="$repo_root/mkosi.profiles/kubernetes-sysext/mkosi.sandbox/etc/yum.repos.d/kubernetes.repo"
 runtime_artifact="$build_dir/katl-runtime-root.squashfs"
 runtime_metadata="$runtime_artifact.json"
+runtime_package_db="$build_dir/katl-runtime-root/usr/lib/sysimage/rpm"
 base_artifact="$build_dir/katl-kubernetes.raw"
 artifact="$build_dir/$output_name.raw"
 stamp="$build_dir/.katl-stamps/kubernetes-sysext-$output_name.sha256"
 build_commit="${KATL_BUILD_COMMIT:-${KATL_VERSION:-0.0.0-dev}}"
 architecture="${KATL_ARCHITECTURE:-$(uname -m)}"
+
+if [[ ! -d "$runtime_package_db" ]]; then
+    echo "error: runtime build package database not found: $runtime_package_db" >&2
+    echo "rebuild the runtime with scripts/mkosi build-runtime before building a Kubernetes sysext" >&2
+    exit 1
+fi
 
 builder_image_identity() {
     local runtime="${KATL_CONTAINER_RUNTIME:-}"

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -826,6 +826,9 @@ set +e
                 fi
             fi
             if [[ "$status" -eq 0 ]]; then
+                # Keep the RPM database in the unpacked build tree so mkosi can
+                # resolve sysext packages against the runtime base. Exclude it
+                # from the immutable runtime artifact below.
                 rm -rf \
                     "$root/boot" \
                     "$root/buildroot" \
@@ -835,7 +838,6 @@ set +e
                     "$root/usr/bin/dracut" \
                     "$root/usr/bin/lsinitrd" \
                     "$root/usr/lib/dracut" \
-                    "$root/usr/lib/sysimage/rpm" \
                     "$root/var/lib/rpm-state"
                 rm -f \
                     "$root/usr/lib/systemd/system"/dracut-*.service \
@@ -850,7 +852,8 @@ set +e
                     -all-root \
                     -comp zstd \
                     -b 1M \
-                    -Xcompression-level 22; then
+                    -Xcompression-level 22 \
+                    -e usr/lib/sysimage/rpm; then
                     status=1
                 elif ! sha256=$(mkosi_artifacts write-runtime-root --artifact "$artifact"); then
                     status=1


### PR DESCRIPTION
## What changed

- retain the runtime RPM database in the unpacked build tree while excluding it from the shipped immutable SquashFS
- fail early with recovery guidance when the Kubernetes sysext base lacks package state
- refresh the bundle recipe digest and revisions for every supported Kubernetes payload

## Why

Runtime artifact slimming removed the package database from both the release image and mkosi's build-time base tree. The sysext build therefore treated runtime dependencies as absent, reinstalled them into the overlay, and failed when `pam` encountered the runtime's `/var/run` symlink.

This restores package-aware sysext resolution without exposing RPM state in the release artifact. The refreshed `v1.36.0-katl.16` runtime, sysext, artifact inspections, and staged bundle checksums were validated locally.
