### PR TITLE
release: approve generated catalog checks

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -513,7 +513,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
-      actions: read
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -573,14 +573,17 @@ jobs:
           git switch -c "$branch"
           git add internal/installer/kubernetescompat/catalog.json
           git commit -m "release: record supported Kubernetes compatibility"
+          head_sha="$(git rev-parse HEAD)"
           git push --set-upstream origin "$branch"
           echo "name=$branch" >> "$GITHUB_OUTPUT"
+          echo "sha=$head_sha" >> "$GITHUB_OUTPUT"
 
       - name: Open compatibility pull request
         if: ${{ steps.compatibility.outputs.changed == 'true' }}
         uses: actions/github-script@v8
         env:
           HEAD_BRANCH: ${{ steps.compatibility-branch.outputs.name }}
+          HEAD_SHA: ${{ steps.compatibility-branch.outputs.sha }}
         with:
           script: |
             const { data: pull } = await github.rest.pulls.create({
@@ -592,6 +595,16 @@ jobs:
               body: "Records the newly published immutable bundles for every supported Kubernetes payload built by the producer.",
               draft: false,
             });
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH
+                }) {
+                  pullRequest { number }
+                }
+              }
+            `, { pullRequestId: pull.node_id });
 
             const openPulls = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
@@ -622,13 +635,34 @@ jobs:
               });
             }
 
-            await github.graphql(`
-              mutation($pullRequestId: ID!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $pullRequestId,
-                  mergeMethod: SQUASH
-                }) {
-                  pullRequest { number }
-                }
+            let validationRun;
+            for (let attempt = 0; attempt < 12; attempt++) {
+              const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "fast-checks.yml",
+                branch: process.env.HEAD_BRANCH,
+                event: "pull_request",
+                per_page: 10,
+              });
+              validationRun = runs.workflow_runs.find(run =>
+                run.head_sha === process.env.HEAD_SHA
+              );
+              if (validationRun) {
+                break;
               }
-            `, { pullRequestId: pull.node_id });
+              await new Promise(resolve => setTimeout(resolve, 5000));
+            }
+            if (!validationRun) {
+              throw new Error(`Fast Checks pull_request run was not created for ${process.env.HEAD_BRANCH}@${process.env.HEAD_SHA}`);
+            }
+            if (validationRun.conclusion === "action_required") {
+              await github.request("POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve", {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: validationRun.id,
+              });
+              core.info(`Approved Fast Checks run ${validationRun.id} for generated PR #${pull.number}`);
+            } else {
+              core.info(`Fast Checks run ${validationRun.id} requires no approval (${validationRun.status}/${validationRun.conclusion || "pending"})`);
+            }

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:c859619e457d8ea5e4c1a4b9e866f0c164d899d230e67dba521213ada715a7c2",
+  "recipeDigest": "sha256:f3165c164ac7a43e69b7662ff6e990644894d712c0d53928860a1fcb4bb4291f",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 20,
+      "artifactRevision": 21,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 18,
+      "artifactRevision": 19,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 17,
+      "artifactRevision": 18,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 17,
+      "artifactRevision": 18,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -117,8 +117,8 @@ func TestKubernetesBundleWorkflowRetiresSupersededCompatibilityPRs(t *testing.T)
 	if !ok {
 		t.Fatal("Kubernetes bundle workflow has no compatibility job")
 	}
-	if got := compatibility.Permissions["actions"]; got != "read" {
-		t.Fatalf("compatibility actions permission = %q, want read", got)
+	if got := compatibility.Permissions["actions"]; got != "write" {
+		t.Fatalf("compatibility actions permission = %q, want write", got)
 	}
 
 	var script string
@@ -139,6 +139,11 @@ func TestKubernetesBundleWorkflowRetiresSupersededCompatibilityPRs(t *testing.T)
 		"github.rest.issues.createComment",
 		"github.rest.pulls.update",
 		`state: "closed"`,
+		"github.rest.actions.listWorkflowRuns",
+		`run.head_sha === process.env.HEAD_SHA`,
+		`validationRun.conclusion === "action_required"`,
+		`/actions/runs/{run_id}/approve`,
+		"run_id: validationRun.id",
 	} {
 		if !strings.Contains(script, contract) {
 			t.Errorf("compatibility pull request step does not enforce %q", contract)


### PR DESCRIPTION
The live PR #147 run confirmed GitHub marks every `github-actions[bot]` compatibility PR workflow as `action_required`, even after prior approvals. Removing the ineffective duplicate dispatch therefore exposed the manual approval requirement directly.

Capture the generated catalog commit SHA, poll only the Fast Checks `pull_request` run on that unique automation branch, and approve it only when its head SHA matches exactly and its conclusion is `action_required`. Auto-merge is enabled before polling so transient API delays remain recoverable.