### PR TITLE
release: link kubernetes bundles upstream

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -175,6 +175,7 @@ jobs:
       OCI_DESCRIPTION: Kubernetes system extension bundle for KatlOS nodes
       OCI_LICENSES: MIT
       OCI_TITLE: KatlOS Kubernetes system extension
+      KUBERNETES_RELEASE_URL: https://github.com/kubernetes/kubernetes/releases/tag/${{ matrix.release.payloadVersion }}
       PAYLOAD_VERSION: ${{ matrix.release.payloadVersion }}
       PUBLISH: ${{ needs.plan.outputs.publish }}
 
@@ -331,10 +332,12 @@ jobs:
             --annotation "org.opencontainers.image.description=${OCI_DESCRIPTION}" \
             --annotation "org.opencontainers.image.licenses=${OCI_LICENSES}" \
             --annotation "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --annotation "org.opencontainers.image.url=${KUBERNETES_RELEASE_URL}" \
             --annotation "org.opencontainers.image.documentation=https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_SHA}/docs/installing.md" \
             --annotation "org.opencontainers.image.revision=${GITHUB_SHA}" \
             --annotation "org.opencontainers.image.version=${ARTIFACT_VERSION}" \
             --annotation "dev.katl.bundle.kind=kubernetes" \
+            --annotation "dev.katl.kubernetes.payload.version=${PAYLOAD_VERSION}" \
             "${RAW}:application/vnd.katl.sysext.raw.v1" \
             "${BUNDLE_DIR}/metadata.json:application/vnd.katl.kubernetes.sysext.metadata.v1+json" \
             "${BUNDLE_DIR}/package-provenance.json:application/vnd.katl.package-provenance.v1+json" \
@@ -343,13 +346,17 @@ jobs:
           jq -e \
             --arg description "$OCI_DESCRIPTION" \
             --arg licenses "$OCI_LICENSES" \
-            --arg source "https://github.com/${GITHUB_REPOSITORY}" '
+            --arg payload_version "$PAYLOAD_VERSION" \
+            --arg source "https://github.com/${GITHUB_REPOSITORY}" \
+            --arg upstream_release "$KUBERNETES_RELEASE_URL" '
             .artifactType == "application/vnd.katl.kubernetes.payload.bundle.v1" and
             .config.mediaType == "application/vnd.katl.kubernetes.payload.bundle.v1+json" and
             (.layers | length) == 4 and
             .annotations["org.opencontainers.image.description"] == $description and
             .annotations["org.opencontainers.image.licenses"] == $licenses and
-            .annotations["org.opencontainers.image.source"] == $source
+            .annotations["org.opencontainers.image.source"] == $source and
+            .annotations["org.opencontainers.image.url"] == $upstream_release and
+            .annotations["dev.katl.kubernetes.payload.version"] == $payload_version
           ' _build/oci-manifest.json >/dev/null
           manifest_digest="$(oras resolve --oci-layout "_build/oci-layout:${VERSION_TAG}")"
           if [[ ! "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -438,10 +445,14 @@ jobs:
           jq -e \
             --arg description "$OCI_DESCRIPTION" \
             --arg licenses "$OCI_LICENSES" \
-            --arg source "https://github.com/${GITHUB_REPOSITORY}" '
+            --arg payload_version "$PAYLOAD_VERSION" \
+            --arg source "https://github.com/${GITHUB_REPOSITORY}" \
+            --arg upstream_release "$KUBERNETES_RELEASE_URL" '
             .annotations["org.opencontainers.image.description"] == $description and
             .annotations["org.opencontainers.image.licenses"] == $licenses and
-            .annotations["org.opencontainers.image.source"] == $source
+            .annotations["org.opencontainers.image.source"] == $source and
+            .annotations["org.opencontainers.image.url"] == $upstream_release and
+            .annotations["dev.katl.kubernetes.payload.version"] == $payload_version
           ' _build/remote-manifest.json >/dev/null
 
           echo "manifest-digest=$manifest_digest" >> "$GITHUB_OUTPUT"

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:c9a390b5fb6734bfe3c5a703ccfe53507b63486abd05a773acfcb05ea57c7aea",
+  "recipeDigest": "sha256:fc729d74f088f15f736f794ff4d41d6da10ccbe353e17dcd9cb372222aceab48",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 18,
+      "artifactRevision": 19,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 16,
+      "artifactRevision": 17,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 15,
+      "artifactRevision": 16,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 15,
+      "artifactRevision": 16,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -1,0 +1,92 @@
+package scriptstest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestKubernetesBundleWorkflowLinksUpstreamRelease(t *testing.T) {
+	repo := repoRoot(t)
+	contents, err := os.ReadFile(filepath.Join(repo, ".github", "workflows", "kubernetes-bundles.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Env   map[string]string `yaml:"env"`
+			Steps []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(contents, &workflow); err != nil {
+		t.Fatalf("parse Kubernetes bundle workflow: %v", err)
+	}
+
+	build, ok := workflow.Jobs["build"]
+	if !ok {
+		t.Fatal("Kubernetes bundle workflow has no build job")
+	}
+	const releaseURL = "https://github.com/kubernetes/kubernetes/releases/tag/${{ matrix.release.payloadVersion }}"
+	if got := build.Env["KUBERNETES_RELEASE_URL"]; got != releaseURL {
+		t.Fatalf("KUBERNETES_RELEASE_URL = %q, want %q", got, releaseURL)
+	}
+
+	var layoutStep, publishStep string
+	for _, step := range build.Steps {
+		switch step.Name {
+		case "Validate OCI artifact layout":
+			layoutStep = step.Run
+		case "Publish immutable OCI bundle":
+			publishStep = step.Run
+		}
+	}
+	if layoutStep == "" {
+		t.Fatal("Kubernetes bundle workflow has no local OCI layout validation")
+	}
+	if publishStep == "" {
+		t.Fatal("Kubernetes bundle workflow has no immutable OCI publication step")
+	}
+
+	for _, contract := range []string{
+		`--annotation "org.opencontainers.image.url=${KUBERNETES_RELEASE_URL}"`,
+		`--annotation "dev.katl.kubernetes.payload.version=${PAYLOAD_VERSION}"`,
+		`.annotations["org.opencontainers.image.url"] == $upstream_release`,
+		`.annotations["dev.katl.kubernetes.payload.version"] == $payload_version`,
+	} {
+		if !strings.Contains(layoutStep, contract) {
+			t.Errorf("local OCI layout step does not enforce %q", contract)
+		}
+	}
+	for _, contract := range []string{
+		`.annotations["org.opencontainers.image.url"] == $upstream_release`,
+		`.annotations["dev.katl.kubernetes.payload.version"] == $payload_version`,
+	} {
+		if !strings.Contains(publishStep, contract) {
+			t.Errorf("OCI publication step does not enforce %q", contract)
+		}
+	}
+}
+
+func TestPublicKubernetesBundleCheckRequiresUpstreamRelease(t *testing.T) {
+	repo := repoRoot(t)
+	contents, err := os.ReadFile(filepath.Join(repo, "scripts", "check-public-kubernetes-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	check := string(contents)
+	for _, contract := range []string{
+		`upstream_release="https://github.com/kubernetes/kubernetes/releases/tag/${payload_version}"`,
+		`.annotations["org.opencontainers.image.url"] == $upstream_release`,
+		`.annotations["dev.katl.kubernetes.payload.version"] == $payload_version`,
+	} {
+		if !strings.Contains(check, contract) {
+			t.Errorf("public Kubernetes bundle check does not enforce %q", contract)
+		}
+	}
+}

--- a/scripts/check-public-kubernetes-bundle
+++ b/scripts/check-public-kubernetes-bundle
@@ -9,6 +9,7 @@ if [[ ! "$image" =~ ^ghcr\.io/katl-dev/kubernetes:([A-Za-z0-9._-]+)$ ]]; then
 fi
 tag="${BASH_REMATCH[1]}"
 payload_version="${tag%-katl.*}"
+upstream_release="https://github.com/kubernetes/kubernetes/releases/tag/${payload_version}"
 if [[ -n "$expected_digest" && ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
     echo "error: expected OCI manifest digest must be sha256 followed by 64 lowercase hex characters" >&2
     exit 2
@@ -49,7 +50,10 @@ if ! cmp --silent "$work/tag.json" "$work/digest.json"; then
     exit 1
 fi
 
-if ! jq -e --arg tag "$tag" '
+if ! jq -e \
+    --arg payload_version "$payload_version" \
+    --arg tag "$tag" \
+    --arg upstream_release "$upstream_release" '
     .schemaVersion == 2 and
     .mediaType == "application/vnd.oci.image.manifest.v1+json" and
     .artifactType == "application/vnd.katl.kubernetes.payload.bundle.v1" and
@@ -57,6 +61,8 @@ if ! jq -e --arg tag "$tag" '
     (.layers | length) == 4 and
     .annotations["org.opencontainers.image.version"] == $tag and
     .annotations["org.opencontainers.image.source"] == "https://github.com/katl-dev/katl" and
+    .annotations["org.opencontainers.image.url"] == $upstream_release and
+    .annotations["dev.katl.kubernetes.payload.version"] == $payload_version and
     .annotations["org.opencontainers.image.licenses"] == "MIT"
 ' "$work/tag.json" >/dev/null; then
     echo "error: OCI manifest metadata does not match the public Kubernetes bundle contract" >&2


### PR DESCRIPTION
The GitHub Packages page lost its relationship to the upstream Kubernetes release because payload identity was only stored in inner bundle metadata, while the rendered top-level OCI manifest identified Katl alone.

Add the exact Kubernetes release page as `org.opencontainers.image.url` and the payload as `dev.katl.kubernetes.payload.version`. Enforce both in the local layout, after publication, and in anonymous public checks, then advance the immutable bundle revisions.