### PR TITLE
release: retire superseded compatibility prs

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -513,7 +513,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
-      actions: write
+      actions: read
       contents: write
       pull-requests: write
     steps:
@@ -592,12 +592,36 @@ jobs:
               body: "Records the newly published immutable bundles for every supported Kubernetes payload built by the producer.",
               draft: false,
             });
-            await github.rest.actions.createWorkflowDispatch({
+
+            const openPulls = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: "fast-checks.yml",
-              ref: process.env.HEAD_BRANCH,
+              base: "main",
+              state: "open",
+              per_page: 100,
             });
+            const branchPrefix = "automation/kubernetes-compatibility-";
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            const superseded = openPulls.filter(candidate =>
+              candidate.number !== pull.number &&
+              candidate.head.repo?.full_name === repository &&
+              candidate.head.ref.startsWith(branchPrefix)
+            );
+            for (const candidate of superseded) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: candidate.number,
+                body: `Superseded by #${pull.number}, which records newer successfully published Kubernetes bundles. Closing this stale catalog update to prevent older bundle references from being merged.`,
+              });
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: candidate.number,
+                state: "closed",
+              });
+            }
+
             await github.graphql(`
               mutation($pullRequestId: ID!) {
                 enablePullRequestAutoMerge(input: {

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:fc729d74f088f15f736f794ff4d41d6da10ccbe353e17dcd9cb372222aceab48",
+  "recipeDigest": "sha256:c859619e457d8ea5e4c1a4b9e866f0c164d899d230e67dba521213ada715a7c2",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 19,
+      "artifactRevision": 20,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 17,
+      "artifactRevision": 18,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 16,
+      "artifactRevision": 17,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 16,
+      "artifactRevision": 17,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -90,3 +90,61 @@ func TestPublicKubernetesBundleCheckRequiresUpstreamRelease(t *testing.T) {
 		}
 	}
 }
+
+func TestKubernetesBundleWorkflowRetiresSupersededCompatibilityPRs(t *testing.T) {
+	repo := repoRoot(t)
+	contents, err := os.ReadFile(filepath.Join(repo, ".github", "workflows", "kubernetes-bundles.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Permissions map[string]string `yaml:"permissions"`
+			Steps       []struct {
+				Name string `yaml:"name"`
+				Uses string `yaml:"uses"`
+				With struct {
+					Script string `yaml:"script"`
+				} `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(contents, &workflow); err != nil {
+		t.Fatalf("parse Kubernetes bundle workflow: %v", err)
+	}
+
+	compatibility, ok := workflow.Jobs["compatibility"]
+	if !ok {
+		t.Fatal("Kubernetes bundle workflow has no compatibility job")
+	}
+	if got := compatibility.Permissions["actions"]; got != "read" {
+		t.Fatalf("compatibility actions permission = %q, want read", got)
+	}
+
+	var script string
+	for _, step := range compatibility.Steps {
+		if step.Name == "Open compatibility pull request" {
+			script = step.With.Script
+			break
+		}
+	}
+	if script == "" {
+		t.Fatal("Kubernetes bundle workflow has no compatibility pull request step")
+	}
+	for _, contract := range []string{
+		"github.paginate(github.rest.pulls.list",
+		`candidate.head.ref.startsWith(branchPrefix)`,
+		`candidate.head.repo?.full_name === repository`,
+		`candidate.number !== pull.number`,
+		"github.rest.issues.createComment",
+		"github.rest.pulls.update",
+		`state: "closed"`,
+	} {
+		if !strings.Contains(script, contract) {
+			t.Errorf("compatibility pull request step does not enforce %q", contract)
+		}
+	}
+	if strings.Contains(script, "createWorkflowDispatch") {
+		t.Error("compatibility pull request step still dispatches a duplicate Fast Checks run")
+	}
+}


### PR DESCRIPTION
PR #143 remained open after its bot-created `pull_request` check was delayed in `action_required`. The explicitly dispatched duplicate Fast Checks run passed but did not satisfy PR branch protection; newer bundle publication then superseded the catalog and left #143 conflicting.

When a new compatibility PR is created, comment on and close older open same-repository compatibility PRs so stale bundle references cannot linger or be merged. Remove the ineffective duplicate workflow dispatch and reduce the compatibility job from Actions write to read permission.