### PR TITLE
endpoint: migrate legacy VIP routing during upgrade

### DIFF
--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -62,6 +62,9 @@ func waitNodeBootHealth(ctx context.Context, nodeName, endpoint, previousAgentSt
 							if current := status.GetCurrentGenerationId(); current != "" && current != targetGeneration {
 								return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s rejected generation %s during boot health and returned on generation %s", nodeName, targetGeneration, current)
 							}
+							if rollback := strings.TrimSpace(status.GetBootTargetGenerationId()); rollback != "" && rollback != targetGeneration {
+								return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s rejected generation %s during boot health; rollback generation %s is selected for next boot, so reboot the node before retrying the upgrade", nodeName, targetGeneration, rollback)
+							}
 							return katlcAgentConnection{}, verifiedNodeBoot{}, fmt.Errorf("node %s reported generation %s unhealthy after reboot", nodeName, targetGeneration)
 						}
 						if status.GetCurrentGenerationId() == targetGeneration && candidate.GetCommitState() == generation.CommitStateCommitted && candidate.GetBootState() == generation.BootStateGood && candidate.GetHealthState() == generation.HealthStateHealthy {

--- a/cmd/katlctl/upgrade_reboot_test.go
+++ b/cmd/katlctl/upgrade_reboot_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -142,6 +143,32 @@ func TestWaitNodeBootHealthWaitsForKubernetesRecovery(t *testing.T) {
 	}
 	if output := progress.String(); !strings.Contains(output, "waiting-for-kubernetes state=waiting-for-node") || !strings.Contains(output, "Kubernetes node cp-1 is not Ready") {
 		t.Fatalf("progress = %q", output)
+	}
+}
+
+func TestWaitNodeBootHealthRequiresRollbackRebootAfterRejectedTrial(t *testing.T) {
+	fake := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			AgentStartId:           "after",
+			CurrentGenerationId:    "katlos-next",
+			BootTargetGenerationId: "katlos-previous",
+		},
+		generation: &agentapi.Generation{
+			GenerationId: "katlos-next",
+			CommitState:  generation.CommitStateCommitted,
+			BootState:    generation.BootStateFailed,
+			HealthState:  generation.HealthStateUnhealthy,
+		},
+	}
+	installKatlcDial(t, nil, fake)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, _, err := waitNodeBootHealth(ctx, "cp-1", "10.0.0.11:9443", "before", "katlos-next", io.Discard)
+	if err == nil ||
+		!strings.Contains(err.Error(), "rollback generation katlos-previous is selected for next boot") ||
+		!strings.Contains(err.Error(), "reboot the node before retrying") {
+		t.Fatalf("waitNodeBootHealth() error = %v, want actionable rollback reboot", err)
 	}
 }
 

--- a/cmd/katldev/build.go
+++ b/cmd/katldev/build.go
@@ -38,6 +38,7 @@ type kubernetesBuildArtifact struct {
 }
 
 var katlOSBuildVersionPattern = regexp.MustCompile(`^[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
+var katlOSBaseVersionPattern = regexp.MustCompile(`^([0-9]{4}\.[0-9]+\.[0-9]+)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 
 func newBuildCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -86,6 +87,10 @@ func newBuildUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 			if err != nil {
 				return err
 			}
+			version, err = resolveKatlOSBuildVersion(repoRoot, version)
+			if err != nil {
+				return err
+			}
 			artifact, err := buildKatlOSUpgrade(ctx, repoRoot, version, stderr, runBuildCommand)
 			if err != nil {
 				return err
@@ -93,12 +98,13 @@ func newBuildUpgradeCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 			return writeKatlOSUpgradeArtifact(stdout, artifact)
 		},
 	}
-	cmd.Flags().StringVar(&version, "version", "", "KatlOS version to embed in the locally built image")
+	cmd.Flags().StringVar(&version, "version", "", "KatlOS version to embed (default local.<checkout commit>)")
 	return cmd
 }
 
 func newBuildISOCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var version string
+	cmd := &cobra.Command{
 		Use:   "iso",
 		Short: "Build and verify the current checkout's installer ISO",
 		Args:  cobra.NoArgs,
@@ -107,26 +113,48 @@ func newBuildISOCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Co
 			if err != nil {
 				return err
 			}
-			artifact, err := buildInstallerISO(ctx, repoRoot, stderr, runBuildCommand)
+			version, err = resolveKatlOSBuildVersion(repoRoot, version)
+			if err != nil {
+				return err
+			}
+			artifact, err := buildInstallerISO(ctx, repoRoot, version, stderr, runBuildCommand)
 			if err != nil {
 				return err
 			}
 			return writeInstallerISOArtifact(stdout, artifact)
 		},
 	}
+	cmd.Flags().StringVar(&version, "version", "", "KatlOS version to embed (default local.<checkout commit>)")
+	return cmd
 }
 
-func buildInstallerISO(ctx context.Context, repoRoot string, stderr io.Writer, run buildCommandRunner) (installerISOArtifact, error) {
+func buildInstallerISO(ctx context.Context, repoRoot, version string, stderr io.Writer, run buildCommandRunner) (installerISOArtifact, error) {
 	if run == nil {
 		return installerISOArtifact{}, fmt.Errorf("build command runner is required")
 	}
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if !katlOSBuildVersionPattern.MatchString(version) {
+		return installerISOArtifact{}, fmt.Errorf("KatlOS build version %q must look like 2026.7.0-local.1a2b3c4", version)
+	}
+	architecture, err := developmentArtifactArchitecture(runtime.GOARCH)
+	if err != nil {
+		return installerISOArtifact{}, err
+	}
+	buildID := version
+	if revision, dirty := checkoutRevision(repoRoot); revision != "" {
+		buildID = revision
+		if dirty {
+			buildID += "-dirty"
+		}
+	}
+	environment := []string{"KATL_VERSION=" + version, "KATL_ARCHITECTURE=" + architecture, "KATL_BUILD_COMMIT=" + buildID}
 	iso := filepath.Join(repoRoot, "_build", "mkosi", "katl-installer.iso")
-	fmt.Fprintln(stderr, "katldev build: building the current checkout installer ISO")
-	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "mkosi"), []string{"build-installer-iso"}, nil, stderr, stderr); err != nil {
+	fmt.Fprintf(stderr, "katldev build: building KatlOS %s installer ISO from the current checkout\n", version)
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "mkosi"), []string{"build-installer-iso"}, environment, stderr, stderr); err != nil {
 		return installerISOArtifact{}, fmt.Errorf("build installer ISO: %w", err)
 	}
 	fmt.Fprintln(stderr, "katldev build: verifying the completed installer ISO")
-	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "check-installer-iso"), []string{iso}, nil, stderr, stderr); err != nil {
+	if err := run(ctx, repoRoot, filepath.Join(repoRoot, "scripts", "check-installer-iso"), []string{iso}, environment, stderr, stderr); err != nil {
 		return installerISOArtifact{}, fmt.Errorf("verify installer ISO: %w", err)
 	}
 	digest, err := sha256File(iso)
@@ -153,6 +181,43 @@ func buildInstallerISO(ctx context.Context, repoRoot string, stderr io.Writer, r
 		}
 	}
 	return artifact, nil
+}
+
+func resolveKatlOSBuildVersion(repoRoot, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		requested = strings.TrimSpace(os.Getenv("KATL_VERSION"))
+	}
+	if requested != "" {
+		requested = strings.TrimPrefix(requested, "v")
+		if !katlOSBuildVersionPattern.MatchString(requested) {
+			return "", fmt.Errorf("KatlOS build version %q must look like 2026.7.0-local.1a2b3c4", requested)
+		}
+		return requested, nil
+	}
+
+	tagOutput, err := exec.Command("git", "-C", repoRoot, "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*", "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("derive local KatlOS version from the nearest release tag: %w; use --version to set one explicitly", err)
+	}
+	revision, _ := checkoutRevision(repoRoot)
+	if revision == "" {
+		return "", fmt.Errorf("derive local KatlOS version: current checkout has no commit; use --version to set one explicitly")
+	}
+	return localKatlOSBuildVersion(strings.TrimSpace(string(tagOutput)), revision)
+}
+
+func localKatlOSBuildVersion(tag, revision string) (string, error) {
+	tag = strings.TrimPrefix(strings.TrimSpace(tag), "v")
+	matches := katlOSBaseVersionPattern.FindStringSubmatch(tag)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("nearest KatlOS tag %q is not a supported calendar version; use --version to set one explicitly", tag)
+	}
+	revision = strings.TrimSpace(revision)
+	if len(revision) < 7 {
+		return "", fmt.Errorf("checkout revision %q is too short to identify a local build", revision)
+	}
+	return matches[1] + "-local." + revision[:7], nil
 }
 
 func runBuildCommand(ctx context.Context, dir, name string, args, environment []string, stdout, stderr io.Writer) error {

--- a/cmd/katldev/main_test.go
+++ b/cmd/katldev/main_test.go
@@ -46,6 +46,11 @@ func TestRootAndInstallerCommandsShowHelpWithoutArguments(t *testing.T) {
 
 func TestBuildInstallerISOComposesSupportedPipeline(t *testing.T) {
 	repo := t.TempDir()
+	version := "2026.7.0-local.1a2b3c4"
+	architecture, err := developmentArtifactArchitecture(runtime.GOARCH)
+	if err != nil {
+		t.Skip(err)
+	}
 	iso := filepath.Join(repo, "_build", "mkosi", "katl-installer.iso")
 	contents := []byte("current checkout installer ISO")
 	type call struct {
@@ -70,13 +75,13 @@ func TestBuildInstallerISOComposesSupportedPipeline(t *testing.T) {
 		return nil
 	}
 	var stdout, stderr bytes.Buffer
-	artifact, err := buildInstallerISO(context.Background(), repo, &stderr, runner)
+	artifact, err := buildInstallerISO(context.Background(), repo, version, &stderr, runner)
 	if err != nil {
 		t.Fatal(err)
 	}
 	wantCalls := []call{
-		{dir: repo, name: filepath.Join(repo, "scripts", "mkosi"), args: []string{"build-installer-iso"}},
-		{dir: repo, name: filepath.Join(repo, "scripts", "check-installer-iso"), args: []string{iso}},
+		{dir: repo, name: filepath.Join(repo, "scripts", "mkosi"), args: []string{"build-installer-iso"}, env: []string{"KATL_VERSION=" + version, "KATL_ARCHITECTURE=" + architecture, "KATL_BUILD_COMMIT=" + version}},
+		{dir: repo, name: filepath.Join(repo, "scripts", "check-installer-iso"), args: []string{iso}, env: []string{"KATL_VERSION=" + version, "KATL_ARCHITECTURE=" + architecture, "KATL_BUILD_COMMIT=" + version}},
 	}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("build calls = %#v, want %#v", calls, wantCalls)
@@ -93,7 +98,7 @@ func TestBuildInstallerISOComposesSupportedPipeline(t *testing.T) {
 			t.Fatalf("output missing %q:\n%s", want, stdout.String())
 		}
 	}
-	for _, want := range []string{"building the current checkout", "verifying the completed installer ISO"} {
+	for _, want := range []string{"building KatlOS " + version, "verifying the completed installer ISO"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("progress missing %q:\n%s", want, stderr.String())
 		}
@@ -107,12 +112,36 @@ func TestBuildInstallerISOStopsAfterBuildFailure(t *testing.T) {
 		calls++
 		return wantErr
 	}
-	_, err := buildInstallerISO(context.Background(), t.TempDir(), io.Discard, runner)
+	_, err := buildInstallerISO(context.Background(), t.TempDir(), "2026.7.0-local.1a2b3c4", io.Discard, runner)
 	if !errors.Is(err, wantErr) || !strings.Contains(err.Error(), "build installer ISO") {
 		t.Fatalf("buildInstallerISO() error = %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("runner calls = %d, want 1", calls)
+	}
+}
+
+func TestLocalKatlOSBuildVersionUsesReleaseLineAndShortRevision(t *testing.T) {
+	got, err := localKatlOSBuildVersion("v2026.7.0-beta.13", "d3299ef89962")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "2026.7.0-local.d3299ef" {
+		t.Fatalf("localKatlOSBuildVersion() = %q", got)
+	}
+}
+
+func TestLocalKatlOSBuildVersionRejectsUnusableIdentity(t *testing.T) {
+	for _, test := range []struct {
+		tag      string
+		revision string
+	}{
+		{tag: "not-a-release", revision: "d3299ef89962"},
+		{tag: "v2026.7.0-beta.13", revision: "short"},
+	} {
+		if _, err := localKatlOSBuildVersion(test.tag, test.revision); err == nil {
+			t.Fatalf("localKatlOSBuildVersion(%q, %q) succeeded", test.tag, test.revision)
+		}
 	}
 }
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -142,12 +142,13 @@ nix develop --command katldev build iso
 
 The command composes the existing source-fingerprinted `scripts/mkosi`
 pipeline, runs the full ISO verifier, and prints absolute paths for the ISO,
-metadata, and checksum together with the digest and byte size. Set the existing
-`KATL_VERSION` environment variable when the installed development image needs
-a particular KatlOS identity:
+metadata, and checksum together with the digest and byte size. By default it
+derives a checkout-scoped identity such as `2026.7.0-local.1a2b3c4` from the
+nearest KatlOS release line and the current commit. Use `--version` when the
+installed development image needs a particular KatlOS identity:
 
 ```sh
-KATL_VERSION=2026.7.0-dev.12 nix develop --command katldev build iso
+nix develop --command katldev build iso --version 2026.7.0-dev.12
 ```
 
 Copy the reported ISO to a hypervisor under a versioned name and independently
@@ -155,6 +156,12 @@ compare the reported digest after transfer. Published images should continue
 through `katlctl node upgrade` where possible; use the ISO path for clean
 installation, wipe/reinstall recovery, and current-checkout changes which do
 not yet have a published upgrade source.
+
+Build the matching local upgrade image without repeating the derived version:
+
+```sh
+nix develop --command katldev build upgrade
+```
 
 The development shell includes the complete supported VM test toolchain. It
 does not configure host libvirt, `/dev/kvm`, `/dev/net/tun`, networks, storage

--- a/internal/installer/bgpapivip/bgpapivip.go
+++ b/internal/installer/bgpapivip/bgpapivip.go
@@ -525,6 +525,13 @@ func normalizeHealth(health Health, endpoint Endpoint, vip netip.Prefix) (Health
 		localHost = "::1"
 	}
 	health.Host = defaultString(health.Host, localHost)
+	// Configurations rendered before routed VIP failover used the VIP itself
+	// as the local readiness target. Normalize that exact persisted form to
+	// the loopback probe so a KatlOS upgrade can start the new controller and
+	// the next cluster apply can render the current files.
+	if health.Host == vip.Addr().String() {
+		health.Host = localHost
+	}
 	health.Path = defaultString(health.Path, defaultHealthPath)
 	health.Interval = defaultString(health.Interval, "2s")
 	health.Timeout = defaultString(health.Timeout, defaultHealthTimeout)

--- a/internal/installer/bgpapivip/bgpapivip_test.go
+++ b/internal/installer/bgpapivip/bgpapivip_test.go
@@ -214,6 +214,39 @@ func TestRenderIPv6LoopbackVIP(t *testing.T) {
 	}
 }
 
+func TestNormalizeMigratesPersistedVIPHealthTargetToLoopback(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		vip        string
+		family     string
+		healthHost string
+		want       string
+	}{
+		{name: "IPv4", vip: "10.40.0.10/32", family: "ipv4", healthHost: "10.40.0.10", want: "127.0.0.1"},
+		{name: "IPv6", vip: "2001:db8:40::10/128", family: "ipv6", healthHost: "2001:db8:40::10", want: "::1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := minimalConfig()
+			config.Endpoint.VIP = test.vip
+			config.Endpoint.AddressFamily = test.family
+			config.Health.Host = test.healthHost
+			if test.family == "ipv6" {
+				config.VIPInterface = VIPInterface{Kind: "loopback", Name: "lo"}
+				config.Routing.SourceAddress = "2001:db8:1::11"
+				config.FabricPeers[0].Address = "2001:db8:1::1"
+				config.FabricPeers[0].AllowedExportPrefixes = []string{test.vip}
+			}
+			got, err := Normalize(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Health.Host != test.want {
+				t.Fatalf("health host = %q, want %q", got.Health.Host, test.want)
+			}
+		})
+	}
+}
+
 func TestRenderAllowsMultipleControlPlanesToAdvertiseSameVIP(t *testing.T) {
 	cp1 := minimalConfig()
 	cp2 := minimalConfig()
@@ -322,7 +355,7 @@ func TestNormalizeRejectsUnsafeInputs(t *testing.T) {
 		{
 			name: "VIP health target",
 			mutate: func(config *Config) {
-				config.Health.Host = "10.40.0.10"
+				config.Health.Host = "10.40.0.20"
 			},
 			want: "health.host must be the local loopback address",
 		},

--- a/internal/installer/bgpapivip/controller.go
+++ b/internal/installer/bgpapivip/controller.go
@@ -1,6 +1,7 @@
 package bgpapivip
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
@@ -117,6 +118,7 @@ type Status struct {
 	VIPInterfaceKind            string              `json:"vipInterfaceKind"`
 	VIPInterfaceReady           bool                `json:"vipInterfaceReady"`
 	LocalVIPOwned               bool                `json:"localVIPOwned"`
+	LocalVIPOwnedReported       bool                `json:"-"`
 	NodeRoleSelected            bool                `json:"nodeRoleSelected"`
 	AdvertiseOnRoles            []string            `json:"advertiseOnRoles"`
 	HealthState                 string              `json:"healthState"`
@@ -396,7 +398,11 @@ func MarshalStatus(status Status) ([]byte, error) {
 }
 
 func DecodeStatus(reader io.Reader) (Status, error) {
-	decoder := json.NewDecoder(reader)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return Status{}, fmt.Errorf("read BGP API VIP status: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	var status Status
 	if err := decoder.Decode(&status); err != nil {
@@ -414,6 +420,13 @@ func DecodeStatus(reader io.Reader) (Status, error) {
 	if status.Kind != StatusKind {
 		return Status{}, fmt.Errorf("status kind must be %s", StatusKind)
 	}
+	var presence struct {
+		LocalVIPOwned *bool `json:"localVIPOwned"`
+	}
+	if err := json.Unmarshal(data, &presence); err != nil {
+		return Status{}, fmt.Errorf("decode BGP API VIP status field presence: %w", err)
+	}
+	status.LocalVIPOwnedReported = presence.LocalVIPOwned != nil
 	return status, nil
 }
 

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/confext"
 	"github.com/katl-dev/katl/internal/installer/configdomain"
 	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
@@ -466,6 +467,15 @@ func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Chan
 		applyOverlay(&merged.Node, nodeOverlay, request.KubernetesInitialized, &domains, &unsafeFiles)
 	}
 	if len(domains.domains) == 0 {
+		endpointDrifted, err := endpointRenderingDrifted(request, merged)
+		if err != nil {
+			return manifest.Manifest{}, nil, nil, err
+		}
+		if endpointDrifted {
+			domains.addEndpointRouting(EndpointRoutingImpact{MayLoseAllFabricPaths: true})
+		}
+	}
+	if len(domains.domains) == 0 {
 		return merged, nil, nil, ErrNoChanges
 	}
 	if _, changed := domains.seen[DomainHostConfiguration]; changed {
@@ -473,6 +483,73 @@ func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Chan
 		domains.hostConfiguration = &hostPlan
 	}
 	return merged, domains.changes(request.ClusterDefaults, roleOverlay, nodeOverlay), unsafeFiles, nil
+}
+
+func endpointRenderingDrifted(request TrustedBundleRequest, desired manifest.Manifest) (bool, error) {
+	if desired.Node.ControlPlaneEndpoint == nil {
+		return false, nil
+	}
+	endpoint, err := controlplaneendpoint.Normalize(*desired.Node.ControlPlaneEndpoint)
+	if err != nil {
+		return false, fmt.Errorf("normalize desired control-plane endpoint: %w", err)
+	}
+	config, err := bgpapivip.FromControlPlaneEndpoint(endpoint)
+	if err != nil {
+		return false, fmt.Errorf("lower desired control-plane endpoint: %w", err)
+	}
+	rendered, err := bgpapivip.RenderNativeEtcFiles(bgpapivip.RenderRequest{
+		Config:   config,
+		NodeRole: desired.Node.SystemRole,
+	})
+	if err != nil {
+		return false, fmt.Errorf("render desired control-plane endpoint: %w", err)
+	}
+	confextRoot, err := currentNodeConfextRoot(request.Root, request.CurrentRecord)
+	if err != nil {
+		return false, err
+	}
+	for _, file := range rendered.NativeEtcFiles() {
+		path := filepath.Join(confextRoot, strings.TrimPrefix(filepath.Clean(file.Path), string(filepath.Separator)))
+		data, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("read current rendered endpoint file %s: %w", file.Path, err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return false, fmt.Errorf("stat current rendered endpoint file %s: %w", file.Path, err)
+		}
+		mode := file.Mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		if string(data) != file.Content || info.Mode().Perm() != mode.Perm() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func currentNodeConfextRoot(root string, record generation.Record) (string, error) {
+	for _, ref := range record.Confexts {
+		if strings.TrimSpace(ref.Name) != "katl-node" {
+			continue
+		}
+		path := filepath.Clean(ref.Path)
+		if !filepath.IsAbs(path) {
+			return "", fmt.Errorf("current katl-node confext path must be absolute")
+		}
+		base := filepath.Clean(root)
+		full := filepath.Join(base, strings.TrimPrefix(path, string(filepath.Separator)))
+		relative, err := filepath.Rel(base, full)
+		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("current katl-node confext path escapes runtime root")
+		}
+		return full, nil
+	}
+	return "", fmt.Errorf("current katl-node confext is required to compare generated endpoint configuration")
 }
 
 func validateOverlay(path string, overlay NodeOverlay) error {

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/confext"
 	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
 	"github.com/katl-dev/katl/internal/installer/generation"
@@ -195,6 +197,60 @@ func TestApplyTrustedBundleReloadsEnabledEndpointRouting(t *testing.T) {
 	}
 	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,endpoint-routing-validate,endpoint-withdraw,endpoint-link-reload,endpoint-routing-reload,endpoint-resume"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)
+	}
+}
+
+func TestPlanTrustedBundleRefreshesStaleRenderedEndpoint(t *testing.T) {
+	root := t.TempDir()
+	current := baseManifest()
+	current.Node.ControlPlaneEndpoint = managedEndpoint("192.0.2.1")
+	currentRecord := currentRecord()
+	selectEndpointAdvertiser(t, root, &currentRecord)
+	writeCurrentEndpointRendering(t, root, currentRecord, current)
+
+	birdPath := currentConfextFilePath(t, root, currentRecord, bgpapivip.BirdConfigPath)
+	if err := os.WriteFile(birdPath, []byte("protocol static katl_api { disabled; }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	request := trustedBundleRequest(root, TrustedBundleRequest{
+		ApplyMode:       generation.ApplyModeAuto,
+		CurrentManifest: current,
+		CurrentRecord:   currentRecord,
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: managedEndpoint("192.0.2.1")},
+		},
+	})
+	result, err := PlanTrustedBundle(request)
+	if err != nil {
+		t.Fatalf("PlanTrustedBundle() error = %v", err)
+	}
+	if result.Plan.Decision.AcceptedMode != generation.ApplyModeLive ||
+		!containsDomain(result.Plan.Decision.ChangedDomains, DomainControlPlaneEndpointRouting) {
+		t.Fatalf("decision = %#v, want live rendered endpoint refresh", result.Plan.Decision)
+	}
+	if !nativeEtcFileContains(result.Files, bgpapivip.BirdConfigPath, "protocol direct katl_api") {
+		t.Fatalf("candidate BIRD config did not replace stale rendering")
+	}
+}
+
+func TestPlanTrustedBundleKeepsMatchingRenderedEndpointAsNoop(t *testing.T) {
+	root := t.TempDir()
+	current := baseManifest()
+	current.Node.ControlPlaneEndpoint = managedEndpoint("192.0.2.1")
+	currentRecord := currentRecord()
+	selectEndpointAdvertiser(t, root, &currentRecord)
+	writeCurrentEndpointRendering(t, root, currentRecord, current)
+
+	_, err := PlanTrustedBundle(trustedBundleRequest(root, TrustedBundleRequest{
+		ApplyMode:       generation.ApplyModeAuto,
+		CurrentManifest: current,
+		CurrentRecord:   currentRecord,
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {ControlPlaneEndpointSet: true, ControlPlaneEndpoint: managedEndpoint("192.0.2.1")},
+		},
+	}))
+	if !errors.Is(err, ErrNoChanges) {
+		t.Fatalf("PlanTrustedBundle() error = %v, want unchanged desired and rendered state", err)
 	}
 }
 
@@ -1070,6 +1126,58 @@ func selectEndpointAdvertiser(t *testing.T, root string, record *generation.Reco
 		t.Fatal(err)
 	}
 	record.Sysexts = append(record.Sysexts, selected)
+}
+
+func writeCurrentEndpointRendering(t *testing.T, root string, record generation.Record, current manifest.Manifest) {
+	t.Helper()
+	endpoint, err := controlplaneendpoint.Normalize(*current.Node.ControlPlaneEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := bgpapivip.FromControlPlaneEndpoint(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := bgpapivip.RenderNativeEtcFiles(bgpapivip.RenderRequest{
+		Config:   config,
+		NodeRole: current.Node.SystemRole,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range rendered.NativeEtcFiles() {
+		path := currentConfextFilePath(t, root, record, file.Path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		mode := file.Mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		if err := os.WriteFile(path, []byte(file.Content), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func currentConfextFilePath(t *testing.T, root string, record generation.Record, path string) string {
+	t.Helper()
+	for _, ref := range record.Confexts {
+		if ref.Name == "katl-node" {
+			return filepath.Join(root, strings.TrimPrefix(ref.Path, "/"), strings.TrimPrefix(path, "/"))
+		}
+	}
+	t.Fatal("current record has no katl-node confext")
+	return ""
+}
+
+func nativeEtcFileContains(files []confext.NativeEtcFile, path, substring string) bool {
+	for _, file := range files {
+		if file.Path == path {
+			return strings.Contains(file.Content, substring)
+		}
+	}
+	return false
 }
 
 func baseManifest() manifest.Manifest {

--- a/internal/installer/generation/boot_health.go
+++ b/internal/installer/generation/boot_health.go
@@ -215,8 +215,6 @@ func failBootedGeneration(request BootHealthRequest, generationID string, now ti
 		if strings.TrimSpace(selection.PreviousKnownGoodBootEntry) != "" {
 			selection.DefaultBootEntry = selection.PreviousKnownGoodBootEntry
 		}
-		selection.BootedGenerationID = previousID
-		selection.BootedBootEntry = selection.DefaultBootEntry
 	} else {
 		selection.RecoveryRequired = true
 	}
@@ -243,23 +241,29 @@ func failBootedGeneration(request BootHealthRequest, generationID string, now ti
 }
 
 func inferBootedSelection(selection BootSelectionRecord, spec GenerationSpec, generationID string, commandLine string) BootSelectionRecord {
-	if !selection.PendingHealthValidation {
-		return selection
-	}
 	cmdlineGeneration, err := SelectedGenerationFromCommandLine(commandLine)
 	if err != nil || cmdlineGeneration != generationID {
 		return selection
 	}
-	trialID := strings.TrimSpace(selection.TrialGenerationID)
-	targetID := strings.TrimSpace(selection.TargetBootGenerationID)
-	if generationID != trialID && generationID != targetID {
-		return selection
+	if selection.PendingHealthValidation {
+		trialID := strings.TrimSpace(selection.TrialGenerationID)
+		targetID := strings.TrimSpace(selection.TargetBootGenerationID)
+		if generationID != trialID && generationID != targetID {
+			return selection
+		}
+	} else {
+		failedID := strings.TrimSpace(selection.FailedBootGenerationID)
+		if failedID == "" ||
+			generationID != strings.TrimSpace(selection.DefaultGenerationID) ||
+			strings.TrimSpace(selection.BootedGenerationID) != failedID {
+			return selection
+		}
 	}
 	selection.BootedGenerationID = generationID
 	switch {
-	case generationID == trialID && strings.TrimSpace(selection.TrialBootEntry) != "":
+	case generationID == strings.TrimSpace(selection.TrialGenerationID) && strings.TrimSpace(selection.TrialBootEntry) != "":
 		selection.BootedBootEntry = strings.TrimSpace(selection.TrialBootEntry)
-	case generationID == targetID && strings.TrimSpace(selection.TargetBootEntry) != "":
+	case generationID == strings.TrimSpace(selection.TargetBootGenerationID) && strings.TrimSpace(selection.TargetBootEntry) != "":
 		selection.BootedBootEntry = strings.TrimSpace(selection.TargetBootEntry)
 	default:
 		selection.BootedBootEntry = strings.TrimSpace(spec.Boot.LoaderEntryPath)
@@ -288,7 +292,7 @@ func validateBootedSelection(selection BootSelectionRecord, spec GenerationSpec,
 	if cmdlineGeneration != generationID {
 		return fmt.Errorf("kernel command line generation %s does not match selected generation %s", cmdlineGeneration, generationID)
 	}
-	rootUUID, err := rootPartUUIDFromCommandLine(commandLine)
+	rootUUID, err := SelectedRootPartUUIDFromCommandLine(commandLine)
 	if err != nil {
 		return err
 	}
@@ -325,7 +329,7 @@ func validRollbackTarget(root string, generationID string) bool {
 	return IsKnownGood(status)
 }
 
-func rootPartUUIDFromCommandLine(commandLine string) (string, error) {
+func SelectedRootPartUUIDFromCommandLine(commandLine string) (string, error) {
 	for _, field := range strings.Fields(commandLine) {
 		value, ok := strings.CutPrefix(field, "root=PARTUUID=")
 		if !ok {

--- a/internal/installer/generation/boot_health_test.go
+++ b/internal/installer/generation/boot_health_test.go
@@ -292,8 +292,8 @@ func TestRecordBootHealthTimeoutRestoresPreviousAndRequestsReboot(t *testing.T) 
 	if selection.DefaultGenerationID != "gen0" || selection.FailedBootGenerationID != "gen1" || selection.RecoveryRequired {
 		t.Fatalf("selection after timeout = %#v", selection)
 	}
-	if selection.BootedGenerationID != "gen0" || selection.BootedBootEntry != "loader/entries/katl-gen0.conf" {
-		t.Fatalf("rollback boot evidence = %#v, want gen0 evidence", selection)
+	if selection.BootedGenerationID != "gen1" || selection.BootedBootEntry != "loader/entries/katl-gen1.conf" {
+		t.Fatalf("failed trial boot evidence = %#v, want gen1 until the rollback boot occurs", selection)
 	}
 	if _, err := RecordBootHealth(BootHealthRequest{Root: root, GenerationID: "gen0", CommandLine: bootHealthCommandLine("gen0"), Result: BootHealthSuccess, Now: now.Add(time.Minute)}); err != nil {
 		t.Fatalf("RecordBootHealth(recovered gen0 success) error = %v", err)

--- a/internal/installer/katlosimage/host_upgrade.go
+++ b/internal/installer/katlosimage/host_upgrade.go
@@ -32,6 +32,7 @@ type HostUpgradePlan struct {
 	Status          generation.GenerationStatus
 	BootSelection   generation.BootSelectionRecord
 	PreservedAssets []PreservedAsset
+	BundledAssets   []BundledAsset
 }
 
 type PreservedAsset struct {
@@ -40,6 +41,14 @@ type PreservedAsset struct {
 	SourcePath string
 	TargetPath string
 	Directory  bool
+	SHA256     string
+}
+
+type BundledAsset struct {
+	Kind       string
+	Name       string
+	SourcePath string
+	TargetPath string
 	SHA256     string
 }
 
@@ -95,7 +104,7 @@ func (p Payload) HostUpgradePlan(request HostUpgradeRequest) (HostUpgradePlan, e
 		Architecture:          p.Index.Architecture,
 		RuntimeArtifactSHA256: p.Runtime.SHA256,
 	}
-	sysexts, sysextAssets, err := upgradeSysexts(request.PreviousSpec, generationID, root, p.Kubernetes, request.Bootstrapped)
+	sysexts, sysextAssets, bundledAssets, err := upgradeSysexts(p, request.PreviousSpec, generationID, root, request.Bootstrapped)
 	if err != nil {
 		return HostUpgradePlan{}, err
 	}
@@ -148,6 +157,7 @@ func (p Payload) HostUpgradePlan(request HostUpgradeRequest) (HostUpgradePlan, e
 		Status:          status,
 		BootSelection:   selection,
 		PreservedAssets: append(sysextAssets, confextAssets...),
+		BundledAssets:   bundledAssets,
 	}, nil
 }
 
@@ -221,32 +231,74 @@ func StagePreservedAssets(root string, plan HostUpgradePlan) error {
 	return nil
 }
 
-func upgradeSysexts(previous generation.GenerationSpec, generationID string, root generation.RootSelection, _ Component, bootstrapped bool) ([]generation.ExtensionRef, []PreservedAsset, error) {
+func StageBundledAssets(root string, plan HostUpgradePlan) error {
+	for _, asset := range plan.BundledAssets {
+		if !filepath.IsAbs(asset.SourcePath) {
+			return fmt.Errorf("bundled %s %q source path must be absolute", asset.Kind, asset.Name)
+		}
+		target, err := rootedPath(root, asset.TargetPath)
+		if err != nil {
+			return err
+		}
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("clear bundled %s %q target: %w", asset.Kind, asset.Name, err)
+		}
+		if err := copyFile(filepath.Clean(asset.SourcePath), target); err != nil {
+			return fmt.Errorf("stage bundled %s %q: %w", asset.Kind, asset.Name, err)
+		}
+		if err := verifyFileSHA256(target, asset.SHA256); err != nil {
+			return fmt.Errorf("verify bundled %s %q: %w", asset.Kind, asset.Name, err)
+		}
+	}
+	return nil
+}
+
+func upgradeSysexts(payload Payload, previous generation.GenerationSpec, generationID string, root generation.RootSelection, bootstrapped bool) ([]generation.ExtensionRef, []PreservedAsset, []BundledAsset, error) {
 	previousKubernetes, hasPreviousKubernetes := selectedKubernetes(previous.Sysexts)
 	if bootstrapped && !hasPreviousKubernetes {
-		return nil, nil, fmt.Errorf("bootstrapped node current generation has no Kubernetes sysext to preserve")
+		return nil, nil, nil, fmt.Errorf("bootstrapped node current generation has no Kubernetes sysext to preserve")
 	}
 	if hasPreviousKubernetes {
 		if err := generation.ValidatePair(root, previousKubernetes); err != nil {
-			return nil, nil, fmt.Errorf("preserved Kubernetes sysext is incompatible with upgraded runtime: %w", err)
+			return nil, nil, nil, fmt.Errorf("preserved Kubernetes sysext is incompatible with upgraded runtime: %w", err)
 		}
 	}
-	return rehomeSysexts(previous, generationID)
-}
 
-func rehomeSysexts(previous generation.GenerationSpec, generationID string) ([]generation.ExtensionRef, []PreservedAsset, error) {
 	refs := make([]generation.ExtensionRef, 0, len(previous.Sysexts))
 	assets := make([]PreservedAsset, 0, len(previous.Sysexts))
+	bundled := make([]BundledAsset, 0, 1)
 	for _, ref := range previous.Sysexts {
+		if ref.Name == EndpointAdvertiserName {
+			if len(bundled) != 0 {
+				return nil, nil, nil, fmt.Errorf("current generation contains multiple %s sysexts", EndpointAdvertiserName)
+			}
+			target := filepath.Join(generation.GenerationRecordsDir, generationID, "sysext", EndpointAdvertiserName+".raw")
+			replacement, err := payload.EndpointAdvertiserExtensionRef(target)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("replace bundled %s sysext: %w", EndpointAdvertiserName, err)
+			}
+			if err := generation.ValidatePair(root, replacement); err != nil {
+				return nil, nil, nil, fmt.Errorf("bundled %s sysext is incompatible with upgraded runtime: %w", EndpointAdvertiserName, err)
+			}
+			refs = append(refs, replacement)
+			bundled = append(bundled, BundledAsset{
+				Kind:       "sysext",
+				Name:       EndpointAdvertiserName,
+				SourcePath: payload.ComponentPath(payload.EndpointAdvertiser),
+				TargetPath: replacement.Path,
+				SHA256:     replacement.SHA256,
+			})
+			continue
+		}
 		path, err := rehomeGenerationPath(previous.GenerationID, generationID, ref.Path, "sysext")
 		if err != nil {
-			return nil, nil, fmt.Errorf("preserve sysext %q: %w", ref.Name, err)
+			return nil, nil, nil, fmt.Errorf("preserve sysext %q: %w", ref.Name, err)
 		}
 		assets = append(assets, PreservedAsset{Kind: "sysext", Name: ref.Name, SourcePath: ref.Path, TargetPath: path, SHA256: ref.SHA256})
 		ref.Path = path
 		refs = append(refs, ref)
 	}
-	return refs, assets, nil
+	return refs, assets, bundled, nil
 }
 
 func rehomeConfexts(previous generation.GenerationSpec, generationID string) ([]generation.GeneratedConfext, []PreservedAsset, error) {

--- a/internal/installer/katlosimage/image_test.go
+++ b/internal/installer/katlosimage/image_test.go
@@ -288,7 +288,8 @@ func TestHostUpgradePlanPreservesKubernetesOnBootstrappedNode(t *testing.T) {
 	}
 }
 
-func TestHostUpgradePlanPreservesNonKubernetesSysextBeforeBootstrap(t *testing.T) {
+func TestHostUpgradePlanReplacesBundledEndpointAdvertiserBeforeBootstrap(t *testing.T) {
+	root := t.TempDir()
 	payload := upgradePayload(t, nil)
 	previousSpec, _ := knownGoodGeneration(t, "gen0", strings.Repeat("b", sha256.Size*2), "v1.35.0")
 	previousSpec.Sysexts = []generation.ExtensionRef{{
@@ -314,8 +315,28 @@ func TestHostUpgradePlanPreservesNonKubernetesSysextBeforeBootstrap(t *testing.T
 	if err != nil {
 		t.Fatalf("HostUpgradePlan() error = %v", err)
 	}
-	if len(plan.Spec.Sysexts) != 1 || plan.Spec.Sysexts[0].Name != EndpointAdvertiserName || plan.Spec.Sysexts[0].Path != "/var/lib/katl/generations/gen1/sysext/katl-endpoint-advertiser.raw" {
-		t.Fatalf("candidate sysexts = %#v, want preserved endpoint advertiser", plan.Spec.Sysexts)
+	if len(plan.Spec.Sysexts) != 1 || plan.Spec.Sysexts[0].Name != EndpointAdvertiserName || plan.Spec.Sysexts[0].Path != "/var/lib/katl/generations/gen1/sysext/endpoint-advertiser.raw" {
+		t.Fatalf("candidate sysexts = %#v, want bundled endpoint advertiser replacement", plan.Spec.Sysexts)
+	}
+	if got := plan.Spec.Sysexts[0]; got.SHA256 != payload.EndpointAdvertiser.SHA256 || got.ArtifactVersion != payload.EndpointAdvertiser.Version {
+		t.Fatalf("candidate endpoint advertiser = %#v, want payload component %#v", got, payload.EndpointAdvertiser)
+	}
+	if len(plan.BundledAssets) != 1 || plan.BundledAssets[0].Name != EndpointAdvertiserName {
+		t.Fatalf("bundled assets = %#v", plan.BundledAssets)
+	}
+	if err := StageBundledAssets(root, plan); err != nil {
+		t.Fatalf("StageBundledAssets() error = %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(root, strings.TrimPrefix(plan.Spec.Sysexts[0].Path, "/")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.ReadFile(payload.ComponentPath(payload.EndpointAdvertiser))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(staged, source) {
+		t.Fatal("staged endpoint advertiser differs from bundled component")
 	}
 }
 

--- a/internal/installer/katlosimage/image_test.go
+++ b/internal/installer/katlosimage/image_test.go
@@ -431,7 +431,7 @@ func TestHostUpgradeRollbackMetadataRestoresPreviousKnownGood(t *testing.T) {
 		t.Fatalf("ReadBootSelection() error = %v", err)
 	}
 	if selection.DefaultGenerationID != "gen0" ||
-		selection.BootedGenerationID != "gen0" ||
+		selection.BootedGenerationID != "gen1" ||
 		selection.FailedBootGenerationID != "gen1" ||
 		selection.TrialGenerationID != "" ||
 		selection.PendingHealthValidation ||

--- a/internal/katlc/agent/endpoint_status.go
+++ b/internal/katlc/agent/endpoint_status.go
@@ -147,7 +147,7 @@ func endpointProductState(config bgpapivip.Config, live bgpapivip.Status, peers 
 			return "waiting-for-peer"
 		}
 	}
-	if live.AdvertisementState == bgpapivip.AdvertisementAdvertised && !live.LocalVIPOwned {
+	if live.AdvertisementState == bgpapivip.AdvertisementAdvertised && live.LocalVIPOwnedReported && !live.LocalVIPOwned {
 		return "failed"
 	}
 	if live.AdvertisementState == bgpapivip.AdvertisementAdvertised {

--- a/internal/katlc/agent/endpoint_status_test.go
+++ b/internal/katlc/agent/endpoint_status_test.go
@@ -93,6 +93,50 @@ func TestControlPlaneEndpointStatusDistinguishesStartupStates(t *testing.T) {
 	}
 }
 
+func TestControlPlaneEndpointStatusDistinguishesLegacyMissingVIPOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		omitOwned bool
+		want      string
+	}{
+		{name: "legacy field omitted", omitOwned: true, want: "advertised"},
+		{name: "current field explicitly false", want: "failed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeManagedEndpointConfig(t, root, true)
+			live := bgpapivip.Status{
+				APIVersion:             bgpapivip.StatusAPIVersion,
+				Kind:                   bgpapivip.StatusKind,
+				VIPInterfaceReady:      true,
+				HealthState:            bgpapivip.HealthHealthy,
+				AdvertisementState:     bgpapivip.AdvertisementAdvertised,
+				BirdProcessActive:      true,
+				BirdControlSocketReady: true,
+				PeerSummary: []bgpapivip.PeerRuntimeStatus{{
+					Name: "10.0.0.1", Kind: "fabric", SessionState: "established",
+				}},
+			}
+			data, err := bgpapivip.MarshalStatus(live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.omitOwned {
+				data = []byte(strings.Replace(string(data), "  \"localVIPOwned\": false,\n", "", 1))
+			}
+			writeTestFile(t, filepath.Join(root, bgpapivip.LiveStatusPath), string(data))
+
+			status, err := controlPlaneEndpointStatus(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.GetState() != test.want {
+				t.Fatalf("state = %q, want %q; status = %#v", status.GetState(), test.want, status)
+			}
+		})
+	}
+}
+
 func TestControlPlaneEndpointStatusIsAbsentForExternalEndpointNode(t *testing.T) {
 	status, err := controlPlaneEndpointStatus(t.TempDir())
 	if err != nil || status != nil {

--- a/internal/katlc/agent/endpoint_status_test.go
+++ b/internal/katlc/agent/endpoint_status_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
@@ -96,6 +97,28 @@ func TestControlPlaneEndpointStatusIsAbsentForExternalEndpointNode(t *testing.T)
 	status, err := controlPlaneEndpointStatus(t.TempDir())
 	if err != nil || status != nil {
 		t.Fatalf("external endpoint status = %#v, %v", status, err)
+	}
+}
+
+func TestControlPlaneEndpointStatusAcceptsPersistedVIPHealthTarget(t *testing.T) {
+	root := t.TempDir()
+	writeManagedEndpointConfig(t, root, true)
+	path := filepath.Join(root, bgpapivip.ConfigPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.Replace(string(data), "  health: {}\n", "  health:\n    host: 10.40.0.10\n", 1))
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := controlPlaneEndpointStatus(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.GetEndpoint() != "api.home.example:6443" || status.GetState() != "starting" {
+		t.Fatalf("endpoint status = %#v", status)
 	}
 }
 

--- a/internal/katlc/agent/host_upgrade.go
+++ b/internal/katlc/agent/host_upgrade.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -48,12 +50,38 @@ func (s *Server) validateHostUpgradePlan(req *agentapi.HostUpgradeOperationReque
 	if err != nil {
 		return fmt.Errorf("read current generation %q: %w", currentID, err)
 	}
+	if err := validateHostUpgradeBootEvidence(s.Root, currentID, previousSpec); err != nil {
+		return err
+	}
 	kubernetesState, err := s.kubernetesNodeState()
 	if err != nil {
 		return fmt.Errorf("inspect Kubernetes node state: %w", err)
 	}
 	if err := katlosimage.ValidateHostUpgradeSource(previousSpec, previousStatus, kubernetesState.bootstrapped); err != nil {
 		return fmt.Errorf("%w; inspect the current generation, then recover it or wipe and reinstall this node before retrying the upgrade", err)
+	}
+	return nil
+}
+
+func validateHostUpgradeBootEvidence(root, currentID string, current generation.GenerationSpec) error {
+	data, err := os.ReadFile(filepath.Join(runtimeRoot(root), "proc/cmdline"))
+	if err != nil {
+		return fmt.Errorf("read running kernel command line: %w", err)
+	}
+	commandLine := string(data)
+	bootedID, err := generation.SelectedGenerationFromCommandLine(commandLine)
+	if err != nil {
+		return fmt.Errorf("read running generation from kernel command line: %w", err)
+	}
+	if bootedID != currentID {
+		return fmt.Errorf("running kernel selected generation %q but durable state identifies %q as current; reboot into the selected known-good generation before retrying the upgrade", bootedID, currentID)
+	}
+	rootPartUUID, err := generation.SelectedRootPartUUIDFromCommandLine(commandLine)
+	if err != nil {
+		return fmt.Errorf("read running root from kernel command line: %w", err)
+	}
+	if !strings.EqualFold(rootPartUUID, strings.TrimSpace(current.Root.PartitionUUID)) {
+		return fmt.Errorf("running root PARTUUID %q does not match current generation %q root PARTUUID %q; reboot into the selected known-good generation before retrying the upgrade", rootPartUUID, currentID, current.Root.PartitionUUID)
 	}
 	return nil
 }

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -114,6 +114,9 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	if err := katlosimage.StagePreservedAssets(runtimeRoot(e.Root), plan); err != nil {
 		return e.failHostUpgrade(record, "write-candidate-generation", err)
 	}
+	if err := katlosimage.StageBundledAssets(runtimeRoot(e.Root), plan); err != nil {
+		return e.failHostUpgrade(record, "write-candidate-generation", err)
+	}
 	if err := generation.WriteGeneration(e.Root, plan.Spec, plan.Status); err != nil {
 		return e.failHostUpgrade(record, "write-candidate-generation", err)
 	}

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -58,6 +58,9 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("read current generation: %w", err))
 	}
+	if err := validateHostUpgradeBootEvidence(e.Root, currentID, previousSpec); err != nil {
+		return e.failHostUpgrade(record, "verify-katlos-image", err)
+	}
 	inactiveSlot, err := inactiveRoot(previousSpec.Root.Slot)
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", err)

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -170,6 +170,7 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 
 	runtimeBytes := []byte("next runtime root")
 	ukiBytes := []byte("next runtime uki")
+	nextEndpointAdvertiserBytes := []byte("next endpoint advertiser sysext")
 	payloadRoot := filepath.Join(root, "payload")
 	if err := os.MkdirAll(filepath.Join(payloadRoot, "components/runtime"), 0o755); err != nil {
 		t.Fatal(err)
@@ -177,10 +178,16 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(payloadRoot, "components/boot"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(payloadRoot, "components/sysext"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(payloadRoot, "components/runtime/root.squashfs"), runtimeBytes, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(payloadRoot, "components/boot/katl.efi"), ukiBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payloadRoot, "components/sysext/endpoint-advertiser.raw"), nextEndpointAdvertiserBytes, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	payload := katlosimage.Payload{
@@ -190,6 +197,12 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 		Index:          katlosimage.Index{ImageRole: katlosimage.RoleUpgrade, Version: "2026.7.0-dev.1", Architecture: "x86_64", RuntimeInterface: "katl-runtime-1"},
 		Runtime:        katlosimage.Component{Name: "runtime-root", Role: katlosimage.ComponentRuntimeRoot, Path: "components/runtime/root.squashfs", SizeBytes: int64(len(runtimeBytes)), SHA256: testSHA(runtimeBytes), Version: "2026.7.0-dev.1", Architecture: "x86_64"},
 		Boot:           katlosimage.Component{Name: "runtime-uki", Role: katlosimage.ComponentRuntimeUKI, Path: "components/boot/katl.efi", SizeBytes: int64(len(ukiBytes)), SHA256: testSHA(ukiBytes), Version: "2026.7.0-dev.1", Architecture: "x86_64"},
+		EndpointAdvertiser: katlosimage.Component{
+			Name: "endpoint-advertiser", Role: katlosimage.ComponentEndpointAdvertiser, Path: "components/sysext/endpoint-advertiser.raw",
+			SizeBytes: int64(len(nextEndpointAdvertiserBytes)), SHA256: testSHA(nextEndpointAdvertiserBytes), Version: "2026.7.0-dev.1",
+			PayloadVersion: "2026.7.0-dev.1", Architecture: "x86_64",
+			Compatibility: katlosimage.Compatibility{RuntimeInterface: "katl-runtime-1"},
+		},
 	}
 	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
 	if err != nil {
@@ -309,8 +322,15 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	if spec.Root.Slot != "root-b" || spec.Root.PartitionUUID != "bbbbbbbb-1111-2222-3333-444444444444" || status.BootState != generation.BootStateTrying {
 		t.Fatalf("candidate generation = spec %+v status %+v", spec, status)
 	}
-	if len(spec.Sysexts) != 1 || spec.Sysexts[0].Name != katlosimage.EndpointAdvertiserName || spec.Sysexts[0].Path != "/var/lib/katl/generations/gen1/sysext/katl-endpoint-advertiser.raw" {
-		t.Fatalf("candidate sysexts = %+v, want preserved endpoint advertiser", spec.Sysexts)
+	if len(spec.Sysexts) != 1 || spec.Sysexts[0].Name != katlosimage.EndpointAdvertiserName || spec.Sysexts[0].Path != "/var/lib/katl/generations/gen1/sysext/endpoint-advertiser.raw" || spec.Sysexts[0].SHA256 != testSHA(nextEndpointAdvertiserBytes) {
+		t.Fatalf("candidate sysexts = %+v, want bundled endpoint advertiser replacement", spec.Sysexts)
+	}
+	stagedEndpointAdvertiser, err := os.ReadFile(filepath.Join(root, strings.TrimPrefix(spec.Sysexts[0].Path, "/")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(stagedEndpointAdvertiser, nextEndpointAdvertiserBytes) {
+		t.Fatalf("staged endpoint advertiser = %q", stagedEndpointAdvertiser)
 	}
 	selection, err := generation.ReadBootSelection(root)
 	if err != nil {

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -112,6 +112,12 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "etc/machine-id"), []byte("0123456789abcdef0123456789abcdef\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(root, "proc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "proc/cmdline"), []byte("root=PARTUUID=aaaaaaaa-1111-2222-3333-444444444444 rootfstype=squashfs ro katl.generation=gen0 katl.root-slot=root-a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	endpointAdvertiserBytes := []byte("endpoint advertiser sysext")
 	previous := generation.GenerationSpec{

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -582,6 +582,28 @@ func TestHostUpgradeDryRunAllowsHealthySourceBeforeBootstrap(t *testing.T) {
 	}
 }
 
+func TestHostUpgradeRejectsDurableRollbackBeforeReboot(t *testing.T) {
+	server := newTestServer(t)
+	writeKnownGoodHostUpgradeSource(t, server.Root)
+	writeProcCmdline(t, server.Root, "root=PARTUUID=22222222-2222-2222-2222-222222222222 rootfstype=squashfs ro katl.generation=failed-trial katl.root-slot=root-b")
+	req := hostUpgradeSubmitRequest("req-host-upgrade-before-rollback-reboot")
+	req.DryRun = true
+
+	_, err := server.SubmitOperation(context.Background(), req)
+	if status.Code(err) != codes.FailedPrecondition ||
+		!strings.Contains(err.Error(), `running kernel selected generation "failed-trial"`) ||
+		!strings.Contains(err.Error(), "reboot into the selected known-good generation") {
+		t.Fatalf("SubmitOperation() error = %v, want actionable boot-evidence refusal", err)
+	}
+	ids, listErr := server.Store.OperationIDs()
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("operation ids = %v, want no record for unsafe retry", ids)
+	}
+}
+
 func TestSubmitOperationRejectsUnsafeHostUpgradeReference(t *testing.T) {
 	server := newTestServer(t)
 	server.Dispatcher = dispatchFunc(func(context.Context, operation.OperationRecord) error { return nil })
@@ -620,6 +642,7 @@ func hostUpgradeSubmitRequest(clientRequestID string) *agentapi.SubmitOperationR
 func writeKnownGoodHostUpgradeSource(t *testing.T, root string) {
 	t.Helper()
 	writeCleanGenerationZeroState(t, root)
+	writeProcCmdline(t, root, "root=PARTUUID=11111111-1111-1111-1111-111111111111 rootfstype=squashfs ro katl.generation=generation-0 katl.root-slot=root-a")
 	spec, _, err := generation.ReadGeneration(root, "generation-0")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -5,7 +5,7 @@
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 25,
+      "artifactRevision": 26,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 23,
+      "artifactRevision": 24,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 22,
+      "artifactRevision": 23,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 22,
+      "artifactRevision": 23,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:2a8d6b235feb3c1b8517787ca769d5cf8e2bc878346d4cc48f62ccc54ca51480",
+  "recipeDigest": "sha256:c62e61ac421b901938fb5c63ac65297a5a792df8ddcae8fd0b8ab948563a9d1e",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 27,
+      "artifactRevision": 28,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 25,
+      "artifactRevision": 26,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 24,
+      "artifactRevision": 25,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 24,
+      "artifactRevision": 25,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:c62e61ac421b901938fb5c63ac65297a5a792df8ddcae8fd0b8ab948563a9d1e",
+  "recipeDigest": "sha256:54e9c78d8ec45538aa03284154da76217eab881132538a7d88ffe9df5e8ead18",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 28,
+      "artifactRevision": 29,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 26,
+      "artifactRevision": 27,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 25,
+      "artifactRevision": 26,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 25,
+      "artifactRevision": 26,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -5,7 +5,7 @@
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 24,
+      "artifactRevision": 25,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 22,
+      "artifactRevision": 23,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 21,
+      "artifactRevision": 22,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 21,
+      "artifactRevision": 22,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,11 +1,11 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:5de8695495a9aa9a581d024d6a07ea84f4956a554e7cf08b6827c34b7f82615d",
+  "recipeDigest": "sha256:2a8d6b235feb3c1b8517787ca769d5cf8e2bc878346d4cc48f62ccc54ca51480",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 26,
+      "artifactRevision": 27,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -15,7 +15,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 24,
+      "artifactRevision": 25,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -25,7 +25,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 23,
+      "artifactRevision": 24,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -35,7 +35,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 23,
+      "artifactRevision": 24,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/endpoint_advertiser_sysext_test.go
+++ b/internal/scriptstest/endpoint_advertiser_sysext_test.go
@@ -72,7 +72,9 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",
 		"ExecStart=/usr/bin/systemctl daemon-reload",
-		"start katl-app-bgp-api-vip.path",
+		"ExecStart=/usr/bin/systemctl start katl-app-bgp-api-vip.service",
+		"ExecStart=-/usr/bin/systemctl start katl-app-bgp-api-vip.path",
+		"ExecStop=-/usr/bin/systemctl stop katl-app-bgp-api-vip.path",
 	} {
 		if !strings.Contains(activationUnit, want) {
 			t.Fatalf("endpoint activation unit is missing %q", want)

--- a/mkosi.profiles/runtime/katl-endpoint-activate.service
+++ b/mkosi.profiles/runtime/katl-endpoint-activate.service
@@ -9,8 +9,11 @@ ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/systemctl daemon-reload
-ExecStart=/usr/bin/systemctl start katl-app-bgp-api-vip.path
-ExecStop=/usr/bin/systemctl stop katl-app-bgp-api-vip.path
+ExecStart=/usr/bin/systemctl start katl-app-bgp-api-vip.service
+# Older endpoint extensions predate the path watcher. Starting a missing unit
+# must not reject an otherwise compatible KatlOS upgrade generation.
+ExecStart=-/usr/bin/systemctl start katl-app-bgp-api-vip.path
+ExecStop=-/usr/bin/systemctl stop katl-app-bgp-api-vip.path
 ExecStop=/usr/bin/systemctl stop katl-app-bgp-api-vip.service
 RemainAfterExit=yes
 


### PR DESCRIPTION
## Summary

- identify local KatlOS builds as `local.<short-sha>`
- replace and activate the bundled endpoint advertiser during host upgrades
- detect stale generated endpoint files and refresh them online during whole-cluster apply
- report VIP ownership correctly while migrating legacy endpoint configuration

The upgrade path preserved an older endpoint extension and unchanged manifest intent hid renderer drift, leaving upgraded control planes owning the VIP without originating its route.

Validated through the public katldev workflow, an online legacy-to-direct migration on the physical multi-control-plane lab, the routed BGP/VIP VM scenario, and the repository fast gate.
