### PR TITLE
networking: route VIP only from healthy control planes

### DIFF
--- a/cmd/katl-endpoint-advertiser/main.go
+++ b/cmd/katl-endpoint-advertiser/main.go
@@ -41,21 +41,9 @@ func run(args []string, stderr io.Writer) error {
 	}
 
 	if command == "withdraw" {
-		return withdraw(context.Background())
+		return withdraw(context.Background(), *configPath)
 	}
-	file, err := os.Open(*configPath)
-	if err != nil {
-		return fmt.Errorf("open generated config: %w", err)
-	}
-	object, err := bgpapivip.Decode(file)
-	closeErr := file.Close()
-	if err != nil {
-		return err
-	}
-	if closeErr != nil {
-		return closeErr
-	}
-	config, err := bgpapivip.Normalize(object.Spec)
+	config, err := loadConfig(*configPath)
 	if err != nil {
 		return err
 	}
@@ -64,11 +52,13 @@ func run(args []string, stderr io.Writer) error {
 		return fmt.Errorf("invalid generated health interval %q", config.Health.Interval)
 	}
 	client := bgpapivip.CommandBirdClient{Config: config}
+	owner := bgpapivip.NetlinkVIPOwner{}
 	controller := bgpapivip.Controller{
 		Config:            config,
 		AppPayloadVersion: version,
 		Bird:              client,
 		Interface:         bgpapivip.LinuxInterfaceChecker{},
+		Owner:             owner,
 		Writer:            bgpapivip.FileStatusWriter{LivePath: *statusPath},
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -88,7 +78,7 @@ func run(args []string, stderr io.Writer) error {
 			lastState = state
 		}
 		if runErr != nil {
-			return failClosed(runErr, client, bgpapivip.ExecRunner{})
+			return failClosed(runErr, owner, config, bgpapivip.ExecRunner{})
 		}
 		select {
 		case <-ctx.Done():
@@ -101,26 +91,51 @@ func run(args []string, stderr io.Writer) error {
 	}
 }
 
-func failClosed(runErr error, client bgpapivip.BirdClient, runner bgpapivip.CommandRunner) error {
+func loadConfig(path string) (bgpapivip.Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return bgpapivip.Config{}, fmt.Errorf("open generated config: %w", err)
+	}
+	object, err := bgpapivip.Decode(file)
+	closeErr := file.Close()
+	if err != nil {
+		return bgpapivip.Config{}, err
+	}
+	if closeErr != nil {
+		return bgpapivip.Config{}, closeErr
+	}
+	config, err := bgpapivip.Normalize(object.Spec)
+	if err != nil {
+		return bgpapivip.Config{}, err
+	}
+	return config, nil
+}
+
+func failClosed(runErr error, owner bgpapivip.VIPOwner, config bgpapivip.Config, runner bgpapivip.CommandRunner) error {
 	if runErr == nil {
 		return nil
 	}
-	return errors.Join(runErr, withdrawWith(context.Background(), client, runner))
+	return errors.Join(runErr, withdrawWith(context.Background(), owner, config, runner))
 }
 
-func withdraw(parent context.Context) error {
-	return withdrawWith(parent, bgpapivip.CommandBirdClient{}, bgpapivip.ExecRunner{})
+func withdraw(parent context.Context, configPath string) error {
+	config, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+	return withdrawWith(parent, bgpapivip.NetlinkVIPOwner{}, config, bgpapivip.ExecRunner{})
 }
 
-func withdrawWith(parent context.Context, client bgpapivip.BirdClient, runner bgpapivip.CommandRunner) error {
+func withdrawWith(parent context.Context, owner bgpapivip.VIPOwner, config bgpapivip.Config, runner bgpapivip.CommandRunner) error {
 	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
-	if err := client.SetAdvertisement(ctx, false); err == nil {
+	releaseErr := owner.SetOwned(ctx, config, false)
+	if releaseErr == nil {
 		return nil
 	}
-	output, err := runner.Output(ctx, "systemctl", "stop", "katl-app-bird.service")
-	if err != nil {
-		return fmt.Errorf("withdraw route and stop routing daemon: %s", string(output))
+	output, stopErr := runner.Output(ctx, "systemctl", "stop", "katl-app-bird.service")
+	if stopErr != nil {
+		stopErr = fmt.Errorf("stop routing daemon after local endpoint release failed: %s", string(output))
 	}
-	return nil
+	return errors.Join(fmt.Errorf("release local endpoint address: %w", releaseErr), stopErr)
 }

--- a/cmd/katl-endpoint-advertiser/main_test.go
+++ b/cmd/katl-endpoint-advertiser/main_test.go
@@ -10,25 +10,26 @@ import (
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 )
 
-func TestWithdrawDisablesOnlyRouteSourceWhenBirdResponds(t *testing.T) {
-	bird := &fakeBirdClient{}
+func TestWithdrawReleasesVIPWithoutStoppingBird(t *testing.T) {
+	owner := &fakeVIPOwner{owned: true}
 	runner := &fakeCommandRunner{}
-	if err := withdrawWith(context.Background(), bird, runner); err != nil {
+	if err := withdrawWith(context.Background(), owner, bgpapivip.Config{}, runner); err != nil {
 		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(bird.advertisements, []bool{false}) {
-		t.Fatalf("advertisements = %#v", bird.advertisements)
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("fallback calls = %#v", runner.calls)
 	}
+	if owner.owned {
+		t.Fatal("withdraw retained local VIP ownership")
+	}
 }
 
-func TestWithdrawStopsDedicatedBirdWhenRouteDisableCannotBeConfirmed(t *testing.T) {
-	bird := &fakeBirdClient{setErr: errors.New("control socket unavailable")}
+func TestWithdrawStopsDedicatedBirdWhenVIPCannotBeReleased(t *testing.T) {
+	owner := &fakeVIPOwner{owned: true, err: errors.New("netlink unavailable")}
 	runner := &fakeCommandRunner{}
-	if err := withdrawWith(context.Background(), bird, runner); err != nil {
-		t.Fatal(err)
+	err := withdrawWith(context.Background(), owner, bgpapivip.Config{}, runner)
+	if err == nil || !strings.Contains(err.Error(), "netlink unavailable") {
+		t.Fatalf("withdrawWith() error = %v", err)
 	}
 	want := [][]string{{"systemctl", "stop", "katl-app-bird.service"}}
 	if !reflect.DeepEqual(runner.calls, want) {
@@ -37,49 +38,52 @@ func TestWithdrawStopsDedicatedBirdWhenRouteDisableCannotBeConfirmed(t *testing.
 }
 
 func TestWithdrawFailsWhenNeitherRouteNorDaemonCanBeStopped(t *testing.T) {
-	bird := &fakeBirdClient{setErr: errors.New("control socket unavailable")}
+	owner := &fakeVIPOwner{owned: true, err: errors.New("netlink unavailable")}
 	runner := &fakeCommandRunner{err: errors.New("systemctl failed"), output: []byte("access denied")}
-	err := withdrawWith(context.Background(), bird, runner)
+	err := withdrawWith(context.Background(), owner, bgpapivip.Config{}, runner)
 	if err == nil || !strings.Contains(err.Error(), "access denied") {
 		t.Fatalf("withdrawWith() error = %v", err)
 	}
 }
 
 func TestControllerErrorFailsClosedBeforeSystemdRestart(t *testing.T) {
-	bird := &fakeBirdClient{}
+	owner := &fakeVIPOwner{owned: true}
 	runner := &fakeCommandRunner{}
 	runErr := errors.New("routing status unavailable")
 
-	err := failClosed(runErr, bird, runner)
+	err := failClosed(runErr, owner, bgpapivip.Config{}, runner)
 	if !errors.Is(err, runErr) {
 		t.Fatalf("failClosed() error = %v", err)
-	}
-	if !reflect.DeepEqual(bird.advertisements, []bool{false}) {
-		t.Fatalf("advertisements = %#v", bird.advertisements)
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("fallback calls = %#v", runner.calls)
 	}
-}
-
-type fakeBirdClient struct {
-	setErr         error
-	advertisements []bool
-}
-
-func (b *fakeBirdClient) Status(context.Context) (bgpapivip.BirdRuntimeStatus, error) {
-	return bgpapivip.BirdRuntimeStatus{}, nil
-}
-
-func (b *fakeBirdClient) SetAdvertisement(_ context.Context, enabled bool) error {
-	b.advertisements = append(b.advertisements, enabled)
-	return b.setErr
+	if owner.owned {
+		t.Fatal("failClosed retained local VIP ownership")
+	}
 }
 
 type fakeCommandRunner struct {
 	calls  [][]string
 	output []byte
 	err    error
+}
+
+type fakeVIPOwner struct {
+	owned bool
+	err   error
+}
+
+func (o *fakeVIPOwner) Owned(context.Context, bgpapivip.Config) (bool, error) {
+	return o.owned, o.err
+}
+
+func (o *fakeVIPOwner) SetOwned(_ context.Context, _ bgpapivip.Config, owned bool) error {
+	if o.err != nil {
+		return o.err
+	}
+	o.owned = owned
+	return nil
 }
 
 func (r *fakeCommandRunner) Output(_ context.Context, name string, args ...string) ([]byte, error) {

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -66,6 +66,7 @@ type controlPlaneEndpointReport struct {
 	State                 string                               `json:"state"`
 	LocalAPIReady         bool                                 `json:"localAPIReady"`
 	RouteOriginated       bool                                 `json:"routeOriginated"`
+	LocalVIPOwned         bool                                 `json:"localVIPOwned"`
 	SelectedSourceAddress string                               `json:"selectedSourceAddress,omitempty"`
 	RouterID              string                               `json:"routerID,omitempty"`
 	Peers                 []controlPlaneEndpointPeerReport     `json:"peers,omitempty"`
@@ -401,6 +402,7 @@ func newControlPlaneEndpointReport(status *agentapi.ControlPlaneEndpointStatus) 
 		State:                 status.GetState(),
 		LocalAPIReady:         status.GetLocalApiReady(),
 		RouteOriginated:       status.GetRouteOriginated(),
+		LocalVIPOwned:         status.GetLocalVipOwned(),
 		SelectedSourceAddress: status.GetSelectedSourceAddress(),
 		RouterID:              status.GetRouterId(),
 		LastTransitionTime:    status.GetLastTransitionTime(),
@@ -471,10 +473,10 @@ func writeHostStatus(stdout io.Writer, output string, report hostStatusReport) e
 		}
 	}
 	w = tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-	if _, err := fmt.Fprintln(w, "\nCONTROL PLANE ENDPOINT\tVIP\tSTATE\tLOCAL API\tROUTE\tPEERS\tEXCHANGES"); err != nil {
+	if _, err := fmt.Fprintln(w, "\nCONTROL PLANE ENDPOINT\tVIP\tSTATE\tLOCAL API\tLOCAL VIP\tROUTE\tPEERS\tEXCHANGES"); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d/%d\t%d\n", endpoint.Endpoint, endpoint.VIP, endpoint.State, yesNo(endpoint.LocalAPIReady), yesNo(endpoint.RouteOriginated), established, len(endpoint.Peers), len(endpoint.RouteExchange)); err != nil {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d/%d\t%d\n", endpoint.Endpoint, endpoint.VIP, endpoint.State, yesNo(endpoint.LocalAPIReady), yesNo(endpoint.LocalVIPOwned), yesNo(endpoint.RouteOriginated), established, len(endpoint.Peers), len(endpoint.RouteExchange)); err != nil {
 		return err
 	}
 	if endpoint.FailureReason != "" {

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -48,7 +48,7 @@ clusters:
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	output := stdout.String()
-	for _, want := range []string{"NODE", "HEALTH", "KUBERNETES", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "waiting-for-node", "Kubernetes node cp-1 is not Ready", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy", "CONTROL PLANE ENDPOINT", "api.home.example:6443", "10.40.0.10/32", "failed", "1/1", "endpoint routing control socket unavailable"} {
+	for _, want := range []string{"NODE", "HEALTH", "KUBERNETES", "KATLOS", "GENERATION", "NEXT BOOT", "ACTIVITY", "cp-1", "OK", "waiting-for-node", "Kubernetes node cp-1 is not Ready", "2026.7.0-alpha.10", "generation-0", "generation-staged", "busy", "CONTROL PLANE ENDPOINT", "LOCAL VIP", "api.home.example:6443", "10.40.0.10/32", "failed", "1/1", "endpoint routing control socket unavailable"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}
@@ -63,7 +63,7 @@ clusters:
 func TestHostStatusJSON(t *testing.T) {
 	fake := healthyHostClient("machine-a", "agent-a", "generation-0")
 	fake.nodeStatus.ControlPlaneEndpoint = &agentapi.ControlPlaneEndpointStatus{
-		Endpoint: "api.home.example:6443", Vip: "10.40.0.10/32", State: "advertised", LocalApiReady: true, RouteOriginated: true,
+		Endpoint: "api.home.example:6443", Vip: "10.40.0.10/32", State: "advertised", LocalApiReady: true, LocalVipOwned: true, RouteOriginated: true,
 		RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", ListenAddress: "127.0.0.1", ListenPort: 179, PeerAsn: 64512, State: "established", AcceptedRoutes: 3, ExportedRoutes: 3}},
 	}
 	installKatlcDial(t, nil, fake)
@@ -79,7 +79,7 @@ func TestHostStatusJSON(t *testing.T) {
 	if report.Node != "node-a" || report.Endpoint != "node-a.test:9443" || report.Health != "OK" || report.Generation != "generation-0" || report.Activity != "idle" {
 		t.Fatalf("report = %#v", report)
 	}
-	if report.ControlPlaneEndpoint == nil || report.ControlPlaneEndpoint.State != "advertised" || len(report.ControlPlaneEndpoint.RouteExchange) != 1 || report.ControlPlaneEndpoint.RouteExchange[0].ExportedRoutes != 3 {
+	if report.ControlPlaneEndpoint == nil || report.ControlPlaneEndpoint.State != "advertised" || !report.ControlPlaneEndpoint.LocalVIPOwned || len(report.ControlPlaneEndpoint.RouteExchange) != 1 || report.ControlPlaneEndpoint.RouteExchange[0].ExportedRoutes != 3 {
 		t.Fatalf("control-plane endpoint report = %#v", report.ControlPlaneEndpoint)
 	}
 }

--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -171,7 +171,7 @@ func nodeUpgradeRecovery(status *agentapi.NodeStatus) nodeRecovery {
 		return recovery
 	}
 	if endpoint := status.GetControlPlaneEndpoint(); endpoint != nil {
-		if !endpoint.GetLocalApiReady() || !endpoint.GetRouteOriginated() || !strings.EqualFold(endpoint.GetState(), "advertised") {
+		if !endpoint.GetLocalApiReady() || !endpoint.GetLocalVipOwned() || !endpoint.GetRouteOriginated() || !strings.EqualFold(endpoint.GetState(), "advertised") {
 			recovery.State = "waiting-for-managed-endpoint"
 			recovery.Reason = "managed API endpoint is " + firstNonEmpty(strings.TrimSpace(endpoint.GetState()), "not ready")
 			return recovery

--- a/cmd/katlctl/upgrade_reboot_test.go
+++ b/cmd/katlctl/upgrade_reboot_test.go
@@ -53,7 +53,7 @@ func TestNodeUpgradeRecoveryRequiresKubernetesAndManagedRouting(t *testing.T) {
 			status: &agentapi.NodeStatus{
 				Kubernetes: readyKubernetes,
 				ControlPlaneEndpoint: &agentapi.ControlPlaneEndpointStatus{
-					State: "advertised", LocalApiReady: true, RouteOriginated: true,
+					State: "advertised", LocalApiReady: true, LocalVipOwned: true, RouteOriginated: true,
 					RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "passive"}},
 				},
 			},
@@ -64,7 +64,7 @@ func TestNodeUpgradeRecoveryRequiresKubernetesAndManagedRouting(t *testing.T) {
 			status: &agentapi.NodeStatus{
 				Kubernetes: readyKubernetes,
 				ControlPlaneEndpoint: &agentapi.ControlPlaneEndpointStatus{
-					State: "advertised", LocalApiReady: true, RouteOriginated: true,
+					State: "advertised", LocalApiReady: true, LocalVipOwned: true, RouteOriginated: true,
 					RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "established"}},
 				},
 			},
@@ -116,7 +116,7 @@ func TestWaitNodeBootHealthWaitsForKubernetesRecovery(t *testing.T) {
 			ControlPlaneComponentsReady: true,
 		}
 		fake.nodeStatus.ControlPlaneEndpoint = &agentapi.ControlPlaneEndpointStatus{
-			State: "advertised", LocalApiReady: true, RouteOriginated: true,
+			State: "advertised", LocalApiReady: true, LocalVipOwned: true, RouteOriginated: true,
 			RouteExchange: []*agentapi.ControlPlaneEndpointRouteExchangeStatus{{Name: "cilium", State: "established"}},
 		}
 	}

--- a/internal/installer/bgpapivip/bgpapivip.go
+++ b/internal/installer/bgpapivip/bgpapivip.go
@@ -520,7 +520,11 @@ func validateAdvertiseOn(advertiseOn AdvertiseOn) error {
 func normalizeHealth(health Health, endpoint Endpoint, vip netip.Prefix) (Health, error) {
 	health.Probe = defaultString(health.Probe, "readyz")
 	health.Scheme = defaultString(health.Scheme, "https")
-	health.Host = defaultString(health.Host, vip.Addr().String())
+	localHost := "127.0.0.1"
+	if vip.Addr().Is6() {
+		localHost = "::1"
+	}
+	health.Host = defaultString(health.Host, localHost)
 	health.Path = defaultString(health.Path, defaultHealthPath)
 	health.Interval = defaultString(health.Interval, "2s")
 	health.Timeout = defaultString(health.Timeout, defaultHealthTimeout)
@@ -541,8 +545,8 @@ func normalizeHealth(health Health, endpoint Endpoint, vip netip.Prefix) (Health
 	if health.Scheme != "https" {
 		return Health{}, fmt.Errorf("health.scheme must be https")
 	}
-	if health.Host != vip.Addr().String() {
-		return Health{}, fmt.Errorf("health.host must be endpoint.vip address")
+	if health.Host != localHost {
+		return Health{}, fmt.Errorf("health.host must be the local loopback address %s", localHost)
 	}
 	if health.Path != defaultHealthPath {
 		return Health{}, fmt.Errorf("health.path must be /readyz")
@@ -747,7 +751,6 @@ func renderNetwork(config Config) string {
 	b.WriteString("[Match]\n")
 	b.WriteString("Name=" + config.VIPInterface.Name + "\n\n")
 	b.WriteString("[Network]\n")
-	b.WriteString("Address=" + config.Endpoint.VIP + "\n")
 	if config.VIPInterface.MTU != 0 {
 		b.WriteString("MTUBytes=" + strconv.Itoa(config.VIPInterface.MTU) + "\n")
 	}
@@ -772,10 +775,9 @@ func renderBirdConfig(config Config) string {
 	}
 	b.WriteByte('\n')
 	b.WriteString("protocol device katl_device {}\n\n")
-	b.WriteString("protocol static katl_api {\n")
-	b.WriteString("  disabled;\n")
+	b.WriteString("protocol direct katl_api {\n")
 	b.WriteString("  " + family + " { table katl_fabric; };\n")
-	b.WriteString("  route " + config.Endpoint.VIP + " blackhole;\n")
+	b.WriteString("  interface \"" + config.VIPInterface.Name + "\";\n")
 	b.WriteString("}\n\n")
 	for _, exchange := range config.RouteExchange {
 		b.WriteString(renderRouteExchange(config, exchange))
@@ -795,7 +797,7 @@ func renderPeerFilter(config Config, peer Peer) string {
 	filterName := "katl_export_" + name
 	var b strings.Builder
 	b.WriteString("filter " + filterName + " {\n")
-	b.WriteString("  if source = RTS_STATIC && net = " + config.Endpoint.VIP + " then accept;\n")
+	b.WriteString("  if source = RTS_DEVICE && net = " + config.Endpoint.VIP + " then accept;\n")
 	if len(config.RouteExchange) > 0 {
 		b.WriteString("  if source = RTS_BGP then accept;\n")
 	}
@@ -878,8 +880,8 @@ func renderBirdDropIn() string {
 
 func renderKubeletDropIn() string {
 	return "[Unit]\n" +
-		"Wants=katl-app-bgp-api-vip.service\n" +
-		"After=katl-app-bgp-api-vip.service\n"
+		"Wants=katl-app-bgp-api-vip.path\n" +
+		"After=katl-app-bgp-api-vip.path\n"
 }
 
 func allPeers(config Config) []Peer {

--- a/internal/installer/bgpapivip/bgpapivip_test.go
+++ b/internal/installer/bgpapivip/bgpapivip_test.go
@@ -46,7 +46,9 @@ func TestFromControlPlaneEndpointRendersManagedPolicy(t *testing.T) {
 	bird := fileContent(t, plan.Files, BirdConfigPath)
 	for _, want := range []string{
 		"router id from \"*\";",
-		"protocol static katl_api {\n  disabled;",
+		"protocol direct katl_api {",
+		"interface \"katl-api\";",
+		"if source = RTS_DEVICE && net = 10.40.0.10/32 then accept;",
 		"local 127.0.0.1 port 179 as 64512;",
 		"neighbor 127.0.0.1 as 64512;",
 		"if net ~ [ 10.50.0.0/16{32,32} ] then accept;",
@@ -118,7 +120,8 @@ func TestRenderNativeEtcFilesMinimalIPv4DummyVIP(t *testing.T) {
 	assertFile(t, plan.Files, ConfigPath, "kind: BGPAPIEndpoint\n")
 	assertFile(t, plan.Files, AdvertisementEnabledPath, "enabled\n")
 	assertFile(t, plan.Files, DummyNetDevPath, "Name=katl-api0\nKind=dummy\n")
-	assertFile(t, plan.Files, NetworkPath, "Address=10.40.0.10/32\n")
+	assertFile(t, plan.Files, NetworkPath, "[Network]\nMTUBytes=1500\n")
+	assertFileAbsent(t, plan.Files, NetworkPath, "Address=")
 	if filepath.Base(NetworkPath) >= "10-lan.network" {
 		t.Fatalf("managed VIP network file %q must take precedence over Katl's default DHCP match", NetworkPath)
 	}
@@ -132,6 +135,7 @@ func TestRenderNativeEtcFilesMinimalIPv4DummyVIP(t *testing.T) {
 		t.Fatalf("normalized endpoint = %#v", plan.Config.Endpoint)
 	}
 	if plan.Config.Health.Path != "/readyz" ||
+		plan.Config.Health.Host != "127.0.0.1" ||
 		plan.Config.Health.Timeout != defaultHealthTimeout ||
 		plan.Config.Health.FailureThreshold != 3 ||
 		plan.Config.Health.TLSServerName != "api.home.example" {
@@ -182,10 +186,8 @@ func TestRenderStartsWithdrawnByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderNativeEtcFiles() error = %v", err)
 	}
-	bird := fileContent(t, plan.Files, BirdConfigPath)
-	if !strings.Contains(bird, "protocol static katl_api {\n  disabled;\n") {
-		t.Fatalf("bird.conf did not start withdrawn:\n%s", bird)
-	}
+	assertFileAbsent(t, plan.Files, NetworkPath, "Address=")
+	assertFile(t, plan.Files, BirdConfigPath, "protocol direct katl_api {\n")
 	if !*plan.Config.Advertisement.StartWithdrawn || !*plan.Config.Advertisement.AdvertiseAfterHealthy || !*plan.Config.Advertisement.WithdrawOnFailure {
 		t.Fatalf("advertisement defaults = %#v", plan.Config.Advertisement)
 	}
@@ -207,6 +209,9 @@ func TestRenderIPv6LoopbackVIP(t *testing.T) {
 	assertNoFile(t, plan.Files, DummyNetDevPath)
 	assertFile(t, plan.Files, NetworkPath, "Name=lo\n")
 	assertFile(t, plan.Files, BirdConfigPath, "  ipv6 {\n")
+	if plan.Config.Health.Host != "::1" || healthTarget(plan.Config.Health) != "https://[::1]:6443/readyz" {
+		t.Fatalf("IPv6 local health = %#v target=%q", plan.Config.Health, healthTarget(plan.Config.Health))
+	}
 }
 
 func TestRenderAllowsMultipleControlPlanesToAdvertiseSameVIP(t *testing.T) {
@@ -315,6 +320,13 @@ func TestNormalizeRejectsUnsafeInputs(t *testing.T) {
 			want: "advertiseOn.roles[0] must be control-plane",
 		},
 		{
+			name: "VIP health target",
+			mutate: func(config *Config) {
+				config.Health.Host = "10.40.0.10"
+			},
+			want: "health.host must be the local loopback address",
+		},
+		{
 			name: "vip as source",
 			mutate: func(config *Config) {
 				config.Routing.SourceAddress = "10.40.0.10"
@@ -384,6 +396,14 @@ func assertFile(t *testing.T, files []confext.NativeEtcFile, path, contains stri
 	content := fileContent(t, files, path)
 	if !strings.Contains(content, contains) {
 		t.Fatalf("%s missing %q:\n%s", path, contains, content)
+	}
+}
+
+func assertFileAbsent(t *testing.T, files []confext.NativeEtcFile, path, contains string) {
+	t.Helper()
+	content := fileContent(t, files, path)
+	if strings.Contains(content, contains) {
+		t.Fatalf("%s unexpectedly contains %q:\n%s", path, contains, content)
 	}
 }
 

--- a/internal/installer/bgpapivip/controller.go
+++ b/internal/installer/bgpapivip/controller.go
@@ -9,9 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +34,6 @@ const (
 
 type BirdClient interface {
 	Status(context.Context) (BirdRuntimeStatus, error)
-	SetAdvertisement(context.Context, bool) error
 }
 
 type HealthChecker interface {
@@ -41,6 +42,11 @@ type HealthChecker interface {
 
 type InterfaceChecker interface {
 	Ready(context.Context, Config) (bool, error)
+}
+
+type VIPOwner interface {
+	Owned(context.Context, Config) (bool, error)
+	SetOwned(context.Context, Config, bool) error
 }
 
 type StatusWriter interface {
@@ -54,11 +60,13 @@ type Controller struct {
 	Bird              BirdClient
 	Health            HealthChecker
 	Interface         InterfaceChecker
+	Owner             VIPOwner
 	Writer            StatusWriter
 	Clock             func() time.Time
 
 	started           bool
-	advertised        bool
+	routeOriginated   bool
+	routeInitialized  bool
 	lastAdvertisement time.Time
 	lastHealth        time.Time
 	successCount      int
@@ -73,6 +81,7 @@ type BirdRuntimeStatus struct {
 	RouterID           string
 	Peers              []PeerRuntimeStatus
 	FailureReason      string
+	RouteOriginated    bool
 }
 
 type PeerRuntimeStatus struct {
@@ -107,6 +116,7 @@ type Status struct {
 	VIPInterfaceName            string              `json:"vipInterfaceName"`
 	VIPInterfaceKind            string              `json:"vipInterfaceKind"`
 	VIPInterfaceReady           bool                `json:"vipInterfaceReady"`
+	LocalVIPOwned               bool                `json:"localVIPOwned"`
 	NodeRoleSelected            bool                `json:"nodeRoleSelected"`
 	AdvertiseOnRoles            []string            `json:"advertiseOnRoles"`
 	HealthState                 string              `json:"healthState"`
@@ -154,34 +164,31 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 	if c.Bird == nil {
 		return Status{}, fmt.Errorf("bird client is required")
 	}
+	if c.Owner == nil {
+		return Status{}, fmt.Errorf("VIP owner is required")
+	}
 	if c.Health == nil {
 		c.Health = HTTPHealthChecker{}
 	}
 	now := c.now()
 	var failure string
-	var startWithdrawFailure string
+	var startReleaseFailure string
 	if !c.started {
-		if err := c.Bird.SetAdvertisement(ctx, false); err != nil {
-			startWithdrawFailure = "start withdrawn: " + inventory.Redact(err.Error())
+		if err := c.Owner.SetOwned(ctx, config, false); err != nil {
+			startReleaseFailure = "start without local VIP: " + inventory.Redact(err.Error())
 		}
 		c.started = true
-		c.advertised = false
-		c.lastAdvertisement = now
 	}
 
-	bird, err := c.Bird.Status(ctx)
+	bird, birdErr := c.Bird.Status(ctx)
 	birdReady := bird.ProcessActive && bird.ControlSocketReady
-	// The generated BIRD configuration starts the API route disabled. While the
-	// controller has never advertised it, an unavailable startup socket is a
-	// safe dependency-wait state that can be retried. Once BIRD is ready, a
-	// failed explicit withdrawal is a real controller failure.
-	if startWithdrawFailure != "" && birdReady {
-		failure = startWithdrawFailure
+	if startReleaseFailure != "" && failure == "" {
+		failure = startReleaseFailure
 	}
-	if err != nil && (c.advertised || birdReady) && failure == "" {
-		failure = inventory.Redact(err.Error())
+	if birdErr != nil && (bird.RouteOriginated || birdReady) && failure == "" {
+		failure = inventory.Redact(birdErr.Error())
 	}
-	if bird.FailureReason != "" && (c.advertised || birdReady) && failure == "" {
+	if bird.FailureReason != "" && (bird.RouteOriginated || birdReady) && failure == "" {
 		failure = inventory.Redact(bird.FailureReason)
 	}
 	interfaceReady := true
@@ -192,13 +199,18 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 			failure = inventory.Redact(err.Error())
 		}
 	}
+	localVIPOwned, ownerErr := c.Owner.Owned(ctx, config)
+	ownerReady := ownerErr == nil
+	if ownerErr != nil && failure == "" {
+		failure = inventory.Redact(ownerErr.Error())
+	}
 	health := c.Health.Check(ctx, config.Health)
 	if health.CheckedAt.IsZero() {
 		health.CheckedAt = now
 	}
 	c.lastHealth = health.CheckedAt.UTC()
 
-	dependenciesReady := bird.ProcessActive && bird.ControlSocketReady && interfaceReady
+	dependenciesReady := birdErr == nil && bird.FailureReason == "" && bird.ProcessActive && bird.ControlSocketReady && interfaceReady && ownerReady
 	if health.Healthy && dependenciesReady {
 		c.successCount++
 		c.failureCount = 0
@@ -208,32 +220,45 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 	}
 	healthAllowsAdvertise := c.successCount >= config.Health.SuccessThreshold
 	healthRequiresWithdraw := c.failureCount >= config.Health.FailureThreshold
-	desiredAdvertised := c.advertised
+	desiredOwned := localVIPOwned
 	withdrawReason := ""
 	switch {
 	case !dependenciesReady:
-		desiredAdvertised = false
+		desiredOwned = false
 		withdrawReason = "dependency-not-ready"
 	case !*config.Advertisement.Enabled:
-		desiredAdvertised = false
+		desiredOwned = false
 		withdrawReason = "advertisement-disabled"
 	case healthAllowsAdvertise:
-		desiredAdvertised = true
+		desiredOwned = true
 	case healthRequiresWithdraw:
-		desiredAdvertised = false
+		desiredOwned = false
 		withdrawReason = "local-health-failed"
-	case !c.advertised:
+	case !localVIPOwned:
 		withdrawReason = "waiting-for-health-threshold"
 	}
-	if desiredAdvertised != c.advertised {
-		if err := c.Bird.SetAdvertisement(ctx, desiredAdvertised); err != nil {
-			failure = inventory.Redact(err.Error())
+	if desiredOwned != localVIPOwned {
+		if err := c.Owner.SetOwned(ctx, config, desiredOwned); err != nil {
+			if failure == "" {
+				failure = inventory.Redact(err.Error())
+			}
 		} else {
-			c.advertised = desiredAdvertised
-			c.lastAdvertisement = now
+			localVIPOwned = desiredOwned
+			refreshed, refreshErr := c.Bird.Status(ctx)
+			if refreshErr != nil {
+				if failure == "" {
+					failure = inventory.Redact(refreshErr.Error())
+				}
+			} else {
+				bird = refreshed
+			}
 		}
 	}
-	status := c.status(config, health, bird, interfaceReady, withdrawReason, failure, now)
+	c.observeRouteTransition(bird.RouteOriginated, now)
+	if localVIPOwned && !bird.RouteOriginated && withdrawReason == "" {
+		withdrawReason = "waiting-for-route-advertisement"
+	}
+	status := c.status(config, health, bird, interfaceReady, localVIPOwned, withdrawReason, failure, now)
 	if err := c.write(ctx, status); err != nil {
 		return status, err
 	}
@@ -252,20 +277,32 @@ func (c *Controller) Stop(ctx context.Context) (Status, error) {
 	if c.Bird == nil {
 		return Status{}, fmt.Errorf("bird client is required")
 	}
+	if c.Owner == nil {
+		return Status{}, fmt.Errorf("VIP owner is required")
+	}
 	now := c.now()
 	failure := ""
-	if err := c.Bird.SetAdvertisement(ctx, false); err != nil {
-		failure = inventory.Redact(err.Error())
-	}
 	c.started = true
-	c.advertised = false
-	c.lastAdvertisement = now
+	localVIPOwned, ownerErr := c.Owner.Owned(ctx, config)
+	if ownerErr != nil && failure == "" {
+		failure = inventory.Redact(ownerErr.Error())
+	}
+	if localVIPOwned {
+		if err := c.Owner.SetOwned(ctx, config, false); err != nil {
+			if failure == "" {
+				failure = inventory.Redact(err.Error())
+			}
+		} else {
+			localVIPOwned = false
+		}
+	}
 	bird, err := c.Bird.Status(ctx)
 	if err != nil && failure == "" {
 		failure = inventory.Redact(err.Error())
 	}
+	c.observeRouteTransition(bird.RouteOriginated, now)
 	health := HealthResult{Healthy: false, CheckedAt: now}
-	status := c.status(config, health, bird, true, "service-stop", failure, now)
+	status := c.status(config, health, bird, true, localVIPOwned, "service-stop", failure, now)
 	if err := c.write(ctx, status); err != nil {
 		return status, err
 	}
@@ -273,6 +310,14 @@ func (c *Controller) Stop(ctx context.Context) (Status, error) {
 		return status, fmt.Errorf("%s", failure)
 	}
 	return status, nil
+}
+
+func (c *Controller) observeRouteTransition(originated bool, now time.Time) {
+	if !c.routeInitialized || c.routeOriginated != originated {
+		c.routeOriginated = originated
+		c.routeInitialized = true
+		c.lastAdvertisement = now
+	}
 }
 
 func (h HTTPHealthChecker) Check(ctx context.Context, health Health) HealthResult {
@@ -372,7 +417,7 @@ func DecodeStatus(reader io.Reader) (Status, error) {
 	return status, nil
 }
 
-func (c *Controller) status(config Config, health HealthResult, bird BirdRuntimeStatus, interfaceReady bool, withdrawReason string, failure string, now time.Time) Status {
+func (c *Controller) status(config Config, health HealthResult, bird BirdRuntimeStatus, interfaceReady bool, localVIPOwned bool, withdrawReason string, failure string, now time.Time) Status {
 	healthState := HealthUnhealthy
 	if health.Healthy {
 		healthState = HealthHealthy
@@ -380,7 +425,7 @@ func (c *Controller) status(config Config, health HealthResult, bird BirdRuntime
 		healthState = HealthUnknown
 	}
 	advertisement := AdvertisementWithdrawn
-	if c.advertised {
+	if bird.RouteOriginated {
 		advertisement = AdvertisementAdvertised
 		withdrawReason = ""
 	}
@@ -397,6 +442,7 @@ func (c *Controller) status(config Config, health HealthResult, bird BirdRuntime
 		VIPInterfaceName:            config.VIPInterface.Name,
 		VIPInterfaceKind:            config.VIPInterface.Kind,
 		VIPInterfaceReady:           interfaceReady,
+		LocalVIPOwned:               localVIPOwned,
 		NodeRoleSelected:            true,
 		AdvertiseOnRoles:            append([]string(nil), config.AdvertiseOn.Roles...),
 		HealthState:                 healthState,
@@ -405,7 +451,7 @@ func (c *Controller) status(config Config, health HealthResult, bird BirdRuntime
 		HealthFailure:               inventory.Redact(health.Error),
 		LastHealthTransition:        formatTime(c.lastHealth),
 		AdvertisementState:          advertisement,
-		Withdrawn:                   !c.advertised,
+		Withdrawn:                   !bird.RouteOriginated,
 		WithdrawReason:              withdrawReason,
 		LastAdvertisementTransition: formatTime(c.lastAdvertisement),
 		BirdProcessActive:           bird.ProcessActive,
@@ -449,7 +495,7 @@ func redactPeers(peers []PeerRuntimeStatus) []PeerRuntimeStatus {
 }
 
 func healthTarget(health Health) string {
-	return fmt.Sprintf("%s://%s:%d%s", health.Scheme, health.Host, health.Port, health.Path)
+	return fmt.Sprintf("%s://%s%s", health.Scheme, net.JoinHostPort(health.Host, strconv.Itoa(health.Port)), health.Path)
 }
 
 func digestString(value string) string {

--- a/internal/installer/bgpapivip/controller_test.go
+++ b/internal/installer/bgpapivip/controller_test.go
@@ -33,8 +33,11 @@ func TestControllerStartsWithdrawnThenAdvertisesAfterHealthy(t *testing.T) {
 	if status.AdvertisementState != AdvertisementAdvertised || status.Withdrawn {
 		t.Fatalf("status advertisement = %#v", status)
 	}
-	if status.HealthState != HealthHealthy || status.HealthTarget != "https://10.40.0.10:6443/readyz" {
+	if status.HealthState != HealthHealthy || status.HealthTarget != "https://127.0.0.1:6443/readyz" {
 		t.Fatalf("status health = %#v", status)
+	}
+	if !status.LocalVIPOwned {
+		t.Fatalf("advertised endpoint does not own its VIP: %#v", status)
 	}
 }
 
@@ -68,6 +71,9 @@ func TestControllerWithdrawsAfterHealthFailure(t *testing.T) {
 	}
 	if status.AdvertisementState != AdvertisementWithdrawn || !status.Withdrawn || status.WithdrawReason != "local-health-failed" {
 		t.Fatalf("status advertisement = %#v", status)
+	}
+	if status.LocalVIPOwned {
+		t.Fatalf("withdrawn endpoint still owns its VIP: %#v", status)
 	}
 	if strings.Contains(status.HealthFailure, "secret-token") || !strings.Contains(status.HealthFailure, "[REDACTED]") {
 		t.Fatalf("status leaked health failure: %#v", status.HealthFailure)
@@ -117,9 +123,7 @@ func TestControllerReportsUnavailableAPIAsHealthStateNotRuntimeFailure(t *testin
 
 func TestControllerRestartStartsWithdrawnBeforeAdvertising(t *testing.T) {
 	bird := &fakeBird{status: readyBirdStatus()}
-	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
-	controller.started = true
-	controller.advertised = true
+	bird.status.RouteOriginated = true
 
 	restarted := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
 	if _, err := restarted.RunOnce(context.Background()); err != nil {
@@ -149,6 +153,9 @@ func TestControllerStopWithdrawsAndWritesDurableStatus(t *testing.T) {
 	}
 	if status.AdvertisementState != AdvertisementWithdrawn || status.WithdrawReason != "service-stop" {
 		t.Fatalf("stop status = %#v", status)
+	}
+	if status.LocalVIPOwned {
+		t.Fatalf("stopped endpoint still owns its VIP: %#v", status)
 	}
 	for _, path := range []string{live, operation} {
 		data, err := os.ReadFile(path)
@@ -200,13 +207,14 @@ func TestControllerStatusRedactsBirdFailuresAndPeerState(t *testing.T) {
 	}
 }
 
-func TestControllerReturnsAdvertisementFailureAndKeepsWithdrawn(t *testing.T) {
-	bird := &fakeBird{status: readyBirdStatus(), setErr: errors.New("birdc configure failed")}
+func TestControllerReturnsVIPAcquisitionFailureAndKeepsWithdrawn(t *testing.T) {
+	bird := &fakeBird{status: readyBirdStatus()}
 	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
+	controller.Owner.(*fakeVIPOwner).acquireErr = errors.New("netlink acquire failed")
 	controller.Config.Health.SuccessThreshold = 1
 	status, err := controller.RunOnce(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "birdc configure failed") {
-		t.Fatalf("RunOnce() error = %v, want bird failure", err)
+	if err == nil || !strings.Contains(err.Error(), "netlink acquire failed") {
+		t.Fatalf("RunOnce() error = %v, want netlink failure", err)
 	}
 	if status.AdvertisementState != AdvertisementWithdrawn || !status.RecoveryRequired {
 		t.Fatalf("status = %#v", status)
@@ -220,7 +228,6 @@ func TestControllerRetriesWhileBirdControlSocketStarts(t *testing.T) {
 			FailureReason:  "dial /run/katl-bird/bird.ctl: no such file or directory",
 		},
 		statusErr: errors.New("query endpoint routing status: control socket unavailable"),
-		setErr:    errors.New("disable endpoint route: control socket unavailable"),
 	}
 	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
 	controller.Config.Health.SuccessThreshold = 1
@@ -241,7 +248,6 @@ func TestControllerRetriesWhileBirdControlSocketStarts(t *testing.T) {
 
 	bird.status = readyBirdStatus()
 	bird.statusErr = nil
-	bird.setErr = nil
 	status, err = controller.RunOnce(context.Background())
 	if err != nil {
 		t.Fatalf("ready RunOnce() error = %v", err)
@@ -254,7 +260,7 @@ func TestControllerRetriesWhileBirdControlSocketStarts(t *testing.T) {
 	}
 }
 
-func TestControllerFailsWhenAdvertisedRouteCannotBeWithdrawn(t *testing.T) {
+func TestControllerFailsWhenLocalVIPCannotBeReleased(t *testing.T) {
 	bird := &fakeBird{status: readyBirdStatus()}
 	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
 	controller.Config.Health.SuccessThreshold = 1
@@ -262,20 +268,17 @@ func TestControllerFailsWhenAdvertisedRouteCannotBeWithdrawn(t *testing.T) {
 		t.Fatalf("advertise RunOnce() error = %v", err)
 	}
 
-	bird.status = BirdRuntimeStatus{
-		ReadinessState: "not-ready",
-		FailureReason:  "dial /run/katl-bird/bird.ctl: connection refused",
-	}
-	bird.statusErr = errors.New("query endpoint routing status: control socket unavailable")
-	bird.setErr = errors.New("disable endpoint route: control socket unavailable")
+	controller.Owner.(*fakeVIPOwner).releaseErr = errors.New("netlink release failed")
+	controller.Health = fakeHealth{result: HealthResult{Healthy: false}}
+	controller.Config.Health.FailureThreshold = 1
 	status, err := controller.RunOnce(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "control socket unavailable") {
+	if err == nil || !strings.Contains(err.Error(), "netlink release failed") {
 		t.Fatalf("withdraw RunOnce() error = %v", err)
 	}
 	if !status.RecoveryRequired || status.FailureReason == "" {
 		t.Fatalf("withdraw status = %#v", status)
 	}
-	if got, want := bird.advertisements, []bool{false, true, false}; !reflect.DeepEqual(got, want) {
+	if got, want := bird.advertisements, []bool{false, true}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("withdraw advertisements = %#v, want %#v", got, want)
 	}
 }
@@ -297,6 +300,41 @@ func TestControllerWithdrawsWhenDependencyNotReady(t *testing.T) {
 	}
 	if status.VIPInterfaceReady || status.WithdrawReason != "dependency-not-ready" {
 		t.Fatalf("status = %#v", status)
+	}
+	if status.LocalVIPOwned {
+		t.Fatalf("dependency withdrawal retained local VIP: %#v", status)
+	}
+}
+
+func TestControllerRouteAdvertisementFollowsVIPOwnership(t *testing.T) {
+	var events []string
+	bird := &fakeBird{status: readyBirdStatus(), events: &events}
+	owner := &fakeVIPOwner{events: &events, bird: bird}
+	health := &sequenceHealth{results: []HealthResult{
+		{Healthy: true, StatusCode: 200},
+		{Healthy: true, StatusCode: 200},
+		{Healthy: false},
+	}}
+	controller := testController(bird, health)
+	controller.Owner = owner
+	controller.Config.Health.SuccessThreshold = 2
+	controller.Config.Health.FailureThreshold = 1
+
+	for range health.results {
+		if _, err := controller.RunOnce(context.Background()); err != nil {
+			t.Fatalf("RunOnce() error = %v", err)
+		}
+	}
+	want := []string{
+		"vip-release",
+		"route-withdraw",
+		"vip-acquire",
+		"route-advertise",
+		"vip-release",
+		"route-withdraw",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
 	}
 }
 
@@ -323,6 +361,7 @@ func testController(bird *fakeBird, health HealthChecker) *Controller {
 		AppPayloadVersion: "bgp-api-vip-v0.1.0",
 		Bird:              bird,
 		Health:            health,
+		Owner:             &fakeVIPOwner{bird: bird},
 		Clock: func() time.Time {
 			return time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
 		},
@@ -350,17 +389,24 @@ func readyBirdStatus() BirdRuntimeStatus {
 type fakeBird struct {
 	status         BirdRuntimeStatus
 	statusErr      error
-	setErr         error
 	advertisements []bool
+	events         *[]string
 }
 
 func (b *fakeBird) Status(context.Context) (BirdRuntimeStatus, error) {
 	return b.status, b.statusErr
 }
 
-func (b *fakeBird) SetAdvertisement(_ context.Context, enabled bool) error {
+func (b *fakeBird) observeVIP(enabled bool) {
 	b.advertisements = append(b.advertisements, enabled)
-	return b.setErr
+	b.status.RouteOriginated = enabled
+	if b.events != nil {
+		event := "route-withdraw"
+		if enabled {
+			event = "route-advertise"
+		}
+		*b.events = append(*b.events, event)
+	}
 }
 
 type fakeHealth struct {
@@ -388,6 +434,40 @@ func (h *sequenceHealth) Check(context.Context, Health) HealthResult {
 type fakeInterface struct {
 	ready bool
 	err   error
+}
+
+type fakeVIPOwner struct {
+	owned      bool
+	err        error
+	acquireErr error
+	releaseErr error
+	events     *[]string
+	bird       *fakeBird
+}
+
+func (o *fakeVIPOwner) Owned(context.Context, Config) (bool, error) {
+	return o.owned, o.err
+}
+
+func (o *fakeVIPOwner) SetOwned(_ context.Context, _ Config, owned bool) error {
+	if o.events != nil {
+		event := "vip-release"
+		if owned {
+			event = "vip-acquire"
+		}
+		*o.events = append(*o.events, event)
+	}
+	if owned && o.acquireErr != nil {
+		return o.acquireErr
+	}
+	if !owned && o.releaseErr != nil {
+		return o.releaseErr
+	}
+	o.owned = owned
+	if o.bird != nil {
+		o.bird.observeVIP(owned)
+	}
+	return nil
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/internal/installer/bgpapivip/runtime.go
+++ b/internal/installer/bgpapivip/runtime.go
@@ -2,10 +2,14 @@ package bgpapivip
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
 	"os/exec"
 	"strings"
+	"syscall"
+	"time"
 )
 
 const BirdControlSocketPath = "/run/katl-bird/bird.ctl"
@@ -41,6 +45,15 @@ func (c CommandBirdClient) Status(ctx context.Context) (BirdRuntimeStatus, error
 	}
 	status.ReadinessState = "ready"
 	status.Peers = parseProtocolStatus(string(output), c.Config)
+	routeOutput, routeErr := c.run(ctx, "show", "route", "table", "katl_fabric", "for", c.Config.Endpoint.VIP, "protocol", "katl_api")
+	if routeErr != nil {
+		if routeIsAbsent(string(routeOutput)) {
+			return status, nil
+		}
+		status.FailureReason = boundedCommandFailure(routeOutput, routeErr)
+		return status, fmt.Errorf("query endpoint route status: %s", status.FailureReason)
+	}
+	status.RouteOriginated = routeIsOriginated(string(routeOutput), c.Config.Endpoint.VIP)
 	for _, peer := range status.Peers {
 		if status.RouterID == "" && peer.LocalAddress != "" {
 			status.RouterID = peer.LocalAddress
@@ -50,18 +63,6 @@ func (c CommandBirdClient) Status(ctx context.Context) (BirdRuntimeStatus, error
 		status.RouterID = c.Config.Routing.RouterID
 	}
 	return status, nil
-}
-
-func (c CommandBirdClient) SetAdvertisement(ctx context.Context, enabled bool) error {
-	action := "disable"
-	if enabled {
-		action = "enable"
-	}
-	output, err := c.run(ctx, action, "katl_api")
-	if err != nil {
-		return fmt.Errorf("%s endpoint route: %s", action, boundedCommandFailure(output, err))
-	}
-	return nil
 }
 
 func (c CommandBirdClient) run(ctx context.Context, args ...string) ([]byte, error) {
@@ -78,6 +79,14 @@ func (c CommandBirdClient) run(ctx context.Context, args ...string) ([]byte, err
 	return runner.Output(ctx, birdc, command...)
 }
 
+func routeIsOriginated(output, prefix string) bool {
+	return strings.Contains(output, prefix) && strings.Contains(output, "[katl_api ")
+}
+
+func routeIsAbsent(output string) bool {
+	return strings.Contains(output, "Network not found")
+}
+
 func (c CommandBirdClient) socket() string {
 	if strings.TrimSpace(c.Socket) != "" {
 		return strings.TrimSpace(c.Socket)
@@ -88,21 +97,189 @@ func (c CommandBirdClient) socket() string {
 type LinuxInterfaceChecker struct{}
 
 func (LinuxInterfaceChecker) Ready(_ context.Context, config Config) (bool, error) {
+	_, err := net.InterfaceByName(config.VIPInterface.Name)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+type NetlinkVIPOwner struct{}
+
+func (NetlinkVIPOwner) Owned(ctx context.Context, config Config) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 	iface, err := net.InterfaceByName(config.VIPInterface.Name)
 	if err != nil {
 		return false, nil
 	}
-	addresses, err := iface.Addrs()
+	address, err := netip.ParsePrefix(config.Endpoint.VIP)
 	if err != nil {
-		return false, fmt.Errorf("inspect endpoint interface: %w", err)
+		return false, fmt.Errorf("parse endpoint address: %w", err)
 	}
-	want := strings.SplitN(config.Endpoint.VIP, "/", 2)[0]
-	for _, address := range addresses {
-		if strings.SplitN(address.String(), "/", 2)[0] == want {
-			return true, nil
+	rib, err := syscall.NetlinkRIB(syscall.RTM_GETADDR, syscall.AF_UNSPEC)
+	if err != nil {
+		return false, fmt.Errorf("list route netlink addresses: %w", err)
+	}
+	return netlinkAddressOwned(rib, iface.Index, address)
+}
+
+func (o NetlinkVIPOwner) SetOwned(ctx context.Context, config Config, owned bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	current, err := o.Owned(ctx, config)
+	if err != nil {
+		return err
+	}
+	if current == owned {
+		return nil
+	}
+	iface, err := net.InterfaceByName(config.VIPInterface.Name)
+	if err != nil {
+		if !owned {
+			return nil
+		}
+		return fmt.Errorf("find endpoint interface %q: %w", config.VIPInterface.Name, err)
+	}
+	address, err := netip.ParsePrefix(config.Endpoint.VIP)
+	if err != nil {
+		return fmt.Errorf("parse endpoint address: %w", err)
+	}
+	action := "release"
+	if owned {
+		action = "acquire"
+	}
+	if err := setNetlinkAddress(ctx, iface.Index, address, owned); err != nil {
+		return fmt.Errorf("%s local endpoint address: %w", action, err)
+	}
+	return nil
+}
+
+func netlinkAddressOwned(rib []byte, interfaceIndex int, address netip.Prefix) (bool, error) {
+	messages, err := syscall.ParseNetlinkMessage(rib)
+	if err != nil {
+		return false, fmt.Errorf("parse route netlink addresses: %w", err)
+	}
+	want := address.Addr().AsSlice()
+	for _, message := range messages {
+		if message.Header.Type != syscall.RTM_NEWADDR || len(message.Data) < syscall.SizeofIfAddrmsg {
+			continue
+		}
+		data := message.Data
+		if int(binary.NativeEndian.Uint32(data[4:8])) != interfaceIndex || int(data[1]) != address.Bits() {
+			continue
+		}
+		for attributes := data[syscall.SizeofIfAddrmsg:]; len(attributes) >= syscall.SizeofRtAttr; {
+			length := int(binary.NativeEndian.Uint16(attributes[0:2]))
+			if length < syscall.SizeofRtAttr || length > len(attributes) {
+				return false, fmt.Errorf("parse route netlink address attribute")
+			}
+			attributeType := binary.NativeEndian.Uint16(attributes[2:4])
+			value := attributes[syscall.SizeofRtAttr:length]
+			if (attributeType == syscall.IFA_LOCAL || attributeType == syscall.IFA_ADDRESS) && net.IP(value).Equal(net.IP(want)) {
+				return true, nil
+			}
+			aligned := (length + 3) &^ 3
+			if aligned > len(attributes) {
+				return false, fmt.Errorf("parse aligned route netlink address attribute")
+			}
+			attributes = attributes[aligned:]
 		}
 	}
 	return false, nil
+}
+
+func setNetlinkAddress(ctx context.Context, interfaceIndex int, address netip.Prefix, owned bool) error {
+	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, syscall.NETLINK_ROUTE)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(fd)
+	if err := syscall.Bind(fd, &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}); err != nil {
+		return err
+	}
+	timeout := 2 * time.Second
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < timeout {
+			timeout = remaining
+		}
+	}
+	if timeout <= 0 {
+		return context.DeadlineExceeded
+	}
+	timeval := syscall.NsecToTimeval(timeout.Nanoseconds())
+	if err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &timeval); err != nil {
+		return err
+	}
+	request := marshalNetlinkAddressRequest(interfaceIndex, address, owned)
+	if err := syscall.Sendto(fd, request, 0, &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}); err != nil {
+		return err
+	}
+	response := make([]byte, 4096)
+	count, _, err := syscall.Recvfrom(fd, response, 0)
+	if err != nil {
+		return err
+	}
+	messages, err := syscall.ParseNetlinkMessage(response[:count])
+	if err != nil {
+		return err
+	}
+	for _, message := range messages {
+		if message.Header.Type != syscall.NLMSG_ERROR || len(message.Data) < 4 {
+			continue
+		}
+		code := int32(binary.NativeEndian.Uint32(message.Data[:4]))
+		if code == 0 {
+			return nil
+		}
+		return syscall.Errno(-code)
+	}
+	return fmt.Errorf("route netlink did not acknowledge address change")
+}
+
+func marshalNetlinkAddressRequest(interfaceIndex int, address netip.Prefix, owned bool) []byte {
+	ip := address.Addr().AsSlice()
+	attributeLength := syscall.SizeofRtAttr + len(ip)
+	attributeSize := (attributeLength + 3) &^ 3
+	attributeCount := 1
+	if address.Addr().Is4() {
+		attributeCount = 2
+	}
+	length := syscall.SizeofNlMsghdr + syscall.SizeofIfAddrmsg + attributeSize*attributeCount
+	request := make([]byte, length)
+	binary.NativeEndian.PutUint32(request[0:4], uint32(length))
+	messageType := uint16(syscall.RTM_DELADDR)
+	flags := uint16(syscall.NLM_F_REQUEST | syscall.NLM_F_ACK)
+	if owned {
+		messageType = syscall.RTM_NEWADDR
+		flags |= syscall.NLM_F_CREATE | syscall.NLM_F_EXCL
+	}
+	binary.NativeEndian.PutUint16(request[4:6], messageType)
+	binary.NativeEndian.PutUint16(request[6:8], flags)
+	binary.NativeEndian.PutUint32(request[8:12], 1)
+	body := request[syscall.SizeofNlMsghdr:]
+	if address.Addr().Is4() {
+		body[0] = syscall.AF_INET
+	} else {
+		body[0] = syscall.AF_INET6
+	}
+	body[1] = uint8(address.Bits())
+	body[3] = syscall.RT_SCOPE_UNIVERSE
+	binary.NativeEndian.PutUint32(body[4:8], uint32(interfaceIndex))
+	attributes := body[syscall.SizeofIfAddrmsg:]
+	writeNetlinkAddressAttribute(attributes, syscall.IFA_ADDRESS, ip)
+	if attributeCount == 2 {
+		writeNetlinkAddressAttribute(attributes[attributeSize:], syscall.IFA_LOCAL, ip)
+	}
+	return request
+}
+
+func writeNetlinkAddressAttribute(target []byte, attributeType uint16, value []byte) {
+	binary.NativeEndian.PutUint16(target[0:2], uint16(syscall.SizeofRtAttr+len(value)))
+	binary.NativeEndian.PutUint16(target[2:4], attributeType)
+	copy(target[syscall.SizeofRtAttr:], value)
 }
 
 func parseProtocolStatus(output string, config Config) []PeerRuntimeStatus {

--- a/internal/installer/bgpapivip/runtime_test.go
+++ b/internal/installer/bgpapivip/runtime_test.go
@@ -2,31 +2,13 @@ package bgpapivip
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"net/netip"
 	"reflect"
+	"syscall"
 	"testing"
 )
-
-func TestCommandBirdClientControlsOnlyAPIRoute(t *testing.T) {
-	runner := &recordingCommandRunner{outputs: [][]byte{
-		[]byte("BIRD ready.\n"),
-		[]byte("BIRD ready.\n"),
-	}}
-	client := CommandBirdClient{Runner: runner}
-	if err := client.SetAdvertisement(context.Background(), false); err != nil {
-		t.Fatal(err)
-	}
-	if err := client.SetAdvertisement(context.Background(), true); err != nil {
-		t.Fatal(err)
-	}
-	want := [][]string{
-		{"birdc", "-s", BirdControlSocketPath, "disable", "katl_api"},
-		{"birdc", "-s", BirdControlSocketPath, "enable", "katl_api"},
-	}
-	if !reflect.DeepEqual(runner.commands, want) {
-		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
-	}
-}
 
 func TestCommandBirdClientReportsBoundedPeerState(t *testing.T) {
 	config := minimalConfig()
@@ -43,19 +25,24 @@ katl_exchange_cilium BGP katl_exchange_cilium_table up 12:00:00 Established
 	Routes: 3 imported, 0 exported, 3 preferred
 katl_exchange_cilium_to_fabric Pipe katl_exchange_cilium_table up 12:00:00
 	Routes: 0 imported, 3 exported, 3 preferred
+`), []byte(`Table katl_fabric:
+10.40.0.10/32  unicast [katl_api 12:00:00] * (240)
 `)}}
 	client := CommandBirdClient{Runner: runner, Config: config}
 	status, err := client.Status(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !status.ControlSocketReady || len(status.Peers) != 3 || status.Peers[0].SessionState != "established" || status.Peers[0].ExportedRoutes != 1 || status.RouterID != "10.0.0.11" {
+	if !status.ControlSocketReady || !status.RouteOriginated || len(status.Peers) != 3 || status.Peers[0].SessionState != "established" || status.Peers[0].ExportedRoutes != 1 || status.RouterID != "10.0.0.11" {
 		t.Fatalf("status = %#v", status)
 	}
 	if status.Peers[1].AcceptedRoutes != 3 || status.Peers[2].ExportedRoutes != 3 {
 		t.Fatalf("route exchange status = %#v", status.Peers[1:])
 	}
-	want := [][]string{{"birdc", "-s", BirdControlSocketPath, "show", "protocols", "all"}}
+	want := [][]string{
+		{"birdc", "-s", BirdControlSocketPath, "show", "protocols", "all"},
+		{"birdc", "-s", BirdControlSocketPath, "show", "route", "table", "katl_fabric", "for", "10.40.0.10/32", "protocol", "katl_api"},
+	}
 	if !reflect.DeepEqual(runner.commands, want) {
 		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
 	}
@@ -70,8 +57,66 @@ func TestCommandBirdClientFailsClosedWhenControlSocketIsUnavailable(t *testing.T
 	}
 }
 
+func TestCommandBirdClientTreatsMissingDirectRouteAsReadyAndWithdrawn(t *testing.T) {
+	config, err := Normalize(minimalConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingCommandRunner{
+		outputs: [][]byte{
+			[]byte("katl_api Direct --- up\n"),
+			[]byte("BIRD 3.3.1 ready.\nNetwork not found\n"),
+		},
+		errs: []error{nil, errors.New("exit status 1")},
+	}
+	client := CommandBirdClient{Runner: runner, Config: config}
+	status, err := client.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.ProcessActive || !status.ControlSocketReady || status.RouteOriginated || status.FailureReason != "" {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestNetlinkAddressRequestAndOwnership(t *testing.T) {
+	for _, prefix := range []string{"10.40.0.10/32", "2001:db8::10/128"} {
+		t.Run(prefix, func(t *testing.T) {
+			address := netip.MustParsePrefix(prefix)
+			request := marshalNetlinkAddressRequest(17, address, true)
+			if got := binary.NativeEndian.Uint16(request[4:6]); got != syscall.RTM_NEWADDR {
+				t.Fatalf("message type = %d, want RTM_NEWADDR", got)
+			}
+			flags := binary.NativeEndian.Uint16(request[6:8])
+			if flags&syscall.NLM_F_ACK == 0 || flags&syscall.NLM_F_CREATE == 0 || flags&syscall.NLM_F_EXCL == 0 {
+				t.Fatalf("message flags = %#x", flags)
+			}
+			owned, err := netlinkAddressOwned(request, 17, address)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !owned {
+				t.Fatalf("%s was not found in encoded route netlink state", prefix)
+			}
+			owned, err = netlinkAddressOwned(request, 18, address)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if owned {
+				t.Fatalf("%s matched the wrong interface", prefix)
+			}
+
+			release := marshalNetlinkAddressRequest(17, address, false)
+			if got := binary.NativeEndian.Uint16(release[4:6]); got != syscall.RTM_DELADDR {
+				t.Fatalf("release message type = %d, want RTM_DELADDR", got)
+			}
+		})
+	}
+}
+
 type recordingCommandRunner struct {
 	outputs  [][]byte
+	errs     []error
 	err      error
 	commands [][]string
 }
@@ -82,6 +127,11 @@ func (r *recordingCommandRunner) Output(_ context.Context, name string, args ...
 	if len(r.outputs) > 0 {
 		output = r.outputs[0]
 		r.outputs = r.outputs[1:]
+	}
+	if len(r.errs) > 0 {
+		err := r.errs[0]
+		r.errs = r.errs[1:]
+		return output, err
 	}
 	return output, r.err
 }

--- a/internal/installer/bgpapivip/testdata/minimal-ipv4-dummy.golden
+++ b/internal/installer/bgpapivip/testdata/minimal-ipv4-dummy.golden
@@ -47,7 +47,7 @@ spec:
     health:
         probe: readyz
         scheme: https
-        host: 10.40.0.10
+        host: 127.0.0.1
         port: 6443
         path: /readyz
         interval: 2s
@@ -67,14 +67,13 @@ ipv4 table katl_fabric;
 
 protocol device katl_device {}
 
-protocol static katl_api {
-  disabled;
+protocol direct katl_api {
   ipv4 { table katl_fabric; };
-  route 10.40.0.10/32 blackhole;
+  interface "katl-api0";
 }
 
 filter katl_export_katl_fabric_router_a {
-  if source = RTS_STATIC && net = 10.40.0.10/32 then accept;
+  if source = RTS_DEVICE && net = 10.40.0.10/32 then accept;
   reject;
 }
 
@@ -98,7 +97,6 @@ Kind=dummy
 Name=katl-api0
 
 [Network]
-Address=10.40.0.10/32
 MTUBytes=1500
 --- /etc/systemd/system/katl-app-bgp-api-vip.service.d/10-katl-config.conf
 [Service]
@@ -112,5 +110,5 @@ After=network-online.target
 Environment=KATL_BIRD_CONFIG=/etc/katl/apps/bird/bird.conf
 --- /etc/systemd/system/kubelet.service.d/20-katl-control-plane-endpoint.conf
 [Unit]
-Wants=katl-app-bgp-api-vip.service
-After=katl-app-bgp-api-vip.service
+Wants=katl-app-bgp-api-vip.path
+After=katl-app-bgp-api-vip.path

--- a/internal/installer/configapply/executor.go
+++ b/internal/installer/configapply/executor.go
@@ -273,6 +273,7 @@ func (e Executor) commandsForDomain(domain string) ([]Command, error) {
 		commands = append(commands,
 			Command{Name: "endpoint-routing-validate", Argv: []string{"/usr/bin/bird", "-p", "-c", bgpapivip.BirdConfigPath}},
 			Command{Name: "endpoint-withdraw", Argv: []string{"systemctl", "stop", "katl-app-bgp-api-vip.service"}},
+			Command{Name: "endpoint-link-reload", Argv: []string{"networkctl", "reload"}},
 			Command{Name: "endpoint-routing-reload", Argv: []string{"/usr/bin/birdc", "-s", bgpapivip.BirdControlSocketPath, "configure"}},
 			Command{Name: "endpoint-resume", Argv: []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}},
 		)

--- a/internal/installer/configapply/executor_test.go
+++ b/internal/installer/configapply/executor_test.go
@@ -329,7 +329,7 @@ func TestExecutorRunsBirdWhenVIPAdvertisementIsEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExecuteLive() error = %v", err)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-link-reload,endpoint-routing-reload,endpoint-resume"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
 }

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -192,7 +192,7 @@ func TestApplyTrustedBundleReloadsEnabledEndpointRouting(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(result.Tree.ConfextDir, "etc/katl/apps/bgp-api-vip/advertisement-enabled")); err != nil {
 		t.Fatalf("candidate advertisement marker: %v", err)
 	}
-	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-routing-reload,endpoint-resume"; got != want {
+	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-link-reload,endpoint-routing-reload,endpoint-resume"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
 	}
 }

--- a/internal/katlc/agent/destructive_reset_executor.go
+++ b/internal/katlc/agent/destructive_reset_executor.go
@@ -82,18 +82,9 @@ func (e *Executor) executeDestructiveReset(ctx context.Context, record operation
 		return errors.Join(err, markErr)
 	}
 
-	routingPaused, err := pauseManagedRoutingForPowerTransition(ctx, e.Root, e.endpointLifecycleRunner())
-	if err != nil {
-		_, markErr := e.failRecordPhase(record.OperationID, "destructive-reset-routing-pause-failed", "schedule-poweroff", "destructive-reset", "power off the node manually after repairing managed routing withdrawal", err)
-		return errors.Join(err, markErr)
-	}
 	result := e.poweroffRunner()(ctx, destructiveResetPoweroffArgv, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		var resumeErr error
-		if routingPaused {
-			resumeErr = resumeManagedRoutingAfterFailedPowerTransition(context.Background(), e.Root, e.endpointLifecycleRunner())
-		}
-		err := errors.Join(fmt.Errorf("schedule poweroff: %s", toolFailure(result)), resumeErr)
+		err := fmt.Errorf("schedule poweroff: %s", toolFailure(result))
 		_, markErr := e.failRecordPhase(record.OperationID, "destructive-reset-poweroff-schedule-failed", "schedule-poweroff", "destructive-reset", "power off the node manually; Katl disk boot artifacts have already been removed", err)
 		return errors.Join(err, markErr)
 	}

--- a/internal/katlc/agent/endpoint_lifecycle.go
+++ b/internal/katlc/agent/endpoint_lifecycle.go
@@ -18,50 +18,17 @@ import (
 )
 
 const (
-	endpointAdvertiserUnit    = "katl-app-bgp-api-vip.service"
-	endpointRoutingUnit       = "katl-app-bird.service"
-	endpointAdvertiserCommand = "/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser"
-	managedEndpointInterface  = "/usr/bin/networkctl"
-	managedEndpointIP         = "/usr/bin/ip"
-	managedEndpointKubectl    = "/usr/bin/kubectl"
+	endpointAdvertiserUnit     = "katl-app-bgp-api-vip.service"
+	endpointAdvertiserPathUnit = "katl-app-bgp-api-vip.path"
+	endpointRoutingUnit        = "katl-app-bird.service"
+	endpointAdvertiserCommand  = "/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser"
+	managedEndpointIP          = "/usr/bin/ip"
+	managedEndpointKubectl     = "/usr/bin/kubectl"
 )
 
-// pauseManagedRoutingForPowerTransition withdraws both the API VIP and routes
-// learned from local route-exchange peers before the node loses power. Stopping
-// only the endpoint advertiser leaves BIRD's fabric session established, so a
-// router can retain a dead ECMP path to workload VIPs while the node reboots.
-func pauseManagedRoutingForPowerTransition(ctx context.Context, root string, run ToolRunner) (bool, error) {
-	paused, err := pauseManagedEndpoint(ctx, root, run)
-	if err != nil || !paused {
-		return paused, err
-	}
-	result := run(ctx, []string{"systemctl", "stop", endpointRoutingUnit}, nil)
-	if result.Err != nil || result.ExitStatus != 0 {
-		resumeErr := resumeManagedRoutingAfterFailedPowerTransition(context.Background(), root, run)
-		return false, errors.Join(fmt.Errorf("stop managed route exports: %s", toolFailure(result)), resumeErr)
-	}
-	return true, nil
-}
-
-func resumeManagedRoutingAfterFailedPowerTransition(ctx context.Context, root string, run ToolRunner) error {
-	configured, err := managedEndpointConfigured(root)
-	if err != nil || !configured {
-		return err
-	}
-	if run == nil {
-		return fmt.Errorf("endpoint lifecycle runner is not configured")
-	}
-	result := run(ctx, []string{"systemctl", "start", endpointRoutingUnit}, nil)
-	if result.Err != nil || result.ExitStatus != 0 {
-		return fmt.Errorf("resume managed route exports: %s", toolFailure(result))
-	}
-	return resumeManagedEndpoint(ctx, root, run)
-}
-
 type managedJoinEndpoint struct {
-	VIP       string
-	Interface string
-	API       string
+	VIP string
+	API string
 }
 
 type managedJoinRoute struct {
@@ -78,7 +45,11 @@ func pauseManagedEndpoint(ctx context.Context, root string, run ToolRunner) (boo
 	if run == nil {
 		return false, fmt.Errorf("endpoint lifecycle runner is not configured")
 	}
-	result := run(ctx, []string{"systemctl", "stop", endpointAdvertiserUnit}, nil)
+	result := run(ctx, []string{"systemctl", "stop", endpointAdvertiserPathUnit}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return false, fmt.Errorf("stop managed control-plane endpoint watcher: %s", toolFailure(result))
+	}
+	result = run(ctx, []string{"systemctl", "stop", endpointAdvertiserUnit}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
 		return false, fmt.Errorf("stop managed control-plane endpoint: %s", toolFailure(result))
 	}
@@ -97,7 +68,11 @@ func resumeManagedEndpoint(ctx context.Context, root string, run ToolRunner) err
 	if run == nil {
 		return fmt.Errorf("endpoint lifecycle runner is not configured")
 	}
-	result := run(ctx, []string{"systemctl", "start", endpointAdvertiserUnit}, nil)
+	result := run(ctx, []string{"systemctl", "start", endpointAdvertiserPathUnit}, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return fmt.Errorf("resume managed control-plane endpoint watcher: %s", toolFailure(result))
+	}
+	result = run(ctx, []string{"systemctl", "start", endpointAdvertiserUnit}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
 		return fmt.Errorf("resume managed control-plane endpoint: %s", toolFailure(result))
 	}
@@ -105,9 +80,7 @@ func resumeManagedEndpoint(ctx context.Context, root string, run ToolRunner) err
 }
 
 // suspendManagedEndpointForJoin keeps a joining control-plane node from
-// capturing stable-endpoint traffic before its local API server exists. The
-// generated endpoint uses a Katl-owned dummy device, so taking that device
-// offline does not disturb the node's management network.
+// capturing stable-endpoint traffic before its local API server exists.
 func suspendManagedEndpointForJoin(ctx context.Context, root, discoveryPath string, run ToolRunner) (bool, *managedJoinRoute, error) {
 	endpoint, configured, err := managedJoinEndpointConfig(root)
 	if err != nil || !configured {
@@ -119,19 +92,11 @@ func suspendManagedEndpointForJoin(ctx context.Context, root, discoveryPath stri
 	if _, err := pauseManagedEndpoint(ctx, root, run); err != nil {
 		return false, nil, err
 	}
-	result := run(ctx, []string{managedEndpointInterface, "down", endpoint.Interface}, nil)
-	if result.Err != nil || result.ExitStatus != 0 {
-		return false, nil, fmt.Errorf("take managed control-plane endpoint off the local path: %s", toolFailure(result))
-	}
-	result = run(ctx, []string{managedEndpointIP, "address", "flush", "dev", endpoint.Interface, "to", endpoint.VIP}, nil)
-	if result.Err != nil || result.ExitStatus != 0 {
-		return false, nil, fmt.Errorf("remove managed control-plane endpoint address from the local path: %s", toolFailure(result))
-	}
 	route, err := installManagedJoinRoute(ctx, root, discoveryPath, endpoint, run)
 	if err != nil {
 		return false, nil, err
 	}
-	result = run(ctx, []string{
+	result := run(ctx, []string{
 		managedEndpointKubectl,
 		"--kubeconfig", rootedRuntimePath(root, discoveryPath),
 		"--server", endpoint.API,
@@ -229,24 +194,6 @@ func joinDiscoveryHost(root, discoveryPath string) (string, error) {
 }
 
 func resumeManagedEndpointAfterJoin(ctx context.Context, root string, run ToolRunner) error {
-	endpoint, configured, err := managedJoinEndpointConfig(root)
-	if err != nil || !configured {
-		return err
-	}
-	if run == nil {
-		return fmt.Errorf("endpoint lifecycle runner is not configured")
-	}
-	result := run(ctx, []string{managedEndpointInterface, "up", endpoint.Interface}, nil)
-	if result.Err != nil || result.ExitStatus != 0 {
-		return fmt.Errorf("restore managed control-plane endpoint interface: %s", toolFailure(result))
-	}
-	// networkctl applies the generated desired state asynchronously. Replace the
-	// exact generated host address as an idempotent, immediate handoff so the
-	// stable endpoint is usable for post-kubeadm health checks.
-	result = run(ctx, []string{managedEndpointIP, "address", "replace", endpoint.VIP, "dev", endpoint.Interface}, nil)
-	if result.Err != nil || result.ExitStatus != 0 {
-		return fmt.Errorf("restore managed control-plane endpoint address: %s", toolFailure(result))
-	}
 	return resumeManagedEndpoint(ctx, root, run)
 }
 
@@ -272,9 +219,8 @@ func managedJoinEndpointConfig(root string) (managedJoinEndpoint, bool, error) {
 		return managedJoinEndpoint{}, false, fmt.Errorf("managed control-plane join requires a Katl-owned dummy VIP interface, got %q", config.VIPInterface.Kind)
 	}
 	return managedJoinEndpoint{
-		VIP:       strings.TrimSpace(config.Endpoint.VIP),
-		Interface: strings.TrimSpace(config.VIPInterface.Name),
-		API:       "https://" + net.JoinHostPort(config.Endpoint.Host, strconv.Itoa(config.Endpoint.Port)),
+		VIP: strings.TrimSpace(config.Endpoint.VIP),
+		API: "https://" + net.JoinHostPort(config.Endpoint.Host, strconv.Itoa(config.Endpoint.Port)),
 	}, true, nil
 }
 

--- a/internal/katlc/agent/endpoint_lifecycle_test.go
+++ b/internal/katlc/agent/endpoint_lifecycle_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
@@ -39,65 +38,14 @@ func TestManagedEndpointLifecycleFollowsGeneratedEnablement(t *testing.T) {
 		t.Fatalf("resume managed endpoint: %v", err)
 	}
 	want := [][]string{
+		{"systemctl", "stop", endpointAdvertiserPathUnit},
 		{"systemctl", "stop", endpointAdvertiserUnit},
 		{endpointAdvertiserCommand, "withdraw"},
+		{"systemctl", "start", endpointAdvertiserPathUnit},
 		{"systemctl", "start", endpointAdvertiserUnit},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("endpoint lifecycle commands = %#v, want %#v", calls, want)
-	}
-}
-
-func TestPowerTransitionLifecycleWithdrawsAndRestoresAllManagedRoutes(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
-	var calls [][]string
-	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
-		calls = append(calls, append([]string(nil), argv...))
-		return ToolResult{}
-	}
-
-	paused, err := pauseManagedRoutingForPowerTransition(context.Background(), root, run)
-	if err != nil || !paused {
-		t.Fatalf("pause managed routing = %v, %v", paused, err)
-	}
-	if err := resumeManagedRoutingAfterFailedPowerTransition(context.Background(), root, run); err != nil {
-		t.Fatalf("resume managed routing: %v", err)
-	}
-	want := [][]string{
-		{"systemctl", "stop", endpointAdvertiserUnit},
-		{endpointAdvertiserCommand, "withdraw"},
-		{"systemctl", "stop", endpointRoutingUnit},
-		{"systemctl", "start", endpointRoutingUnit},
-		{"systemctl", "start", endpointAdvertiserUnit},
-	}
-	if !reflect.DeepEqual(calls, want) {
-		t.Fatalf("power transition lifecycle commands = %#v, want %#v", calls, want)
-	}
-}
-
-func TestPowerTransitionPauseRestoresRoutingWhenFabricWithdrawalFails(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
-	var calls [][]string
-	run := func(_ context.Context, argv []string, _ func(int)) ToolResult {
-		calls = append(calls, append([]string(nil), argv...))
-		if reflect.DeepEqual(argv, []string{"systemctl", "stop", endpointRoutingUnit}) {
-			return ToolResult{Err: errors.New("bird stop failed"), ExitStatus: 1}
-		}
-		return ToolResult{}
-	}
-
-	paused, err := pauseManagedRoutingForPowerTransition(context.Background(), root, run)
-	if err == nil || paused || !strings.Contains(err.Error(), "stop managed route exports") {
-		t.Fatalf("pause managed routing = %v, %v", paused, err)
-	}
-	wantTail := [][]string{
-		{"systemctl", "start", endpointRoutingUnit},
-		{"systemctl", "start", endpointAdvertiserUnit},
-	}
-	if !reflect.DeepEqual(calls[len(calls)-2:], wantTail) {
-		t.Fatalf("routing restore commands = %#v, want tail %#v", calls, wantTail)
 	}
 }
 
@@ -125,16 +73,14 @@ func TestManagedEndpointJoinLifecycleRemovesAndRestoresLocalVIP(t *testing.T) {
 		t.Fatalf("resumeManagedEndpointAfterJoin(): %v", err)
 	}
 	want := [][]string{
+		{"systemctl", "stop", endpointAdvertiserPathUnit},
 		{"systemctl", "stop", endpointAdvertiserUnit},
 		{endpointAdvertiserCommand, "withdraw"},
-		{managedEndpointInterface, "down", "katl-api0"},
-		{managedEndpointIP, "address", "flush", "dev", "katl-api0", "to", "10.40.0.10/32"},
 		{managedEndpointIP, "-json", "route", "get", "10.0.0.10"},
 		{managedEndpointIP, "route", "add", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"},
 		{managedEndpointKubectl, "--kubeconfig", filepath.Join(root, discoveryPath), "--server", "https://api.home.example:6443", "--request-timeout=10s", "get", "--raw=/version"},
 		{managedEndpointIP, "route", "del", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"},
-		{managedEndpointInterface, "up", "katl-api0"},
-		{managedEndpointIP, "address", "replace", "10.40.0.10/32", "dev", "katl-api0"},
+		{"systemctl", "start", endpointAdvertiserPathUnit},
 		{"systemctl", "start", endpointAdvertiserUnit},
 	}
 	if !reflect.DeepEqual(calls, want) {

--- a/internal/katlc/agent/endpoint_status.go
+++ b/internal/katlc/agent/endpoint_status.go
@@ -69,6 +69,7 @@ func endpointStatusFrom(config bgpapivip.Config, live *bgpapivip.Status) *agenta
 	if live != nil {
 		report.LocalApiReady = live.HealthState == bgpapivip.HealthHealthy
 		report.RouteOriginated = live.AdvertisementState == bgpapivip.AdvertisementAdvertised
+		report.LocalVipOwned = live.LocalVIPOwned
 		report.LastTransitionTime = firstNonEmpty(live.LastAdvertisementTransition, live.LastHealthTransition, live.UpdatedAt)
 		report.FailureReason = strings.TrimSpace(live.FailureReason)
 		for _, peer := range live.PeerSummary {
@@ -146,8 +147,14 @@ func endpointProductState(config bgpapivip.Config, live bgpapivip.Status, peers 
 			return "waiting-for-peer"
 		}
 	}
+	if live.AdvertisementState == bgpapivip.AdvertisementAdvertised && !live.LocalVIPOwned {
+		return "failed"
+	}
 	if live.AdvertisementState == bgpapivip.AdvertisementAdvertised {
 		return "advertised"
+	}
+	if live.LocalVIPOwned {
+		return "waiting-for-route"
 	}
 	return "withdrawn"
 }

--- a/internal/katlc/agent/endpoint_status_test.go
+++ b/internal/katlc/agent/endpoint_status_test.go
@@ -18,6 +18,7 @@ func TestControlPlaneEndpointStatusReportsBoundedProductState(t *testing.T) {
 		EndpointPort:                6443,
 		VIPPrefix:                   "10.40.0.10/32",
 		VIPInterfaceReady:           true,
+		LocalVIPOwned:               true,
 		HealthState:                 bgpapivip.HealthHealthy,
 		AdvertisementState:          bgpapivip.AdvertisementAdvertised,
 		BirdProcessActive:           true,
@@ -39,7 +40,7 @@ func TestControlPlaneEndpointStatusReportsBoundedProductState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.GetEndpoint() != "api.home.example:6443" || status.GetVip() != "10.40.0.10/32" || status.GetState() != "advertised" || !status.GetLocalApiReady() || !status.GetRouteOriginated() {
+	if status.GetEndpoint() != "api.home.example:6443" || status.GetVip() != "10.40.0.10/32" || status.GetState() != "advertised" || !status.GetLocalApiReady() || !status.GetLocalVipOwned() || !status.GetRouteOriginated() {
 		t.Fatalf("endpoint status = %#v", status)
 	}
 	if status.GetSelectedSourceAddress() != "10.0.0.11" || status.GetRouterId() != "10.0.0.11" || status.GetLastTransitionTime() != "2026-07-19T12:00:00Z" {

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -978,7 +978,7 @@ func bootstrapReadinessCommands(candidate, configPath string) [][]string {
 
 func runPostKubeadmHealthCommand(ctx context.Context, argv []string, started func(int)) ToolResult {
 	commands := postKubeadmHealthCommands(argv...)
-	retryKubectl := len(argv) > 0 && argv[0] == OperationKindKubeadmControlPlaneConfig
+	retryKubectl := len(argv) > 0 && retryPostKubeadmKubectl(argv[0])
 	var stdout, stderr bytes.Buffer
 	for _, argv := range commands {
 		result := runChildProcess(ctx, argv, started)
@@ -1001,6 +1001,17 @@ func runPostKubeadmHealthCommand(ctx context.Context, argv []string, started fun
 		}
 	}
 	return ToolResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes(), ExitStatus: 0}
+}
+
+func retryPostKubeadmKubectl(kind string) bool {
+	switch kind {
+	case bootstrapplan.OperationKindInit,
+		bootstrapplan.OperationKindJoinControlPlane,
+		OperationKindKubeadmControlPlaneConfig:
+		return true
+	default:
+		return false
+	}
 }
 
 func postKubeadmHealthCommands(args ...string) [][]string {

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/artifact"
+	"github.com/katl-dev/katl/internal/installer/bootstrapplan"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
@@ -524,6 +525,20 @@ func TestBootstrapReadinessReloadsSystemdAfterExtensionRefresh(t *testing.T) {
 	)
 }
 
+func TestPostKubeadmHealthRetriesControlPlaneKubectl(t *testing.T) {
+	tests := map[string]bool{
+		bootstrapplan.OperationKindInit:             true,
+		bootstrapplan.OperationKindJoinControlPlane: true,
+		OperationKindKubeadmControlPlaneConfig:      true,
+		bootstrapplan.OperationKindJoinWorker:       false,
+	}
+	for kind, want := range tests {
+		if got := retryPostKubeadmKubectl(kind); got != want {
+			t.Errorf("retryPostKubeadmKubectl(%q) = %t, want %t", kind, got, want)
+		}
+	}
+}
+
 func TestExecutorPostKubeadmHealthFailureRequiresRepair(t *testing.T) {
 	server := newTestServer(t)
 	seedBootstrapRuntimeRoot(t, server.Root)
@@ -717,10 +732,9 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 	executor.RunTool = func(_ context.Context, _ []string, started func(int)) ToolResult {
 		wantPrefix := []string{
 			"readiness",
+			"systemctl stop " + endpointAdvertiserPathUnit,
 			"systemctl stop " + endpointAdvertiserUnit,
 			endpointAdvertiserCommand + " withdraw",
-			managedEndpointInterface + " down katl-api0",
-			managedEndpointIP + " address flush dev katl-api0 to 10.40.0.10/32",
 			managedEndpointIP + " -json route get 10.0.0.11",
 			managedEndpointIP + " route add 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
 			managedEndpointKubectl + " probe-stable-endpoint",
@@ -749,17 +763,15 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 	}
 	want := []string{
 		"readiness",
+		"systemctl stop " + endpointAdvertiserPathUnit,
 		"systemctl stop " + endpointAdvertiserUnit,
 		endpointAdvertiserCommand + " withdraw",
-		managedEndpointInterface + " down katl-api0",
-		managedEndpointIP + " address flush dev katl-api0 to 10.40.0.10/32",
 		managedEndpointIP + " -json route get 10.0.0.11",
 		managedEndpointIP + " route add 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
 		managedEndpointKubectl + " probe-stable-endpoint",
 		"kubeadm",
 		managedEndpointIP + " route del 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
-		managedEndpointInterface + " up katl-api0",
-		managedEndpointIP + " address replace 10.40.0.10/32 dev katl-api0",
+		"systemctl start " + endpointAdvertiserPathUnit,
 		"systemctl start " + endpointAdvertiserUnit,
 		"post-health",
 	}

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -147,17 +147,9 @@ func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agen
 	if s.RunReboot == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node reboot runner is not configured")
 	}
-	routingPaused, err := pauseManagedRoutingForPowerTransition(ctx, s.Root, s.RunEndpointLifecycle)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "prepare node routing for reboot: %s", inventory.Redact(err.Error()))
-	}
 	result := s.RunReboot(ctx, []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		var resumeErr error
-		if routingPaused {
-			resumeErr = resumeManagedRoutingAfterFailedPowerTransition(context.Background(), s.Root, s.RunEndpointLifecycle)
-		}
-		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(errors.Join(errors.New(toolFailure(result)), resumeErr).Error()))
+		return nil, status.Errorf(codes.Internal, "schedule reboot: %s", inventory.Redact(toolFailure(result)))
 	}
 	return &agentapi.RebootAccepted{Scheduled: true, TargetGenerationId: target}, nil
 }
@@ -192,17 +184,9 @@ func (s *Server) Shutdown(ctx context.Context, req *agentapi.ShutdownRequest) (*
 	if s.RunShutdown == nil {
 		return nil, status.Error(codes.FailedPrecondition, "node shutdown runner is not configured")
 	}
-	routingPaused, err := pauseManagedRoutingForPowerTransition(ctx, s.Root, s.RunEndpointLifecycle)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "prepare node routing for shutdown: %s", inventory.Redact(err.Error()))
-	}
 	result := s.RunShutdown(ctx, []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
-		var resumeErr error
-		if routingPaused {
-			resumeErr = resumeManagedRoutingAfterFailedPowerTransition(context.Background(), s.Root, s.RunEndpointLifecycle)
-		}
-		return nil, status.Errorf(codes.Internal, "schedule shutdown: %s", inventory.Redact(errors.Join(errors.New(toolFailure(result)), resumeErr).Error()))
+		return nil, status.Errorf(codes.Internal, "schedule shutdown: %s", inventory.Redact(toolFailure(result)))
 	}
 	return &agentapi.ShutdownAccepted{Scheduled: true}, nil
 }

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -247,51 +247,17 @@ func TestRebootSchedulesCommittedSelectedGeneration(t *testing.T) {
 	}
 }
 
-func TestRebootWithdrawsManagedRoutesBeforeScheduling(t *testing.T) {
-	server := newTestServer(t)
-	writeCleanGenerationZeroState(t, server.Root)
-	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
-	var actions []string
-	server.RunEndpointLifecycle = func(_ context.Context, got []string, _ func(int)) ToolResult {
-		actions = append(actions, strings.Join(got, " "))
-		return ToolResult{}
-	}
-	server.RunReboot = func(_ context.Context, got []string, _ func(int)) ToolResult {
-		actions = append(actions, strings.Join(got, " "))
-		return ToolResult{}
-	}
-	machineID, err := server.machineID()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = server.Reboot(context.Background(), &agentapi.RebootRequest{
-		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
-		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{
-		"systemctl stop " + endpointAdvertiserUnit,
-		endpointAdvertiserCommand + " withdraw",
-		"systemctl stop " + endpointRoutingUnit,
-		"systemd-run --unit=katl-reboot --collect --on-active=2s systemctl reboot",
-	}
-	if !reflect.DeepEqual(actions, want) {
-		t.Fatalf("reboot actions = %#v, want %#v", actions, want)
-	}
-}
-
-func TestRebootRefusesWhenManagedEndpointCannotWithdraw(t *testing.T) {
+func TestRebootLeavesManagedRouteWithdrawalToSystemdShutdown(t *testing.T) {
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
 	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
 	server.RunEndpointLifecycle = func(_ context.Context, _ []string, _ func(int)) ToolResult {
-		return ToolResult{Err: errors.New("withdraw failed"), ExitStatus: 1}
+		t.Fatal("reboot must leave service teardown to systemd")
+		return ToolResult{Err: errors.New("unexpected endpoint lifecycle call")}
 	}
-	rebootCalled := false
-	server.RunReboot = func(_ context.Context, _ []string, _ func(int)) ToolResult {
-		rebootCalled = true
+	var argv []string
+	server.RunReboot = func(_ context.Context, got []string, _ func(int)) ToolResult {
+		argv = append([]string(nil), got...)
 		return ToolResult{}
 	}
 	machineID, err := server.machineID()
@@ -302,25 +268,26 @@ func TestRebootRefusesWhenManagedEndpointCannotWithdraw(t *testing.T) {
 		ApiVersion: generation.APIVersion, Kind: RebootRequestKind, Actor: "test",
 		ExpectedMachineId: machineID, TargetGenerationId: "generation-0",
 	})
-	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "prepare node routing for reboot") {
-		t.Fatalf("Reboot() error = %v", err)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if rebootCalled {
-		t.Fatal("reboot was scheduled without withdrawing the managed endpoint")
+	want := []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("reboot argv = %#v, want %#v", argv, want)
 	}
 }
 
-func TestRebootRestoresManagedRoutingWhenSchedulingFails(t *testing.T) {
+func TestRebootSchedulingFailureDoesNotDisruptManagedRouting(t *testing.T) {
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
 	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
-	var actions []string
-	server.RunEndpointLifecycle = func(_ context.Context, got []string, _ func(int)) ToolResult {
-		actions = append(actions, strings.Join(got, " "))
-		return ToolResult{}
+	server.RunEndpointLifecycle = func(_ context.Context, _ []string, _ func(int)) ToolResult {
+		t.Fatal("a failed reboot schedule must not disrupt endpoint services")
+		return ToolResult{Err: errors.New("unexpected endpoint lifecycle call")}
 	}
+	var argv []string
 	server.RunReboot = func(_ context.Context, got []string, _ func(int)) ToolResult {
-		actions = append(actions, strings.Join(got, " "))
+		argv = append([]string(nil), got...)
 		return ToolResult{Err: errors.New("systemd-run failed"), ExitStatus: 1}
 	}
 	machineID, err := server.machineID()
@@ -334,16 +301,9 @@ func TestRebootRestoresManagedRoutingWhenSchedulingFails(t *testing.T) {
 	if status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "schedule reboot") {
 		t.Fatalf("Reboot() error = %v", err)
 	}
-	want := []string{
-		"systemctl stop " + endpointAdvertiserUnit,
-		endpointAdvertiserCommand + " withdraw",
-		"systemctl stop " + endpointRoutingUnit,
-		"systemd-run --unit=katl-reboot --collect --on-active=2s systemctl reboot",
-		"systemctl start " + endpointRoutingUnit,
-		"systemctl start " + endpointAdvertiserUnit,
-	}
-	if !reflect.DeepEqual(actions, want) {
-		t.Fatalf("reboot recovery actions = %#v, want %#v", actions, want)
+	want := []string{"systemd-run", "--unit=katl-reboot", "--collect", "--on-active=2s", "systemctl", "reboot"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("reboot argv = %#v, want %#v", argv, want)
 	}
 }
 
@@ -374,16 +334,16 @@ func TestShutdownSchedulesPoweroff(t *testing.T) {
 	}
 }
 
-func TestShutdownWithdrawsManagedRoutesBeforeScheduling(t *testing.T) {
+func TestShutdownLeavesManagedRouteWithdrawalToSystemd(t *testing.T) {
 	server := newTestServer(t)
 	writeTestFile(t, filepath.Join(server.Root, bgpapivip.AdvertisementEnabledPath), "enabled\n")
-	var actions []string
-	server.RunEndpointLifecycle = func(_ context.Context, got []string, _ func(int)) ToolResult {
-		actions = append(actions, strings.Join(got, " "))
-		return ToolResult{}
+	server.RunEndpointLifecycle = func(_ context.Context, _ []string, _ func(int)) ToolResult {
+		t.Fatal("shutdown must leave service teardown to systemd")
+		return ToolResult{Err: errors.New("unexpected endpoint lifecycle call")}
 	}
+	var argv []string
 	server.RunShutdown = func(_ context.Context, got []string, _ func(int)) ToolResult {
-		actions = append(actions, strings.Join(got, " "))
+		argv = append([]string(nil), got...)
 		return ToolResult{}
 	}
 	machineID, err := server.machineID()
@@ -397,14 +357,9 @@ func TestShutdownWithdrawsManagedRoutesBeforeScheduling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{
-		"systemctl stop " + endpointAdvertiserUnit,
-		endpointAdvertiserCommand + " withdraw",
-		"systemctl stop " + endpointRoutingUnit,
-		"systemd-run --unit=katl-shutdown --collect --on-active=2s systemctl poweroff",
-	}
-	if !reflect.DeepEqual(actions, want) {
-		t.Fatalf("shutdown actions = %#v, want %#v", actions, want)
+	want := []string{"systemd-run", "--unit=katl-shutdown", "--collect", "--on-active=2s", "systemctl", "poweroff"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("shutdown argv = %#v, want %#v", argv, want)
 	}
 }
 

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -294,6 +294,7 @@ type ControlPlaneEndpointStatus struct {
 	RouteExchange         []*ControlPlaneEndpointRouteExchangeStatus `protobuf:"bytes,9,rep,name=route_exchange,json=routeExchange,proto3" json:"route_exchange,omitempty"`
 	LastTransitionTime    string                                     `protobuf:"bytes,10,opt,name=last_transition_time,json=lastTransitionTime,proto3" json:"last_transition_time,omitempty"`
 	FailureReason         string                                     `protobuf:"bytes,11,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	LocalVipOwned         bool                                       `protobuf:"varint,12,opt,name=local_vip_owned,json=localVipOwned,proto3" json:"local_vip_owned,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -403,6 +404,13 @@ func (x *ControlPlaneEndpointStatus) GetFailureReason() string {
 		return x.FailureReason
 	}
 	return ""
+}
+
+func (x *ControlPlaneEndpointStatus) GetLocalVipOwned() bool {
+	if x != nil {
+		return x.LocalVipOwned
+	}
+	return false
 }
 
 type ControlPlaneEndpointPeerStatus struct {
@@ -3890,7 +3898,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\n" +
 	"node_ready\x18\x05 \x01(\bR\tnodeReady\x12C\n" +
 	"\x1econtrol_plane_components_ready\x18\x06 \x01(\bR\x1bcontrolPlaneComponentsReady\x12%\n" +
-	"\x0efailure_reason\x18\a \x01(\tR\rfailureReason\"\x85\x04\n" +
+	"\x0efailure_reason\x18\a \x01(\tR\rfailureReason\"\xad\x04\n" +
 	"\x1aControlPlaneEndpointStatus\x12\x1a\n" +
 	"\bendpoint\x18\x01 \x01(\tR\bendpoint\x12\x10\n" +
 	"\x03vip\x18\x02 \x01(\tR\x03vip\x12\x14\n" +
@@ -3903,7 +3911,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0eroute_exchange\x18\t \x03(\v26.katl.agent.v1.ControlPlaneEndpointRouteExchangeStatusR\rrouteExchange\x120\n" +
 	"\x14last_transition_time\x18\n" +
 	" \x01(\tR\x12lastTransitionTime\x12%\n" +
-	"\x0efailure_reason\x18\v \x01(\tR\rfailureReason\"\x89\x01\n" +
+	"\x0efailure_reason\x18\v \x01(\tR\rfailureReason\x12&\n" +
+	"\x0flocal_vip_owned\x18\f \x01(\bR\rlocalVipOwned\"\x89\x01\n" +
 	"\x1eControlPlaneEndpointPeerStatus\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x12\x14\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -60,6 +60,7 @@ message ControlPlaneEndpointStatus {
   repeated ControlPlaneEndpointRouteExchangeStatus route_exchange = 9;
   string last_transition_time = 10;
   string failure_reason = 11;
+  bool local_vip_owned = 12;
 }
 
 message ControlPlaneEndpointPeerStatus {

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:e79d24aac827004116f7f1435dfff82a10cab154e9ca76c3130e0953a2eb1d99",
+  "recipeDigest": "sha256:c9a390b5fb6734bfe3c5a703ccfe53507b63486abd05a773acfcb05ea57c7aea",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 17,
+      "artifactRevision": 18,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 15,
+      "artifactRevision": 16,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 14,
+      "artifactRevision": 15,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 14,
+      "artifactRevision": 15,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/endpoint_advertiser_sysext_test.go
+++ b/internal/scriptstest/endpoint_advertiser_sysext_test.go
@@ -22,6 +22,7 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	for _, want := range []string{
 		"ConditionPathExists=/etc/katl/apps/bird/bird.conf",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
+		"Group=katl",
 		"ExecStart=/usr/bin/bird ",
 		"RestrictAddressFamilies=AF_INET AF_NETLINK AF_UNIX",
 	} {
@@ -36,8 +37,13 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	appUnit := read("mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service")
 	for _, want := range []string{
 		"Requires=katl-app-bird.service",
+		"After=katl-app-bird.service",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
+		"ConditionPathExists=/etc/kubernetes/pki/ca.crt",
+		"ExecStopPost=/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser withdraw",
+		"CapabilityBoundingSet=CAP_NET_ADMIN",
+		"SupplementaryGroups=katl",
 		"RestrictAddressFamilies=AF_INET AF_NETLINK AF_UNIX",
 	} {
 		if !strings.Contains(appUnit, want) {
@@ -47,13 +53,26 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	if strings.Contains(appUnit, "WantedBy=") {
 		t.Fatal("endpoint advertiser unit must be selected by Katl rather than enabled globally")
 	}
+	if strings.Contains(appUnit, "DefaultDependencies=no") || strings.Contains(birdUnit, "DefaultDependencies=no") {
+		t.Fatal("endpoint services must retain systemd's default shutdown ordering")
+	}
+	pathUnit := read("mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.path")
+	for _, want := range []string{
+		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
+		"PathExists=/etc/kubernetes/pki/ca.crt",
+		"Unit=katl-app-bgp-api-vip.service",
+	} {
+		if !strings.Contains(pathUnit, want) {
+			t.Fatalf("endpoint bootstrap path unit is missing %q", want)
+		}
+	}
 
 	activationUnit := read("mkosi.profiles/runtime/katl-endpoint-activate.service")
 	for _, want := range []string{
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
 		"ExecStart=/usr/bin/systemctl daemon-reload",
-		"start katl-app-bgp-api-vip.service",
+		"start katl-app-bgp-api-vip.path",
 	} {
 		if !strings.Contains(activationUnit, want) {
 			t.Fatalf("endpoint activation unit is missing %q", want)
@@ -64,6 +83,12 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 	}
 
 	build := read("mkosi.profiles/endpoint-advertiser-sysext/mkosi.build")
+	if !strings.Contains(build, "katl-app-bgp-api-vip.path") {
+		t.Fatal("endpoint sysext must package the bootstrap path unit")
+	}
+	if strings.Contains(pathUnit, "DefaultDependencies=no") {
+		t.Fatal("endpoint path watcher must retain systemd's default shutdown ordering")
+	}
 	if !strings.Contains(build, `ln -sf /dev/null "$DESTDIR/usr/lib/systemd/system/bird.service"`) {
 		t.Fatal("endpoint sysext must mask Fedora's generic bird.service")
 	}

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -17,11 +17,16 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
 		t.Fatalf("MkdirAll(%s) error = %v", bin, err)
 	}
 	preserveFile(t, filepath.Join(repo, "_build", "mkosi", "katl-installer.packages.tsv"))
+	installerManifest := filepath.Join(repo, "_build", "mkosi", "katl-installer.manifest")
+	preserveFile(t, installerManifest)
 	mkosiArgs := filepath.Join(tmp, "mkosi-args.txt")
 	mkosiEnv := filepath.Join(tmp, "mkosi-env.txt")
 	goArgs := filepath.Join(tmp, "go-args.txt")
 	goEnv := filepath.Join(tmp, "go-env.txt")
-	writeFakeExecutable(t, bin, "mkosi", `printf '%s\n' "$@" > "$KATL_FAKE_MKOSI_ARGS"
+writeFakeExecutable(t, bin, "mkosi", `printf '%s\n' "$@" > "$KATL_FAKE_MKOSI_ARGS"
+cat > "$KATL_FAKE_INSTALLER_MANIFEST" <<'EOF'
+{"packages":[{"type":"rpm","name":"systemd","version":"0:259.6-1.fc44","architecture":"x86_64"}]}
+EOF
 {
   printf 'MKOSI_DNF=%s\n' "${MKOSI_DNF:-}"
   printf 'TMPDIR=%s\n' "${TMPDIR:-}"
@@ -34,15 +39,12 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
   printf 'GOMODCACHE=%s\n' "${GOMODCACHE:-}"
 } > "$KATL_FAKE_GO_ENV"
 `)
-	writeFakeExecutable(t, bin, "rpm", "printf 'systemd\\t0:259.6-1.fc44.x86_64\\n'\n")
 	for _, tool := range []string{"dnf5", "ukify", "xargs"} {
 		writeFakeExecutable(t, bin, tool, "exit 0\n")
 	}
 	for _, name := range []string{"katl-installer.iso", "katl-installer.iso.json", "katl-installer.iso.sha256"} {
 		preserveFile(t, filepath.Join(repo, "_build", "mkosi", name))
 	}
-	seedInstallerRPMCache(t, repo)
-
 	cmd := exec.Command(filepath.Join(repo, "scripts", "mkosi"), "build-installer")
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(),
@@ -50,6 +52,7 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
 		"KATL_CONTAINER_RUNTIME=direct",
 		"KATL_FAKE_MKOSI_ARGS="+mkosiArgs,
 		"KATL_FAKE_MKOSI_ENV="+mkosiEnv,
+		"KATL_FAKE_INSTALLER_MANIFEST="+installerManifest,
 		"KATL_FAKE_GO_ARGS="+goArgs,
 		"KATL_FAKE_GO_ENV="+goEnv,
 		"GOCACHE="+filepath.Join(tmp, "go-cache"),
@@ -68,7 +71,7 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
 		t.Fatalf("extra search path %q does not include fake tool dir %q", args[1], bin)
 	}
 	installerPackageSet := "KATL_INSTALLER_PACKAGE_SET=" + filepath.Join(repo, "_build", "mkosi", "katl-installer.packages.tsv")
-	for _, want := range []string{"--profile", "installer-image", "-f", "build", "--environment", installerPackageSet} {
+	for _, want := range []string{"--profile", "installer-image", "-f", "build", "--environment", installerPackageSet, "--manifest-format", "json"} {
 		if !containsString(args, want) {
 			t.Fatalf("mkosi args missing %q: %#v", want, args)
 		}

--- a/internal/scriptstest/mkosi_script_test.go
+++ b/internal/scriptstest/mkosi_script_test.go
@@ -23,7 +23,7 @@ func TestMkosiDirectInstallerUsesDevShellTools(t *testing.T) {
 	mkosiEnv := filepath.Join(tmp, "mkosi-env.txt")
 	goArgs := filepath.Join(tmp, "go-args.txt")
 	goEnv := filepath.Join(tmp, "go-env.txt")
-writeFakeExecutable(t, bin, "mkosi", `printf '%s\n' "$@" > "$KATL_FAKE_MKOSI_ARGS"
+	writeFakeExecutable(t, bin, "mkosi", `printf '%s\n' "$@" > "$KATL_FAKE_MKOSI_ARGS"
 cat > "$KATL_FAKE_INSTALLER_MANIFEST" <<'EOF'
 {"packages":[{"type":"rpm","name":"systemd","version":"0:259.6-1.fc44","architecture":"x86_64"}]}
 EOF

--- a/internal/vmtest/scenarios/bgp_api_vip_vmtest_test.go
+++ b/internal/vmtest/scenarios/bgp_api_vip_vmtest_test.go
@@ -58,6 +58,12 @@ type bgpAPIVIPInputs struct {
 	ControlPlaneMetadata   string                        `json:"controlPlaneMetadata"`
 	ControlPlaneAddress    string                        `json:"controlPlaneAddress"`
 	ControlPlaneMAC        string                        `json:"controlPlaneMAC"`
+	ControlPlane2Disk      string                        `json:"controlPlane2Disk"`
+	ControlPlane2ESP       string                        `json:"controlPlane2ESP"`
+	ControlPlane2Fixture   string                        `json:"controlPlane2Fixture"`
+	ControlPlane2Metadata  string                        `json:"controlPlane2Metadata"`
+	ControlPlane2Address   string                        `json:"controlPlane2Address"`
+	ControlPlane2MAC       string                        `json:"controlPlane2MAC"`
 	WorkerDisk             string                        `json:"workerDisk"`
 	WorkerDiskFormat       string                        `json:"workerDiskFormat"`
 	WorkerESP              string                        `json:"workerESP"`
@@ -121,6 +127,7 @@ func bgpAPIVIPWorldRun(t *testing.T) (bgpAPIVIPRun, bool) {
 	kvm := vmtest.DefaultOptions().KVM
 	specs := []vmtest.NodeSpec{
 		{Name: "cp-1", Role: vmtest.ControlPlane},
+		{Name: "cp-2", Role: vmtest.ControlPlane},
 		{Name: "worker-1", Role: vmtest.Worker},
 	}
 	if err := ensurePublishedRuntimeFixturesForWorld(world, repo, specs, kvm); err != nil {
@@ -141,6 +148,11 @@ func planBGPAPIVIPWorldRun(world vmtest.World, repo string, kvm vmtest.KVMPolicy
 	run := bgpAPIVIPRun{WorldScenario: scenario}
 	buildRoots := publishedRuntimeBuildRoots(world, repo)
 	cp, err := vmtest.AddPublishedInstalledRuntimeNodeFromBuildRoots(scenario, buildRoots, vmtest.NodeSpec{Name: "cp-1", Role: vmtest.ControlPlane})
+	if err != nil {
+		_ = scenario.WriteSetupFailure(err)
+		return run, err
+	}
+	cp2, err := vmtest.AddPublishedInstalledRuntimeNodeFromBuildRoots(scenario, buildRoots, vmtest.NodeSpec{Name: "cp-2", Role: vmtest.ControlPlane})
 	if err != nil {
 		_ = scenario.WriteSetupFailure(err)
 		return run, err
@@ -189,6 +201,12 @@ func planBGPAPIVIPWorldRun(world vmtest.World, repo string, kvm vmtest.KVMPolicy
 			ControlPlaneMetadata:   cp.Config.NodeMetadata,
 			ControlPlaneAddress:    cp.Node.Address,
 			ControlPlaneMAC:        cp.Node.MACAddress,
+			ControlPlane2Disk:      cp2.Config.Disk,
+			ControlPlane2ESP:       cp2.Config.ESPArtifacts,
+			ControlPlane2Fixture:   cp2.Config.FixtureManifest,
+			ControlPlane2Metadata:  cp2.Config.NodeMetadata,
+			ControlPlane2Address:   cp2.Node.Address,
+			ControlPlane2MAC:       cp2.Node.MACAddress,
 			WorkerDisk:             worker.Config.Disk,
 			WorkerDiskFormat:       string(worker.Config.DiskFormat),
 			WorkerESP:              worker.Config.ESPArtifacts,
@@ -200,7 +218,11 @@ func planBGPAPIVIPWorldRun(world vmtest.World, repo string, kvm vmtest.KVMPolicy
 			RouterMAC:              router.MACAddress,
 			ClientAddress:          client.Address,
 			ClientMAC:              client.MACAddress,
-			WorldProvenance:        multiNodeWorldProvenanceForSpecs(world, repo, []vmtest.NodeSpec{{Name: "cp-1", Role: vmtest.ControlPlane}, {Name: "worker-1", Role: vmtest.Worker}}),
+			WorldProvenance: multiNodeWorldProvenanceForSpecs(world, repo, []vmtest.NodeSpec{
+				{Name: "cp-1", Role: vmtest.ControlPlane},
+				{Name: "cp-2", Role: vmtest.ControlPlane},
+				{Name: "worker-1", Role: vmtest.Worker},
+			}),
 		},
 	}, nil
 }
@@ -247,9 +269,17 @@ func runBGPAPIVIPProof(t *testing.T, run bgpAPIVIPRun) {
 	}
 	defer stopNode(t, cpNode)
 
-	workerNode, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "worker-1", run.Inputs.WorkerDisk, run.Inputs.WorkerESP, run.Inputs.WorkerFixture, run.Inputs.WorkerMetadata, vmtest.DiskFormat(run.Inputs.WorkerDiskFormat), run.Inputs.WorkerMAC), vmtest.VMRunner{})
+	cp2Node, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "cp-2", run.Inputs.ControlPlane2Disk, run.Inputs.ControlPlane2ESP, run.Inputs.ControlPlane2Fixture, run.Inputs.ControlPlane2Metadata, vmtest.DiskFormat(run.Inputs.ControlPlaneDiskFormat), run.Inputs.ControlPlane2MAC), vmtest.VMRunner{})
 	if err != nil {
 		collectTwoNodeDiagnostics("", cpNode)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("start cp-2 VM: %v", err)
+	}
+	defer stopNode(t, cp2Node)
+
+	workerNode, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "worker-1", run.Inputs.WorkerDisk, run.Inputs.WorkerESP, run.Inputs.WorkerFixture, run.Inputs.WorkerMetadata, vmtest.DiskFormat(run.Inputs.WorkerDiskFormat), run.Inputs.WorkerMAC), vmtest.VMRunner{})
+	if err != nil {
+		collectTwoNodeDiagnostics("", cpNode, cp2Node)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("start worker-1 VM: %v", err)
 	}
@@ -257,7 +287,7 @@ func runBGPAPIVIPProof(t *testing.T, run bgpAPIVIPRun) {
 
 	routerNode, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "fabric-router", run.Inputs.ControlPlaneDisk, run.Inputs.ControlPlaneESP, run.Inputs.ControlPlaneFixture, run.Inputs.ControlPlaneMetadata, vmtest.DiskFormat(run.Inputs.ControlPlaneDiskFormat), run.Inputs.RouterMAC), vmtest.VMRunner{})
 	if err != nil {
-		collectTwoNodeDiagnostics("", cpNode, workerNode)
+		collectTwoNodeDiagnostics("", cpNode, cp2Node, workerNode)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("start fabric-router VM: %v", err)
 	}
@@ -265,7 +295,7 @@ func runBGPAPIVIPProof(t *testing.T, run bgpAPIVIPRun) {
 
 	clientNode, err := vmtest.StartInstalledRuntimeNode(ctx, result, bgpAPIVIPNodeConfig(run, "external-client", run.Inputs.WorkerDisk, run.Inputs.WorkerESP, run.Inputs.WorkerFixture, run.Inputs.WorkerMetadata, vmtest.DiskFormat(run.Inputs.WorkerDiskFormat), run.Inputs.ClientMAC), vmtest.VMRunner{})
 	if err != nil {
-		collectTwoNodeDiagnostics("", cpNode, workerNode, routerNode)
+		collectTwoNodeDiagnostics("", cpNode, cp2Node, workerNode, routerNode)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("start external-client VM: %v", err)
 	}
@@ -293,8 +323,8 @@ func runBGPAPIVIPProof(t *testing.T, run bgpAPIVIPRun) {
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatal(err)
 	}
-	if err := runRealRoutedEndpointProof(ctx, result, cpNode, workerNode, routerNode, clientNode, helper); err != nil {
-		collectTwoNodeDiagnostics("", cpNode, workerNode, routerNode, clientNode)
+	if err := runRealRoutedEndpointProof(ctx, result, cpNode, cp2Node, workerNode, routerNode, clientNode, helper); err != nil {
+		collectTwoNodeDiagnostics("", cpNode, cp2Node, workerNode, routerNode, clientNode)
 		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
 		t.Fatalf("real routed endpoint proof: %v", err)
 	}
@@ -505,6 +535,7 @@ type routedEndpointVMProof struct {
 	Kind                     string   `json:"kind"`
 	VIP                      string   `json:"vip"`
 	ControlPlane             string   `json:"controlPlane"`
+	ControlPlanePeer         string   `json:"controlPlanePeer"`
 	FabricRouter             string   `json:"fabricRouter"`
 	ExternalClient           string   `json:"externalClient"`
 	Worker                   string   `json:"worker"`
@@ -513,21 +544,25 @@ type routedEndpointVMProof struct {
 	RouteAdvertised          bool     `json:"routeAdvertised"`
 	ExternalReadyzReachable  bool     `json:"externalReadyzReachable"`
 	APIFailureWithdrawn      bool     `json:"apiFailureWithdrawn"`
+	FailedNodeVIPReleased    bool     `json:"failedNodeVIPReleased"`
+	FailedNodeReachedPeerVIP bool     `json:"failedNodeReachedPeerVIP"`
+	RemoteAPIRejectedAsLocal bool     `json:"remoteAPIRejectedAsLocal"`
 	APIRecoveryReadvertised  bool     `json:"apiRecoveryReadvertised"`
 	ControllerKillWithdrawn  bool     `json:"controllerKillWithdrawn"`
 	RoutingDaemonKillRemoved bool     `json:"routingDaemonKillRemoved"`
 	Checks                   []string `json:"checks"`
 }
 
-func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, worker, router, client vmtest.RunningInstalledRuntimeNode, helper string) error {
+func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, cp2, worker, router, client vmtest.RunningInstalledRuntimeNode, helper string) error {
 	proof := routedEndpointVMProof{
-		APIVersion:     "katl.dev/v1alpha1",
-		Kind:           "RoutedControlPlaneEndpointVMProof",
-		VIP:            routedEndpointProofVIP + "/32",
-		ControlPlane:   cp.Result.IPAddress,
-		FabricRouter:   router.Result.IPAddress,
-		ExternalClient: client.Result.IPAddress,
-		Worker:         worker.Result.IPAddress,
+		APIVersion:       "katl.dev/v1alpha1",
+		Kind:             "RoutedControlPlaneEndpointVMProof",
+		VIP:              routedEndpointProofVIP + "/32",
+		ControlPlane:     cp.Result.IPAddress,
+		ControlPlanePeer: cp2.Result.IPAddress,
+		FabricRouter:     router.Result.IPAddress,
+		ExternalClient:   client.Result.IPAddress,
+		Worker:           worker.Result.IPAddress,
 	}
 	writeProof := func() {
 		data, _ := json.MarshalIndent(proof, "", "  ")
@@ -541,7 +576,7 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	proof.WorkerArtifactAbsent = true
 	proof.Checks = append(proof.Checks, "worker has no endpoint advertiser payload")
 
-	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, router} {
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, cp2, router} {
 		if err := activateRetainedEndpointSysext(ctx, node); err != nil {
 			return fmt.Errorf("activate endpoint sysext on %s: %w", node.Name, err)
 		}
@@ -557,7 +592,7 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	proof.InitialBirdInactive = true
 	proof.Checks = append(proof.Checks, "BIRD remains inactive without the managed-advertisement marker")
 
-	if err := configureFabricRouter(ctx, router, []string{cp.Result.IPAddress}); err != nil {
+	if err := configureFabricRouter(ctx, router, []string{cp.Result.IPAddress, cp2.Result.IPAddress}); err != nil {
 		return err
 	}
 	if err := assertGuestCommand(ctx, router, []string{"sysctl", "-w", "net.ipv4.ip_forward=1"}); err != nil {
@@ -565,6 +600,11 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	}
 	if err := assertGuestCommand(ctx, client, []string{"ip", "route", "replace", routedEndpointProofVIP + "/32", "via", router.Result.IPAddress}); err != nil {
 		return fmt.Errorf("install external client VIP route: %w", err)
+	}
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, cp2} {
+		if err := assertGuestCommand(ctx, node, []string{"ip", "route", "replace", routedEndpointProofVIP + "/32", "via", router.Result.IPAddress}); err != nil {
+			return fmt.Errorf("install %s fallback VIP route: %w", node.Name, err)
+		}
 	}
 
 	caPEM, certPEM, keyPEM, err := routedEndpointTLSFixture(net.ParseIP(routedEndpointProofVIP))
@@ -581,23 +621,28 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 		{cp, fixtureRoot + "/ca.crt", caPEM, 0o644},
 		{cp, fixtureRoot + "/server.crt", certPEM, 0o644},
 		{cp, fixtureRoot + "/server.key", keyPEM, 0o600},
+		{cp2, fixtureRoot + "/ca.crt", caPEM, 0o644},
+		{cp2, fixtureRoot + "/server.crt", certPEM, 0o644},
+		{cp2, fixtureRoot + "/server.key", keyPEM, 0o600},
 		{client, fixtureRoot + "/ca.crt", caPEM, 0o644},
 	} {
 		if err := writeNodeFile(ctx, target.node, target.path, target.data, target.mode, target.mode == 0o600); err != nil {
 			return err
 		}
 	}
-	if err := assertGuestCommand(ctx, cp, []string{
-		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
-		"/usr/bin/install", "-D", "-m", "0644", fixtureRoot + "/ca.crt", "/etc/kubernetes/pki/ca.crt",
-	}); err != nil {
-		return fmt.Errorf("install kubeadm-compatible API CA: %w", err)
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, cp2} {
+		if err := assertGuestCommand(ctx, node, []string{
+			"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+			"/usr/bin/install", "-D", "-m", "0644", fixtureRoot + "/ca.crt", "/etc/kubernetes/pki/ca.crt",
+		}); err != nil {
+			return fmt.Errorf("install kubeadm-compatible API CA on %s: %w", node.Name, err)
+		}
 	}
 	helperData, err := os.ReadFile(helper)
 	if err != nil {
 		return err
 	}
-	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, client} {
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, cp2, client} {
 		if err := writeNodeFileChunked(ctx, node, fixtureRoot+"/bgp-api-vip-smoke", helperData, 0o755); err != nil {
 			return err
 		}
@@ -607,30 +652,38 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	if err != nil {
 		return err
 	}
-	if err := activateEndpointConfext(ctx, cp, fixtureRoot, endpointPlan); err != nil {
-		return err
-	}
-	if err := createGuestDummyVIP(ctx, cp); err != nil {
-		return err
-	}
-	if err := startReadyzFixture(ctx, cp, fixtureRoot); err != nil {
-		return err
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, cp2} {
+		if err := activateEndpointConfext(ctx, node, fixtureRoot, endpointPlan); err != nil {
+			return err
+		}
+		if err := createGuestDummyVIP(ctx, node); err != nil {
+			return err
+		}
+		if err := startReadyzFixture(ctx, node, fixtureRoot); err != nil {
+			return err
+		}
 	}
 	defer func() {
 		_, _ = runNodeCommand(context.Background(), cp, []string{"systemctl", "stop", "katl-vmtest-readyz.service"}, 8<<10)
+		_, _ = runNodeCommand(context.Background(), cp2, []string{"systemctl", "stop", "katl-vmtest-readyz.service"}, 8<<10)
 	}()
-	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "daemon-reload"}); err != nil {
-		return err
-	}
-	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}); err != nil {
-		return fmt.Errorf("start production endpoint controller: %w", err)
+	for _, node := range []vmtest.RunningInstalledRuntimeNode{cp, cp2} {
+		if err := assertGuestCommand(ctx, node, []string{"systemctl", "daemon-reload"}); err != nil {
+			return err
+		}
+		if err := assertGuestCommand(ctx, node, []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}); err != nil {
+			return fmt.Errorf("start production endpoint controller on %s: %w", node.Name, err)
+		}
 	}
 
-	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, true, 30*time.Second); err != nil {
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, true, 30*time.Second); err != nil {
+		return err
+	}
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp2.Result.IPAddress, true, 30*time.Second); err != nil {
 		return err
 	}
 	proof.RouteAdvertised = true
-	proof.Checks = append(proof.Checks, "fabric router learned the healthy API /32 from production BIRD")
+	proof.Checks = append(proof.Checks, "fabric router learned the healthy API /32 from both control planes")
 	if err := probeReadyzFromClient(ctx, client, fixtureRoot); err != nil {
 		return err
 	}
@@ -640,16 +693,44 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "stop", "katl-vmtest-readyz.service"}); err != nil {
 		return fmt.Errorf("stop API readiness fixture: %w", err)
 	}
-	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, false, 20*time.Second); err != nil {
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, false, 20*time.Second); err != nil {
 		return fmt.Errorf("API failure did not withdraw route: %w", err)
 	}
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp2.Result.IPAddress, true, 20*time.Second); err != nil {
+		return fmt.Errorf("healthy peer route was disrupted: %w", err)
+	}
 	proof.APIFailureWithdrawn = true
-	proof.Checks = append(proof.Checks, "local API failure withdrew only the API route")
+	proof.Checks = append(proof.Checks, "local API failure withdrew only the failed control plane path")
+	status, err := waitForEndpointStatus(ctx, cp, func(status bgpapivip.Status) bool {
+		return status.HealthState == bgpapivip.HealthUnhealthy &&
+			!status.LocalVIPOwned &&
+			status.AdvertisementState == bgpapivip.AdvertisementWithdrawn
+	}, 20*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed control plane did not release local VIP: %w", err)
+	}
+	proof.FailedNodeVIPReleased = true
+	if err := probeReadyzFromClient(ctx, cp, fixtureRoot); err != nil {
+		return fmt.Errorf("failed control plane could not reach healthy peer through VIP: %w", err)
+	}
+	proof.FailedNodeReachedPeerVIP = true
+	if status.HealthState != bgpapivip.HealthUnhealthy {
+		return fmt.Errorf("remote API response changed local health state: %#v", status)
+	}
+	proof.RemoteAPIRejectedAsLocal = true
+	proof.Checks = append(proof.Checks, "failed node released local VIP, reached its peer through the VIP, and kept local health unhealthy")
 	if err := startReadyzFixture(ctx, cp, fixtureRoot); err != nil {
 		return err
 	}
-	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, true, 30*time.Second); err != nil {
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, true, 30*time.Second); err != nil {
 		return fmt.Errorf("API recovery did not readvertise route: %w", err)
+	}
+	if _, err := waitForEndpointStatus(ctx, cp, func(status bgpapivip.Status) bool {
+		return status.HealthState == bgpapivip.HealthHealthy &&
+			status.LocalVIPOwned &&
+			status.AdvertisementState == bgpapivip.AdvertisementAdvertised
+	}, 20*time.Second); err != nil {
+		return fmt.Errorf("API recovery did not restore local VIP: %w", err)
 	}
 	proof.APIRecoveryReadvertised = true
 
@@ -659,7 +740,7 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "kill", "--kill-whom=main", "--signal=SIGKILL", "katl-app-bgp-api-vip.service"}); err != nil {
 		return fmt.Errorf("kill endpoint controller: %w", err)
 	}
-	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, false, 20*time.Second); err != nil {
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, false, 20*time.Second); err != nil {
 		return fmt.Errorf("ungraceful controller death did not withdraw route: %w", err)
 	}
 	proof.ControllerKillWithdrawn = true
@@ -673,7 +754,7 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "start", "katl-app-bgp-api-vip.service"}); err != nil {
 		return err
 	}
-	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, true, 30*time.Second); err != nil {
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, true, 30*time.Second); err != nil {
 		return err
 	}
 
@@ -683,7 +764,7 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, w
 	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "kill", "--kill-whom=main", "--signal=SIGKILL", "katl-app-bird.service"}); err != nil {
 		return fmt.Errorf("kill routing daemon: %w", err)
 	}
-	if _, err := waitForRouterRoute(ctx, router, routedEndpointProofVIP, false, 20*time.Second); err != nil {
+	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, false, 20*time.Second); err != nil {
 		return fmt.Errorf("routing daemon death did not remove route: %w", err)
 	}
 	proof.RoutingDaemonKillRemoved = true
@@ -796,7 +877,6 @@ func activateEndpointConfext(ctx context.Context, node vmtest.RunningInstalledRu
 func createGuestDummyVIP(ctx context.Context, node vmtest.RunningInstalledRuntimeNode) error {
 	for _, argv := range [][]string{
 		{"ip", "link", "add", "katl-api", "type", "dummy"},
-		{"ip", "address", "add", routedEndpointProofVIP + "/32", "dev", "katl-api"},
 		{"ip", "link", "set", "katl-api", "up"},
 	} {
 		if err := assertGuestCommand(ctx, node, argv); err != nil {
@@ -811,7 +891,7 @@ func startReadyzFixture(ctx context.Context, node vmtest.RunningInstalledRuntime
 	return assertGuestCommand(ctx, node, []string{
 		"systemd-run", "--quiet", "--collect", "--unit=katl-vmtest-readyz.service",
 		root + "/bgp-api-vip-smoke", "serve-readyz",
-		"--listen", routedEndpointProofVIP + ":6443", "--cert", root + "/server.crt", "--key", root + "/server.key",
+		"--listen", "0.0.0.0:6443", "--cert", root + "/server.crt", "--key", root + "/server.key",
 	})
 }
 
@@ -830,7 +910,7 @@ func probeReadyzFromClient(ctx context.Context, node vmtest.RunningInstalledRunt
 	return nil
 }
 
-func waitForRouterRoute(ctx context.Context, router vmtest.RunningInstalledRuntimeNode, prefix string, present bool, timeout time.Duration) (string, error) {
+func waitForRouterRouteVia(ctx context.Context, router vmtest.RunningInstalledRuntimeNode, prefix, nextHop string, present bool, timeout time.Duration) (string, error) {
 	deadline := time.Now().Add(timeout)
 	var last string
 	for time.Now().Before(deadline) {
@@ -840,8 +920,8 @@ func waitForRouterRoute(ctx context.Context, router vmtest.RunningInstalledRunti
 		}, 32<<10)
 		if err == nil {
 			last = string(result.Stdout) + string(result.Stderr)
-			hasRoute := result.ExitStatus == 0 && strings.Contains(last, prefix)
-			if hasRoute == present {
+			hasPath := result.ExitStatus == 0 && strings.Contains(last, prefix) && strings.Contains(last, "via "+nextHop)
+			if hasPath == present {
 				return last, nil
 			}
 		} else {
@@ -853,7 +933,38 @@ func waitForRouterRoute(ctx context.Context, router vmtest.RunningInstalledRunti
 		case <-time.After(500 * time.Millisecond):
 		}
 	}
-	return last, fmt.Errorf("fabric route %s presence=%t not observed: %s", prefix, present, strings.TrimSpace(last))
+	return last, fmt.Errorf("fabric route %s via %s presence=%t not observed: %s", prefix, nextHop, present, strings.TrimSpace(last))
+}
+
+func waitForEndpointStatus(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, ready func(bgpapivip.Status) bool, timeout time.Duration) (bgpapivip.Status, error) {
+	deadline := time.Now().Add(timeout)
+	var last bgpapivip.Status
+	var lastErr error
+	for time.Now().Before(deadline) {
+		result, err := runNodeCommand(ctx, node, []string{
+			"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+			"/usr/bin/cat", bgpapivip.LiveStatusPath,
+		}, 32<<10)
+		if err == nil && result.ExitStatus == 0 {
+			status, decodeErr := bgpapivip.DecodeStatus(strings.NewReader(string(result.Stdout)))
+			if decodeErr == nil {
+				last = status
+				if ready(status) {
+					return status, nil
+				}
+			} else {
+				lastErr = decodeErr
+			}
+		} else if err != nil {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return last, fmt.Errorf("endpoint status condition not observed: last=%#v error=%v", last, lastErr)
 }
 
 func guestUnitActive(ctx context.Context, node vmtest.RunningInstalledRuntimeNode, unit string) (bool, error) {

--- a/internal/vmtest/testcmd/bgp-api-vip-smoke/main.go
+++ b/internal/vmtest/testcmd/bgp-api-vip-smoke/main.go
@@ -222,6 +222,7 @@ func runControlPlane(outputDir string, config bgpapivip.Config) error {
 		Bird:              bird,
 		Health:            health,
 		Interface:         bgpapivip.AlwaysReadyInterface{},
+		Owner:             &fakeVIPOwner{bird: bird},
 		Writer: bgpapivip.FileStatusWriter{
 			LivePath:      filepath.Join(outputDir, "status-live.json"),
 			OperationPath: filepath.Join(outputDir, "status-operation.json"),
@@ -290,6 +291,7 @@ func (b *fakeBird) Status(context.Context) (bgpapivip.BirdRuntimeStatus, error) 
 		ControlSocketReady: true,
 		ControlSocketPath:  "/run/katl/apps/bird/bird.ctl",
 		ReadinessState:     "ready",
+		RouteOriginated:    len(b.routeTable) > 0,
 		Peers: []bgpapivip.PeerRuntimeStatus{{
 			Name:           "dev-host",
 			Kind:           "dev-host",
@@ -302,7 +304,7 @@ func (b *fakeBird) Status(context.Context) (bgpapivip.BirdRuntimeStatus, error) 
 	}, nil
 }
 
-func (b *fakeBird) SetAdvertisement(_ context.Context, enabled bool) error {
+func (b *fakeBird) observeOwnership(enabled bool) error {
 	b.advertisements = append(b.advertisements, enabled)
 	change := observedRouteChange{Peer: "dev-host"}
 	for _, peer := range append(append([]bgpapivip.Peer{}, b.config.FabricPeers...), b.config.DevHostPeers...) {
@@ -337,6 +339,23 @@ func (b *fakeBird) routes() []string {
 type sequenceHealth struct {
 	results []bgpapivip.HealthResult
 	next    int
+}
+
+type fakeVIPOwner struct {
+	owned bool
+	bird  *fakeBird
+}
+
+func (o *fakeVIPOwner) Owned(context.Context, bgpapivip.Config) (bool, error) {
+	return o.owned, nil
+}
+
+func (o *fakeVIPOwner) SetOwned(_ context.Context, _ bgpapivip.Config, owned bool) error {
+	o.owned = owned
+	if o.bird != nil {
+		return o.bird.observeOwnership(owned)
+	}
+	return nil
 }
 
 func (h *sequenceHealth) Check(context.Context, bgpapivip.Health) bgpapivip.HealthResult {

--- a/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.path
+++ b/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watch for a bootstrapped Kubernetes control plane
+Documentation=https://katl.dev
+ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml
+ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
+
+[Path]
+PathExists=/etc/kubernetes/pki/ca.crt
+Unit=katl-app-bgp-api-vip.service

--- a/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service
+++ b/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service
@@ -5,6 +5,7 @@ Requires=katl-app-bird.service
 After=katl-app-bird.service
 ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml
 ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
+ConditionPathExists=/etc/kubernetes/pki/ca.crt
 
 [Service]
 Type=simple
@@ -14,6 +15,8 @@ ExecStart=/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser
 ExecStopPost=/usr/lib/katl/endpoint-advertiser/katl-endpoint-advertiser withdraw
 Restart=always
 RestartSec=2s
+CapabilityBoundingSet=CAP_NET_ADMIN
+SupplementaryGroups=katl
 NoNewPrivileges=yes
 PrivateDevices=yes
 PrivateTmp=yes

--- a/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bird.service
+++ b/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bird.service
@@ -9,6 +9,7 @@ ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
 [Service]
 Type=simple
 DynamicUser=yes
+Group=katl
 RuntimeDirectory=katl-bird
 RuntimeDirectoryMode=0750
 ExecStart=/usr/bin/bird -f -c /etc/katl/apps/bird/bird.conf -s /run/katl-bird/bird.ctl

--- a/mkosi.profiles/endpoint-advertiser-sysext/mkosi.build
+++ b/mkosi.profiles/endpoint-advertiser-sysext/mkosi.build
@@ -32,6 +32,7 @@ go build \
 
 install -m 0644 \
     "$repo/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bird.service" \
+    "$repo/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.path" \
     "$repo/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service" \
     "$DESTDIR/usr/lib/systemd/system/"
 

--- a/mkosi.profiles/runtime/katl-endpoint-activate.service
+++ b/mkosi.profiles/runtime/katl-endpoint-activate.service
@@ -9,7 +9,8 @@ ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/systemctl daemon-reload
-ExecStart=/usr/bin/systemctl start katl-app-bgp-api-vip.service
+ExecStart=/usr/bin/systemctl start katl-app-bgp-api-vip.path
+ExecStop=/usr/bin/systemctl stop katl-app-bgp-api-vip.path
 ExecStop=/usr/bin/systemctl stop katl-app-bgp-api-vip.service
 RemainAfterExit=yes
 

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -399,9 +399,23 @@ clear_installer_iso() {
 
 write_installer_package_set() {
     local output="$repo_root/_build/mkosi/katl-installer.packages.tsv"
+    local manifest="$build_dir/katl-installer.manifest"
     local cache_root="$repo_root/_build/mkosi/cache/fedora~44~x86-64~main.cache"
+    if [[ -f "$manifest" ]]; then
+        mkdir -p "$(dirname "$output")"
+        jq -r '
+            .packages[]
+            | select(.type == "rpm")
+            | [
+                .name,
+                (.version + (if .architecture == "" then "" else "." + .architecture end))
+            ]
+            | @tsv
+        ' "$manifest" | sort >"$output"
+        return
+    fi
     if [[ ! -d "$cache_root/usr/lib/sysimage/rpm" ]]; then
-        echo "error: installer RPM database not found: $cache_root/usr/lib/sysimage/rpm" >&2
+        echo "error: installer package manifest not found: $manifest" >&2
         return 1
     fi
     mkdir -p "$(dirname "$output")"
@@ -622,6 +636,7 @@ if [[ "$runtime" == direct ]]; then
     if [[ -n "$installer_package_set" ]]; then
         mkosi_installer_package_set="$repo_root/$installer_package_set"
         mkosi_env+=(--environment "KATL_INSTALLER_PACKAGE_SET=$mkosi_installer_package_set")
+        mkosi_env+=(--manifest-format json)
     fi
     if [[ "$emit_runtime_artifact" == 1 || "$emit_installer_iso" == 1 ]]; then
         echo "error: KATL_CONTAINER_RUNTIME=direct currently supports installer-image builds only" >&2
@@ -671,6 +686,7 @@ run_flags+=(--volume "$package_cache_dir:/mkosi-package-cache")
 if [[ -n "$installer_package_set" ]]; then
     mkosi_installer_package_set="/work/$installer_package_set"
     mkosi_env+=(--environment "KATL_INSTALLER_PACKAGE_SET=$mkosi_installer_package_set")
+    mkosi_env+=(--manifest-format json)
 fi
 
 if [[ "$runtime" == podman ]]; then
@@ -719,9 +735,23 @@ set +e
         go run ./cmd/katl-mkosi-artifacts "$@"
     }
     if [[ "$status" -eq 0 && -n "${KATL_INSTALLER_PACKAGE_SET:-}" ]]; then
+        installer_manifest=/mkosi-build/katl-installer.manifest
         installer_cache_root=/mkosi-cache/fedora~44~x86-64~main.cache
-        if [[ ! -d "$installer_cache_root/usr/lib/sysimage/rpm" ]]; then
-            echo "error: installer RPM database not found: $installer_cache_root/usr/lib/sysimage/rpm" >&2
+        if [[ -f "$installer_manifest" ]]; then
+            if ! jq -r '\''
+                .packages[]
+                | select(.type == "rpm")
+                | [
+                    .name,
+                    (.version + (if .architecture == "" then "" else "." + .architecture end))
+                ]
+                | @tsv
+            '\'' "$installer_manifest" | sort >"$KATL_INSTALLER_PACKAGE_SET"; then
+                echo "error: record installer package set from $installer_manifest" >&2
+                status=1
+            fi
+        elif [[ ! -d "$installer_cache_root/usr/lib/sysimage/rpm" ]]; then
+            echo "error: installer package manifest not found: $installer_manifest" >&2
             status=1
         elif ! rpm \
             --root "$installer_cache_root" \


### PR DESCRIPTION
## What changed

- make the endpoint controller own the API VIP through rtnetlink only after the local API passes readiness thresholds
- let BIRD import that dummy-interface address directly, so removing the address withdraws the route and releases the failed node's local path
- keep health probing on loopback, report local VIP ownership, and preserve online join/config plus systemd-native reboot behavior
- extend the routed endpoint VM journey to prove failed-node fallback through a healthy control-plane peer

## Why

The VIP previously remained assigned by networkd after the local API failed. BIRD withdrew the external route, but Linux retained a local route, so the failed control plane captured its own stable-endpoint traffic instead of following the fabric path to a healthy peer.

## Validation

Katldev proved advertisement, routed readiness, local API failure withdrawal, peer fallback, recovery, a local KatlOS upgrade, and packaged-generation reboot withdrawal/recovery against a host BGP peer. The five-node libvirt journey passed with two control planes, a fabric router, an external client, and fail-closed daemon crash checks.
