### PR TITLE
release: publish inspected Kubernetes bundles

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -190,7 +190,12 @@ jobs:
 
       - name: Set reproducible build timestamp
         shell: bash
-        run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")" >> "$GITHUB_ENV"
+        run: |
+          source_date_epoch="$(git show -s --format=%ct "$GITHUB_SHA")"
+          {
+            echo "SOURCE_DATE_EPOCH=$source_date_epoch"
+            echo "OCI_CREATED=$(date --utc --date="@${source_date_epoch}" +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_ENV"
 
       - name: Set up ORAS
         shell: bash
@@ -322,6 +327,7 @@ jobs:
             --artifact-type application/vnd.katl.kubernetes.payload.bundle.v1 \
             --config "${BUNDLE_DIR}/bundle.json:application/vnd.katl.kubernetes.payload.bundle.v1+json" \
             --annotation "org.opencontainers.image.title=${OCI_TITLE}" \
+            --annotation "org.opencontainers.image.created=${OCI_CREATED}" \
             --annotation "org.opencontainers.image.description=${OCI_DESCRIPTION}" \
             --annotation "org.opencontainers.image.licenses=${OCI_LICENSES}" \
             --annotation "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
@@ -376,7 +382,6 @@ jobs:
           BUNDLE_DIR: ${{ steps.bundle.outputs.bundle-dir }}
           DIGEST_TAG: ${{ steps.bundle.outputs.digest-tag }}
           LOCAL_MANIFEST_DIGEST: ${{ steps.oci-layout.outputs.manifest-digest }}
-          RAW: ${{ steps.bundle.outputs.raw }}
           VERSION_TAG: ${{ steps.bundle.outputs.version-tag }}
         run: |
           resolve_remote_tag() {
@@ -417,24 +422,10 @@ jobs:
             fi
             publication="Reused"
           else
-            oras push "${OCI_REPOSITORY}:${VERSION_TAG},${DIGEST_TAG}" \
-              --artifact-type application/vnd.katl.kubernetes.payload.bundle.v1 \
-              --config "${BUNDLE_DIR}/bundle.json:application/vnd.katl.kubernetes.payload.bundle.v1+json" \
-              --annotation "org.opencontainers.image.title=${OCI_TITLE}" \
-              --annotation "org.opencontainers.image.description=${OCI_DESCRIPTION}" \
-              --annotation "org.opencontainers.image.licenses=${OCI_LICENSES}" \
-              --annotation "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
-              --annotation "org.opencontainers.image.documentation=https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_SHA}/docs/installing.md" \
-              --annotation "org.opencontainers.image.revision=${GITHUB_SHA}" \
-              --annotation "org.opencontainers.image.version=${ARTIFACT_VERSION}" \
-              --annotation "dev.katl.bundle.kind=kubernetes" \
-              "${RAW}:application/vnd.katl.sysext.raw.v1" \
-              "${BUNDLE_DIR}/metadata.json:application/vnd.katl.kubernetes.sysext.metadata.v1+json" \
-              "${BUNDLE_DIR}/package-provenance.json:application/vnd.katl.package-provenance.v1+json" \
-              "${BUNDLE_DIR}/catalog-entry.json:application/vnd.katl.kubernetes.catalog.entry.v1+json" \
-              --format json > _build/oras-push.json
-
-            manifest_digest="$(jq -r '.digest' _build/oras-push.json)"
+            oras cp --from-oci-layout \
+              "_build/oci-layout:${VERSION_TAG}" \
+              "${OCI_REPOSITORY}:${VERSION_TAG},${DIGEST_TAG}"
+            manifest_digest="$(oras resolve "${OCI_REPOSITORY}:${VERSION_TAG}")"
             if [[ "$manifest_digest" != "$LOCAL_MANIFEST_DIGEST" ]]; then
               echo "error: published OCI manifest digest $manifest_digest does not match local digest $LOCAL_MANIFEST_DIGEST" >&2
               exit 1

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:e9ae48a95a80fd0a5e4377037275cd5b93543c328edaca9b80b98ceabf0358eb",
+  "recipeDigest": "sha256:e79d24aac827004116f7f1435dfff82a10cab154e9ca76c3130e0953a2eb1d99",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 16,
+      "artifactRevision": 17,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 14,
+      "artifactRevision": 15,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 13,
+      "artifactRevision": 14,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 13,
+      "artifactRevision": 14,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",


### PR DESCRIPTION
The repaired Kubernetes builds now reach publication, where they exposed a second defect: separate ORAS pushes add different wall-clock creation annotations, so the registry manifest digest cannot match the locally inspected manifest.\n\nThis gives the OCI manifest a reproducible creation time and copies the inspected OCI layout directly to GHCR. It also advances the four artifact revisions past the partially published failed-run tags.