### PR TITLE
release: scope Kubernetes bundle rebuilds

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -7,38 +7,28 @@ on:
     paths:
       - .github/workflows/kubernetes-bundles.yml
       - Containerfile.mkosi
-      - cmd/katl-boot-health/**
-      - "!cmd/katl-boot-health/**/*_test.go"
-      - cmd/katl-console/**
-      - "!cmd/katl-console/**/*_test.go"
-      - cmd/katl-generation-activate/**
-      - "!cmd/katl-generation-activate/**/*_test.go"
       - cmd/katl-kubernetes-release/**
       - "!cmd/katl-kubernetes-release/**/*_test.go"
       - cmd/katl-mkosi-artifacts/**
       - "!cmd/katl-mkosi-artifacts/**/*_test.go"
       - cmd/katl-publish-kubernetes-sysext/**
       - "!cmd/katl-publish-kubernetes-sysext/**/*_test.go"
-      - cmd/katl-runtime-status/**
-      - "!cmd/katl-runtime-status/**/*_test.go"
-      - cmd/katlc/**
-      - "!cmd/katlc/**/*_test.go"
       - containers-policy.json
       - go.mod
       - go.sum
-      - internal/**
-      - "!internal/**/*_test.go"
-      - "!internal/**/testdata/**"
-      - "!internal/installer/kubernetescompat/catalog.json"
-      - "!internal/resourcetest/**"
-      - "!internal/vmtest/**"
+      - internal/installer/artifact/artifact.go
+      - internal/installer/artifact/local.go
+      - internal/installer/sysextcatalog/catalog.go
+      - internal/installer/sysextcatalog/stage.go
+      - internal/kubernetesrelease/**
+      - "!internal/kubernetesrelease/**/*_test.go"
       - internal/kubernetesrelease/supported-versions.json
       - mkosi.conf
       - mkosi.profiles/kubernetes-sysext/**
-      - mkosi.profiles/runtime/**
+      - mkosi.profiles/runtime/mkosi.conf
+      - mkosi.profiles/runtime/os-release.in
       - scripts/build-kubernetes-sysext
       - scripts/check-kubernetes-sysext
-      - scripts/mkosi
   workflow_dispatch:
     inputs:
       payload_version:

--- a/cmd/katl-kubernetes-release/main.go
+++ b/cmd/katl-kubernetes-release/main.go
@@ -173,6 +173,7 @@ func runRefreshRebuilds(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	scopeChanged := supported.RecipeScope != kubernetesrelease.CurrentRecipeScope
 	updated, changed, err := kubernetesrelease.RefreshRecipe(*root, supported)
 	if err != nil {
 		return err
@@ -187,6 +188,10 @@ func runRefreshRebuilds(args []string, stdout, stderr io.Writer) error {
 	}
 	if err := writeAtomic(*path, data); err != nil {
 		return err
+	}
+	if scopeChanged {
+		fmt.Fprintf(stdout, "updated Kubernetes bundle recipe scope to %s and fingerprint to %s without advancing artifact revisions\n", updated.RecipeScope, updated.RecipeDigest)
+		return nil
 	}
 	fmt.Fprintf(stdout, "updated Kubernetes bundle recipe to %s and advanced %d artifact revisions\n", updated.RecipeDigest, len(updated.Versions))
 	return nil
@@ -210,6 +215,9 @@ func runVerifyRecipe(args []string, stdout, stderr io.Writer) error {
 	digest, err := kubernetesrelease.RecipeDigest(*root)
 	if err != nil {
 		return err
+	}
+	if supported.RecipeScope != kubernetesrelease.CurrentRecipeScope {
+		return fmt.Errorf("Kubernetes bundle recipe scope is %q, want %q; run `go run ./cmd/katl-kubernetes-release refresh-rebuilds`", supported.RecipeScope, kubernetesrelease.CurrentRecipeScope)
 	}
 	if supported.RecipeDigest != digest {
 		return fmt.Errorf("Kubernetes bundle recipe changed: manifest has %s, current inputs are %s; run `go run ./cmd/katl-kubernetes-release refresh-rebuilds`", supported.RecipeDigest, digest)

--- a/cmd/katl-kubernetes-release/main_test.go
+++ b/cmd/katl-kubernetes-release/main_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/katl-dev/katl/internal/kubernetesrelease"
 )
 
 const testManifest = `: "${KATL_KUBERNETES_MINOR:=v1.36}"
@@ -16,6 +18,69 @@ KATL_KUBERNETES_ARTIFACT_REVISION_DEFAULT=4
 : "${KATL_KUBERNETES_KUBECTL_VERSION:=0:1.36.0-1}"
 : "${KATL_KUBERNETES_CRITOOLS_VERSION:=0:1.36.0-1}"
 `
+
+func TestRefreshRebuildsRescopesWithoutAdvancingArtifacts(t *testing.T) {
+	supported, err := kubernetesrelease.DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	supported.RecipeScope = ""
+	supported.RecipeDigest = "sha256:" + strings.Repeat("a", 64)
+	before := append([]kubernetesrelease.SupportedVersion(nil), supported.Versions...)
+	data, err := kubernetesrelease.MarshalSupportedVersions(supported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "supported-versions.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{
+		"refresh-rebuilds",
+		"--supported-versions", path,
+		"--repo-root", filepath.Join("..", ".."),
+	}, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	updatedData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := kubernetesrelease.DecodeSupportedVersions(updatedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.RecipeScope != kubernetesrelease.CurrentRecipeScope {
+		t.Fatalf("recipe scope = %q", updated.RecipeScope)
+	}
+	if len(updated.Versions) != len(before) {
+		t.Fatalf("versions = %#v, want %#v", updated.Versions, before)
+	}
+	for index := range before {
+		if updated.Versions[index].ArtifactRevision != before[index].ArtifactRevision {
+			t.Fatalf("artifact revision %s = %d, want %d", updated.Versions[index].PayloadVersion, updated.Versions[index].ArtifactRevision, before[index].ArtifactRevision)
+		}
+	}
+	if !strings.Contains(stdout.String(), "without advancing artifact revisions") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestVerifyRecipeAcceptsScopedRepositoryManifest(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{
+		"verify-recipe",
+		"--supported-versions", filepath.Join("..", "..", "internal", "kubernetesrelease", "supported-versions.json"),
+		"--repo-root", filepath.Join("..", ".."),
+	}, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("run() error = %v, stderr=%s", err, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "Kubernetes bundle recipe is current" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
 
 func TestPrepare(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "kubernetes.env")

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -359,17 +359,20 @@ payload patch, selects the newest compatible cri-tools patch, and starts a new
 payload at artifact revision `1`. Review the policy diff and submit it as a
 normal ready pull request.
 
-Changes to bundle-producing code, profiles, or workflows must rebuild every
-supported payload. Refresh the recipe fingerprint and advance all immutable
-artifact revisions in the same pull request:
+Changes to the Kubernetes sysext profile, package or base-runtime ABI inputs,
+bundle metadata or catalog producers, or publication workflow must rebuild
+every supported payload. Refresh the recipe fingerprint and advance all
+immutable artifact revisions in the same pull request:
 
 ```sh
 go run ./cmd/katl-kubernetes-release refresh-rebuilds
 ```
 
 The Go baseline rejects a changed bundle recipe until this command has updated
-the supported-version policy. Changes that only add a supported payload do not
-advance existing artifact revisions.
+the supported-version policy. KatlOS runtime binaries, agents, installer policy,
+VM infrastructure, documentation, and other product code are outside this
+recipe boundary and must not advance Kubernetes artifact revisions. Changes
+that only add a supported payload do not advance existing artifact revisions.
 
 Manual dispatch remains the explicit dry-run path. Dispatch it with empty
 version inputs to build the whole supported matrix, or select one supported

--- a/docs/internal/kubernetes-sysext-delivery.md
+++ b/docs/internal/kubernetes-sysext-delivery.md
@@ -900,13 +900,20 @@ separate from artifact availability: a version becomes installable only after
 its immutable bundle is published and recorded in the compatibility catalog.
 The initial policy lists the GA releases `v1.36.0` through `v1.36.3`.
 
-Adding a payload starts its artifact revision at `1`. The policy also records a
-fingerprint of every bundle-producing input. A change to those inputs must
-refresh the fingerprint and increment every supported payload's revision, so
-the main-branch producer rebuilds the entire supported matrix without replacing
-an immutable tag. Package changes for an existing payload increment only that
-payload's revision. A successful rebuild updates the catalog mapping but does
-not remove older exact artifact identities or digests.
+Adding a payload starts its artifact revision at `1`. The policy also records
+the named recipe scope and a fingerprint of every bundle-producing input. The
+scope covers the Kubernetes sysext and package policy, the runtime ABI and base
+package inputs used to construct the overlay, the metadata and catalog
+producers, and the publication workflow. It does not cover KatlOS runtime
+binaries, agents, installer policy, VM infrastructure, or unrelated product
+code. A change to a fingerprinted producer input must refresh the fingerprint
+and increment every supported payload's revision, so the main-branch producer
+rebuilds the entire supported matrix without replacing an immutable tag.
+Changing only the definition of the fingerprint scope records the new scope and
+digest without minting payload revisions. Package changes for an existing
+payload increment only that payload's revision. A successful rebuild updates
+the catalog mapping but does not remove older exact artifact identities or
+digests.
 
 Minor updates, such as `v1.36` to `v1.37`, require the same artifact production
 mechanics plus Kubernetes version-skew policy review. Katl should continue to

--- a/internal/kubernetesrelease/recipe.go
+++ b/internal/kubernetesrelease/recipe.go
@@ -15,29 +15,26 @@ import (
 var recipeRoots = []string{
 	".github/workflows/kubernetes-bundles.yml",
 	"Containerfile.mkosi",
-	"cmd/katl-boot-health",
-	"cmd/katl-console",
-	"cmd/katl-generation-activate",
-	"cmd/katl-host-config-activate",
 	"cmd/katl-kubernetes-release",
 	"cmd/katl-mkosi-artifacts",
 	"cmd/katl-publish-kubernetes-sysext",
-	"cmd/katl-runtime-status",
-	"cmd/katlc",
 	"containers-policy.json",
 	"go.mod",
 	"go.sum",
-	"internal",
+	"internal/installer/artifact/artifact.go",
+	"internal/installer/artifact/local.go",
+	"internal/installer/sysextcatalog/catalog.go",
+	"internal/installer/sysextcatalog/stage.go",
+	"internal/kubernetesrelease",
 	"mkosi.conf",
 	"mkosi.profiles/kubernetes-sysext",
-	"mkosi.profiles/runtime",
+	"mkosi.profiles/runtime/mkosi.conf",
+	"mkosi.profiles/runtime/os-release.in",
 	"scripts/build-kubernetes-sysext",
 	"scripts/check-kubernetes-sysext",
-	"scripts/mkosi",
 }
 
 var recipeExcludedPaths = map[string]bool{
-	"internal/installer/kubernetescompat/catalog.json":   true,
 	"internal/kubernetesrelease/supported-versions.json": true,
 }
 
@@ -75,10 +72,21 @@ func RefreshRecipe(root string, supported SupportedVersions) (SupportedVersions,
 	if err != nil {
 		return SupportedVersions{}, false, err
 	}
-	if supported.RecipeDigest == digest {
+	if supported.RecipeScope == CurrentRecipeScope && supported.RecipeDigest == digest {
 		return supported, false, nil
 	}
 	supported.Versions = copyVersions(supported.Versions)
+	if supported.RecipeScope == "" {
+		supported.RecipeScope = CurrentRecipeScope
+		supported.RecipeDigest = digest
+		if err := validateSupportedVersions(supported); err != nil {
+			return SupportedVersions{}, false, err
+		}
+		return supported, true, nil
+	}
+	if supported.RecipeScope != CurrentRecipeScope {
+		return SupportedVersions{}, false, fmt.Errorf("unsupported Kubernetes bundle recipe scope %q", supported.RecipeScope)
+	}
 	supported.RecipeDigest = digest
 	for index := range supported.Versions {
 		supported.Versions[index].ArtifactRevision++

--- a/internal/kubernetesrelease/recipe_test.go
+++ b/internal/kubernetesrelease/recipe_test.go
@@ -14,7 +14,7 @@ func TestRecipeDigestChangesWithProductionInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RecipeDigest() error = %v", err)
 	}
-	path := filepath.Join(root, "scripts", "mkosi")
+	path := filepath.Join(root, "scripts", "build-kubernetes-sysext")
 	if err := os.WriteFile(path, []byte("changed"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -46,11 +46,17 @@ func TestRecipeDigestIgnoresTests(t *testing.T) {
 	}
 }
 
-func TestRecipeDigestTracksControllerAndRuntimeSources(t *testing.T) {
+func TestRecipeDigestTracksBundleProducerSources(t *testing.T) {
 	for _, relative := range []string{
 		"internal/kubernetesrelease/input.go",
-		"internal/operatorconsole/input.go",
-		"cmd/katlc/input.go",
+		"internal/installer/artifact/artifact.go",
+		"internal/installer/artifact/local.go",
+		"internal/installer/sysextcatalog/catalog.go",
+		"internal/installer/sysextcatalog/stage.go",
+		"cmd/katl-mkosi-artifacts/input.go",
+		"cmd/katl-publish-kubernetes-sysext/input.go",
+		"mkosi.profiles/kubernetes-sysext/input.go",
+		"mkosi.profiles/runtime/mkosi.conf",
 	} {
 		t.Run(relative, func(t *testing.T) {
 			root := writeRecipeFixture(t)
@@ -59,6 +65,9 @@ func TestRecipeDigestTracksControllerAndRuntimeSources(t *testing.T) {
 				t.Fatal(err)
 			}
 			path := filepath.Join(root, filepath.FromSlash(relative))
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
 			if err := os.WriteFile(path, []byte("changed"), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -73,9 +82,47 @@ func TestRecipeDigestTracksControllerAndRuntimeSources(t *testing.T) {
 	}
 }
 
+func TestRecipeDigestIgnoresUnrelatedProductAndRuntimeSources(t *testing.T) {
+	for _, relative := range []string{
+		"cmd/katl-boot-health/main.go",
+		"cmd/katlc/input.go",
+		"internal/installer/configapply/input.go",
+		"internal/installer/generation/input.go",
+		"internal/installer/manifest/manifest.go",
+		"internal/operatorconsole/input.go",
+		"internal/installer/sysextcatalog/select.go",
+		"mkosi.profiles/runtime/mkosi.build",
+		"mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-example.service",
+		"scripts/mkosi",
+		"docs/input.md",
+	} {
+		t.Run(relative, func(t *testing.T) {
+			root := writeRecipeFixture(t)
+			first, err := RecipeDigest(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, filepath.FromSlash(relative))
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("changed"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			second, err := RecipeDigest(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first != second {
+				t.Fatalf("%s affected Kubernetes bundle recipe digest", relative)
+			}
+		})
+	}
+}
+
 func TestRecipeDigestTracksSymlinkTarget(t *testing.T) {
 	root := writeRecipeFixture(t)
-	path := filepath.Join(root, "mkosi.profiles", "runtime", "input.link")
+	path := filepath.Join(root, "mkosi.profiles", "kubernetes-sysext", "input.link")
 	first, err := RecipeDigest(root)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +144,7 @@ func TestRecipeDigestTracksSymlinkTarget(t *testing.T) {
 
 func TestRecipeDigestTracksExecutableMode(t *testing.T) {
 	root := writeRecipeFixture(t)
-	path := filepath.Join(root, "scripts", "mkosi")
+	path := filepath.Join(root, "scripts", "build-kubernetes-sysext")
 	first, err := RecipeDigest(root)
 	if err != nil {
 		t.Fatal(err)
@@ -119,6 +166,7 @@ func TestRefreshRecipeAdvancesEverySupportedArtifact(t *testing.T) {
 	supported := SupportedVersions{
 		APIVersion:   APIVersion,
 		Kind:         Kind,
+		RecipeScope:  CurrentRecipeScope,
 		RecipeDigest: "sha256:" + strings.Repeat("a", 64),
 		Versions: []SupportedVersion{
 			testSupportedVersion("v1.35.9", 2),
@@ -141,6 +189,28 @@ func TestRefreshRecipeAdvancesEverySupportedArtifact(t *testing.T) {
 	}
 }
 
+func TestRefreshRecipeChangesScopeWithoutAdvancingArtifacts(t *testing.T) {
+	root := writeRecipeFixture(t)
+	supported := SupportedVersions{
+		APIVersion:   APIVersion,
+		Kind:         Kind,
+		RecipeDigest: "sha256:" + strings.Repeat("a", 64),
+		Versions: []SupportedVersion{
+			testSupportedVersion("v1.35.9", 2),
+			testSupportedVersion("v1.36.3", 1),
+		},
+	}
+	updated, changed, err := RefreshRecipe(root, supported)
+	if err != nil {
+		t.Fatalf("RefreshRecipe() error = %v", err)
+	}
+	if !changed || updated.RecipeScope != CurrentRecipeScope ||
+		updated.Versions[0].ArtifactRevision != 2 ||
+		updated.Versions[1].ArtifactRevision != 1 {
+		t.Fatalf("updated = %#v, changed = %t", updated, changed)
+	}
+}
+
 func TestDefaultRecipeDigestMatchesRepository(t *testing.T) {
 	supported, err := DefaultSupportedVersions()
 	if err != nil {
@@ -152,6 +222,51 @@ func TestDefaultRecipeDigestMatchesRepository(t *testing.T) {
 	}
 	if supported.RecipeDigest != digest {
 		t.Fatalf("recipe digest = %s, want %s; run go run ./cmd/katl-kubernetes-release refresh-rebuilds", supported.RecipeDigest, digest)
+	}
+}
+
+func TestKubernetesBundleWorkflowUsesRecipeBoundary(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "kubernetes-bundles.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		".github/workflows/kubernetes-bundles.yml",
+		"Containerfile.mkosi",
+		"cmd/katl-kubernetes-release/**",
+		"cmd/katl-mkosi-artifacts/**",
+		"cmd/katl-publish-kubernetes-sysext/**",
+		"containers-policy.json",
+		"go.mod",
+		"go.sum",
+		"internal/installer/artifact/artifact.go",
+		"internal/installer/artifact/local.go",
+		"internal/installer/sysextcatalog/catalog.go",
+		"internal/installer/sysextcatalog/stage.go",
+		"internal/kubernetesrelease/**",
+		"mkosi.conf",
+		"mkosi.profiles/kubernetes-sysext/**",
+		"mkosi.profiles/runtime/mkosi.conf",
+		"mkosi.profiles/runtime/os-release.in",
+		"scripts/build-kubernetes-sysext",
+		"scripts/check-kubernetes-sysext",
+	} {
+		if !strings.Contains(workflow, "\n      - "+required+"\n") {
+			t.Fatalf("Kubernetes bundle workflow does not track recipe input %q", required)
+		}
+	}
+	for _, unrelated := range []string{
+		"cmd/katlc/**",
+		"internal/**",
+		"internal/installer/manifest/**",
+		"internal/installer/sysextcatalog/**",
+		"mkosi.profiles/runtime/**",
+		"scripts/mkosi",
+	} {
+		if strings.Contains(workflow, "\n      - "+unrelated+"\n") {
+			t.Fatalf("Kubernetes bundle workflow tracks unrelated product input %q", unrelated)
+		}
 	}
 }
 
@@ -174,18 +289,11 @@ func writeRecipeFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	directories := map[string]bool{
-		"cmd/katl-boot-health":               true,
-		"cmd/katl-console":                   true,
-		"cmd/katl-generation-activate":       true,
-		"cmd/katl-host-config-activate":      true,
 		"cmd/katl-kubernetes-release":        true,
 		"cmd/katl-mkosi-artifacts":           true,
 		"cmd/katl-publish-kubernetes-sysext": true,
-		"cmd/katl-runtime-status":            true,
-		"cmd/katlc":                          true,
-		"internal":                           true,
+		"internal/kubernetesrelease":         true,
 		"mkosi.profiles/kubernetes-sysext":   true,
-		"mkosi.profiles/runtime":             true,
 	}
 	for _, input := range recipeRoots {
 		path := filepath.Join(root, filepath.FromSlash(input))
@@ -207,8 +315,11 @@ func writeRecipeFixture(t *testing.T) string {
 	}
 	for relative, content := range map[string]string{
 		"cmd/katl-mkosi-artifacts/main_test.go": "test",
-		"internal/kubernetesrelease/input.go":   "controller",
+		"cmd/katlc/input.go":                    "agent",
+		"docs/input.md":                         "documentation",
 		"internal/operatorconsole/input.go":     "runtime",
+		"mkosi.profiles/runtime/mkosi.build":    "runtime build",
+		"mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-example.service": "runtime unit",
 	} {
 		path := filepath.Join(root, filepath.FromSlash(relative))
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -218,7 +329,7 @@ func writeRecipeFixture(t *testing.T) string {
 			t.Fatal(err)
 		}
 	}
-	link := filepath.Join(root, "mkosi.profiles", "runtime", "input.link")
+	link := filepath.Join(root, "mkosi.profiles", "kubernetes-sysext", "input.link")
 	if err := os.Symlink("target-a", link); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -1,7 +1,8 @@
 {
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
-  "recipeDigest": "sha256:92338e4758b0b5348787dac3e50493f5aabd06c9dee113d718370c9b379cdbae",
+  "recipeScope": "kubernetes-bundle-v1",
+  "recipeDigest": "sha256:97cd743e29a60f7716dbe0ffd72e54b732fdbbb4ce0df9c3c74d47b6ea5e97dc",
   "versions": [
     {
       "payloadVersion": "v1.36.0",

--- a/internal/kubernetesrelease/supported_versions.go
+++ b/internal/kubernetesrelease/supported_versions.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	APIVersion = "katl.dev/v1alpha1"
-	Kind       = "KubernetesSupportedVersions"
+	APIVersion         = "katl.dev/v1alpha1"
+	Kind               = "KubernetesSupportedVersions"
+	CurrentRecipeScope = "kubernetes-bundle-v1"
 )
 
 //go:embed supported-versions.json
@@ -23,11 +24,13 @@ var (
 	versionPattern = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
 	packagePattern = regexp.MustCompile(`^0:([0-9]+)\.([0-9]+)\.([0-9]+)-[A-Za-z0-9._+~-]+$`)
 	digestPattern  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	scopePattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]*$`)
 )
 
 type SupportedVersions struct {
 	APIVersion   string             `json:"apiVersion"`
 	Kind         string             `json:"kind"`
+	RecipeScope  string             `json:"recipeScope,omitempty"`
 	RecipeDigest string             `json:"recipeDigest"`
 	Versions     []SupportedVersion `json:"versions"`
 }
@@ -94,6 +97,8 @@ func (supported SupportedVersions) Select(payloadVersion string) ([]SupportedVer
 }
 
 func (supported SupportedVersions) ChangedSince(previous SupportedVersions) ([]SupportedVersion, error) {
+	recipeChanged := supported.RecipeDigest != previous.RecipeDigest
+	scopeChangedWithoutRebuild := previous.RecipeScope == "" && supported.RecipeScope == CurrentRecipeScope
 	previousByPayload := make(map[string]SupportedVersion, len(previous.Versions))
 	for _, version := range previous.Versions {
 		previousByPayload[version.PayloadVersion] = version
@@ -106,7 +111,7 @@ func (supported SupportedVersions) ChangedSince(previous SupportedVersions) ([]S
 			continue
 		}
 		if old == version {
-			if supported.RecipeDigest != previous.RecipeDigest {
+			if recipeChanged && !scopeChangedWithoutRebuild {
 				return nil, fmt.Errorf("Kubernetes bundle recipe changed without advancing %s artifactRevision", version.PayloadVersion)
 			}
 			continue
@@ -164,6 +169,9 @@ func validateSupportedVersions(supported SupportedVersions) error {
 	}
 	if supported.Kind != Kind {
 		return fmt.Errorf("supported Kubernetes versions kind must be %s", Kind)
+	}
+	if supported.RecipeScope != "" && !scopePattern.MatchString(supported.RecipeScope) {
+		return fmt.Errorf("supported Kubernetes versions recipeScope must be a lowercase recipe scope")
 	}
 	if !digestPattern.MatchString(supported.RecipeDigest) {
 		return fmt.Errorf("supported Kubernetes versions recipeDigest must be a sha256 digest")

--- a/internal/kubernetesrelease/supported_versions_test.go
+++ b/internal/kubernetesrelease/supported_versions_test.go
@@ -19,6 +19,9 @@ func TestDefaultSupportedVersions(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("versions = %v, want %v", got, want)
 	}
+	if supported.RecipeScope != CurrentRecipeScope {
+		t.Fatalf("recipe scope = %q, want %q", supported.RecipeScope, CurrentRecipeScope)
+	}
 }
 
 func TestSupportedVersionArtifactVersion(t *testing.T) {
@@ -82,6 +85,39 @@ func TestSupportedVersionsChangedSinceRequiresRevision(t *testing.T) {
 	}
 }
 
+func TestSupportedVersionsChangedSinceRequiresRevisionForRecipeChange(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := supported
+	previous.Versions = copyVersions(supported.Versions)
+	previous.RecipeDigest = "sha256:" + strings.Repeat("a", 64)
+
+	if _, err := supported.ChangedSince(previous); err == nil || !strings.Contains(err.Error(), "recipe changed without advancing") {
+		t.Fatalf("ChangedSince() error = %v", err)
+	}
+}
+
+func TestSupportedVersionsChangedSinceAllowsRecipeRescopeWithoutRebuild(t *testing.T) {
+	supported, err := DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := supported
+	previous.Versions = copyVersions(supported.Versions)
+	previous.RecipeScope = ""
+	previous.RecipeDigest = "sha256:" + strings.Repeat("a", 64)
+
+	changed, err := supported.ChangedSince(previous)
+	if err != nil {
+		t.Fatalf("ChangedSince() error = %v", err)
+	}
+	if len(changed) != 0 {
+		t.Fatalf("changed = %#v, want no artifact rebuilds", changed)
+	}
+}
+
 func TestDecodeSupportedVersionsRejectsInvalidPolicy(t *testing.T) {
 	validVersion := `{
 		"payloadVersion": "v1.36.0",
@@ -108,6 +144,7 @@ func TestDecodeSupportedVersionsRejectsInvalidPolicy(t *testing.T) {
 		{name: "zero revision", versions: strings.Replace(validVersion, `"artifactRevision": 1`, `"artifactRevision": 0`, 1), want: "at least 1"},
 		{name: "package mismatch", versions: strings.Replace(validVersion, `"kubeadm": "0:1.36.0-1"`, `"kubeadm": "0:1.36.1-1"`, 1), want: "does not match its payload"},
 		{name: "bad digest", versions: validVersion, digest: "sha256:nope", want: "recipeDigest"},
+		{name: "bad scope", versions: validVersion, extra: `, "recipeScope": "Kubernetes Bundle"`, want: "recipeScope"},
 		{name: "unknown field", versions: validVersion, extra: `, "unknown": true`, want: "unknown field"},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- narrow the Kubernetes recipe fingerprint and workflow paths to bundle, metadata, ABI, and publication inputs
- exclude unrelated KatlOS runtime, agent, installer-policy, VM, documentation, and test changes
- record the one-time scoped-recipe transition without advancing existing artifact revisions

The root cause was a recipe and workflow boundary that covered all internal code and most runtime inputs. Comparing this manifest with current `main` now produces an empty build matrix, so landing the fix does not publish Kubernetes bundles.
