### PR TITLE
kubernetes: support control-plane replacement

### DIFF
--- a/cmd/katl-host-config-activate/main.go
+++ b/cmd/katl-host-config-activate/main.go
@@ -42,7 +42,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 			return err
 		}
 	}
-	value, err := configapply.ReadGenerationManifest(*root, selected)
+	value, _, err := configapply.ReadEffectiveGenerationManifest(*root, selected)
 	if err != nil {
 		return err
 	}

--- a/cmd/katlctl/etcd.go
+++ b/cmd/katlctl/etcd.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type etcdStatusClient interface {
+	GetEtcdStatus(context.Context, *agentapi.GetEtcdStatusRequest, ...grpc.CallOption) (*agentapi.EtcdStatus, error)
+}
+
+type etcdOptions struct {
+	configPath  string
+	coordinator string
+	output      string
+}
+
+type etcdRemoveOptions struct {
+	etcdOptions
+	targetNode string
+	memberID   string
+	timeout    time.Duration
+}
+
+type etcdRemovalPlan struct {
+	Coordinator inventory.PlannedNode
+	Target      inventory.PlannedNode
+	Status      *agentapi.EtcdStatus
+	Member      *agentapi.EtcdMember
+}
+
+func newEtcdCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{Use: "etcd", Short: "Inspect and maintain stacked etcd membership"}
+	statusOpts := etcdOptions{output: "text"}
+	members := &cobra.Command{
+		Use:   "members",
+		Short: "Show stacked etcd members and endpoint health",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return runEtcdMembers(ctx, statusOpts, stdout)
+		},
+	}
+	members.Flags().StringVar(&statusOpts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
+	members.Flags().StringVar(&statusOpts.coordinator, "coordinator", "", "healthy control-plane node used for inspection")
+	members.Flags().StringVarP(&statusOpts.output, "output", "o", "text", "output format: text or json")
+	cmd.AddCommand(members)
+
+	removeOpts := etcdRemoveOptions{etcdOptions: etcdOptions{output: "text"}, timeout: 5 * time.Minute}
+	remove := &cobra.Command{
+		Use:   "remove NODE",
+		Short: "Remove one explicitly identified stale etcd member",
+		Long:  "Remove one stale stacked-etcd member after validating cluster identity, node name, peer URL, current membership, and quorum safety on a surviving control plane.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			removeOpts.targetNode = args[0]
+			return runEtcdRemove(ctx, removeOpts, stdout, stderr)
+		},
+	}
+	remove.Flags().StringVar(&removeOpts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
+	remove.Flags().StringVar(&removeOpts.coordinator, "coordinator", "", "healthy surviving control-plane node")
+	remove.Flags().StringVar(&removeOpts.memberID, "member-id", "", "observed hexadecimal member ID to remove")
+	remove.Flags().DurationVar(&removeOpts.timeout, "timeout", removeOpts.timeout, "operation wait timeout")
+	remove.Flags().StringVarP(&removeOpts.output, "output", "o", "text", "output format: text or json")
+	cmd.AddCommand(remove)
+	_ = stderr
+	return cmd
+}
+
+func runEtcdMembers(ctx context.Context, opts etcdOptions, stdout io.Writer) error {
+	if opts.output != "text" && opts.output != "json" {
+		return fmt.Errorf("--output = %q, want text or json", opts.output)
+	}
+	inv, err := loadWipeInventory(opts.configPath, "")
+	if err != nil {
+		return err
+	}
+	coordinator, err := selectEtcdCoordinator(inv, opts.coordinator, "")
+	if err != nil {
+		return err
+	}
+	status, err := getEtcdStatus(ctx, coordinator)
+	if err != nil {
+		return err
+	}
+	return printEtcdStatus(stdout, coordinator.Name, status, opts.output)
+}
+
+func runEtcdRemove(ctx context.Context, opts etcdRemoveOptions, stdout, stderr io.Writer) error {
+	if strings.TrimSpace(opts.memberID) == "" {
+		return fmt.Errorf("--member-id is required; run 'katlctl cluster etcd members' and confirm the stale member identity")
+	}
+	if opts.timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive")
+	}
+	inv, err := loadWipeInventory(opts.configPath, "")
+	if err != nil {
+		return err
+	}
+	plan, err := planEtcdRemoval(ctx, inv, opts.targetNode, opts.coordinator, opts.memberID)
+	if err != nil {
+		return err
+	}
+	if err := submitEtcdRemoval(ctx, plan, opts.timeout, stderr, "katlctl cluster etcd remove"); err != nil {
+		return err
+	}
+	post, err := getEtcdStatus(ctx, plan.Coordinator)
+	if err != nil {
+		return err
+	}
+	return printEtcdStatus(stdout, plan.Coordinator.Name, post, opts.output)
+}
+
+func planEtcdRemoval(ctx context.Context, inv inventory.Inventory, targetName, coordinatorName, confirmedMemberID string) (etcdRemovalPlan, error) {
+	plan, err := planWipeInventory(inv)
+	if err != nil {
+		return etcdRemovalPlan{}, err
+	}
+	var target inventory.PlannedNode
+	for _, node := range plan.Nodes {
+		if node.Name == strings.TrimSpace(targetName) {
+			target = node
+			break
+		}
+	}
+	if target.Name == "" {
+		return etcdRemovalPlan{}, fmt.Errorf("node %q is not in the cluster config", targetName)
+	}
+	if target.SystemRole != inventory.RoleControlPlane {
+		return etcdRemovalPlan{}, fmt.Errorf("node %q is not a control-plane node", target.Name)
+	}
+	coordinator, err := selectEtcdCoordinator(inv, coordinatorName, target.Name)
+	if err != nil {
+		return etcdRemovalPlan{}, err
+	}
+	status, err := getEtcdStatus(ctx, coordinator)
+	if err != nil {
+		return etcdRemovalPlan{}, err
+	}
+	expectedPeer := etcdPeerURL(target.Address)
+	var member *agentapi.EtcdMember
+	for _, candidate := range status.GetMembers() {
+		if candidate.GetName() == target.Name && containsString(candidate.GetPeerUrls(), expectedPeer) {
+			member = candidate
+			break
+		}
+	}
+	if member == nil {
+		return etcdRemovalPlan{}, fmt.Errorf("etcd member for %s with peer URL %s is not present", target.Name, expectedPeer)
+	}
+	if strings.TrimSpace(confirmedMemberID) != "" && !strings.EqualFold(strings.TrimSpace(confirmedMemberID), member.GetId()) {
+		return etcdRemovalPlan{}, fmt.Errorf("--member-id %s does not match current member %s for %s", confirmedMemberID, member.GetId(), target.Name)
+	}
+	if member.GetId() == status.GetLocalMemberId() {
+		return etcdRemovalPlan{}, fmt.Errorf("coordinator %s cannot remove its own member; choose another healthy control plane", coordinator.Name)
+	}
+	if status.GetHealthyMembers() < status.GetQuorum() {
+		return etcdRemovalPlan{}, fmt.Errorf("etcd has %d healthy members, below quorum %d", status.GetHealthyMembers(), status.GetQuorum())
+	}
+	healthySurvivors := status.GetHealthyMembers()
+	if member.GetHealthy() {
+		healthySurvivors--
+	}
+	postQuorum := uint32((len(status.GetMembers())-1)/2 + 1)
+	if healthySurvivors < postQuorum {
+		return etcdRemovalPlan{}, fmt.Errorf("removal would leave %d healthy members, below resulting quorum %d", healthySurvivors, postQuorum)
+	}
+	return etcdRemovalPlan{Coordinator: coordinator, Target: target, Status: status, Member: member}, nil
+}
+
+func selectEtcdCoordinator(inv inventory.Inventory, requested, excluded string) (inventory.PlannedNode, error) {
+	plan, err := planWipeInventory(inv)
+	if err != nil {
+		return inventory.PlannedNode{}, err
+	}
+	var candidates []inventory.PlannedNode
+	for _, node := range plan.Nodes {
+		if node.SystemRole == inventory.RoleControlPlane && node.Name != excluded {
+			candidates = append(candidates, node)
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Name < candidates[j].Name })
+	if strings.TrimSpace(requested) != "" {
+		for _, node := range candidates {
+			if node.Name == strings.TrimSpace(requested) {
+				return node, nil
+			}
+		}
+		return inventory.PlannedNode{}, fmt.Errorf("coordinator %q is not a surviving control-plane node", requested)
+	}
+	if len(candidates) == 0 {
+		return inventory.PlannedNode{}, fmt.Errorf("no surviving control-plane node can coordinate etcd maintenance")
+	}
+	return candidates[0], nil
+}
+
+func getEtcdStatus(ctx context.Context, coordinator inventory.PlannedNode) (*agentapi.EtcdStatus, error) {
+	connector := newWipeClusterConnector()
+	conn, err := connector.Connect(ctx, coordinator)
+	if err != nil {
+		return nil, fmt.Errorf("connect etcd coordinator %s: %w", coordinator.Name, err)
+	}
+	defer closeAgentConnection(conn)
+	client, ok := conn.Client.(etcdStatusClient)
+	if !ok {
+		return nil, fmt.Errorf("node %s agent does not support etcd maintenance", coordinator.Name)
+	}
+	status, err := client.GetEtcdStatus(ctx, &agentapi.GetEtcdStatusRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("inspect etcd through %s: %w", coordinator.Name, err)
+	}
+	if status.GetClusterId() == "" || len(status.GetMembers()) == 0 {
+		return nil, fmt.Errorf("node %s returned incomplete etcd status", coordinator.Name)
+	}
+	return status, nil
+}
+
+func submitEtcdRemoval(ctx context.Context, plan etcdRemovalPlan, timeout time.Duration, progress io.Writer, actor string) error {
+	connector := newWipeClusterConnector()
+	conn, err := connector.Connect(ctx, plan.Coordinator)
+	if err != nil {
+		return fmt.Errorf("connect etcd coordinator %s: %w", plan.Coordinator.Name, err)
+	}
+	defer closeAgentConnection(conn)
+	nodeStatus, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return fmt.Errorf("status etcd coordinator %s: %w", plan.Coordinator.Name, err)
+	}
+	requestID, err := clientRequestID("")
+	if err != nil {
+		return err
+	}
+	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
+		ApiVersion:        operation.APIVersion,
+		Kind:              "SubmitOperationRequest",
+		ClientRequestId:   requestID,
+		OperationKind:     "etcd-member-remove",
+		Actor:             actor,
+		ExpectedMachineId: nodeStatus.GetMachineId(),
+		OperationTimeout:  timeout.String(),
+		EtcdMemberRemove: &agentapi.EtcdMemberRemoveOperationRequest{
+			TargetNodeName:      plan.Target.Name,
+			TargetMemberId:      plan.Member.GetId(),
+			TargetPeerUrl:       etcdPeerURL(plan.Target.Address),
+			ExpectedClusterId:   plan.Status.GetClusterId(),
+			ExpectedMemberCount: uint32(len(plan.Status.GetMembers())),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("submit etcd member removal on %s: %w", plan.Coordinator.Name, err)
+	}
+	if progress != nil {
+		fmt.Fprintf(progress, "etcd member removal node=%s member=%s coordinator=%s status=accepted\n", plan.Target.Name, plan.Member.GetId(), plan.Coordinator.Name)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	current := accepted.GetInitialStatus()
+	for {
+		if current == nil || !current.GetTerminal() {
+			current, err = conn.Client.GetOperation(waitCtx, &agentapi.GetOperationRequest{OperationId: accepted.GetOperationId(), ExpectedRequestDigest: accepted.GetRequestDigest()})
+			if err != nil {
+				return fmt.Errorf("wait for etcd member removal: %w", err)
+			}
+		}
+		if current.GetTerminal() {
+			if current.GetResult() != operation.ResultSucceeded {
+				return fmt.Errorf("etcd member removal stopped at %s: %s", current.GetPhase(), current.GetFailureReason())
+			}
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("wait for etcd member removal: %w", waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func etcdPeerURL(address string) string {
+	host := strings.TrimSpace(address)
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	return "https://" + net.JoinHostPort(host, "2380")
+}
+
+func printEtcdStatus(w io.Writer, coordinator string, status *agentapi.EtcdStatus, output string) error {
+	if output == "json" {
+		return json.NewEncoder(w).Encode(map[string]any{"coordinator": coordinator, "etcd": status})
+	}
+	fmt.Fprintf(w, "etcd cluster=%s coordinator=%s healthy=%d/%d quorum=%d\n", status.GetClusterId(), coordinator, status.GetHealthyMembers(), len(status.GetMembers()), status.GetQuorum())
+	table := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(table, "NODE\tMEMBER\tPEER\tHEALTH\tLEADER")
+	for _, member := range status.GetMembers() {
+		health := "unhealthy"
+		if member.GetHealthy() {
+			health = "healthy"
+		}
+		peer := ""
+		if len(member.GetPeerUrls()) > 0 {
+			peer = member.GetPeerUrls()[0]
+		}
+		fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%t\n", member.GetName(), member.GetId(), peer, health, member.GetLeader())
+	}
+	return table.Flush()
+}

--- a/cmd/katlctl/etcd_test.go
+++ b/cmd/katlctl/etcd_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/bootstrap/cluster"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+func TestWipeNodePlansSafeControlPlaneMembershipRemoval(t *testing.T) {
+	inventoryPath := writeThreeControlPlaneInventory(t)
+	cp3 := readyWipeClusterClient("machine-cp-3")
+	cp3.nodeStatus.Kubernetes = &agentapi.KubernetesStatus{State: "ready", Role: "control-plane"}
+	cp1 := readyWipeClusterClient("machine-cp-1")
+	cp1.etcdStatus = healthyThreeMemberEtcdStatus()
+	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{"cp-1": cp1, "cp-3": cp3})
+	oldConnector := newWipeClusterConnector
+	newWipeClusterConnector = func() cluster.AgentConnector { return connector }
+	t.Cleanup(func() { newWipeClusterConnector = oldConnector })
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"node", "wipe", "cp-3", "--inventory", inventoryPath, "--plan", "--output", "json",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report wipeNodeReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.EtcdCleanup != "planned" || report.EtcdCoordinator != "cp-1" || report.EtcdMemberID != "3" {
+		t.Fatalf("etcd plan = %+v", report)
+	}
+	if cp1.submitRequest != nil || cp3.submitRequest != nil {
+		t.Fatalf("plan submitted operations: cp1=%+v cp3=%+v", cp1.submitRequest, cp3.submitRequest)
+	}
+}
+
+func TestEtcdRemoveRequiresObservedMemberID(t *testing.T) {
+	err := runEtcdRemove(context.Background(), etcdRemoveOptions{
+		etcdOptions: etcdOptions{configPath: writeThreeControlPlaneInventory(t), output: "text"},
+		targetNode:  "cp-3",
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("runEtcdRemove() error = nil")
+	}
+}
+
+func healthyThreeMemberEtcdStatus() *agentapi.EtcdStatus {
+	return &agentapi.EtcdStatus{
+		ClusterId: "64", LocalMemberId: "1", LeaderId: "1", Quorum: 2, HealthyMembers: 3,
+		Members: []*agentapi.EtcdMember{
+			{Id: "1", Name: "cp-1", PeerUrls: []string{"https://10.0.0.11:2380"}, ClientUrls: []string{"https://10.0.0.11:2379"}, Healthy: true, Leader: true},
+			{Id: "2", Name: "cp-2", PeerUrls: []string{"https://10.0.0.12:2380"}, ClientUrls: []string{"https://10.0.0.12:2379"}, Healthy: true},
+			{Id: "3", Name: "cp-3", PeerUrls: []string{"https://10.0.0.13:2380"}, ClientUrls: []string{"https://10.0.0.13:2379"}, Healthy: true},
+		},
+	}
+}
+
+func writeThreeControlPlaneInventory(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cluster.yaml")
+	data := `controlPlaneEndpoint: api.katl.test:6443
+kubernetesVersion: v1.36.1
+nodes:
+- name: cp-1
+  address: 10.0.0.11
+  systemRole: control-plane
+  access: {method: agent}
+  kubeadmConfig: {ref: control-plane, path: /etc/katl/kubeadm/control-plane/config.yaml, intent: control-plane}
+  kubernetesVersion: v1.36.1
+- name: cp-2
+  address: 10.0.0.12
+  systemRole: control-plane
+  access: {method: agent}
+  kubeadmConfig: {ref: control-plane, path: /etc/katl/kubeadm/control-plane/config.yaml, intent: control-plane}
+  kubernetesVersion: v1.36.1
+- name: cp-3
+  address: 10.0.0.13
+  systemRole: control-plane
+  access: {method: agent}
+  kubeadmConfig: {ref: control-plane, path: /etc/katl/kubeadm/control-plane/config.yaml, intent: control-plane}
+  kubernetesVersion: v1.36.1
+`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -35,7 +35,7 @@ func newClusterApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	f := cmd.Flags()
 	f.StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	f.StringVar(&opts.inventoryPath, "inventory", "", "advanced cluster inventory")
-	f.StringVar(&opts.coordinator, "coordinator", "", "coordinator control-plane node changed last")
+	f.StringVar(&opts.coordinator, "coordinator", "", "control-plane coordinator used for joins and changed last")
 	f.StringVar(&opts.generationID, "generation", "", "active desired generation ID")
 	f.StringVar(&opts.configName, "config-name", "", "selected KubeadmConfig name")
 	f.StringVar(&opts.rolloutID, "rollout-id", "", "rollout identity")
@@ -511,6 +511,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 				strings.Join(kubernetesStates, ", "),
 			)
 		}
+		requestedCoordinator := strings.TrimSpace(opts.coordinator)
 		for _, input := range prepared {
 			if input.kubernetesState == "not-configured" {
 				continue
@@ -519,7 +520,18 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 				if strings.TrimSpace(joinCoordinator) == "" {
 					joinCoordinator = input.node.Name
 				}
+				if input.node.Name == requestedCoordinator {
+					joinCoordinator = input.node.Name
+					break
+				}
 			}
+		}
+		if requestedCoordinator != "" && joinCoordinator != requestedCoordinator {
+			return activatedClusterConfig{}, fmt.Errorf(
+				"coordinator %q cannot coordinate the replacement join: it must be an existing ready control-plane node (%s)",
+				requestedCoordinator,
+				strings.Join(kubernetesStates, ", "),
+			)
 		}
 		if joinCoordinator == "" {
 			return activatedClusterConfig{}, fmt.Errorf(

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -64,8 +64,8 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 	}
 	preBootstrap := false
 	var stagedNodes []string
+	activated := activatedClusterConfig{}
 	if strings.TrimSpace(opts.configPath) != "" {
-		var activated activatedClusterConfig
 		activated, err = activateClusterConfig(ctx, opts, inv.Nodes)
 		if err != nil {
 			return err
@@ -79,6 +79,35 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 	}
 
 	results := map[string]any{}
+	var joined []string
+	for _, node := range activated.joinNodes {
+		if err := clusterApplyProgress(opts.progress, "phase=node-join node=%s coordinator=%s status=started", node, activated.joinCoordinator); err != nil {
+			return err
+		}
+		deps := agentBootstrapDependencies()
+		deps.Actor = "katlctl cluster apply"
+		deps.Progress = func(progress cluster.AgentBootstrapProgress) {
+			if progress.Node != node || strings.TrimSpace(progress.Phase) == "" {
+				return
+			}
+			_ = clusterApplyProgress(opts.progress, "phase=node-join node=%s step=%s status=running", node, progress.Phase)
+		}
+		if _, err := runAgentNodeJoin(ctx, cluster.Request{
+			Inventory: inv,
+			InitNode:  activated.joinCoordinator,
+		}, node, deps); err != nil {
+			return fmt.Errorf("join replacement node %s: %w", node, err)
+		}
+		joinedGeneration, err := currentClusterApplyGeneration(ctx, inv.Nodes, node)
+		if err != nil {
+			return fmt.Errorf("refresh replacement node %s after join: %w", node, err)
+		}
+		generations[node] = joinedGeneration
+		joined = append(joined, node)
+		if err := clusterApplyProgress(opts.progress, "phase=node-join node=%s status=succeeded", node); err != nil {
+			return err
+		}
+	}
 	for _, component := range []string{"control-plane", "kubelet", "kube-proxy"} {
 		if !components[component] {
 			continue
@@ -122,6 +151,7 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 	}
 	report := map[string]any{
 		"nodes":      len(inv.Nodes),
+		"joined":     joined,
 		"kubernetes": results,
 		"result":     "succeeded",
 	}
@@ -130,6 +160,33 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 		report["stagedNodes"] = stagedNodes
 	}
 	return json.NewEncoder(stdout).Encode(report)
+}
+
+func currentClusterApplyGeneration(ctx context.Context, nodes []inventory.Node, nodeName string) (string, error) {
+	var selected inventory.Node
+	for _, node := range nodes {
+		if node.Name == nodeName {
+			selected = node
+			break
+		}
+	}
+	if selected.Name == "" {
+		return "", fmt.Errorf("node is not present in cluster inventory")
+	}
+	conn, err := dialKatlcAgent(ctx, cluster.AgentEndpoint(selected.Address, "9443"))
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return "", err
+	}
+	generationID := strings.TrimSpace(status.GetCurrentGenerationId())
+	if generationID == "" {
+		return "", fmt.Errorf("agent did not report a current generation")
+	}
+	return generationID, nil
 }
 
 func runKubeadmControlPlaneConfig(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout io.Writer) error {
@@ -320,10 +377,12 @@ func kubeadmConfigInventory(opts kubeadmControlPlaneConfigOptions) (inventory.In
 }
 
 type activatedClusterConfig struct {
-	generations  map[string]string
-	components   map[string]bool
-	preBootstrap bool
-	stagedNodes  []string
+	generations     map[string]string
+	components      map[string]bool
+	preBootstrap    bool
+	stagedNodes     []string
+	joinNodes       []string
+	joinCoordinator string
 }
 
 func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOptions, nodes []inventory.Node) (activatedClusterConfig, error) {
@@ -444,11 +503,30 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		kubernetesStates = append(kubernetesStates, input.node.Name+"="+firstNonEmpty(input.kubernetesState, "unknown"))
 	}
 	preBootstrap := len(prepared) > 0 && notConfigured == len(prepared)
+	joinCoordinator := ""
 	if notConfigured > 0 && !preBootstrap {
-		return activatedClusterConfig{}, fmt.Errorf(
-			"cluster has mixed Kubernetes lifecycle state (%s); recover or wipe the inconsistent nodes before applying cluster config",
-			strings.Join(kubernetesStates, ", "),
-		)
+		if notConfigured != 1 {
+			return activatedClusterConfig{}, fmt.Errorf(
+				"cluster apply can join one fresh replacement node at a time; found mixed Kubernetes lifecycle state (%s)",
+				strings.Join(kubernetesStates, ", "),
+			)
+		}
+		for _, input := range prepared {
+			if input.kubernetesState == "not-configured" {
+				continue
+			}
+			if input.node.SystemRole == inventory.RoleControlPlane && input.kubernetesState == "ready" {
+				if strings.TrimSpace(joinCoordinator) == "" {
+					joinCoordinator = input.node.Name
+				}
+			}
+		}
+		if joinCoordinator == "" {
+			return activatedClusterConfig{}, fmt.Errorf(
+				"cluster has one fresh node but no ready control plane can coordinate its join (%s)",
+				strings.Join(kubernetesStates, ", "),
+			)
+		}
 	}
 
 	for _, input := range prepared {
@@ -509,7 +587,22 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		}
 	}
 	sort.Strings(stagedNodes)
-	return activatedClusterConfig{generations: result, components: components, preBootstrap: preBootstrap, stagedNodes: stagedNodes}, nil
+	var joinNodes []string
+	if notConfigured == 1 && !preBootstrap {
+		for _, input := range prepared {
+			if input.kubernetesState == "not-configured" {
+				joinNodes = append(joinNodes, input.node.Name)
+			}
+		}
+	}
+	return activatedClusterConfig{
+		generations:     result,
+		components:      components,
+		preBootstrap:    preBootstrap,
+		stagedNodes:     stagedNodes,
+		joinNodes:       joinNodes,
+		joinCoordinator: joinCoordinator,
+	}, nil
 }
 
 func containsKubernetesConfigDomain(domains []string) bool {

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -256,7 +256,6 @@ func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConf
 		conn           katlcAgentConnection
 		machine        string
 		payloadVersion string
-		payloadSHA256  string
 		generation     string
 	}
 	targets := make([]target, 0, len(nodes))
@@ -294,21 +293,19 @@ func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConf
 		}
 		node.KubeadmConfig.Ref = configName
 		payloadVersion := ""
-		payloadSHA256 := ""
 		for _, ref := range gen.Sysexts {
 			if ref.Name == "kubernetes" && ref.PayloadVersion != "" && ref.Sha256 != "" {
 				payloadVersion = ref.PayloadVersion
-				payloadSHA256 = ref.Sha256
 				break
 			}
 		}
 		if payloadVersion == "" {
 			return nil, fmt.Errorf("node %s generation %s has no active Kubernetes payload", node.Name, generationID)
 		}
-		if len(targets) > 0 && (payloadVersion != targets[0].payloadVersion || payloadSHA256 != targets[0].payloadSHA256) {
-			return nil, fmt.Errorf("node %s active Kubernetes payload does not match %s", node.Name, targets[0].node.Name)
+		if len(targets) > 0 && payloadVersion != targets[0].payloadVersion {
+			return nil, fmt.Errorf("node %s active Kubernetes payload version does not match %s", node.Name, targets[0].node.Name)
 		}
-		targets = append(targets, target{node: node, conn: conn, machine: status.MachineId, payloadVersion: payloadVersion, payloadSHA256: payloadSHA256, generation: generationID})
+		targets = append(targets, target{node: node, conn: conn, machine: status.MachineId, payloadVersion: payloadVersion, generation: generationID})
 	}
 	var summary []map[string]string
 	for i, t := range targets {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
@@ -209,7 +210,7 @@ func TestRunClusterApplySkipsKubernetesComponentsBeforeBootstrap(t *testing.T) {
 	}
 }
 
-func TestActivateClusterConfigRejectsMixedKubernetesStateBeforeMutation(t *testing.T) {
+func TestActivateClusterConfigPlansOneFreshReplacementNode(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")
 	source := configBundleSource() + `    - name: cp-2
@@ -229,7 +230,7 @@ func TestActivateClusterConfigRejectsMixedKubernetesStateBeforeMutation(t *testi
 			CurrentGenerationId: "generation-0",
 			Kubernetes:          &agentapi.KubernetesStatus{State: "not-configured"},
 		},
-		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
 	}
 	second := &fakeKatlcAgentClient{
 		nodeStatus: &agentapi.NodeStatus{
@@ -237,7 +238,7 @@ func TestActivateClusterConfigRejectsMixedKubernetesStateBeforeMutation(t *testi
 			CurrentGenerationId: "generation-1",
 			Kubernetes:          &agentapi.KubernetesStatus{State: "ready"},
 		},
-		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
 	}
 	previousDial := dialKatlcAgent
 	defer func() { dialKatlcAgent = previousDial }()
@@ -246,15 +247,96 @@ func TestActivateClusterConfigRejectsMixedKubernetesStateBeforeMutation(t *testi
 		return katlcAgentConnection{Client: clients[endpoint], Close: func() error { return nil }}, nil
 	}
 
-	_, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, []inventory.Node{
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, []inventory.Node{
 		{Name: "cp-1", Address: "10.0.0.11", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
 		{Name: "cp-2", Address: "10.0.0.12", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "mixed Kubernetes lifecycle state (cp-1=not-configured, cp-2=ready)") {
-		t.Fatalf("activateClusterConfig() error = %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(activated.joinNodes, []string{"cp-1"}) || activated.joinCoordinator != "cp-2" {
+		t.Fatalf("replacement plan = nodes %#v coordinator %q", activated.joinNodes, activated.joinCoordinator)
 	}
 	if len(first.submitRequests) != 0 || len(second.submitRequests) != 0 {
-		t.Fatalf("mutation started with mixed Kubernetes state: first=%#v second=%#v", first.submitRequests, second.submitRequests)
+		t.Fatalf("no-op config unexpectedly mutated nodes: first=%#v second=%#v", first.submitRequests, second.submitRequests)
+	}
+}
+
+func TestRunClusterApplyRefreshesReplacementGenerationAfterJoin(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "cluster.yaml")
+	source := configBundleSource() + `    - name: cp-2
+      controlPlane: true
+      bootstrap:
+        address: 10.0.0.12
+      install:
+        targetDisk:
+          byID: /dev/disk/by-id/ata-cp-2-root
+`
+	if err := os.WriteFile(configPath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	generation := func(id string) *agentapi.Generation {
+		return &agentapi.Generation{
+			GenerationId: id,
+			CommitState:  "committed",
+			HealthState:  "healthy",
+			ConfigApply:  &agentapi.ConfigApplyStatus{SelectedKubeadmConfigName: "control-plane"},
+			Sysexts:      []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: strings.Repeat("c", 64)}},
+		}
+	}
+	cp1 := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-cp-1", Kubernetes: &agentapi.KubernetesStatus{State: "ready"}},
+		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+		generation:      generation("generation-cp-1"),
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "operation-cp-1", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded},
+	}
+	cp2StatusCalls := 0
+	cp2 := &fakeKatlcAgentClient{
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-2", CurrentGenerationId: "generation-0", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
+		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+		generation:      generation("generation-joined"),
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "operation-cp-2", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded},
+	}
+	cp2.onGetNodeStatus = func() {
+		cp2StatusCalls++
+		if cp2StatusCalls == 2 {
+			cp2.nodeStatus.CurrentGenerationId = "generation-joined"
+			cp2.nodeStatus.Kubernetes.State = "ready"
+		}
+	}
+	clients := map[string]*fakeKatlcAgentClient{"10.0.0.11:9443": cp1, "10.0.0.12:9443": cp2}
+	previousDial := dialKatlcAgent
+	previousJoin := runAgentNodeJoin
+	defer func() {
+		dialKatlcAgent = previousDial
+		runAgentNodeJoin = previousJoin
+	}()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		client := clients[endpoint]
+		if client == nil {
+			return katlcAgentConnection{}, os.ErrNotExist
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	runAgentNodeJoin = func(_ context.Context, _ cluster.Request, nodeName string, _ cluster.AgentBootstrapDependencies) (cluster.Result, error) {
+		if nodeName != "cp-2" {
+			t.Fatalf("join node = %q, want cp-2", nodeName)
+		}
+		return cluster.Result{}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), `"joined":["cp-2"]`) {
+		t.Fatalf("stdout = %s, missing replacement join", stdout.String())
+	}
+	if cp2.generationRequest == nil || cp2.generationRequest.GenerationId != "generation-joined" {
+		t.Fatalf("replacement generation request = %#v, want generation-joined", cp2.generationRequest)
 	}
 }
 

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -38,8 +38,9 @@ func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) 
 		t.Fatal(err)
 	}
 	clients := map[string]*fakeKatlcAgentClient{}
-	for _, name := range []string{"cp-1", "cp-2", "cp-3"} {
-		clients[name] = &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine-" + name}, generation: &agentapi.Generation{GenerationId: "gen-2", CommitState: "committed", HealthState: "healthy", ConfigApply: &agentapi.ConfigApplyStatus{KubeadmActionRequired: true, SelectedKubeadmConfigName: "control-plane"}, Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: strings.Repeat("c", 64)}}}, submitAccepted: &agentapi.OperationAccepted{OperationId: "op-" + name, RequestDigest: strings.Repeat("f", 64)}, operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded}}
+	for index, name := range []string{"cp-1", "cp-2", "cp-3"} {
+		payloadDigest := strings.Repeat(string(rune('a'+index)), 64)
+		clients[name] = &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine-" + name}, generation: &agentapi.Generation{GenerationId: "gen-2", CommitState: "committed", HealthState: "healthy", ConfigApply: &agentapi.ConfigApplyStatus{KubeadmActionRequired: true, SelectedKubeadmConfigName: "control-plane"}, Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: payloadDigest}}}, submitAccepted: &agentapi.OperationAccepted{OperationId: "op-" + name, RequestDigest: strings.Repeat("f", 64)}, operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded}}
 	}
 	byEndpoint := map[string]*fakeKatlcAgentClient{"192.0.2.1:9443": clients["cp-1"], "192.0.2.2:9443": clients["cp-2"], "192.0.2.3:9443": clients["cp-3"]}
 	previous := dialKatlcAgent

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -220,6 +220,13 @@ func TestActivateClusterConfigPlansOneFreshReplacementNode(t *testing.T) {
       install:
         targetDisk:
           byID: /dev/disk/by-id/ata-cp-2-root
+    - name: cp-3
+      controlPlane: true
+      bootstrap:
+        address: 10.0.0.13
+      install:
+        targetDisk:
+          byID: /dev/disk/by-id/ata-cp-3-root
 `
 	if err := os.WriteFile(configPath, []byte(source), 0o600); err != nil {
 		t.Fatal(err)
@@ -240,25 +247,34 @@ func TestActivateClusterConfigPlansOneFreshReplacementNode(t *testing.T) {
 		},
 		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
 	}
+	third := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-3",
+			CurrentGenerationId: "generation-1",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "ready"},
+		},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+	}
 	previousDial := dialKatlcAgent
 	defer func() { dialKatlcAgent = previousDial }()
 	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
-		clients := map[string]*fakeKatlcAgentClient{"10.0.0.11:9443": first, "10.0.0.12:9443": second}
+		clients := map[string]*fakeKatlcAgentClient{"10.0.0.11:9443": first, "10.0.0.12:9443": second, "10.0.0.13:9443": third}
 		return katlcAgentConnection{Client: clients[endpoint], Close: func() error { return nil }}, nil
 	}
 
-	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, []inventory.Node{
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1", coordinator: "cp-3"}, []inventory.Node{
 		{Name: "cp-1", Address: "10.0.0.11", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
 		{Name: "cp-2", Address: "10.0.0.12", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
+		{Name: "cp-3", Address: "10.0.0.13", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(activated.joinNodes, []string{"cp-1"}) || activated.joinCoordinator != "cp-2" {
+	if !reflect.DeepEqual(activated.joinNodes, []string{"cp-1"}) || activated.joinCoordinator != "cp-3" {
 		t.Fatalf("replacement plan = nodes %#v coordinator %q", activated.joinNodes, activated.joinCoordinator)
 	}
-	if len(first.submitRequests) != 0 || len(second.submitRequests) != 0 {
-		t.Fatalf("no-op config unexpectedly mutated nodes: first=%#v second=%#v", first.submitRequests, second.submitRequests)
+	if len(first.submitRequests) != 0 || len(second.submitRequests) != 0 || len(third.submitRequests) != 0 {
+		t.Fatalf("no-op config unexpectedly mutated nodes: first=%#v second=%#v third=%#v", first.submitRequests, second.submitRequests, third.submitRequests)
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -51,6 +51,7 @@ var (
 var runBootstrap = cluster.Run
 var runAgentBootstrap = cluster.RunAgentBootstrap
 var runAgentWorkerJoin = cluster.RunAgentWorkerJoin
+var runAgentNodeJoin = cluster.RunAgentNodeJoin
 var dialVMTestAgent = vmtest.DialAgent
 var dialKatlcAgent = dialKatlcAgentTCP
 var operatorKubectlRunner cluster.KubectlCommandRunner = execWipeNodeKubectlRunner{}
@@ -112,6 +113,7 @@ Start with "katlctl install discover" for a waiting installer or
 	clusterCmd.AddCommand(newClusterStatusCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newClusterBootstrapCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newClusterApplyCommand(ctx, stdout, stderr))
+	clusterCmd.AddCommand(newEtcdCommand(ctx, stdout, stderr))
 	clusterCmd.AddCommand(newWipeClusterCommand(ctx, stdout, stderr, "katlctl cluster wipe"))
 	cmd.AddCommand(clusterCmd)
 
@@ -192,44 +194,47 @@ func rejectUnknownSubcommand(command *cobra.Command, args []string) error {
 
 func setMinimumInvocationExamples(root *cobra.Command) {
 	examples := map[string]string{
-		"katlctl":                     "katlctl install discover",
-		"katlctl version":             "katlctl version",
-		"katlctl cluster":             "katlctl cluster bootstrap --config cluster.yaml",
-		"katlctl cluster status":      "katlctl cluster status --config cluster.yaml",
-		"katlctl cluster apply":       "katlctl cluster apply --config cluster.yaml",
-		"katlctl context save":        "katlctl context save --config cluster.yaml",
-		"katlctl cluster bootstrap":   "katlctl cluster bootstrap --config cluster.yaml",
-		"katlctl cluster wipe":        "katlctl cluster wipe --config cluster.yaml --all",
-		"katlctl kubernetes":          "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
-		"katlctl kubernetes upgrade":  "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
-		"katlctl config":              "katlctl config validate cluster.yaml",
-		"katlctl config init":         "katlctl config init cluster.yaml --node cp-1=control-plane,192.0.2.10,/dev/disk/by-id/ata-root",
-		"katlctl config validate":     "katlctl config validate cluster.yaml",
-		"katlctl config schema":       "katlctl config schema",
-		"katlctl config bundle":       "katlctl config bundle cluster.yaml --output cluster.katlcfg",
-		"katlctl config render-node":  "katlctl config render-node --config cluster.yaml --node cp-1 --desired-version 1",
-		"katlctl context":             "katlctl context show",
-		"katlctl context path":        "katlctl context path",
-		"katlctl context list":        "katlctl context list",
-		"katlctl context current":     "katlctl context current",
-		"katlctl context use":         "katlctl context use homelab",
-		"katlctl context show":        "katlctl context show",
-		"katlctl install":             "katlctl install discover",
-		"katlctl install discover":    "katlctl install discover",
-		"katlctl install apply":       "katlctl install apply --config cluster.yaml",
-		"katlctl install status":      "katlctl install status",
-		"katlctl operations":          "katlctl operations list --config cluster.yaml --node cp-1",
-		"katlctl operations status":   "katlctl operations status OPERATION_ID --config cluster.yaml --node cp-1",
-		"katlctl operations list":     "katlctl operations list --config cluster.yaml --node cp-1",
-		"katlctl node":                "katlctl node status cp-1 --config cluster.yaml",
-		"katlctl node status":         "katlctl node status cp-1 --config cluster.yaml",
-		"katlctl node reboot":         "katlctl node reboot cp-1 --config cluster.yaml",
-		"katlctl node shutdown":       "katlctl node shutdown cp-1 --config cluster.yaml",
-		"katlctl node upgrade":        "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml",
-		"katlctl node apply":          "katlctl node apply cp-1 --config cluster.yaml",
-		"katlctl node apply validate": "katlctl node apply validate --config cluster.yaml --node cp-1",
-		"katlctl node apply status":   "katlctl node apply status --node cp-1",
-		"katlctl node wipe":           "katlctl node wipe worker-1 --config cluster.yaml --kubeconfig kubeconfig",
+		"katlctl":                      "katlctl install discover",
+		"katlctl version":              "katlctl version",
+		"katlctl cluster":              "katlctl cluster bootstrap --config cluster.yaml",
+		"katlctl cluster status":       "katlctl cluster status --config cluster.yaml",
+		"katlctl cluster apply":        "katlctl cluster apply --config cluster.yaml",
+		"katlctl cluster etcd":         "katlctl cluster etcd members --config cluster.yaml",
+		"katlctl cluster etcd members": "katlctl cluster etcd members --config cluster.yaml",
+		"katlctl cluster etcd remove":  "katlctl cluster etcd remove cp-3 --member-id MEMBER_ID --config cluster.yaml",
+		"katlctl context save":         "katlctl context save --config cluster.yaml",
+		"katlctl cluster bootstrap":    "katlctl cluster bootstrap --config cluster.yaml",
+		"katlctl cluster wipe":         "katlctl cluster wipe --config cluster.yaml --all",
+		"katlctl kubernetes":           "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
+		"katlctl kubernetes upgrade":   "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
+		"katlctl config":               "katlctl config validate cluster.yaml",
+		"katlctl config init":          "katlctl config init cluster.yaml --node cp-1=control-plane,192.0.2.10,/dev/disk/by-id/ata-root",
+		"katlctl config validate":      "katlctl config validate cluster.yaml",
+		"katlctl config schema":        "katlctl config schema",
+		"katlctl config bundle":        "katlctl config bundle cluster.yaml --output cluster.katlcfg",
+		"katlctl config render-node":   "katlctl config render-node --config cluster.yaml --node cp-1 --desired-version 1",
+		"katlctl context":              "katlctl context show",
+		"katlctl context path":         "katlctl context path",
+		"katlctl context list":         "katlctl context list",
+		"katlctl context current":      "katlctl context current",
+		"katlctl context use":          "katlctl context use homelab",
+		"katlctl context show":         "katlctl context show",
+		"katlctl install":              "katlctl install discover",
+		"katlctl install discover":     "katlctl install discover",
+		"katlctl install apply":        "katlctl install apply --config cluster.yaml",
+		"katlctl install status":       "katlctl install status",
+		"katlctl operations":           "katlctl operations list --config cluster.yaml --node cp-1",
+		"katlctl operations status":    "katlctl operations status OPERATION_ID --config cluster.yaml --node cp-1",
+		"katlctl operations list":      "katlctl operations list --config cluster.yaml --node cp-1",
+		"katlctl node":                 "katlctl node status cp-1 --config cluster.yaml",
+		"katlctl node status":          "katlctl node status cp-1 --config cluster.yaml",
+		"katlctl node reboot":          "katlctl node reboot cp-1 --config cluster.yaml",
+		"katlctl node shutdown":        "katlctl node shutdown cp-1 --config cluster.yaml",
+		"katlctl node upgrade":         "katlctl node upgrade 2026.7.0 cp-1 --config cluster.yaml",
+		"katlctl node apply":           "katlctl node apply cp-1 --config cluster.yaml",
+		"katlctl node apply validate":  "katlctl node apply validate --config cluster.yaml --node cp-1",
+		"katlctl node apply status":    "katlctl node apply status --node cp-1",
+		"katlctl node wipe":            "katlctl node wipe worker-1 --config cluster.yaml --kubeconfig kubeconfig",
 	}
 	var visit func(*cobra.Command)
 	visit = func(command *cobra.Command) {
@@ -911,14 +916,25 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return err
 	}
 	notConfigured := strings.TrimSpace(statuses[target.Name].GetKubernetes().GetState()) == "not-configured"
+	var etcdPlan etcdRemovalPlan
 	if target.SystemRole == inventory.RoleControlPlane && !notConfigured {
-		report.KubernetesCleanup = "refused"
-		report.Nodes = append(report.Nodes, wipeClusterNodeResult{Node: target.Name, Result: "refused"})
-		report.Refusals = append(report.Refusals, "single enrolled control-plane wipe requires etcd membership coordination before node-local reset")
-		if printErr := printWipeNodeReport(stdout, report); printErr != nil {
-			return printErr
+		fullInventory, inventoryErr := wipeNodeInventory(opts)
+		if inventoryErr != nil {
+			return inventoryErr
 		}
-		return fmt.Errorf("single enrolled control-plane wipe requires etcd membership coordination")
+		etcdPlan, err = planEtcdRemoval(ctx, fullInventory, target.Name, "", "")
+		if err != nil {
+			report.EtcdCleanup = "refused"
+			report.Nodes = append(report.Nodes, wipeClusterNodeResult{Node: target.Name, Result: "refused"})
+			report.Refusals = append(report.Refusals, inventory.Redact(err.Error()))
+			if printErr := printWipeNodeReport(stdout, report); printErr != nil {
+				return printErr
+			}
+			return fmt.Errorf("control-plane etcd cleanup preflight: %w", err)
+		}
+		report.EtcdCleanup = "planned"
+		report.EtcdCoordinator = etcdPlan.Coordinator.Name
+		report.EtcdMemberID = etcdPlan.Member.GetId()
 	}
 	if opts.planOnly {
 		if notConfigured {
@@ -941,7 +957,28 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 			}
 			return fmt.Errorf("--kubeconfig is required for an enrolled node")
 		}
-		cleanup := cleanupWipeNodeKubernetes(ctx, strings.TrimSpace(opts.kubeconfigPath), target, strings.TrimSpace(opts.timeout))
+		cleanup := wipeNodeCleanupResult{Status: "succeeded"}
+		if target.SystemRole == inventory.RoleControlPlane {
+			cleanup = prepareWipeNodeKubernetes(ctx, strings.TrimSpace(opts.kubeconfigPath), target, strings.TrimSpace(opts.timeout))
+			if err := submitEtcdRemoval(ctx, etcdPlan, waitTimeout, stderr, "katlctl node wipe"); err != nil {
+				report.EtcdCleanup = "recovery-required"
+				report.KubernetesCleanup = cleanup.Status
+				report.KubernetesDiagnostics = cleanup.Diagnostics
+				report.Refusals = append(report.Refusals, inventory.Redact(err.Error()))
+				if printErr := printWipeNodeReport(stdout, report); printErr != nil {
+					return printErr
+				}
+				return fmt.Errorf("control-plane etcd cleanup failed before node-local wipe: %w", err)
+			}
+			report.EtcdCleanup = "succeeded"
+			deleted := deleteWipeNodeKubernetes(ctx, strings.TrimSpace(opts.kubeconfigPath), target)
+			cleanup.Diagnostics = append(cleanup.Diagnostics, deleted.Diagnostics...)
+			if deleted.Status == "recovery-required" {
+				cleanup.Status = deleted.Status
+			}
+		} else {
+			cleanup = cleanupWipeNodeKubernetes(ctx, strings.TrimSpace(opts.kubeconfigPath), target, strings.TrimSpace(opts.timeout))
+		}
 		report.KubernetesCleanup = cleanup.Status
 		report.KubernetesDiagnostics = cleanup.Diagnostics
 		if cleanup.Status == "recovery-required" {
@@ -960,6 +997,34 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		return printErr
 	}
 	return submitErr
+}
+
+func wipeNodeInventory(opts wipeNodeOptions) (inventory.Inventory, error) {
+	if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.inventoryPath) != "" {
+		inv, err := loadWipeInventory(opts.configPath, opts.inventoryPath)
+		if err != nil {
+			return inventory.Inventory{}, err
+		}
+		return overlayWipeContext(inv, opts.workstationConfig, opts.contextName)
+	}
+	topology, err := workstation.ResolveTopology(workstation.ResolveRequest{
+		ConfigPath:  strings.TrimSpace(opts.workstationConfig),
+		ContextName: strings.TrimSpace(opts.contextName),
+	})
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("resolve cluster from workstation context: %w", err)
+	}
+	inv := inventory.Inventory{}
+	for _, node := range topology.Nodes {
+		host, _, err := net.SplitHostPort(node.ManagementEndpoint)
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("node %q management endpoint: %w", node.Name, err)
+		}
+		inv.Nodes = append(inv.Nodes, inventory.Node{
+			Name: node.Name, Address: host, SystemRole: node.SystemRole, Access: inventory.Access{Method: "agent"},
+		})
+	}
+	return inv, nil
 }
 
 func resolveWipeNodeTarget(opts wipeNodeOptions) (inventory.PlannedNode, bool, error) {
@@ -1076,6 +1141,9 @@ type wipeClusterReport struct {
 type wipeNodeReport struct {
 	wipeClusterReport
 	KubernetesDiagnostics []string `json:"kubernetesDiagnostics,omitempty"`
+	EtcdCleanup           string   `json:"etcdCleanup,omitempty"`
+	EtcdCoordinator       string   `json:"etcdCoordinator,omitempty"`
+	EtcdMemberID          string   `json:"etcdMemberID,omitempty"`
 }
 
 type wipeClusterTarget struct {
@@ -1406,7 +1474,13 @@ func printWipeClusterReport(stdout io.Writer, report wipeClusterReport) error {
 
 func printWipeNodeReport(stdout io.Writer, report wipeNodeReport) error {
 	if report.Output == "text" {
-		return printWipeText(stdout, report.wipeClusterReport)
+		if err := printWipeText(stdout, report.wipeClusterReport); err != nil {
+			return err
+		}
+		if strings.TrimSpace(report.EtcdCleanup) != "" {
+			fmt.Fprintf(stdout, "etcd cleanup=%s coordinator=%s member=%s\n", report.EtcdCleanup, report.EtcdCoordinator, report.EtcdMemberID)
+		}
+		return nil
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
@@ -1510,6 +1584,42 @@ func cleanupWipeNodeKubernetes(ctx context.Context, kubeconfigPath string, node 
 	}
 	if len(result.Diagnostics) > 0 {
 		result.Status = "best-effort"
+	}
+	return result
+}
+
+func prepareWipeNodeKubernetes(ctx context.Context, kubeconfigPath string, node inventory.PlannedNode, timeout string) wipeNodeCleanupResult {
+	result := wipeNodeCleanupResult{Status: "succeeded"}
+	run := func(name string, args ...string) {
+		argv := append([]string{"kubectl", "--kubeconfig", kubeconfigPath}, args...)
+		output, err := operatorKubectlRunner.Run(ctx, argv)
+		if err != nil {
+			result.Diagnostics = append(result.Diagnostics, inventory.Redact(fmt.Sprintf("%s failed: %v", name, err)))
+		} else if output.ExitStatus != 0 {
+			result.Diagnostics = append(result.Diagnostics, inventory.Redact(fmt.Sprintf("%s failed: %s", name, strings.TrimSpace(output.Stderr))))
+		}
+	}
+	run("cordon node", "cordon", node.Name)
+	if strings.TrimSpace(timeout) == "" {
+		timeout = "10m"
+	}
+	run("drain node", "drain", node.Name, "--ignore-daemonsets", "--delete-emptydir-data", "--force", "--timeout="+timeout)
+	if len(result.Diagnostics) > 0 {
+		result.Status = "best-effort"
+	}
+	return result
+}
+
+func deleteWipeNodeKubernetes(ctx context.Context, kubeconfigPath string, node inventory.PlannedNode) wipeNodeCleanupResult {
+	result := wipeNodeCleanupResult{Status: "succeeded"}
+	argv := []string{"kubectl", "--kubeconfig", kubeconfigPath, "delete", "node", node.Name, "--ignore-not-found=true"}
+	output, err := operatorKubectlRunner.Run(ctx, argv)
+	if err != nil {
+		result.Status = "recovery-required"
+		result.Diagnostics = append(result.Diagnostics, inventory.Redact(fmt.Sprintf("delete node failed: %v", err)))
+	} else if output.ExitStatus != 0 {
+		result.Status = "recovery-required"
+		result.Diagnostics = append(result.Diagnostics, inventory.Redact(fmt.Sprintf("delete node failed: %s", strings.TrimSpace(output.Stderr))))
 	}
 	return result
 }

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -220,23 +220,25 @@ func TestPublicHelpHidesInternalOperationAndTestInputs(t *testing.T) {
 
 func TestConfigInputFlagsUseOneName(t *testing.T) {
 	want := map[string]bool{
-		"katlctl cluster apply":       true,
-		"katlctl cluster status":      true,
-		"katlctl context save":        true,
-		"katlctl cluster bootstrap":   true,
-		"katlctl cluster wipe":        true,
-		"katlctl config render-node":  true,
-		"katlctl install apply":       true,
-		"katlctl kubernetes upgrade":  true,
-		"katlctl operations list":     true,
-		"katlctl operations status":   true,
-		"katlctl node apply":          true,
-		"katlctl node apply validate": true,
-		"katlctl node reboot":         true,
-		"katlctl node shutdown":       true,
-		"katlctl node status":         true,
-		"katlctl node upgrade":        true,
-		"katlctl node wipe":           true,
+		"katlctl cluster apply":        true,
+		"katlctl cluster etcd members": true,
+		"katlctl cluster etcd remove":  true,
+		"katlctl cluster status":       true,
+		"katlctl context save":         true,
+		"katlctl cluster bootstrap":    true,
+		"katlctl cluster wipe":         true,
+		"katlctl config render-node":   true,
+		"katlctl install apply":        true,
+		"katlctl kubernetes upgrade":   true,
+		"katlctl operations list":      true,
+		"katlctl operations status":    true,
+		"katlctl node apply":           true,
+		"katlctl node apply validate":  true,
+		"katlctl node reboot":          true,
+		"katlctl node shutdown":        true,
+		"katlctl node status":          true,
+		"katlctl node upgrade":         true,
+		"katlctl node wipe":            true,
 	}
 	root := newKatlctlCommand(context.Background(), io.Discard, io.Discard)
 	var visit func(*cobra.Command)
@@ -1798,7 +1800,7 @@ func TestWipeNodeReportsRecoveryRequiredBeforeLocalReset(t *testing.T) {
 	}
 }
 
-func TestWipeNodeRefusesControlPlaneBeforeMutation(t *testing.T) {
+func TestWipeNodeRefusesControlPlaneWithoutSurvivingCoordinator(t *testing.T) {
 	inventoryPath := writeInventory(t)
 	client := readyWipeClusterClient("cp-machine")
 	client.nodeStatus.Kubernetes = &agentapi.KubernetesStatus{State: "ready", Role: "control-plane"}
@@ -1825,14 +1827,14 @@ func TestWipeNodeRefusesControlPlaneBeforeMutation(t *testing.T) {
 		"--kubeconfig", "admin.conf",
 		"--client-request-id", "wipe-node-req",
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "etcd membership coordination") {
-		t.Fatalf("run() error = %v, want etcd coordinator refusal", err)
+	if err == nil || !strings.Contains(err.Error(), "no surviving control-plane") {
+		t.Fatalf("run() error = %v, want surviving coordinator refusal", err)
 	}
 	var report wipeNodeReport
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatalf("decode report: %v\n%s", err, stdout.String())
 	}
-	if report.KubernetesCleanup != "refused" || len(report.Refusals) != 1 {
+	if report.EtcdCleanup != "refused" || len(report.Refusals) != 1 {
 		t.Fatalf("report = %#v", report)
 	}
 	if len(kubectl.calls) != 0 {
@@ -2554,6 +2556,8 @@ type fakeKatlcAgentClient struct {
 	submitAccepted          *agentapi.OperationAccepted
 	nodeStatus              *agentapi.NodeStatus
 	nodeStatusErr           error
+	etcdStatus              *agentapi.EtcdStatus
+	etcdStatusErr           error
 	onGetNodeStatus         func()
 	generation              *agentapi.Generation
 	generationRequest       *agentapi.GetGenerationRequest
@@ -2641,6 +2645,10 @@ func (c *fakeKatlcAgentClient) GetNodeStatus(context.Context, *agentapi.GetNodeS
 		c.onGetNodeStatus()
 	}
 	return c.nodeStatus, c.nodeStatusErr
+}
+
+func (c *fakeKatlcAgentClient) GetEtcdStatus(context.Context, *agentapi.GetEtcdStatusRequest, ...grpc.CallOption) (*agentapi.EtcdStatus, error) {
+	return c.etcdStatus, c.etcdStatusErr
 }
 
 func (c *fakeKatlcAgentClient) Reboot(_ context.Context, req *agentapi.RebootRequest, _ ...grpc.CallOption) (*agentapi.RebootAccepted, error) {

--- a/docs/internal/katlctl-wipe-contract.md
+++ b/docs/internal/katlctl-wipe-contract.md
@@ -141,13 +141,18 @@ Graceful Kubernetes cleanup:
 - `katlctl` first attempts to cordon the Kubernetes Node.
 - It then attempts a bounded drain that evicts ordinary workload pods and ignores
   DaemonSet-managed pods. Mirror/static pods are not deleted through the API.
-- It deletes the Kubernetes Node object after drain attempts complete or time
-  out.
+- For a worker, it deletes the Kubernetes Node object after drain attempts
+  complete or time out.
 - A pre-bootstrap control-plane node can be reset without choosing an inventory
   init node, even when the topology contains multiple control planes.
-- A single enrolled control-plane wipe is refused before mutation because
-  stacked-etcd membership coordination is not yet implemented. Discarding the
-  whole cluster belongs to `katlctl cluster wipe`.
+- For an enrolled control plane, it selects a different healthy control plane,
+  captures the current cluster ID and membership, and requires the target name,
+  member ID, and configured peer URL to identify one member.
+- It refuses removal unless current quorum is healthy and the remaining healthy
+  members satisfy the resulting quorum. The coordinator cannot remove itself.
+- It drains first, executes the typed `etcd-member-remove` operation on the
+  coordinator, verifies the expected member disappeared from the same cluster,
+  and only then deletes the Kubernetes Node and triggers node-local reset.
 
 Node-local wipe trigger:
 
@@ -166,11 +171,12 @@ Node-local wipe trigger:
 
 Result:
 
-- Success leaves the wiped node powered off and ready for first
-  install/bootstrap again. Enrolled worker replacement also leaves the
-  remaining cluster without that Kubernetes Node.
-- The command does not automatically bootstrap the wiped node back into the
-  cluster. Rejoin is a later explicit install/bootstrap action.
+- Success leaves the wiped node powered off and ready for install again. The
+  remaining cluster has neither the Kubernetes Node nor, for a control plane,
+  the old etcd member.
+- Reinstall is followed by the normal whole-cluster `katlctl cluster apply`.
+  One fresh node is joined to the existing cluster without rerunning cluster
+  bootstrap.
 
 ## `katlctl cluster wipe`
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -21,6 +21,7 @@ networks.
 | Installed node | Inspect or reboot one host | [Access installed nodes](access.md#routine-host-management) |
 | Installed or bootstrapped node | Change supported runtime configuration | [Apply node configuration](configure-nodes.md) |
 | Healthy installed node | Stage a new KatlOS release | [Upgrade a KatlOS host](upgrade-host.md) |
+| One control plane is being replaced | Preserve the healthy cluster and rejoin one fresh node | [Wipe and reinstall](wipe-reinstall.md#plan-one-node-replacement) |
 | Cluster is intentionally being discarded | Reset boot state and reinstall | [Wipe and reinstall](wipe-reinstall.md) |
 | A step failed or its state is unclear | Collect evidence and classify the failure | [Troubleshoot KatlOS](troubleshoot.md) |
 
@@ -79,6 +80,6 @@ the planner so they produce an explicit lifecycle action instead of being
 silently ignored. Disk policy and Kubernetes version selection use their named
 install or upgrade workflows.
 
-There is no supported beta workflow for automatic host fleet rollout, etcd
-disaster recovery, failed control-plane replacement, agent-token rotation, or
+There is no supported beta workflow for automatic host fleet rollout, loss of
+etcd quorum, snapshot-based etcd disaster recovery, agent-token rotation, or
 general cluster reconciliation.

--- a/docs/operations/wipe-reinstall.md
+++ b/docs/operations/wipe-reinstall.md
@@ -68,17 +68,32 @@ Kubernetes Node first. If Kubernetes cleanup fails, Katl reports recovery
 required and refuses the node-local wipe.
 
 A control-plane node that has not joined Kubernetes can be reset without a
-kubeconfig or an init-node choice, including from a configuration containing
-multiple control planes:
+kubeconfig. For an enrolled control plane, Katl first drains the node, validates
+its exact stacked-etcd member against a healthy surviving control plane, proves
+that removal preserves quorum, removes and verifies the member, then deletes
+the Kubernetes Node before the node-local reset:
 
 ```sh
-katlctl node wipe cp-1 --config ./cluster.yaml --plan
-katlctl node wipe cp-1 --config ./cluster.yaml
+katlctl node wipe cp-3 --config ./cluster.yaml --plan
+katlctl node wipe cp-3 --config ./cluster.yaml \
+  --kubeconfig ./kubeconfig
 ```
 
-The report identifies the single control-plane target and says
-`kubernetesCleanup: not-needed`. A single enrolled control-plane wipe remains
-refused because supported etcd membership coordination is not implemented.
+The plan reports the coordinator and observed member ID. Katl refuses a missing
+or ambiguous member, a coordinator that would remove itself, changed cluster or
+member identity, or insufficient healthy quorum.
+
+If the node failed before a clean wipe, inspect membership from a survivor and
+explicitly confirm the stale member ID:
+
+```sh
+katlctl cluster etcd members --config ./cluster.yaml
+katlctl cluster etcd remove cp-3 --member-id MEMBER_ID \
+  --config ./cluster.yaml
+```
+
+This recovery command only removes etcd membership. Delete a remaining
+Kubernetes Node object if necessary, then reinstall the failed machine.
 
 ## Reinstall
 
@@ -87,9 +102,12 @@ After every selected wipe operation succeeds and powers off its node:
 1. select the verified installer ISO or PXE path and start the node;
 2. apply the intended `ClusterConfig` source and node selection;
 3. inspect the target disk again before authorizing installer wipe;
-4. complete generation 0 handoff; and
-5. treat the result as a new cluster identity unless a future supported
-   recovery operation explicitly says otherwise.
+4. wait for generation 0 handoff; and
+5. run `katlctl cluster apply --config ./cluster.yaml`.
 
-Do not claim preserved `/var/lib/etcd`, kubelet state, or Katl operation records
-as recovered merely because they remained on disk between reset and reinstall.
+For a single replacement in a healthy existing cluster, `cluster apply`
+recognizes the one fresh node, uses a ready surviving control plane to mint
+short-lived join material, joins the replacement without rerunning `kubeadm
+init`, and then reconciles the complete cluster config online. Repeating the
+unchanged apply after success is a no-op. Do not run `cluster bootstrap` again
+on the provisioned cluster.

--- a/docs/support.md
+++ b/docs/support.md
@@ -79,12 +79,13 @@ After a partial kubeadm or Kubernetes mutation, the node may report that manual
 recovery is required.
 
 Kubernetes upgrades support an explicit serial rollout to a newer patch or the
-next minor using a published Katl bundle. They do not provide automatic fleet
-rollout, automatic post-mutation repair, etcd disaster recovery, failed
-control-plane replacement, or general cluster reconciliation. Wipe/reinstall is
-destructive recovery, not backup or same-cluster disaster recovery. Keep
-independent etcd, workload, and data backups; do not rely on Katl generation
-rollback as a cluster backup.
+next minor using a published Katl bundle. A healthy multi-control-plane cluster
+supports replacing one control plane at a time, including explicit stale etcd
+member removal when quorum remains. This is not etcd disaster recovery,
+automatic post-mutation repair, or general cluster reconciliation.
+Wipe/reinstall is destructive recovery, not backup. Keep independent etcd,
+workload, and data backups; do not rely on Katl generation rollback as a
+cluster backup.
 
 ## Explicitly Unsupported
 

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -301,7 +301,9 @@ func RunAgentNodeJoin(ctx context.Context, request Request, nodeName string, dep
 	}
 	switch target.Action {
 	case inventory.ActionControlPlaneJoin:
-		material, err := createJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps, "control-plane", joinDiscoveryOverride{})
+		material, err := createJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps, "control-plane", joinDiscoveryOverride{
+			Endpoint: endpointForNode(initNode),
+		})
 		if err != nil {
 			result.addPhase("control-plane-join", target.Name, target.Action, "failed")
 			return result, fmt.Errorf("control-plane join material for %s: %s", target.Name, inventory.Redact(err.Error()))
@@ -313,7 +315,9 @@ func RunAgentNodeJoin(ctx context.Context, request Request, nodeName string, dep
 		}
 		result.addOperationPhase("control-plane-join", target.Name, target.Action, "passed", operationRef)
 	case inventory.ActionWorkerJoin:
-		material, err := createWorkerJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps)
+		material, err := createJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps, "worker", joinDiscoveryOverride{
+			Endpoint: endpointForNode(initNode),
+		})
 		if err != nil {
 			result.addPhase("worker-join", target.Name, target.Action, "failed")
 			return result, fmt.Errorf("worker join material for %s: %s", target.Name, inventory.Redact(err.Error()))
@@ -530,6 +534,28 @@ func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, en
 	if err := validateEndpointLike(endpoint); err != nil {
 		return nil, fmt.Errorf("init-node discovery endpoint: %w", err)
 	}
+	if certificateAuthorityData == "" {
+		if len(material.GetDiscoveryKubeconfig()) != 0 {
+			discoveryKubeconfig, err := rewriteJoinDiscoveryEndpoint(material.GetDiscoveryKubeconfig(), endpoint)
+			if err != nil {
+				return nil, err
+			}
+			argv[2] = endpoint
+			return &agentapi.WorkerJoinMaterial{
+				JoinArgv:            argv,
+				ExpiresAt:           material.GetExpiresAt(),
+				DiscoveryKubeconfig: discoveryKubeconfig,
+			}, nil
+		}
+		if _, _, _, err := joinDiscovery(JoinMaterial{Argv: argv}); err != nil {
+			return nil, err
+		}
+		argv[2] = endpoint
+		return &agentapi.WorkerJoinMaterial{
+			JoinArgv:  argv,
+			ExpiresAt: material.GetExpiresAt(),
+		}, nil
+	}
 	token := strings.TrimSpace(flagValue(argv, "--token"))
 	if token == "" {
 		return nil, errors.New("join material is missing bootstrap token")
@@ -539,37 +565,40 @@ func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, en
 		return nil, errors.New("join discovery is missing certificate authority data")
 	}
 	argv[2] = endpoint
-	discoveryKubeconfig, err := yaml.Marshal(map[string]any{
-		"apiVersion": "v1",
-		"kind":       "Config",
-		"clusters": []any{map[string]any{
-			"name": "katl-discovery",
-			"cluster": map[string]any{
-				"certificate-authority-data": certificateAuthorityData,
-				"server":                     "https://" + endpoint,
-			},
-		}},
-		"contexts": []any{map[string]any{
-			"name": "katl-discovery",
-			"context": map[string]any{
-				"cluster": "katl-discovery",
-				"user":    "katl-bootstrap",
-			},
-		}},
-		"current-context": "katl-discovery",
-		"users": []any{map[string]any{
-			"name": "katl-bootstrap",
-			"user": map[string]any{"token": token},
-		}},
-	})
+	discoveryKubeconfig, err := RenderJoinDiscoveryKubeconfig(JoinMaterial{Argv: argv}, endpoint, certificateAuthorityData)
 	if err != nil {
-		return nil, fmt.Errorf("render join discovery kubeconfig: %w", err)
+		return nil, err
 	}
 	return &agentapi.WorkerJoinMaterial{
 		JoinArgv:            argv,
 		ExpiresAt:           material.GetExpiresAt(),
 		DiscoveryKubeconfig: discoveryKubeconfig,
 	}, nil
+}
+
+func rewriteJoinDiscoveryEndpoint(data []byte, endpoint string) ([]byte, error) {
+	var config map[string]any
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("parse join discovery kubeconfig: %w", err)
+	}
+	clusters, ok := config["clusters"].([]any)
+	if !ok || len(clusters) != 1 {
+		return nil, errors.New("join discovery kubeconfig must contain exactly one cluster")
+	}
+	entry, ok := clusters[0].(map[string]any)
+	if !ok {
+		return nil, errors.New("join discovery kubeconfig cluster entry is invalid")
+	}
+	clusterConfig, ok := entry["cluster"].(map[string]any)
+	if !ok {
+		return nil, errors.New("join discovery kubeconfig cluster is invalid")
+	}
+	clusterConfig["server"] = "https://" + endpoint
+	rendered, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("render join discovery kubeconfig: %w", err)
+	}
+	return rendered, nil
 }
 
 func submitAndWaitControlPlaneJoin(ctx context.Context, node inventory.PlannedNode, plan inventory.Plan, status *agentapi.NodeStatus, material workerJoinMaterial, deps AgentBootstrapDependencies) (operationReference, error) {

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -28,13 +28,14 @@ const (
 )
 
 type AgentBootstrapDependencies struct {
-	Connector       AgentConnector
-	Actor           string
-	WatchTimeout    time.Duration
-	PollInterval    time.Duration
-	OperationWait   time.Duration
-	BootstrapRunner BootstrapRunner
-	Progress        func(AgentBootstrapProgress)
+	Connector           AgentConnector
+	Actor               string
+	ExistingClusterJoin bool
+	WatchTimeout        time.Duration
+	PollInterval        time.Duration
+	OperationWait       time.Duration
+	BootstrapRunner     BootstrapRunner
+	Progress            func(AgentBootstrapProgress)
 }
 
 type AgentBootstrapProgress struct {
@@ -249,9 +250,10 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	return result, nil
 }
 
-// RunAgentWorkerJoin joins one fresh worker to an already initialized cluster.
+// RunAgentNodeJoin joins one fresh node to an already initialized cluster.
 // It deliberately does not run bootstrap-init or rewrite operator kubeconfig.
-func RunAgentWorkerJoin(ctx context.Context, request Request, workerName string, deps AgentBootstrapDependencies) (Result, error) {
+func RunAgentNodeJoin(ctx context.Context, request Request, nodeName string, deps AgentBootstrapDependencies) (Result, error) {
+	deps.ExistingClusterJoin = true
 	inv := request.Inventory
 	if strings.TrimSpace(request.ControlPlaneEndpoint) != "" {
 		inv.ControlPlaneEndpoint = strings.TrimSpace(request.ControlPlaneEndpoint)
@@ -287,28 +289,51 @@ func RunAgentWorkerJoin(ctx context.Context, request Request, workerName string,
 	if err != nil {
 		return result, err
 	}
-	var worker inventory.PlannedNode
-	for _, candidate := range workerNodes(plan) {
-		if candidate.Name == strings.TrimSpace(workerName) {
-			worker = candidate
+	var target inventory.PlannedNode
+	for _, candidate := range plan.Nodes {
+		if candidate.Name == strings.TrimSpace(nodeName) && candidate.Name != initNode.Name {
+			target = candidate
 			break
 		}
 	}
-	if worker.Name == "" {
-		return result, fmt.Errorf("worker %q is not a worker join target", workerName)
+	if target.Name == "" {
+		return result, fmt.Errorf("node %q is not a join target", nodeName)
 	}
-	material, err := createWorkerJoinMaterial(ctx, initNode, worker, statuses[initNode.Name], "existing-cluster", deps)
-	if err != nil {
-		result.addPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "failed")
-		return result, fmt.Errorf("worker join material for %s: %s", worker.Name, inventory.Redact(err.Error()))
+	switch target.Action {
+	case inventory.ActionControlPlaneJoin:
+		material, err := createJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps, "control-plane", joinDiscoveryOverride{})
+		if err != nil {
+			result.addPhase("control-plane-join", target.Name, target.Action, "failed")
+			return result, fmt.Errorf("control-plane join material for %s: %s", target.Name, inventory.Redact(err.Error()))
+		}
+		operationRef, err := submitAndWaitControlPlaneJoin(ctx, target, plan, statuses[target.Name], material, deps)
+		if err != nil {
+			result.addOperationPhase("control-plane-join", target.Name, target.Action, "failed", operationRef)
+			return result, fmt.Errorf("control-plane join operation on %s: %s", target.Name, inventory.Redact(err.Error()))
+		}
+		result.addOperationPhase("control-plane-join", target.Name, target.Action, "passed", operationRef)
+	case inventory.ActionWorkerJoin:
+		material, err := createWorkerJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps)
+		if err != nil {
+			result.addPhase("worker-join", target.Name, target.Action, "failed")
+			return result, fmt.Errorf("worker join material for %s: %s", target.Name, inventory.Redact(err.Error()))
+		}
+		operationRef, err := submitAndWaitWorkerJoin(ctx, target, plan, statuses[target.Name], material, deps)
+		if err != nil {
+			result.addOperationPhase("worker-join", target.Name, target.Action, "failed", operationRef)
+			return result, fmt.Errorf("worker join operation on %s: %s", target.Name, inventory.Redact(err.Error()))
+		}
+		result.addOperationPhase("worker-join", target.Name, target.Action, "passed", operationRef)
+	default:
+		return result, fmt.Errorf("node %q has unsupported join action %q", target.Name, target.Action)
 	}
-	operationRef, err := submitAndWaitWorkerJoin(ctx, worker, plan, statuses[worker.Name], material, deps)
-	if err != nil {
-		result.addOperationPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "failed", operationRef)
-		return result, fmt.Errorf("worker join operation on %s: %s", worker.Name, inventory.Redact(err.Error()))
-	}
-	result.addOperationPhase("worker-join", worker.Name, inventory.ActionWorkerJoin, "passed", operationRef)
 	return result, nil
+}
+
+// RunAgentWorkerJoin is retained for the hidden compatibility path used by
+// existing VM journeys. New lifecycle coordination uses RunAgentNodeJoin.
+func RunAgentWorkerJoin(ctx context.Context, request Request, workerName string, deps AgentBootstrapDependencies) (Result, error) {
+	return RunAgentNodeJoin(ctx, request, workerName, deps)
 }
 
 func validateAgentPlan(plan inventory.Plan) error {
@@ -612,6 +637,7 @@ func bootstrapOperationRequest(node inventory.PlannedNode, plan inventory.Plan, 
 			KubernetesBundleRef:      plan.KubernetesBundleRef,
 			BootstrapProfileRef:      bootstrapProfileRef(node),
 			ControlPlaneEndpoint:     plan.ControlPlaneEndpoint,
+			ExistingClusterJoin:      deps.ExistingClusterJoin,
 		},
 	}
 }

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -135,6 +135,9 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 	if cp2Req.OperationKind != "bootstrap-join-control-plane" || cp2Req.ExpectedMachineId != "machine-cp-2" {
 		t.Fatalf("control-plane submit request = %#v", cp2Req)
 	}
+	if cp2Req.Bootstrap.GetExistingClusterJoin() {
+		t.Fatalf("initial control-plane join was marked as an existing-cluster replacement")
+	}
 	if cp2Req.Bootstrap.JoinMaterialRef != "operation:bootstrap-init-1/control-plane:cp-2" {
 		t.Fatalf("join material ref = %q", cp2Req.Bootstrap.JoinMaterialRef)
 	}
@@ -165,6 +168,64 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 		if !strings.Contains(manifest, want) {
 			t.Fatalf("node label manifest = %q, want %q", manifest, want)
 		}
+	}
+}
+
+func TestRunAgentNodeJoinAddsControlPlaneWithoutRerunningInit(t *testing.T) {
+	inv := validSingleNodeInventory()
+	inv.ControlPlaneEndpoint = "api.katl.test:6443"
+	inv.Nodes = append(inv.Nodes, inventory.Node{
+		Name:              "cp-2",
+		Address:           "10.0.0.12",
+		SystemRole:        inventory.RoleControlPlane,
+		Access:            inventory.Access{Method: "agent"},
+		KubeadmConfig:     inventory.KubeadmConfig{Ref: "control-plane", Path: "/etc/katl/kubeadm/control-plane/config.yaml", Intent: inventory.IntentControlPlane},
+		KubernetesVersion: "v1.36.1",
+	})
+	cp1 := &fakeAgentClient{
+		status: readyAgentStatusWithKinds("machine-cp-1", "bootstrap-init"),
+		createMaterial: &agentapi.CreateWorkerJoinMaterialResponse{
+			MaterialRef: "operation:existing-cluster/control-plane:cp-2",
+			WorkerJoinMaterial: &agentapi.WorkerJoinMaterial{
+				JoinArgv: []string{
+					"kubeadm", "join", "api.katl.test:6443",
+					"--token", "abcdef.0123456789abcdef",
+					"--discovery-token-ca-cert-hash", "sha256:" + strings.Repeat("a", 64),
+					"--control-plane", "--certificate-key", strings.Repeat("b", 64),
+				},
+				ExpiresAt: "2026-06-16T13:00:00Z",
+			},
+		},
+	}
+	cp2 := &fakeAgentClient{
+		status: readyAgentStatusWithKinds("machine-cp-2", "bootstrap-join-control-plane"),
+		accepted: &agentapi.OperationAccepted{
+			OperationId:   "replace-cp-2",
+			RequestDigest: "digest-cp-2",
+			InitialStatus: &agentapi.OperationStatus{OperationId: "replace-cp-2", Terminal: true, Result: operation.ResultSucceeded},
+		},
+	}
+	result, err := RunAgentNodeJoin(context.Background(), Request{
+		Inventory: inv,
+		InitNode:  "cp-1",
+	}, "cp-2", AgentBootstrapDependencies{
+		Connector: newFakeAgentConnector(map[string]*fakeAgentClient{"cp-1": cp1, "cp-2": cp2}),
+		Actor:     "katlctl cluster apply",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := phaseNames(result.Phases); !reflect.DeepEqual(got, []string{"plan", "readiness", "control-plane-join"}) {
+		t.Fatalf("phases = %#v", got)
+	}
+	if len(cp1.submitRequests) != 0 {
+		t.Fatalf("coordinator submitted bootstrap init: %#v", cp1.submitRequests)
+	}
+	if len(cp1.createMaterialRequests) != 1 || cp1.createMaterialRequests[0].RequestRef != "operation:existing-cluster/control-plane:cp-2" {
+		t.Fatalf("join material requests = %#v", cp1.createMaterialRequests)
+	}
+	if len(cp2.submitRequests) != 1 || cp2.submitRequests[0].OperationKind != "bootstrap-join-control-plane" || !cp2.submitRequests[0].Bootstrap.GetExistingClusterJoin() {
+		t.Fatalf("replacement submit requests = %#v", cp2.submitRequests)
 	}
 }
 

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -194,6 +194,24 @@ func TestRunAgentNodeJoinAddsControlPlaneWithoutRerunningInit(t *testing.T) {
 					"--control-plane", "--certificate-key", strings.Repeat("b", 64),
 				},
 				ExpiresAt: "2026-06-16T13:00:00Z",
+				DiscoveryKubeconfig: []byte(`apiVersion: v1
+kind: Config
+clusters:
+  - name: katl-discovery
+    cluster:
+      certificate-authority-data: ca-data
+      server: https://api.katl.test:6443
+contexts:
+  - name: katl-discovery
+    context:
+      cluster: katl-discovery
+      user: katl-bootstrap
+current-context: katl-discovery
+users:
+  - name: katl-bootstrap
+    user:
+      token: abcdef.0123456789abcdef
+`),
 			},
 		},
 	}
@@ -226,6 +244,25 @@ func TestRunAgentNodeJoinAddsControlPlaneWithoutRerunningInit(t *testing.T) {
 	}
 	if len(cp2.submitRequests) != 1 || cp2.submitRequests[0].OperationKind != "bootstrap-join-control-plane" || !cp2.submitRequests[0].Bootstrap.GetExistingClusterJoin() {
 		t.Fatalf("replacement submit requests = %#v", cp2.submitRequests)
+	}
+	replacement := cp2.submitRequests[0].Bootstrap
+	if got := replacement.WorkerJoinMaterial.GetJoinArgv()[2]; got != "10.0.0.11:6443" {
+		t.Fatalf("replacement discovery endpoint = %q, want coordinator endpoint", got)
+	}
+	discovery := string(replacement.WorkerJoinMaterial.GetDiscoveryKubeconfig())
+	for _, want := range []string{"server: https://10.0.0.11:6443", "certificate-authority-data: ca-data", "token: abcdef.0123456789abcdef"} {
+		if !strings.Contains(discovery, want) {
+			t.Fatalf("replacement discovery kubeconfig = %q, want %q", discovery, want)
+		}
+	}
+	if got := replacement.ControlPlaneEndpoint; got != "api.katl.test:6443" {
+		t.Fatalf("replacement control-plane endpoint = %q, want stable cluster endpoint", got)
+	}
+	if got := cp1.createMaterial.GetWorkerJoinMaterial().GetJoinArgv()[2]; got != "api.katl.test:6443" {
+		t.Fatalf("source join material endpoint = %q, want unmodified agent response", got)
+	}
+	if !strings.Contains(string(cp1.createMaterial.GetWorkerJoinMaterial().GetDiscoveryKubeconfig()), "server: https://api.katl.test:6443") {
+		t.Fatalf("source discovery kubeconfig was modified")
 	}
 }
 

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -1442,6 +1442,48 @@ func joinDiscovery(material JoinMaterial) (string, string, []string, error) {
 	return endpoint, token, []string{hash}, nil
 }
 
+func RenderJoinDiscoveryKubeconfig(material JoinMaterial, endpoint, certificateAuthorityData string) ([]byte, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if err := validateEndpointLike(endpoint); err != nil {
+		return nil, fmt.Errorf("join discovery endpoint: %w", err)
+	}
+	_, token, _, err := joinDiscovery(material)
+	if err != nil {
+		return nil, err
+	}
+	certificateAuthorityData = strings.TrimSpace(certificateAuthorityData)
+	if certificateAuthorityData == "" {
+		return nil, errors.New("join discovery is missing certificate authority data")
+	}
+	rendered, err := yaml.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Config",
+		"clusters": []any{map[string]any{
+			"name": "katl-discovery",
+			"cluster": map[string]any{
+				"certificate-authority-data": certificateAuthorityData,
+				"server":                     "https://" + endpoint,
+			},
+		}},
+		"contexts": []any{map[string]any{
+			"name": "katl-discovery",
+			"context": map[string]any{
+				"cluster": "katl-discovery",
+				"user":    "katl-bootstrap",
+			},
+		}},
+		"current-context": "katl-discovery",
+		"users": []any{map[string]any{
+			"name": "katl-bootstrap",
+			"user": map[string]any{"token": token},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("render join discovery kubeconfig: %w", err)
+	}
+	return rendered, nil
+}
+
 func decodeYAMLDocuments(data []byte) ([]map[string]any, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	var docs []map[string]any

--- a/internal/installer/configapply/manifest_state.go
+++ b/internal/installer/configapply/manifest_state.go
@@ -2,6 +2,7 @@ package configapply
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -54,4 +55,32 @@ func ReadGenerationManifest(root, generationID string) (manifest.Manifest, error
 		return manifest.Manifest{}, fmt.Errorf("decode generation manifest: %w", err)
 	}
 	return value, nil
+}
+
+func ReadEffectiveGenerationManifest(root, generationID string) (manifest.Manifest, string, error) {
+	selected := generationID
+	visited := map[string]bool{}
+	for selected != "" {
+		if visited[selected] {
+			return manifest.Manifest{}, "", fmt.Errorf("generation manifest ancestry contains a cycle at %q", selected)
+		}
+		visited[selected] = true
+		value, err := ReadGenerationManifest(root, selected)
+		if err == nil {
+			return value, selected, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return manifest.Manifest{}, "", err
+		}
+		spec, _, specErr := generation.ReadGeneration(root, selected)
+		if specErr != nil {
+			return manifest.Manifest{}, "", fmt.Errorf("read generation %q while resolving its configuration: %w", selected, specErr)
+		}
+		previous := spec.PreviousGenerationID
+		if previous == "" {
+			return manifest.Manifest{}, "", fmt.Errorf("generation %q and its ancestry have no manifest: %w", generationID, err)
+		}
+		selected = previous
+	}
+	return manifest.Manifest{}, "", fmt.Errorf("generation %q has no manifest ancestry", generationID)
 }

--- a/internal/installer/configapply/manifest_state_test.go
+++ b/internal/installer/configapply/manifest_state_test.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
 )
 
 func TestGenerationManifestRoundTrip(t *testing.T) {
@@ -26,5 +29,42 @@ func TestReadGenerationManifestPreservesNotExist(t *testing.T) {
 	_, err := ReadGenerationManifest(t.TempDir(), "generation-0")
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("ReadGenerationManifest() error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestReadEffectiveGenerationManifestInheritsRuntimeUpgradeConfiguration(t *testing.T) {
+	root := t.TempDir()
+	want := baseManifest()
+	if err := WriteGenerationManifest(root, "generation-config", want); err != nil {
+		t.Fatal(err)
+	}
+	createdAt := time.Date(2026, 7, 24, 18, 0, 0, 0, time.UTC)
+	spec := generation.GenerationSpec{
+		APIVersion: generation.APIVersion, Kind: generation.SpecKind,
+		GenerationID: "generation-upgrade", PreviousGenerationID: "generation-config",
+		RuntimeVersion: "2026.7.0", CreatedAt: createdAt,
+		Root: generation.RootSelection{
+			Slot: "root-b", PartitionUUID: "aaaaaaaa-1111-2222-3333-444444444444",
+			RuntimeVersion: "2026.7.0", RuntimeInterface: "katl-runtime-1",
+			Architecture: "x86_64", RuntimeArtifactSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		Boot: generation.BootSelection{
+			UKIPath: "/efi/EFI/Linux/katl_2026.7.0.efi", LoaderEntryPath: "loader/entries/katl-generation-upgrade.conf",
+		},
+	}
+	status, err := generation.NewGenerationStatus(spec, generation.CommitStateCommitted, generation.BootStateTrying, generation.HealthStateUnknown, createdAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := generation.WriteGeneration(root, spec, status); err != nil {
+		t.Fatal(err)
+	}
+
+	got, source, err := ReadEffectiveGenerationManifest(root, spec.GenerationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source != "generation-config" || got.Node.Identity.Hostname != want.Node.Identity.Hostname {
+		t.Fatalf("effective manifest = source %q node %#v, want source generation-config node %#v", source, got.Node, want.Node)
 	}
 }

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -96,6 +96,7 @@ type OperationRecord struct {
 	KubeadmUpgradeEvidence      *KubeadmUpgradeEvidence    `json:"kubeadmUpgradeEvidence,omitempty"`
 	DestructiveResetRequest     *DestructiveReset          `json:"destructiveResetRequest,omitempty"`
 	HostUpgradeRequest          *HostUpgrade               `json:"hostUpgradeRequest,omitempty"`
+	EtcdMemberRemoveRequest     *EtcdMemberRemove          `json:"etcdMemberRemoveRequest,omitempty"`
 	ActivationMode              string                     `json:"activationMode,omitempty"`
 	ActivationState             string                     `json:"activationState,omitempty"`
 	GenerationCommitState       string                     `json:"generationCommitState,omitempty"`
@@ -153,6 +154,7 @@ type BootstrapRequest struct {
 	JoinMaterialDigest             string `json:"joinMaterialDigest,omitempty"`
 	JoinMaterialExpiresAt          string `json:"joinMaterialExpiresAt,omitempty"`
 	TemporaryJoinConfigPath        string `json:"temporaryJoinConfigPath,omitempty"`
+	ExistingClusterJoin            bool   `json:"existingClusterJoin,omitempty"`
 }
 
 type ConfigApplyRequest struct {
@@ -244,6 +246,14 @@ type HostUpgrade struct {
 	ImageSHA256           string `json:"imageSHA256"`
 	ImageSizeBytes        uint64 `json:"imageSizeBytes,omitempty"`
 	CandidateGenerationID string `json:"candidateGenerationID"`
+}
+
+type EtcdMemberRemove struct {
+	TargetNodeName      string `json:"targetNodeName"`
+	TargetMemberID      string `json:"targetMemberID"`
+	TargetPeerURL       string `json:"targetPeerURL"`
+	ExpectedClusterID   string `json:"expectedClusterID"`
+	ExpectedMemberCount uint32 `json:"expectedMemberCount"`
 }
 
 type InvocationRecord struct {
@@ -817,6 +827,11 @@ func ValidateRecord(record OperationRecord) error {
 			return err
 		}
 	}
+	if record.EtcdMemberRemoveRequest != nil {
+		if err := ValidateEtcdMemberRemove(*record.EtcdMemberRemoveRequest); err != nil {
+			return err
+		}
+	}
 	if err := validateRequestBodyConsistency(record); err != nil {
 		return err
 	}
@@ -879,6 +894,9 @@ func validateRequestBodyConsistency(record OperationRecord) error {
 	if record.HostUpgradeRequest != nil {
 		bodyCount++
 	}
+	if record.EtcdMemberRemoveRequest != nil {
+		bodyCount++
+	}
 	if bodyCount > 1 {
 		return fmt.Errorf("operation record has multiple request bodies")
 	}
@@ -905,6 +923,12 @@ func validateRequestBodyConsistency(record OperationRecord) error {
 	}
 	if record.OperationKind == "host-upgrade" && record.HostUpgradeRequest == nil {
 		return fmt.Errorf("host-upgrade operation requires hostUpgradeRequest")
+	}
+	if record.EtcdMemberRemoveRequest != nil && record.OperationKind != "etcd-member-remove" {
+		return fmt.Errorf("operation kind %q cannot include etcdMemberRemoveRequest", record.OperationKind)
+	}
+	if record.OperationKind == "etcd-member-remove" && record.EtcdMemberRemoveRequest == nil {
+		return fmt.Errorf("etcd-member-remove operation requires etcdMemberRemoveRequest")
 	}
 	return nil
 }
@@ -977,6 +1001,9 @@ func ValidateTransition(previous OperationRecord, next OperationRecord) error {
 	}
 	if !hostUpgradeTransitionAllowed(previous.HostUpgradeRequest, next.HostUpgradeRequest) {
 		return fmt.Errorf("operation hostUpgradeRequest is immutable")
+	}
+	if !reflect.DeepEqual(next.EtcdMemberRemoveRequest, previous.EtcdMemberRemoveRequest) {
+		return fmt.Errorf("operation etcdMemberRemoveRequest is immutable")
 	}
 	return nil
 }
@@ -1161,6 +1188,10 @@ func cloneRecord(record OperationRecord) OperationRecord {
 	if record.HostUpgradeRequest != nil {
 		request := *record.HostUpgradeRequest
 		record.HostUpgradeRequest = &request
+	}
+	if record.EtcdMemberRemoveRequest != nil {
+		request := *record.EtcdMemberRemoveRequest
+		record.EtcdMemberRemoveRequest = &request
 	}
 	if record.ExecutorPlan != nil {
 		plan := *record.ExecutorPlan
@@ -1962,6 +1993,32 @@ func ValidateHostUpgrade(request HostUpgrade) error {
 	}
 	if _, err := cleanSegment("hostUpgradeRequest candidateGenerationID", request.CandidateGenerationID); err != nil {
 		return err
+	}
+	return nil
+}
+
+func ValidateEtcdMemberRemove(request EtcdMemberRemove) error {
+	if strings.TrimSpace(request.TargetNodeName) == "" {
+		return fmt.Errorf("etcdMemberRemoveRequest targetNodeName is required")
+	}
+	for name, value := range map[string]string{
+		"targetMemberID":    request.TargetMemberID,
+		"expectedClusterID": request.ExpectedClusterID,
+	} {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return fmt.Errorf("etcdMemberRemoveRequest %s is required", name)
+		}
+		if _, err := strconv.ParseUint(value, 16, 64); err != nil {
+			return fmt.Errorf("etcdMemberRemoveRequest %s must be a hexadecimal etcd ID", name)
+		}
+	}
+	peer, err := url.Parse(strings.TrimSpace(request.TargetPeerURL))
+	if err != nil || peer.Scheme != "https" || peer.Host == "" || peer.Path != "" || peer.RawQuery != "" || peer.Fragment != "" {
+		return fmt.Errorf("etcdMemberRemoveRequest targetPeerURL must be an HTTPS origin")
+	}
+	if request.ExpectedMemberCount < 2 {
+		return fmt.Errorf("etcdMemberRemoveRequest expectedMemberCount must be at least 2")
 	}
 	return nil
 }

--- a/internal/katlc/agent/endpoint_lifecycle.go
+++ b/internal/katlc/agent/endpoint_lifecycle.go
@@ -82,19 +82,33 @@ func resumeManagedEndpoint(ctx context.Context, root string, run ToolRunner) err
 // suspendManagedEndpointForJoin keeps a joining control-plane node from
 // capturing stable-endpoint traffic before its local API server exists.
 func suspendManagedEndpointForJoin(ctx context.Context, root, discoveryPath string, run ToolRunner) (bool, *managedJoinRoute, error) {
-	endpoint, configured, err := managedJoinEndpointConfig(root)
+	configured, err := managedEndpointConfigured(root)
 	if err != nil || !configured {
 		return false, nil, err
-	}
-	if run == nil {
-		return false, nil, fmt.Errorf("endpoint lifecycle runner is not configured")
 	}
 	if _, err := pauseManagedEndpoint(ctx, root, run); err != nil {
 		return false, nil, err
 	}
+	route, err := pinManagedEndpointForJoin(ctx, root, discoveryPath, run)
+	if err != nil {
+		return false, nil, errors.Join(err, resumeManagedEndpoint(ctx, root, run))
+	}
+	return true, route, nil
+}
+
+// pinManagedEndpointForJoin keeps kubeadm's use of the stable endpoint on the
+// selected coordinator until the joining control plane has a healthy local API.
+func pinManagedEndpointForJoin(ctx context.Context, root, discoveryPath string, run ToolRunner) (*managedJoinRoute, error) {
+	endpoint, configured, err := managedJoinEndpointConfig(root)
+	if err != nil || !configured {
+		return nil, err
+	}
+	if run == nil {
+		return nil, fmt.Errorf("endpoint lifecycle runner is not configured")
+	}
 	route, err := installManagedJoinRoute(ctx, root, discoveryPath, endpoint, run)
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
 	result := run(ctx, []string{
 		managedEndpointKubectl,
@@ -105,9 +119,9 @@ func suspendManagedEndpointForJoin(ctx context.Context, root, discoveryPath stri
 	}, nil)
 	if result.Err != nil || result.ExitStatus != 0 {
 		cleanupErr := removeManagedJoinRoute(ctx, route, run)
-		return false, nil, errors.Join(fmt.Errorf("verify managed control-plane endpoint through the join path: %s", toolFailure(result)), cleanupErr)
+		return nil, errors.Join(fmt.Errorf("verify managed control-plane endpoint through the join path: %s", toolFailure(result)), cleanupErr)
 	}
-	return true, route, nil
+	return route, nil
 }
 
 func installManagedJoinRoute(ctx context.Context, root, discoveryPath string, endpoint managedJoinEndpoint, run ToolRunner) (*managedJoinRoute, error) {

--- a/internal/katlc/agent/endpoint_lifecycle_test.go
+++ b/internal/katlc/agent/endpoint_lifecycle_test.go
@@ -158,9 +158,13 @@ func TestManagedEndpointJoinProbeFailureRemovesTemporaryRoute(t *testing.T) {
 	if err == nil || suspended || route != nil {
 		t.Fatalf("suspendManagedEndpointForJoin() = %v, %#v, %v", suspended, route, err)
 	}
-	wantLast := []string{managedEndpointIP, "route", "del", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"}
-	if !reflect.DeepEqual(calls[len(calls)-1], wantLast) {
-		t.Fatalf("last command = %#v, want route cleanup %#v", calls[len(calls)-1], wantLast)
+	wantTail := [][]string{
+		{managedEndpointIP, "route", "del", "10.40.0.10/32", "via", "10.0.0.10", "dev", "enp1s0"},
+		{"systemctl", "start", endpointAdvertiserPathUnit},
+		{"systemctl", "start", endpointAdvertiserUnit},
+	}
+	if !reflect.DeepEqual(calls[len(calls)-len(wantTail):], wantTail) {
+		t.Fatalf("command tail = %#v, want route cleanup and endpoint resume %#v", calls[len(calls)-len(wantTail):], wantTail)
 	}
 }
 

--- a/internal/katlc/agent/etcd_member.go
+++ b/internal/katlc/agent/etcd_member.go
@@ -1,0 +1,337 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const OperationKindEtcdMemberRemove = "etcd-member-remove"
+
+var etcdctlTLSArgs = []string{
+	"--cacert=/etc/kubernetes/pki/etcd/ca.crt",
+	"--cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt",
+	"--key=/etc/kubernetes/pki/etcd/healthcheck-client.key",
+}
+
+func (s *Server) GetEtcdStatus(ctx context.Context, _ *agentapi.GetEtcdStatusRequest) (*agentapi.EtcdStatus, error) {
+	report, err := collectEtcdStatus(ctx, s.etcdRunner())
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "inspect local stacked etcd: %v", err)
+	}
+	return report, nil
+}
+
+func (s *Server) etcdRunner() ToolRunner {
+	if s.RunEtcd != nil {
+		return s.RunEtcd
+	}
+	return runChildProcess
+}
+
+func collectEtcdStatus(ctx context.Context, run ToolRunner) (*agentapi.EtcdStatus, error) {
+	if run == nil {
+		return nil, errors.New("etcd command runner is required")
+	}
+	containerResult := run(ctx, []string{"crictl", "ps", "--name", "etcd", "--state", "Running", "--quiet"}, nil)
+	if containerResult.Err != nil || containerResult.ExitStatus != 0 {
+		return nil, fmt.Errorf("find running etcd container: %s", toolFailure(containerResult))
+	}
+	containerID := ""
+	for _, field := range strings.Fields(string(containerResult.Stdout)) {
+		containerID = field
+		break
+	}
+	if containerID == "" {
+		return nil, errors.New("running etcd container not found")
+	}
+
+	localStatus, err := runEtcdctl(ctx, run, containerID, "https://127.0.0.1:2379", "endpoint", "status", "--write-out=json")
+	if err != nil {
+		return nil, fmt.Errorf("read local endpoint status: %w", err)
+	}
+	var statuses []struct {
+		Status struct {
+			Header struct {
+				ClusterID json.RawMessage `json:"cluster_id"`
+				MemberID  json.RawMessage `json:"member_id"`
+			} `json:"header"`
+			Leader json.RawMessage `json:"leader"`
+		} `json:"Status"`
+	}
+	if err := json.Unmarshal(localStatus.Stdout, &statuses); err != nil || len(statuses) != 1 {
+		return nil, errors.New("decode local endpoint status")
+	}
+	clusterID, err := etcdID(statuses[0].Status.Header.ClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("decode etcd cluster id: %w", err)
+	}
+	localMemberID, err := etcdID(statuses[0].Status.Header.MemberID)
+	if err != nil {
+		return nil, fmt.Errorf("decode local etcd member id: %w", err)
+	}
+	leaderID, err := etcdID(statuses[0].Status.Leader)
+	if err != nil {
+		return nil, fmt.Errorf("decode etcd leader id: %w", err)
+	}
+
+	memberList, err := runEtcdctl(ctx, run, containerID, "https://127.0.0.1:2379", "member", "list", "--write-out=json")
+	if err != nil {
+		return nil, fmt.Errorf("list etcd members: %w", err)
+	}
+	var rawMembers struct {
+		Members []struct {
+			ID         json.RawMessage `json:"ID"`
+			Name       string          `json:"name"`
+			PeerURLs   []string        `json:"peerURLs"`
+			ClientURLs []string        `json:"clientURLs"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal(memberList.Stdout, &rawMembers); err != nil {
+		return nil, fmt.Errorf("decode etcd member list: %w", err)
+	}
+	if len(rawMembers.Members) == 0 {
+		return nil, errors.New("etcd member list is empty")
+	}
+	report := &agentapi.EtcdStatus{
+		ClusterId:     clusterID,
+		LocalMemberId: localMemberID,
+		LeaderId:      leaderID,
+		Quorum:        uint32(len(rawMembers.Members)/2 + 1),
+	}
+	for _, raw := range rawMembers.Members {
+		id, err := etcdID(raw.ID)
+		if err != nil {
+			return nil, fmt.Errorf("decode etcd member %q id: %w", raw.Name, err)
+		}
+		member := &agentapi.EtcdMember{
+			Id:         id,
+			Name:       strings.TrimSpace(raw.Name),
+			PeerUrls:   append([]string(nil), raw.PeerURLs...),
+			ClientUrls: append([]string(nil), raw.ClientURLs...),
+			Leader:     id == leaderID,
+		}
+		if len(member.ClientUrls) == 0 {
+			member.HealthError = "member has no client URL"
+		} else {
+			health, healthErr := runEtcdctl(ctx, run, containerID, member.ClientUrls[0], "endpoint", "health", "--write-out=json")
+			if healthErr != nil {
+				member.HealthError = inventory.Redact(healthErr.Error())
+			} else {
+				var entries []struct {
+					Health bool   `json:"health"`
+					Error  string `json:"error"`
+				}
+				if err := json.Unmarshal(health.Stdout, &entries); err != nil || len(entries) != 1 {
+					member.HealthError = "invalid endpoint health response"
+				} else {
+					member.Healthy = entries[0].Health
+					member.HealthError = inventory.Redact(entries[0].Error)
+				}
+			}
+		}
+		if member.Healthy {
+			report.HealthyMembers++
+		}
+		report.Members = append(report.Members, member)
+	}
+	return report, nil
+}
+
+func runEtcdctl(ctx context.Context, run ToolRunner, containerID, endpoint string, argv ...string) (ToolResult, error) {
+	command := []string{"crictl", "exec", containerID, "etcdctl", "--endpoints=" + endpoint}
+	command = append(command, etcdctlTLSArgs...)
+	command = append(command, argv...)
+	result := run(ctx, command, nil)
+	if result.Err != nil || result.ExitStatus != 0 {
+		return result, fmt.Errorf("%s", toolFailure(result))
+	}
+	return result, nil
+}
+
+func etcdID(raw json.RawMessage) (string, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return "", errors.New("id is empty")
+	}
+	var text string
+	if raw[0] == '"' {
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return "", err
+		}
+	} else {
+		text = string(raw)
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(text), 10, 64)
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatUint(value, 16), nil
+}
+
+func etcdMemberRemoveFromProto(req *agentapi.EtcdMemberRemoveOperationRequest) operation.EtcdMemberRemove {
+	if req == nil {
+		return operation.EtcdMemberRemove{}
+	}
+	return operation.EtcdMemberRemove{
+		TargetNodeName:      strings.TrimSpace(req.TargetNodeName),
+		TargetMemberID:      strings.ToLower(strings.TrimSpace(req.TargetMemberId)),
+		TargetPeerURL:       strings.TrimSpace(req.TargetPeerUrl),
+		ExpectedClusterID:   strings.ToLower(strings.TrimSpace(req.ExpectedClusterId)),
+		ExpectedMemberCount: req.ExpectedMemberCount,
+	}
+}
+
+func validateEtcdMemberRemoveRequest(kind string, req *agentapi.EtcdMemberRemoveOperationRequest) error {
+	if kind != OperationKindEtcdMemberRemove {
+		return fmt.Errorf("operationKind must be %q", OperationKindEtcdMemberRemove)
+	}
+	return operation.ValidateEtcdMemberRemove(etcdMemberRemoveFromProto(req))
+}
+
+func (e *Executor) executeEtcdMemberRemove(ctx context.Context, record operation.OperationRecord) error {
+	request := record.EtcdMemberRemoveRequest
+	if request == nil {
+		err := errors.New("etcd member remove request is required")
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-missing-request", "etcd-member-remove-invalid", "preflight-etcd-member-remove", "resubmit a valid etcd member removal", err)
+		return errors.Join(err, markErr)
+	}
+	if err := operation.ValidateEtcdMemberRemove(*request); err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-invalid", "etcd-member-remove-invalid", "preflight-etcd-member-remove", "resubmit a valid etcd member removal", err)
+		return errors.Join(err, markErr)
+	}
+	report, err := collectEtcdStatus(ctx, e.toolRunner())
+	if err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-preflight-failed", "etcd-member-remove-preflight", "preflight-etcd-member-remove", "restore etcd health before removing a member", err)
+		return errors.Join(err, markErr)
+	}
+	target, err := validateEtcdRemovalPreconditions(report, *request)
+	if err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-refused", "etcd-member-remove-preflight", "preflight-etcd-member-remove", "inspect current etcd membership and resubmit the observed identity", err)
+		return errors.Join(err, markErr)
+	}
+	containerResult := e.toolRunner()(ctx, []string{"crictl", "ps", "--name", "etcd", "--state", "Running", "--quiet"}, nil)
+	containerFields := strings.Fields(string(containerResult.Stdout))
+	if containerResult.Err != nil || containerResult.ExitStatus != 0 || len(containerFields) == 0 {
+		err := fmt.Errorf("find running etcd container after preflight: %s", toolFailure(containerResult))
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-container-disappeared", "etcd-member-remove-preflight", "preflight-etcd-member-remove", "restore local etcd health before removing a member", err)
+		return errors.Join(err, markErr)
+	}
+	containerID := containerFields[0]
+
+	now := e.clock()
+	record, err = e.Store.Update(record.OperationID, "etcd-member-remove-start", "etcd-member-remove", func(record operation.OperationRecord) (operation.OperationRecord, error) {
+		record.Phase = "remove-etcd-member"
+		record.ExternalMutationStarted = true
+		record.MutationScopes = appendMissing(record.MutationScopes, "etcd-state")
+		record.NextAction = "remove only the validated etcd member"
+		record.UpdatedAt = now
+		return record, nil
+	})
+	if err != nil {
+		return err
+	}
+	if target.GetLeader() {
+		if _, err := runEtcdctl(ctx, e.toolRunner(), containerID, "https://127.0.0.1:2379", "move-leader", report.GetLocalMemberId()); err != nil {
+			_, markErr := e.failRecordPhase(record.OperationID, "etcd-leader-transfer-failed", "etcd-member-remove", "remove-etcd-member", "restore etcd health before retrying member removal", fmt.Errorf("move leadership to coordinator: %w", err))
+			return errors.Join(err, markErr)
+		}
+	}
+	if _, err := runEtcdctl(ctx, e.toolRunner(), containerID, "https://127.0.0.1:2379", "member", "remove", request.TargetMemberID); err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-failed", "etcd-member-remove", "remove-etcd-member", "inspect current membership before deciding whether removal must be retried", err)
+		return errors.Join(err, markErr)
+	}
+	post, err := collectEtcdStatus(ctx, e.toolRunner())
+	if err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-postflight-failed", "etcd-member-remove-postflight", "verify-etcd-member-remove", "inspect etcd membership from a healthy control plane", err)
+		return errors.Join(err, markErr)
+	}
+	if post.GetClusterId() != request.ExpectedClusterID || len(post.GetMembers()) != int(request.ExpectedMemberCount)-1 || findEtcdMember(post, request.TargetMemberID) != nil || post.GetHealthyMembers() < post.GetQuorum() {
+		err := errors.New("post-removal etcd membership did not match the expected healthy cluster")
+		_, markErr := e.failRecordPhase(record.OperationID, "etcd-member-remove-postflight-refused", "etcd-member-remove-postflight", "verify-etcd-member-remove", "inspect etcd membership from a healthy control plane", err)
+		return errors.Join(err, markErr)
+	}
+	completed := e.clock()
+	_, err = e.Store.Update(record.OperationID, "etcd-member-remove-complete", "operation-complete", func(record operation.OperationRecord) (operation.OperationRecord, error) {
+		record.Phase = operation.HostBookkeepingCompletionPhase
+		record.CompletedPhases = appendMissing(record.CompletedPhases, "accepted", "preflight-etcd-member-remove", "remove-etcd-member", "verify-etcd-member-remove", operation.HostBookkeepingCompletionPhase)
+		record.PhaseIndex = len(record.CompletedPhases)
+		record.MutatingToolRan = true
+		record.MutatingToolInvocations = appendMissing(record.MutatingToolInvocations, "etcdctl member remove")
+		record.Terminal = true
+		record.Result = operation.ResultSucceeded
+		record.NextAction = "the removed control-plane node can now be reset or replaced"
+		record.CompletedAt = &completed
+		record.UpdatedAt = completed
+		return record, nil
+	})
+	return err
+}
+
+func validateEtcdRemovalPreconditions(report *agentapi.EtcdStatus, request operation.EtcdMemberRemove) (*agentapi.EtcdMember, error) {
+	if report.GetClusterId() != request.ExpectedClusterID {
+		return nil, fmt.Errorf("etcd cluster id %s does not match expected %s", report.GetClusterId(), request.ExpectedClusterID)
+	}
+	if len(report.GetMembers()) != int(request.ExpectedMemberCount) {
+		return nil, fmt.Errorf("etcd member count %d does not match expected %d", len(report.GetMembers()), request.ExpectedMemberCount)
+	}
+	target := findEtcdMember(report, request.TargetMemberID)
+	if target == nil || target.GetName() != request.TargetNodeName || !containsText(target.GetPeerUrls(), request.TargetPeerURL) {
+		return nil, errors.New("target member id, node name, and peer URL do not identify the same current etcd member")
+	}
+	if target.GetId() == report.GetLocalMemberId() {
+		return nil, errors.New("coordinator cannot remove its own local etcd member")
+	}
+	if report.GetHealthyMembers() < report.GetQuorum() {
+		return nil, fmt.Errorf("current etcd cluster has %d healthy members, below quorum %d", report.GetHealthyMembers(), report.GetQuorum())
+	}
+	healthySurvivors := report.GetHealthyMembers()
+	if target.GetHealthy() {
+		healthySurvivors--
+	}
+	postQuorum := uint32((len(report.GetMembers())-1)/2 + 1)
+	if healthySurvivors < postQuorum {
+		return nil, fmt.Errorf("removal would leave %d healthy members, below resulting quorum %d", healthySurvivors, postQuorum)
+	}
+	if len(report.GetMembers()) <= 1 {
+		return nil, errors.New("cannot remove the only etcd member")
+	}
+	return target, nil
+}
+
+func findEtcdMember(report *agentapi.EtcdStatus, id string) *agentapi.EtcdMember {
+	for _, member := range report.GetMembers() {
+		if strings.EqualFold(member.GetId(), strings.TrimSpace(id)) {
+			return member
+		}
+	}
+	return nil
+}
+
+func containsText(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func validateEtcdPeerURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return errors.New("invalid etcd peer URL")
+	}
+	return nil
+}

--- a/internal/katlc/agent/etcd_member_test.go
+++ b/internal/katlc/agent/etcd_member_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+)
+
+func TestCollectEtcdStatusReportsMemberIdentityAndHealth(t *testing.T) {
+	report, err := collectEtcdStatus(context.Background(), fakeEtcdRunner(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.GetClusterId() != "64" || report.GetLocalMemberId() != "1" || report.GetLeaderId() != "1" {
+		t.Fatalf("identity = cluster %s local %s leader %s", report.GetClusterId(), report.GetLocalMemberId(), report.GetLeaderId())
+	}
+	if len(report.GetMembers()) != 3 || report.GetHealthyMembers() != 3 || report.GetQuorum() != 2 {
+		t.Fatalf("status = %+v", report)
+	}
+	if report.GetMembers()[2].GetName() != "cp-3" || report.GetMembers()[2].GetId() != "3" || !report.GetMembers()[2].GetHealthy() {
+		t.Fatalf("cp-3 = %+v", report.GetMembers()[2])
+	}
+}
+
+func TestValidateEtcdRemovalPreconditionsAllowsOneFailedMemberWithQuorum(t *testing.T) {
+	report := &agentapi.EtcdStatus{
+		ClusterId:      "64",
+		LocalMemberId:  "1",
+		LeaderId:       "1",
+		Quorum:         2,
+		HealthyMembers: 2,
+		Members: []*agentapi.EtcdMember{
+			{Id: "1", Name: "cp-1", Healthy: true, PeerUrls: []string{"https://10.0.0.1:2380"}},
+			{Id: "2", Name: "cp-2", Healthy: true, PeerUrls: []string{"https://10.0.0.2:2380"}},
+			{Id: "3", Name: "cp-3", PeerUrls: []string{"https://10.0.0.3:2380"}},
+		},
+	}
+	target, err := validateEtcdRemovalPreconditions(report, operation.EtcdMemberRemove{
+		TargetNodeName: "cp-3", TargetMemberID: "3", TargetPeerURL: "https://10.0.0.3:2380",
+		ExpectedClusterID: "64", ExpectedMemberCount: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.GetName() != "cp-3" {
+		t.Fatalf("target = %+v", target)
+	}
+	report.HealthyMembers = 1
+	if _, err := validateEtcdRemovalPreconditions(report, operation.EtcdMemberRemove{
+		TargetNodeName: "cp-3", TargetMemberID: "3", TargetPeerURL: "https://10.0.0.3:2380",
+		ExpectedClusterID: "64", ExpectedMemberCount: 3,
+	}); err == nil || !strings.Contains(err.Error(), "below quorum") {
+		t.Fatalf("unsafe removal error = %v", err)
+	}
+}
+
+func TestEtcdMemberRemoveOperationValidatesAndVerifiesRemoval(t *testing.T) {
+	server := newTestServer(t)
+	executor := NewExecutor(server.Root, server.Store, "agent-test")
+	executor.Async = false
+	executor.Now = server.Now
+	removed := false
+	executor.RunTool = func(ctx context.Context, argv []string, started func(int)) ToolResult {
+		joined := strings.Join(argv, " ")
+		if strings.Contains(joined, "member remove 3") {
+			removed = true
+			return ToolResult{Stdout: []byte("Member 3 removed")}
+		}
+		return fakeEtcdRunner(removed)(ctx, argv, started)
+	}
+	server.Dispatcher = executor
+
+	req := submitRequest("req-etcd-remove")
+	req.Bootstrap = nil
+	req.OperationKind = OperationKindEtcdMemberRemove
+	req.EtcdMemberRemove = &agentapi.EtcdMemberRemoveOperationRequest{
+		TargetNodeName: "cp-3", TargetMemberId: "3", TargetPeerUrl: "https://10.0.0.3:2380",
+		ExpectedClusterId: "64", ExpectedMemberCount: 3,
+	}
+	accepted, err := server.SubmitOperation(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := server.Store.Read(accepted.GetOperationId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed || !record.Terminal {
+		t.Fatalf("removed=%v record=%+v", removed, record)
+	}
+	if record.Result != operation.ResultSucceeded || !record.ExternalMutationStarted || !record.MutatingToolRan {
+		t.Fatalf("record = %+v", record)
+	}
+}
+
+func fakeEtcdRunner(removed bool) ToolRunner {
+	return func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		joined := strings.Join(argv, " ")
+		switch {
+		case joined == "crictl ps --name etcd --state Running --quiet":
+			return ToolResult{Stdout: []byte("etcd-container\n")}
+		case strings.Contains(joined, "endpoint status"):
+			return ToolResult{Stdout: []byte(`[{"Endpoint":"https://127.0.0.1:2379","Status":{"header":{"cluster_id":100,"member_id":1},"leader":1}}]`)}
+		case strings.Contains(joined, "member list"):
+			members := `{"members":[{"ID":1,"name":"cp-1","peerURLs":["https://10.0.0.1:2380"],"clientURLs":["https://10.0.0.1:2379"]},{"ID":2,"name":"cp-2","peerURLs":["https://10.0.0.2:2380"],"clientURLs":["https://10.0.0.2:2379"]}`
+			if !removed {
+				members += `,{"ID":3,"name":"cp-3","peerURLs":["https://10.0.0.3:2380"],"clientURLs":["https://10.0.0.3:2379"]}`
+			}
+			return ToolResult{Stdout: []byte(members + `]}`)}
+		case strings.Contains(joined, "endpoint health"):
+			return ToolResult{Stdout: []byte(`[{"health":true}]`)}
+		default:
+			return ToolResult{Err: fmt.Errorf("unexpected command: %s", joined), ExitStatus: 1}
+		}
+	}
+}

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -202,6 +202,9 @@ func (e *Executor) Execute(ctx context.Context, record operation.OperationRecord
 	if record.KubernetesSysextUpdate != nil {
 		return e.executeKubeadmUpgrade(ctx, record)
 	}
+	if record.EtcdMemberRemoveRequest != nil {
+		return e.executeEtcdMemberRemove(ctx, record)
+	}
 	plan, err := executorPlan(record)
 	if err != nil {
 		_, markErr := e.failRecord(record.OperationID, "executor-plan-refused", "executor-plan-refused", "agent executor could not read operation tool plan", err)
@@ -240,7 +243,7 @@ func (e *Executor) Execute(ctx context.Context, record operation.OperationRecord
 	}
 	endpointSuspended := false
 	var managedRoute *managedJoinRoute
-	if record.OperationKind == bootstrapplan.OperationKindJoinControlPlane {
+	if record.OperationKind == bootstrapplan.OperationKindJoinControlPlane && (record.BootstrapRequest == nil || !record.BootstrapRequest.ExistingClusterJoin) {
 		lifecycleCtx, lifecycleCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		endpointSuspended, managedRoute, err = suspendManagedEndpointForJoin(lifecycleCtx, e.Root, joinDiscoveryConfigPath(record), e.endpointLifecycleRunner())
 		lifecycleCancel()

--- a/internal/katlc/agent/executor.go
+++ b/internal/katlc/agent/executor.go
@@ -243,12 +243,16 @@ func (e *Executor) Execute(ctx context.Context, record operation.OperationRecord
 	}
 	endpointSuspended := false
 	var managedRoute *managedJoinRoute
-	if record.OperationKind == bootstrapplan.OperationKindJoinControlPlane && (record.BootstrapRequest == nil || !record.BootstrapRequest.ExistingClusterJoin) {
+	if record.OperationKind == bootstrapplan.OperationKindJoinControlPlane {
 		lifecycleCtx, lifecycleCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		endpointSuspended, managedRoute, err = suspendManagedEndpointForJoin(lifecycleCtx, e.Root, joinDiscoveryConfigPath(record), e.endpointLifecycleRunner())
+		if record.BootstrapRequest != nil && record.BootstrapRequest.ExistingClusterJoin {
+			managedRoute, err = pinManagedEndpointForJoin(lifecycleCtx, e.Root, joinDiscoveryConfigPath(record), e.endpointLifecycleRunner())
+		} else {
+			endpointSuspended, managedRoute, err = suspendManagedEndpointForJoin(lifecycleCtx, e.Root, joinDiscoveryConfigPath(record), e.endpointLifecycleRunner())
+		}
 		lifecycleCancel()
 		if err != nil {
-			_, markErr := e.failRecordPhase(record.OperationID, "managed-endpoint-suspend-failed", "managed-endpoint-lifecycle", "suspend-managed-endpoint", "repair the managed endpoint lifecycle before retrying the control-plane join", err)
+			_, markErr := e.failRecordPhase(record.OperationID, "managed-endpoint-join-path-failed", "managed-endpoint-lifecycle", "prepare-managed-endpoint", "repair the managed endpoint join path before retrying the control-plane join", err)
 			return errors.Join(err, markErr)
 		}
 		if endpointSuspended {

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -792,7 +792,7 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 	}
 }
 
-func TestExistingClusterControlPlaneJoinUsesHealthyStableEndpoint(t *testing.T) {
+func TestExistingClusterControlPlaneJoinPinsStableEndpointToCoordinator(t *testing.T) {
 	server := newTestServer(t)
 	seedBootstrapRuntimeRootForRole(t, server.Root, "control-plane")
 	writeManagedEndpointTestConfig(t, server.Root)
@@ -800,13 +800,27 @@ func TestExistingClusterControlPlaneJoinUsesHealthyStableEndpoint(t *testing.T) 
 	executor.Async = false
 	executor.Now = server.Now
 	source, ref := configureExecutorBundle(t, executor, "v1.35.0", "replacement control-plane Kubernetes sysext")
+	var sequence []string
 	executor.RunReadiness = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
-	executor.RunEndpointLifecycle = func(context.Context, []string, func(int)) ToolResult {
-		t.Fatal("existing-cluster join unexpectedly changed the healthy endpoint path")
+	executor.RunEndpointLifecycle = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		command := strings.Join(argv, " ")
+		if len(argv) > 0 && argv[0] == managedEndpointKubectl {
+			command = managedEndpointKubectl + " probe-stable-endpoint"
+		}
+		sequence = append(sequence, command)
+		if reflect.DeepEqual(argv, []string{managedEndpointIP, "-json", "route", "get", "10.0.0.11"}) {
+			return ToolResult{Stdout: []byte(`[{"dst":"10.0.0.11","dev":"enp1s0"}]`)}
+		}
 		return ToolResult{}
 	}
-	executor.RunTool = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
-	executor.RunPostHealth = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
+	executor.RunTool = func(context.Context, []string, func(int)) ToolResult {
+		sequence = append(sequence, "kubeadm")
+		return ToolResult{}
+	}
+	executor.RunPostHealth = func(context.Context, []string, func(int)) ToolResult {
+		sequence = append(sequence, "post-health")
+		return ToolResult{}
+	}
 	server.Dispatcher = executor
 
 	req := submitRequest("req-existing-cluster-control-plane")
@@ -814,6 +828,7 @@ func TestExistingClusterControlPlaneJoinUsesHealthyStableEndpoint(t *testing.T) 
 	req.OperationKind = "bootstrap-join-control-plane"
 	req.Bootstrap.ExistingClusterJoin = true
 	req.Bootstrap.WorkerJoinMaterial = validControlPlaneJoinMaterial()
+	req.Bootstrap.WorkerJoinMaterial.DiscoveryKubeconfig = []byte("apiVersion: v1\nkind: Config\nclusters:\n  - name: katl-discovery\n    cluster:\n      server: https://10.0.0.11:6443\nusers:\n  - name: katl-bootstrap\n    user:\n      token: ephemeral\n")
 	accepted, err := server.SubmitOperation(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -824,6 +839,17 @@ func TestExistingClusterControlPlaneJoinUsesHealthyStableEndpoint(t *testing.T) 
 	}
 	if !record.Terminal || record.Result != operation.ResultSucceeded || record.BootstrapRequest == nil || !record.BootstrapRequest.ExistingClusterJoin {
 		t.Fatalf("record = %+v, want successful existing-cluster join", record)
+	}
+	want := []string{
+		managedEndpointIP + " -json route get 10.0.0.11",
+		managedEndpointIP + " route add 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
+		managedEndpointKubectl + " probe-stable-endpoint",
+		"kubeadm",
+		managedEndpointIP + " route del 10.40.0.10/32 via 10.0.0.11 dev enp1s0",
+		"post-health",
+	}
+	if !reflect.DeepEqual(sequence, want) {
+		t.Fatalf("existing-cluster join sequence = %#v, want %#v", sequence, want)
 	}
 	for _, phase := range []string{"suspend-managed-endpoint", "restore-managed-endpoint"} {
 		if contains(record.CompletedPhases, phase) {

--- a/internal/katlc/agent/executor_test.go
+++ b/internal/katlc/agent/executor_test.go
@@ -792,6 +792,46 @@ func TestControlPlaneJoinKeepsManagedEndpointOffLocalPathUntilKubeadmCompletes(t
 	}
 }
 
+func TestExistingClusterControlPlaneJoinUsesHealthyStableEndpoint(t *testing.T) {
+	server := newTestServer(t)
+	seedBootstrapRuntimeRootForRole(t, server.Root, "control-plane")
+	writeManagedEndpointTestConfig(t, server.Root)
+	executor := NewExecutor(server.Root, server.Store, "agent-test")
+	executor.Async = false
+	executor.Now = server.Now
+	source, ref := configureExecutorBundle(t, executor, "v1.35.0", "replacement control-plane Kubernetes sysext")
+	executor.RunReadiness = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
+	executor.RunEndpointLifecycle = func(context.Context, []string, func(int)) ToolResult {
+		t.Fatal("existing-cluster join unexpectedly changed the healthy endpoint path")
+		return ToolResult{}
+	}
+	executor.RunTool = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
+	executor.RunPostHealth = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
+	server.Dispatcher = executor
+
+	req := submitRequest("req-existing-cluster-control-plane")
+	setSubmitRequestBundle(req, source, ref)
+	req.OperationKind = "bootstrap-join-control-plane"
+	req.Bootstrap.ExistingClusterJoin = true
+	req.Bootstrap.WorkerJoinMaterial = validControlPlaneJoinMaterial()
+	accepted, err := server.SubmitOperation(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := server.Store.Read(accepted.OperationId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !record.Terminal || record.Result != operation.ResultSucceeded || record.BootstrapRequest == nil || !record.BootstrapRequest.ExistingClusterJoin {
+		t.Fatalf("record = %+v, want successful existing-cluster join", record)
+	}
+	for _, phase := range []string{"suspend-managed-endpoint", "restore-managed-endpoint"} {
+		if contains(record.CompletedPhases, phase) {
+			t.Fatalf("existing-cluster completed phases = %v, unexpectedly includes %s", record.CompletedPhases, phase)
+		}
+	}
+}
+
 func TestSubmitOperationRejectsExpiredWorkerJoinMaterialBeforeMutation(t *testing.T) {
 	server := newTestServer(t)
 	seedBootstrapRuntimeRootForRole(t, server.Root, "worker")

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
+	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/katlosimage"
@@ -57,6 +58,10 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	previousSpec, previousStatus, err := generation.ReadGeneration(e.Root, currentID)
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("read current generation: %w", err))
+	}
+	previousManifest, err := configapply.ReadGenerationManifest(e.Root, currentID)
+	if err != nil {
+		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("read current generation configuration: %w", err))
 	}
 	if err := validateHostUpgradeBootEvidence(e.Root, currentID, previousSpec); err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", err)
@@ -122,6 +127,9 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	}
 	if err := generation.WriteGeneration(e.Root, plan.Spec, plan.Status); err != nil {
 		return e.failHostUpgrade(record, "write-candidate-generation", err)
+	}
+	if err := configapply.WriteGenerationManifest(e.Root, candidate, previousManifest); err != nil {
+		return e.failHostUpgrade(record, "write-candidate-generation", fmt.Errorf("preserve current generation configuration: %w", err))
 	}
 	machineID, err := os.ReadFile(filepath.Join(runtimeRoot(e.Root), "etc/machine-id"))
 	if err != nil {

--- a/internal/katlc/agent/host_upgrade_executor.go
+++ b/internal/katlc/agent/host_upgrade_executor.go
@@ -59,7 +59,7 @@ func (e *Executor) executeHostUpgrade(ctx context.Context, record operation.Oper
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("read current generation: %w", err))
 	}
-	previousManifest, err := configapply.ReadGenerationManifest(e.Root, currentID)
+	previousManifest, _, err := configapply.ReadEffectiveGenerationManifest(e.Root, currentID)
 	if err != nil {
 		return e.failHostUpgrade(record, "verify-katlos-image", fmt.Errorf("read current generation configuration: %w", err))
 	}

--- a/internal/katlc/agent/host_upgrade_executor_test.go
+++ b/internal/katlc/agent/host_upgrade_executor_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/katl-dev/katl/internal/installer/operation"
@@ -156,6 +157,15 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := generation.WriteGeneration(root, previous, previousStatus); err != nil {
+		t.Fatal(err)
+	}
+	previousManifest := bootstrapRuntimeManifest("control-plane")
+	previousManifest.Node.Identity.SSH.AuthorizedKeys = []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"}
+	previousManifest.Install.TargetDisk.ByID = "/dev/disk/by-id/test-root"
+	previousManifest.Install.WipeTarget = true
+	previousManifest.KatlosImage.URL = "https://example.test/katlos-install.squashfs"
+	previousManifest.KatlosImage.SizeBytes = 1
+	if err := configapply.WriteGenerationManifest(root, previous.GenerationID, previousManifest); err != nil {
 		t.Fatal(err)
 	}
 	endpointAdvertiserPath := filepath.Join(root, "var/lib/katl/generations/gen0/sysext/katl-endpoint-advertiser.raw")
@@ -330,6 +340,14 @@ func TestExecutorStagesHostUpgradeAndArmsTrial(t *testing.T) {
 	}
 	if len(spec.Sysexts) != 1 || spec.Sysexts[0].Name != katlosimage.EndpointAdvertiserName || spec.Sysexts[0].Path != "/var/lib/katl/generations/gen1/sysext/endpoint-advertiser.raw" || spec.Sysexts[0].SHA256 != testSHA(nextEndpointAdvertiserBytes) {
 		t.Fatalf("candidate sysexts = %+v, want bundled endpoint advertiser replacement", spec.Sysexts)
+	}
+	candidateManifest, err := configapply.ReadGenerationManifest(root, "gen1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidateManifest.Node.Identity.Hostname != previousManifest.Node.Identity.Hostname ||
+		candidateManifest.Node.SystemRole != previousManifest.Node.SystemRole {
+		t.Fatalf("candidate manifest node = %+v, want current configuration %+v", candidateManifest.Node, previousManifest.Node)
 	}
 	stagedEndpointAdvertiser, err := os.ReadFile(filepath.Join(root, strings.TrimPrefix(spec.Sysexts[0].Path, "/")))
 	if err != nil {

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -54,6 +54,7 @@ var bootstrapOperationKinds = []string{
 	OperationKindKubeadmControlPlaneConfig,
 	OperationKindDestructiveReset,
 	OperationKindHostUpgrade,
+	OperationKindEtcdMemberRemove,
 }
 
 type Dispatcher interface {
@@ -73,6 +74,7 @@ type Server struct {
 	RunJoinMaterial         ToolRunner
 	RunEndpointLifecycle    ToolRunner
 	RunKubernetesStatus     ToolRunner
+	RunEtcd                 ToolRunner
 	RunReboot               ToolRunner
 	RunShutdown             ToolRunner
 	Now                     func() time.Time
@@ -92,6 +94,7 @@ func NewServer(root string, store operation.Store) *Server {
 		RunJoinMaterial:         runChildProcess,
 		RunEndpointLifecycle:    runChildProcess,
 		RunKubernetesStatus:     runChildProcess,
+		RunEtcd:                 runChildProcess,
 		RunReboot:               runChildProcess,
 		RunShutdown:             runChildProcess,
 		Now:                     func() time.Time { return time.Now().UTC() },
@@ -452,6 +455,9 @@ func (s *Server) acceptOperation(req *agentapi.SubmitOperationRequest, digest st
 	if req.GetHostUpgrade() != nil {
 		return s.acceptHostUpgradeOperation(req, digest, id, locks, now)
 	}
+	if req.GetEtcdMemberRemove() != nil {
+		return s.acceptEtcdMemberRemoveOperation(req, digest, id, locks, now)
+	}
 	bootstrapRequest := bootstrapRequestFromProto(req.GetBootstrap())
 	candidateID := strings.TrimSpace(bootstrapRequest.CandidateGenerationID)
 	if candidateID == "" {
@@ -545,6 +551,29 @@ func (s *Server) acceptDestructiveResetOperation(req *agentapi.SubmitOperationRe
 		DestructiveResetRequest:     &resetRequest,
 		ResourceLocks:               locks,
 		NextAction:                  "queued for katlc agent executor",
+	}
+	created, err := s.Store.Create(record, "accepted", now)
+	if err != nil {
+		return operation.OperationRecord{}, nil, status.Errorf(codes.Internal, "create operation record: %v", err)
+	}
+	return created, nil, nil
+}
+
+func (s *Server) acceptEtcdMemberRemoveOperation(req *agentapi.SubmitOperationRequest, digest, id string, locks []string, now time.Time) (operation.OperationRecord, *agentapi.OperationAccepted, error) {
+	remove := etcdMemberRemoveFromProto(req.GetEtcdMemberRemove())
+	record := operation.OperationRecord{
+		OperationID:             id,
+		OperationKind:           req.OperationKind,
+		Scope:                   operationScope(req.OperationKind),
+		ClientRequestID:         req.ClientRequestId,
+		Actor:                   req.Actor,
+		ExpectedMachineID:       req.ExpectedMachineId,
+		RequestDigest:           digest,
+		Phase:                   "accepted",
+		PhasePlan:               []string{"accepted", "preflight-etcd-member-remove", "remove-etcd-member", "verify-etcd-member-remove", operation.HostBookkeepingCompletionPhase},
+		EtcdMemberRemoveRequest: &remove,
+		ResourceLocks:           locks,
+		NextAction:              "queued for katlc agent executor",
 	}
 	created, err := s.Store.Create(record, "accepted", now)
 	if err != nil {
@@ -708,6 +737,9 @@ func (s *Server) validateSubmit(req *agentapi.SubmitOperationRequest) error {
 	if req.GetKubeadmControlPlaneConfig() != nil {
 		bodyCount++
 	}
+	if req.GetEtcdMemberRemove() != nil {
+		bodyCount++
+	}
 	if bodyCount != 1 {
 		return status.Error(codes.InvalidArgument, "exactly one operation request body is required")
 	}
@@ -730,6 +762,10 @@ func (s *Server) validateSubmit(req *agentapi.SubmitOperationRequest) error {
 	} else if req.GetHostUpgrade() != nil {
 		if err := validateHostUpgradeRequest(req.OperationKind, req.GetHostUpgrade()); err != nil {
 			return status.Errorf(codes.InvalidArgument, "host upgrade request: %v", err)
+		}
+	} else if req.GetEtcdMemberRemove() != nil {
+		if err := validateEtcdMemberRemoveRequest(req.OperationKind, req.GetEtcdMemberRemove()); err != nil {
+			return status.Errorf(codes.InvalidArgument, "etcd member remove request: %v", err)
 		}
 	} else {
 		if err := validateBootstrapRequest(req.OperationKind, req.GetBootstrap()); err != nil {
@@ -1153,6 +1189,8 @@ func resourceLocks(kind string) []string {
 		return []string{"generation-state.lock", "kubeadm-state.lock", "destructive-reset.lock"}
 	case OperationKindHostUpgrade:
 		return []string{"generation-state.lock", "sysupdate.lock"}
+	case OperationKindEtcdMemberRemove:
+		return []string{"etcd-state.lock"}
 	default:
 		return nil
 	}
@@ -1172,6 +1210,8 @@ func operationScope(kind string) string {
 		return "destructive-reset"
 	case OperationKindHostUpgrade:
 		return "host-generation"
+	case OperationKindEtcdMemberRemove:
+		return "etcd-state"
 	default:
 		return "host-generation"
 	}
@@ -1297,6 +1337,7 @@ func bootstrapRequestFromProto(request *agentapi.BootstrapOperationRequest) oper
 		CandidateGenerationID:    strings.TrimSpace(request.CandidateGenerationId),
 		KubeadmInputDigest:       strings.TrimSpace(request.KubeadmInputDigest),
 		JoinMaterialRef:          strings.TrimSpace(request.JoinMaterialRef),
+		ExistingClusterJoin:      request.GetExistingClusterJoin(),
 	}
 }
 

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -368,15 +369,45 @@ func (s *Server) CreateWorkerJoinMaterial(ctx context.Context, req *agentapi.Cre
 		material = parsed
 	}
 	expiresAt := startedAt.Add(ttl).UTC()
+	discoveryKubeconfig, err := s.joinDiscoveryKubeconfig(material)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "create join discovery kubeconfig: %v", err)
+	}
 	response := &agentapi.CreateWorkerJoinMaterialResponse{
 		MaterialRef: workerJoinMaterialRef(req.RequestRef, material, expiresAt),
 		WorkerJoinMaterial: &agentapi.WorkerJoinMaterial{
-			JoinArgv:  append([]string(nil), material.Argv...),
-			ExpiresAt: expiresAt.Format(time.RFC3339),
+			JoinArgv:            append([]string(nil), material.Argv...),
+			ExpiresAt:           expiresAt.Format(time.RFC3339),
+			DiscoveryKubeconfig: discoveryKubeconfig,
 		},
 		CreatedAt: formatTime(startedAt),
 	}
 	return response, nil
+}
+
+func (s *Server) joinDiscoveryKubeconfig(material cluster.JoinMaterial) ([]byte, error) {
+	root := strings.TrimSpace(s.Root)
+	if root == "" {
+		root = "/"
+	}
+	data, err := os.ReadFile(filepath.Join(root, "etc/kubernetes/admin.conf"))
+	if err != nil {
+		return nil, fmt.Errorf("read admin kubeconfig: %w", err)
+	}
+	var config struct {
+		Clusters []struct {
+			Cluster struct {
+				CertificateAuthorityData string `yaml:"certificate-authority-data"`
+			} `yaml:"cluster"`
+		} `yaml:"clusters"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("parse admin kubeconfig: %w", err)
+	}
+	if len(config.Clusters) != 1 {
+		return nil, errors.New("admin kubeconfig must contain exactly one cluster")
+	}
+	return cluster.RenderJoinDiscoveryKubeconfig(material, material.Argv[2], config.Clusters[0].Cluster.CertificateAuthorityData)
 }
 
 func (s *Server) acceptOperation(req *agentapi.SubmitOperationRequest, digest string) (operation.OperationRecord, *agentapi.OperationAccepted, error) {

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -2258,6 +2258,7 @@ func validControlPlaneJoinMaterial() *agentapi.WorkerJoinMaterial {
 
 func TestCreateWorkerJoinMaterialRunsKubeadmTokenCreate(t *testing.T) {
 	server := newTestServer(t)
+	writeJoinMaterialAdminKubeconfig(t, server)
 	var calls [][]string
 	server.RunJoinMaterial = func(ctx context.Context, argv []string, started func(int)) ToolResult {
 		calls = append(calls, append([]string(nil), argv...))
@@ -2292,6 +2293,17 @@ func TestCreateWorkerJoinMaterialRunsKubeadmTokenCreate(t *testing.T) {
 	}) {
 		t.Fatalf("join argv = %#v", material.GetJoinArgv())
 	}
+	discovery := string(material.GetDiscoveryKubeconfig())
+	for _, want := range []string{"server: https://api.katl.test:6443", "certificate-authority-data: ca-data", "token: abcdef.0123456789abcdef"} {
+		if !strings.Contains(discovery, want) {
+			t.Fatalf("discovery kubeconfig = %q, want %q", discovery, want)
+		}
+	}
+	for _, secret := range []string{"client-certificate-data", "client-key-data"} {
+		if strings.Contains(discovery, secret) {
+			t.Fatalf("discovery kubeconfig exposed %s", secret)
+		}
+	}
 }
 
 func TestCreateWorkerJoinMaterialRejectsActiveOperationLock(t *testing.T) {
@@ -2310,6 +2322,7 @@ func TestCreateWorkerJoinMaterialRejectsActiveOperationLock(t *testing.T) {
 
 func TestCreateWorkerJoinMaterialSerializesWithSubmitOperation(t *testing.T) {
 	server := newTestServer(t)
+	writeJoinMaterialAdminKubeconfig(t, server)
 	server.Dispatcher = dispatchFunc(func(ctx context.Context, record operation.OperationRecord) error {
 		return nil
 	})
@@ -2354,6 +2367,29 @@ func TestCreateWorkerJoinMaterialSerializesWithSubmitOperation(t *testing.T) {
 	if err := <-submitDone; err != nil {
 		t.Fatalf("SubmitOperation error after material minting finished = %v", err)
 	}
+}
+
+func writeJoinMaterialAdminKubeconfig(t *testing.T, server *Server) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(server.Root, "etc/kubernetes/admin.conf"), `apiVersion: v1
+kind: Config
+clusters:
+  - name: kubernetes
+    cluster:
+      certificate-authority-data: ca-data
+      server: https://api.katl.test:6443
+contexts:
+  - name: admin
+    context:
+      cluster: kubernetes
+      user: admin
+current-context: admin
+users:
+  - name: admin
+    user:
+      client-certificate-data: cert-data
+      client-key-data: key-data
+`)
 }
 
 func TestCreateWorkerJoinMaterialRedactsKubeadmFailure(t *testing.T) {

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -592,6 +592,7 @@ type SubmitOperationRequest struct {
 	DestructiveReset            *DestructiveResetOperationRequest          `protobuf:"bytes,15,opt,name=destructive_reset,json=destructiveReset,proto3" json:"destructive_reset,omitempty"`
 	HostUpgrade                 *HostUpgradeOperationRequest               `protobuf:"bytes,16,opt,name=host_upgrade,json=hostUpgrade,proto3" json:"host_upgrade,omitempty"`
 	KubeadmControlPlaneConfig   *KubeadmControlPlaneConfigOperationRequest `protobuf:"bytes,17,opt,name=kubeadm_control_plane_config,json=kubeadmControlPlaneConfig,proto3" json:"kubeadm_control_plane_config,omitempty"`
+	EtcdMemberRemove            *EtcdMemberRemoveOperationRequest          `protobuf:"bytes,18,opt,name=etcd_member_remove,json=etcdMemberRemove,proto3" json:"etcd_member_remove,omitempty"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -745,6 +746,13 @@ func (x *SubmitOperationRequest) GetKubeadmControlPlaneConfig() *KubeadmControlP
 	return nil
 }
 
+func (x *SubmitOperationRequest) GetEtcdMemberRemove() *EtcdMemberRemoveOperationRequest {
+	if x != nil {
+		return x.EtcdMemberRemove
+	}
+	return nil
+}
+
 type BootstrapOperationRequest struct {
 	state                    protoimpl.MessageState `protogen:"open.v1"`
 	InventoryNodeName        string                 `protobuf:"bytes,1,opt,name=inventory_node_name,json=inventoryNodeName,proto3" json:"inventory_node_name,omitempty"`
@@ -759,6 +767,7 @@ type BootstrapOperationRequest struct {
 	WorkerJoinMaterial       *WorkerJoinMaterial    `protobuf:"bytes,10,opt,name=worker_join_material,json=workerJoinMaterial,proto3" json:"worker_join_material,omitempty"`
 	KubernetesBundleSource   string                 `protobuf:"bytes,11,opt,name=kubernetes_bundle_source,json=kubernetesBundleSource,proto3" json:"kubernetes_bundle_source,omitempty"`
 	KubernetesBundleRef      string                 `protobuf:"bytes,12,opt,name=kubernetes_bundle_ref,json=kubernetesBundleRef,proto3" json:"kubernetes_bundle_ref,omitempty"`
+	ExistingClusterJoin      bool                   `protobuf:"varint,13,opt,name=existing_cluster_join,json=existingClusterJoin,proto3" json:"existing_cluster_join,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -877,6 +886,13 @@ func (x *BootstrapOperationRequest) GetKubernetesBundleRef() string {
 	return ""
 }
 
+func (x *BootstrapOperationRequest) GetExistingClusterJoin() bool {
+	if x != nil {
+		return x.ExistingClusterJoin
+	}
+	return false
+}
+
 type WorkerJoinMaterial struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	JoinArgv            []string               `protobuf:"bytes,1,rep,name=join_argv,json=joinArgv,proto3" json:"join_argv,omitempty"`
@@ -937,6 +953,294 @@ func (x *WorkerJoinMaterial) GetDiscoveryKubeconfig() []byte {
 	return nil
 }
 
+type GetEtcdStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEtcdStatusRequest) Reset() {
+	*x = GetEtcdStatusRequest{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEtcdStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEtcdStatusRequest) ProtoMessage() {}
+
+func (x *GetEtcdStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEtcdStatusRequest.ProtoReflect.Descriptor instead.
+func (*GetEtcdStatusRequest) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{9}
+}
+
+type EtcdStatus struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ClusterId      string                 `protobuf:"bytes,1,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	LocalMemberId  string                 `protobuf:"bytes,2,opt,name=local_member_id,json=localMemberId,proto3" json:"local_member_id,omitempty"`
+	LeaderId       string                 `protobuf:"bytes,3,opt,name=leader_id,json=leaderId,proto3" json:"leader_id,omitempty"`
+	Members        []*EtcdMember          `protobuf:"bytes,4,rep,name=members,proto3" json:"members,omitempty"`
+	Quorum         uint32                 `protobuf:"varint,5,opt,name=quorum,proto3" json:"quorum,omitempty"`
+	HealthyMembers uint32                 `protobuf:"varint,6,opt,name=healthy_members,json=healthyMembers,proto3" json:"healthy_members,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *EtcdStatus) Reset() {
+	*x = EtcdStatus{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EtcdStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EtcdStatus) ProtoMessage() {}
+
+func (x *EtcdStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EtcdStatus.ProtoReflect.Descriptor instead.
+func (*EtcdStatus) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *EtcdStatus) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
+func (x *EtcdStatus) GetLocalMemberId() string {
+	if x != nil {
+		return x.LocalMemberId
+	}
+	return ""
+}
+
+func (x *EtcdStatus) GetLeaderId() string {
+	if x != nil {
+		return x.LeaderId
+	}
+	return ""
+}
+
+func (x *EtcdStatus) GetMembers() []*EtcdMember {
+	if x != nil {
+		return x.Members
+	}
+	return nil
+}
+
+func (x *EtcdStatus) GetQuorum() uint32 {
+	if x != nil {
+		return x.Quorum
+	}
+	return 0
+}
+
+func (x *EtcdStatus) GetHealthyMembers() uint32 {
+	if x != nil {
+		return x.HealthyMembers
+	}
+	return 0
+}
+
+type EtcdMember struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	PeerUrls      []string               `protobuf:"bytes,3,rep,name=peer_urls,json=peerUrls,proto3" json:"peer_urls,omitempty"`
+	ClientUrls    []string               `protobuf:"bytes,4,rep,name=client_urls,json=clientUrls,proto3" json:"client_urls,omitempty"`
+	Healthy       bool                   `protobuf:"varint,5,opt,name=healthy,proto3" json:"healthy,omitempty"`
+	Leader        bool                   `protobuf:"varint,6,opt,name=leader,proto3" json:"leader,omitempty"`
+	HealthError   string                 `protobuf:"bytes,7,opt,name=health_error,json=healthError,proto3" json:"health_error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EtcdMember) Reset() {
+	*x = EtcdMember{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EtcdMember) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EtcdMember) ProtoMessage() {}
+
+func (x *EtcdMember) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EtcdMember.ProtoReflect.Descriptor instead.
+func (*EtcdMember) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *EtcdMember) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *EtcdMember) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *EtcdMember) GetPeerUrls() []string {
+	if x != nil {
+		return x.PeerUrls
+	}
+	return nil
+}
+
+func (x *EtcdMember) GetClientUrls() []string {
+	if x != nil {
+		return x.ClientUrls
+	}
+	return nil
+}
+
+func (x *EtcdMember) GetHealthy() bool {
+	if x != nil {
+		return x.Healthy
+	}
+	return false
+}
+
+func (x *EtcdMember) GetLeader() bool {
+	if x != nil {
+		return x.Leader
+	}
+	return false
+}
+
+func (x *EtcdMember) GetHealthError() string {
+	if x != nil {
+		return x.HealthError
+	}
+	return ""
+}
+
+type EtcdMemberRemoveOperationRequest struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	TargetNodeName      string                 `protobuf:"bytes,1,opt,name=target_node_name,json=targetNodeName,proto3" json:"target_node_name,omitempty"`
+	TargetMemberId      string                 `protobuf:"bytes,2,opt,name=target_member_id,json=targetMemberId,proto3" json:"target_member_id,omitempty"`
+	TargetPeerUrl       string                 `protobuf:"bytes,3,opt,name=target_peer_url,json=targetPeerUrl,proto3" json:"target_peer_url,omitempty"`
+	ExpectedClusterId   string                 `protobuf:"bytes,4,opt,name=expected_cluster_id,json=expectedClusterId,proto3" json:"expected_cluster_id,omitempty"`
+	ExpectedMemberCount uint32                 `protobuf:"varint,5,opt,name=expected_member_count,json=expectedMemberCount,proto3" json:"expected_member_count,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *EtcdMemberRemoveOperationRequest) Reset() {
+	*x = EtcdMemberRemoveOperationRequest{}
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EtcdMemberRemoveOperationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EtcdMemberRemoveOperationRequest) ProtoMessage() {}
+
+func (x *EtcdMemberRemoveOperationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EtcdMemberRemoveOperationRequest.ProtoReflect.Descriptor instead.
+func (*EtcdMemberRemoveOperationRequest) Descriptor() ([]byte, []int) {
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *EtcdMemberRemoveOperationRequest) GetTargetNodeName() string {
+	if x != nil {
+		return x.TargetNodeName
+	}
+	return ""
+}
+
+func (x *EtcdMemberRemoveOperationRequest) GetTargetMemberId() string {
+	if x != nil {
+		return x.TargetMemberId
+	}
+	return ""
+}
+
+func (x *EtcdMemberRemoveOperationRequest) GetTargetPeerUrl() string {
+	if x != nil {
+		return x.TargetPeerUrl
+	}
+	return ""
+}
+
+func (x *EtcdMemberRemoveOperationRequest) GetExpectedClusterId() string {
+	if x != nil {
+		return x.ExpectedClusterId
+	}
+	return ""
+}
+
+func (x *EtcdMemberRemoveOperationRequest) GetExpectedMemberCount() uint32 {
+	if x != nil {
+		return x.ExpectedMemberCount
+	}
+	return 0
+}
+
 type ValidateConfigRequest struct {
 	state                       protoimpl.MessageState `protogen:"open.v1"`
 	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
@@ -956,7 +1260,7 @@ type ValidateConfigRequest struct {
 
 func (x *ValidateConfigRequest) Reset() {
 	*x = ValidateConfigRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -968,7 +1272,7 @@ func (x *ValidateConfigRequest) String() string {
 func (*ValidateConfigRequest) ProtoMessage() {}
 
 func (x *ValidateConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[9]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -981,7 +1285,7 @@ func (x *ValidateConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidateConfigRequest.ProtoReflect.Descriptor instead.
 func (*ValidateConfigRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{9}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ValidateConfigRequest) GetApiVersion() string {
@@ -1080,7 +1384,7 @@ type ConfigValidationResult struct {
 
 func (x *ConfigValidationResult) Reset() {
 	*x = ConfigValidationResult{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1092,7 +1396,7 @@ func (x *ConfigValidationResult) String() string {
 func (*ConfigValidationResult) ProtoMessage() {}
 
 func (x *ConfigValidationResult) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[10]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1105,7 +1409,7 @@ func (x *ConfigValidationResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigValidationResult.ProtoReflect.Descriptor instead.
 func (*ConfigValidationResult) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{10}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ConfigValidationResult) GetApiVersion() string {
@@ -1204,7 +1508,7 @@ type GenerationApplyRequest struct {
 
 func (x *GenerationApplyRequest) Reset() {
 	*x = GenerationApplyRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1216,7 +1520,7 @@ func (x *GenerationApplyRequest) String() string {
 func (*GenerationApplyRequest) ProtoMessage() {}
 
 func (x *GenerationApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[11]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1229,7 +1533,7 @@ func (x *GenerationApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerationApplyRequest.ProtoReflect.Descriptor instead.
 func (*GenerationApplyRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{11}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GenerationApplyRequest) GetApiVersion() string {
@@ -1321,7 +1625,7 @@ type ConfigApplyOperationRequest struct {
 
 func (x *ConfigApplyOperationRequest) Reset() {
 	*x = ConfigApplyOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1333,7 +1637,7 @@ func (x *ConfigApplyOperationRequest) String() string {
 func (*ConfigApplyOperationRequest) ProtoMessage() {}
 
 func (x *ConfigApplyOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[12]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1346,7 +1650,7 @@ func (x *ConfigApplyOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyOperationRequest.ProtoReflect.Descriptor instead.
 func (*ConfigApplyOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{12}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ConfigApplyOperationRequest) GetCandidateGenerationId() string {
@@ -1406,7 +1710,7 @@ type KubeadmControlPlaneConfigOperationRequest struct {
 
 func (x *KubeadmControlPlaneConfigOperationRequest) Reset() {
 	*x = KubeadmControlPlaneConfigOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1418,7 +1722,7 @@ func (x *KubeadmControlPlaneConfigOperationRequest) String() string {
 func (*KubeadmControlPlaneConfigOperationRequest) ProtoMessage() {}
 
 func (x *KubeadmControlPlaneConfigOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[13]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1431,7 +1735,7 @@ func (x *KubeadmControlPlaneConfigOperationRequest) ProtoReflect() protoreflect.
 
 // Deprecated: Use KubeadmControlPlaneConfigOperationRequest.ProtoReflect.Descriptor instead.
 func (*KubeadmControlPlaneConfigOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{13}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *KubeadmControlPlaneConfigOperationRequest) GetRolloutId() string {
@@ -1608,7 +1912,7 @@ type KubernetesSysextUpdateOperationRequest struct {
 
 func (x *KubernetesSysextUpdateOperationRequest) Reset() {
 	*x = KubernetesSysextUpdateOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1620,7 +1924,7 @@ func (x *KubernetesSysextUpdateOperationRequest) String() string {
 func (*KubernetesSysextUpdateOperationRequest) ProtoMessage() {}
 
 func (x *KubernetesSysextUpdateOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[14]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1633,7 +1937,7 @@ func (x *KubernetesSysextUpdateOperationRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use KubernetesSysextUpdateOperationRequest.ProtoReflect.Descriptor instead.
 func (*KubernetesSysextUpdateOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{14}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *KubernetesSysextUpdateOperationRequest) GetTargetPayloadVersion() string {
@@ -1782,7 +2086,7 @@ type DestructiveResetOperationRequest struct {
 
 func (x *DestructiveResetOperationRequest) Reset() {
 	*x = DestructiveResetOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1794,7 +2098,7 @@ func (x *DestructiveResetOperationRequest) String() string {
 func (*DestructiveResetOperationRequest) ProtoMessage() {}
 
 func (x *DestructiveResetOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[15]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1807,7 +2111,7 @@ func (x *DestructiveResetOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestructiveResetOperationRequest.ProtoReflect.Descriptor instead.
 func (*DestructiveResetOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{15}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DestructiveResetOperationRequest) GetInventoryNodeName() string {
@@ -1858,7 +2162,7 @@ type HostUpgradeOperationRequest struct {
 
 func (x *HostUpgradeOperationRequest) Reset() {
 	*x = HostUpgradeOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1870,7 +2174,7 @@ func (x *HostUpgradeOperationRequest) String() string {
 func (*HostUpgradeOperationRequest) ProtoMessage() {}
 
 func (x *HostUpgradeOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[16]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1883,7 +2187,7 @@ func (x *HostUpgradeOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostUpgradeOperationRequest.ProtoReflect.Descriptor instead.
 func (*HostUpgradeOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{16}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *HostUpgradeOperationRequest) GetImageUrl() string {
@@ -1936,7 +2240,7 @@ type StageHostUpgradeArtifactRequest struct {
 
 func (x *StageHostUpgradeArtifactRequest) Reset() {
 	*x = StageHostUpgradeArtifactRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1948,7 +2252,7 @@ func (x *StageHostUpgradeArtifactRequest) String() string {
 func (*StageHostUpgradeArtifactRequest) ProtoMessage() {}
 
 func (x *StageHostUpgradeArtifactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[17]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1961,7 +2265,7 @@ func (x *StageHostUpgradeArtifactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StageHostUpgradeArtifactRequest.ProtoReflect.Descriptor instead.
 func (*StageHostUpgradeArtifactRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{17}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *StageHostUpgradeArtifactRequest) GetApiVersion() string {
@@ -2024,7 +2328,7 @@ type HostUpgradeArtifactStaged struct {
 
 func (x *HostUpgradeArtifactStaged) Reset() {
 	*x = HostUpgradeArtifactStaged{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2036,7 +2340,7 @@ func (x *HostUpgradeArtifactStaged) String() string {
 func (*HostUpgradeArtifactStaged) ProtoMessage() {}
 
 func (x *HostUpgradeArtifactStaged) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[18]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2049,7 +2353,7 @@ func (x *HostUpgradeArtifactStaged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostUpgradeArtifactStaged.ProtoReflect.Descriptor instead.
 func (*HostUpgradeArtifactStaged) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{18}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *HostUpgradeArtifactStaged) GetLocalRef() string {
@@ -2087,7 +2391,7 @@ type CreateWorkerJoinMaterialRequest struct {
 
 func (x *CreateWorkerJoinMaterialRequest) Reset() {
 	*x = CreateWorkerJoinMaterialRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2099,7 +2403,7 @@ func (x *CreateWorkerJoinMaterialRequest) String() string {
 func (*CreateWorkerJoinMaterialRequest) ProtoMessage() {}
 
 func (x *CreateWorkerJoinMaterialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[19]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2112,7 +2416,7 @@ func (x *CreateWorkerJoinMaterialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerJoinMaterialRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkerJoinMaterialRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{19}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreateWorkerJoinMaterialRequest) GetApiVersion() string {
@@ -2168,7 +2472,7 @@ type CreateWorkerJoinMaterialResponse struct {
 
 func (x *CreateWorkerJoinMaterialResponse) Reset() {
 	*x = CreateWorkerJoinMaterialResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2180,7 +2484,7 @@ func (x *CreateWorkerJoinMaterialResponse) String() string {
 func (*CreateWorkerJoinMaterialResponse) ProtoMessage() {}
 
 func (x *CreateWorkerJoinMaterialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[20]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2193,7 +2497,7 @@ func (x *CreateWorkerJoinMaterialResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkerJoinMaterialResponse.ProtoReflect.Descriptor instead.
 func (*CreateWorkerJoinMaterialResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{20}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CreateWorkerJoinMaterialResponse) GetMaterialRef() string {
@@ -2231,7 +2535,7 @@ type OperationAccepted struct {
 
 func (x *OperationAccepted) Reset() {
 	*x = OperationAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2243,7 +2547,7 @@ func (x *OperationAccepted) String() string {
 func (*OperationAccepted) ProtoMessage() {}
 
 func (x *OperationAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[21]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2256,7 +2560,7 @@ func (x *OperationAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationAccepted.ProtoReflect.Descriptor instead.
 func (*OperationAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{21}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *OperationAccepted) GetOperationId() string {
@@ -2312,7 +2616,7 @@ type GetOperationRequest struct {
 
 func (x *GetOperationRequest) Reset() {
 	*x = GetOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2324,7 +2628,7 @@ func (x *GetOperationRequest) String() string {
 func (*GetOperationRequest) ProtoMessage() {}
 
 func (x *GetOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[22]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2337,7 +2641,7 @@ func (x *GetOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOperationRequest.ProtoReflect.Descriptor instead.
 func (*GetOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{22}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetOperationRequest) GetOperationId() string {
@@ -2372,7 +2676,7 @@ type ListOperationsRequest struct {
 
 func (x *ListOperationsRequest) Reset() {
 	*x = ListOperationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2384,7 +2688,7 @@ func (x *ListOperationsRequest) String() string {
 func (*ListOperationsRequest) ProtoMessage() {}
 
 func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[23]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2397,7 +2701,7 @@ func (x *ListOperationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationsRequest.ProtoReflect.Descriptor instead.
 func (*ListOperationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{23}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListOperationsRequest) GetActiveOnly() bool {
@@ -2430,7 +2734,7 @@ type ListOperationsResponse struct {
 
 func (x *ListOperationsResponse) Reset() {
 	*x = ListOperationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2442,7 +2746,7 @@ func (x *ListOperationsResponse) String() string {
 func (*ListOperationsResponse) ProtoMessage() {}
 
 func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[24]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2455,7 +2759,7 @@ func (x *ListOperationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOperationsResponse.ProtoReflect.Descriptor instead.
 func (*ListOperationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{24}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListOperationsResponse) GetOperations() []*OperationStatus {
@@ -2503,7 +2807,7 @@ type OperationStatus struct {
 
 func (x *OperationStatus) Reset() {
 	*x = OperationStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2515,7 +2819,7 @@ func (x *OperationStatus) String() string {
 func (*OperationStatus) ProtoMessage() {}
 
 func (x *OperationStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[25]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2528,7 +2832,7 @@ func (x *OperationStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationStatus.ProtoReflect.Descriptor instead.
 func (*OperationStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{25}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *OperationStatus) GetOperationId() string {
@@ -2754,7 +3058,7 @@ type DiagnosticArtifact struct {
 
 func (x *DiagnosticArtifact) Reset() {
 	*x = DiagnosticArtifact{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2766,7 +3070,7 @@ func (x *DiagnosticArtifact) String() string {
 func (*DiagnosticArtifact) ProtoMessage() {}
 
 func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[26]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2779,7 +3083,7 @@ func (x *DiagnosticArtifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiagnosticArtifact.ProtoReflect.Descriptor instead.
 func (*DiagnosticArtifact) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{26}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DiagnosticArtifact) GetArtifactId() string {
@@ -2834,7 +3138,7 @@ type OperationInvocation struct {
 
 func (x *OperationInvocation) Reset() {
 	*x = OperationInvocation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +3150,7 @@ func (x *OperationInvocation) String() string {
 func (*OperationInvocation) ProtoMessage() {}
 
 func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[27]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2859,7 +3163,7 @@ func (x *OperationInvocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationInvocation.ProtoReflect.Descriptor instead.
 func (*OperationInvocation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{27}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *OperationInvocation) GetInvocationId() string {
@@ -2938,7 +3242,7 @@ type WatchOperationRequest struct {
 
 func (x *WatchOperationRequest) Reset() {
 	*x = WatchOperationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2950,7 +3254,7 @@ func (x *WatchOperationRequest) String() string {
 func (*WatchOperationRequest) ProtoMessage() {}
 
 func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[28]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2963,7 +3267,7 @@ func (x *WatchOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchOperationRequest.ProtoReflect.Descriptor instead.
 func (*WatchOperationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{28}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *WatchOperationRequest) GetOperationId() string {
@@ -3016,7 +3320,7 @@ type OperationEvent struct {
 
 func (x *OperationEvent) Reset() {
 	*x = OperationEvent{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3028,7 +3332,7 @@ func (x *OperationEvent) String() string {
 func (*OperationEvent) ProtoMessage() {}
 
 func (x *OperationEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[29]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3041,7 +3345,7 @@ func (x *OperationEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationEvent.ProtoReflect.Descriptor instead.
 func (*OperationEvent) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{29}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *OperationEvent) GetOperationId() string {
@@ -3102,7 +3406,7 @@ type ListGenerationsRequest struct {
 
 func (x *ListGenerationsRequest) Reset() {
 	*x = ListGenerationsRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3114,7 +3418,7 @@ func (x *ListGenerationsRequest) String() string {
 func (*ListGenerationsRequest) ProtoMessage() {}
 
 func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[30]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3127,7 +3431,7 @@ func (x *ListGenerationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsRequest.ProtoReflect.Descriptor instead.
 func (*ListGenerationsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{30}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListGenerationsRequest) GetIncludeConfigApply() bool {
@@ -3146,7 +3450,7 @@ type ListGenerationsResponse struct {
 
 func (x *ListGenerationsResponse) Reset() {
 	*x = ListGenerationsResponse{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3158,7 +3462,7 @@ func (x *ListGenerationsResponse) String() string {
 func (*ListGenerationsResponse) ProtoMessage() {}
 
 func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[31]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3171,7 +3475,7 @@ func (x *ListGenerationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGenerationsResponse.ProtoReflect.Descriptor instead.
 func (*ListGenerationsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{31}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListGenerationsResponse) GetGenerations() []*Generation {
@@ -3191,7 +3495,7 @@ type GetGenerationRequest struct {
 
 func (x *GetGenerationRequest) Reset() {
 	*x = GetGenerationRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3203,7 +3507,7 @@ func (x *GetGenerationRequest) String() string {
 func (*GetGenerationRequest) ProtoMessage() {}
 
 func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[32]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3216,7 +3520,7 @@ func (x *GetGenerationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGenerationRequest.ProtoReflect.Descriptor instead.
 func (*GetGenerationRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{32}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetGenerationRequest) GetGenerationId() string {
@@ -3254,7 +3558,7 @@ type Generation struct {
 
 func (x *Generation) Reset() {
 	*x = Generation{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3266,7 +3570,7 @@ func (x *Generation) String() string {
 func (*Generation) ProtoMessage() {}
 
 func (x *Generation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[33]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3279,7 +3583,7 @@ func (x *Generation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Generation.ProtoReflect.Descriptor instead.
 func (*Generation) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{33}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *Generation) GetGenerationId() string {
@@ -3388,7 +3692,7 @@ type ExtensionRef struct {
 
 func (x *ExtensionRef) Reset() {
 	*x = ExtensionRef{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3400,7 +3704,7 @@ func (x *ExtensionRef) String() string {
 func (*ExtensionRef) ProtoMessage() {}
 
 func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[34]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3413,7 +3717,7 @@ func (x *ExtensionRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionRef.ProtoReflect.Descriptor instead.
 func (*ExtensionRef) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{34}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ExtensionRef) GetName() string {
@@ -3477,7 +3781,7 @@ type GeneratedConfext struct {
 
 func (x *GeneratedConfext) Reset() {
 	*x = GeneratedConfext{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3489,7 +3793,7 @@ func (x *GeneratedConfext) String() string {
 func (*GeneratedConfext) ProtoMessage() {}
 
 func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[35]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3502,7 +3806,7 @@ func (x *GeneratedConfext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GeneratedConfext.ProtoReflect.Descriptor instead.
 func (*GeneratedConfext) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{35}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GeneratedConfext) GetName() string {
@@ -3553,7 +3857,7 @@ type ConfigApplyStatus struct {
 
 func (x *ConfigApplyStatus) Reset() {
 	*x = ConfigApplyStatus{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3565,7 +3869,7 @@ func (x *ConfigApplyStatus) String() string {
 func (*ConfigApplyStatus) ProtoMessage() {}
 
 func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[36]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3578,7 +3882,7 @@ func (x *ConfigApplyStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyStatus.ProtoReflect.Descriptor instead.
 func (*ConfigApplyStatus) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{36}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ConfigApplyStatus) GetPhase() string {
@@ -3680,7 +3984,7 @@ type ConfigApplyDomainAction struct {
 
 func (x *ConfigApplyDomainAction) Reset() {
 	*x = ConfigApplyDomainAction{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3692,7 +3996,7 @@ func (x *ConfigApplyDomainAction) String() string {
 func (*ConfigApplyDomainAction) ProtoMessage() {}
 
 func (x *ConfigApplyDomainAction) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[37]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3705,7 +4009,7 @@ func (x *ConfigApplyDomainAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyDomainAction.ProtoReflect.Descriptor instead.
 func (*ConfigApplyDomainAction) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{37}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ConfigApplyDomainAction) GetDomain() string {
@@ -3769,7 +4073,7 @@ type ConfigApplyEffect struct {
 
 func (x *ConfigApplyEffect) Reset() {
 	*x = ConfigApplyEffect{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3781,7 +4085,7 @@ func (x *ConfigApplyEffect) String() string {
 func (*ConfigApplyEffect) ProtoMessage() {}
 
 func (x *ConfigApplyEffect) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[38]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3794,7 +4098,7 @@ func (x *ConfigApplyEffect) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigApplyEffect.ProtoReflect.Descriptor instead.
 func (*ConfigApplyEffect) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{38}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ConfigApplyEffect) GetAction() string {
@@ -3838,7 +4142,7 @@ type RebootRequest struct {
 
 func (x *RebootRequest) Reset() {
 	*x = RebootRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3850,7 +4154,7 @@ func (x *RebootRequest) String() string {
 func (*RebootRequest) ProtoMessage() {}
 
 func (x *RebootRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[39]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3863,7 +4167,7 @@ func (x *RebootRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebootRequest.ProtoReflect.Descriptor instead.
 func (*RebootRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{39}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *RebootRequest) GetApiVersion() string {
@@ -3911,7 +4215,7 @@ type RebootAccepted struct {
 
 func (x *RebootAccepted) Reset() {
 	*x = RebootAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[40]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3923,7 +4227,7 @@ func (x *RebootAccepted) String() string {
 func (*RebootAccepted) ProtoMessage() {}
 
 func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[40]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3936,7 +4240,7 @@ func (x *RebootAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebootAccepted.ProtoReflect.Descriptor instead.
 func (*RebootAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{40}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *RebootAccepted) GetScheduled() bool {
@@ -3965,7 +4269,7 @@ type ShutdownRequest struct {
 
 func (x *ShutdownRequest) Reset() {
 	*x = ShutdownRequest{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[41]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3977,7 +4281,7 @@ func (x *ShutdownRequest) String() string {
 func (*ShutdownRequest) ProtoMessage() {}
 
 func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[41]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3990,7 +4294,7 @@ func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
 func (*ShutdownRequest) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{41}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ShutdownRequest) GetApiVersion() string {
@@ -4030,7 +4334,7 @@ type ShutdownAccepted struct {
 
 func (x *ShutdownAccepted) Reset() {
 	*x = ShutdownAccepted{}
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[42]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4042,7 +4346,7 @@ func (x *ShutdownAccepted) String() string {
 func (*ShutdownAccepted) ProtoMessage() {}
 
 func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[42]
+	mi := &file_internal_katlc_agentapi_agent_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4055,7 +4359,7 @@ func (x *ShutdownAccepted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAccepted.ProtoReflect.Descriptor instead.
 func (*ShutdownAccepted) Descriptor() ([]byte, []int) {
-	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{42}
+	return file_internal_katlc_agentapi_agent_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ShutdownAccepted) GetScheduled() bool {
@@ -4126,7 +4430,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\bpeer_asn\x18\x04 \x01(\rR\apeerAsn\x12\x14\n" +
 	"\x05state\x18\x05 \x01(\tR\x05state\x12'\n" +
 	"\x0faccepted_routes\x18\x06 \x01(\x04R\x0eacceptedRoutes\x12'\n" +
-	"\x0fexported_routes\x18\a \x01(\x04R\x0eexportedRoutes\"\x8d\b\n" +
+	"\x0fexported_routes\x18\a \x01(\x04R\x0eexportedRoutes\"\xec\b\n" +
 	"\x16SubmitOperationRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -4146,7 +4450,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x18kubernetes_sysext_update\x18\x0e \x01(\v25.katl.agent.v1.KubernetesSysextUpdateOperationRequestR\x16kubernetesSysextUpdate\x12\\\n" +
 	"\x11destructive_reset\x18\x0f \x01(\v2/.katl.agent.v1.DestructiveResetOperationRequestR\x10destructiveReset\x12M\n" +
 	"\fhost_upgrade\x18\x10 \x01(\v2*.katl.agent.v1.HostUpgradeOperationRequestR\vhostUpgrade\x12y\n" +
-	"\x1ckubeadm_control_plane_config\x18\x11 \x01(\v28.katl.agent.v1.KubeadmControlPlaneConfigOperationRequestR\x19kubeadmControlPlaneConfig\"\x96\x05\n" +
+	"\x1ckubeadm_control_plane_config\x18\x11 \x01(\v28.katl.agent.v1.KubeadmControlPlaneConfigOperationRequestR\x19kubeadmControlPlaneConfig\x12]\n" +
+	"\x12etcd_member_remove\x18\x12 \x01(\v2/.katl.agent.v1.EtcdMemberRemoveOperationRequestR\x10etcdMemberRemove\"\xca\x05\n" +
 	"\x19BootstrapOperationRequest\x12.\n" +
 	"\x13inventory_node_name\x18\x01 \x01(\tR\x11inventoryNodeName\x12\x1f\n" +
 	"\vsystem_role\x18\x02 \x01(\tR\n" +
@@ -4161,12 +4466,39 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x14worker_join_material\x18\n" +
 	" \x01(\v2!.katl.agent.v1.WorkerJoinMaterialR\x12workerJoinMaterial\x128\n" +
 	"\x18kubernetes_bundle_source\x18\v \x01(\tR\x16kubernetesBundleSource\x122\n" +
-	"\x15kubernetes_bundle_ref\x18\f \x01(\tR\x13kubernetesBundleRef\"\x83\x01\n" +
+	"\x15kubernetes_bundle_ref\x18\f \x01(\tR\x13kubernetesBundleRef\x122\n" +
+	"\x15existing_cluster_join\x18\r \x01(\bR\x13existingClusterJoin\"\x83\x01\n" +
 	"\x12WorkerJoinMaterial\x12\x1b\n" +
 	"\tjoin_argv\x18\x01 \x03(\tR\bjoinArgv\x12\x1d\n" +
 	"\n" +
 	"expires_at\x18\x02 \x01(\tR\texpiresAt\x121\n" +
-	"\x14discovery_kubeconfig\x18\x03 \x01(\fR\x13discoveryKubeconfig\"\xc5\x03\n" +
+	"\x14discovery_kubeconfig\x18\x03 \x01(\fR\x13discoveryKubeconfig\"\x16\n" +
+	"\x14GetEtcdStatusRequest\"\xe6\x01\n" +
+	"\n" +
+	"EtcdStatus\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x01 \x01(\tR\tclusterId\x12&\n" +
+	"\x0flocal_member_id\x18\x02 \x01(\tR\rlocalMemberId\x12\x1b\n" +
+	"\tleader_id\x18\x03 \x01(\tR\bleaderId\x123\n" +
+	"\amembers\x18\x04 \x03(\v2\x19.katl.agent.v1.EtcdMemberR\amembers\x12\x16\n" +
+	"\x06quorum\x18\x05 \x01(\rR\x06quorum\x12'\n" +
+	"\x0fhealthy_members\x18\x06 \x01(\rR\x0ehealthyMembers\"\xc3\x01\n" +
+	"\n" +
+	"EtcdMember\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1b\n" +
+	"\tpeer_urls\x18\x03 \x03(\tR\bpeerUrls\x12\x1f\n" +
+	"\vclient_urls\x18\x04 \x03(\tR\n" +
+	"clientUrls\x12\x18\n" +
+	"\ahealthy\x18\x05 \x01(\bR\ahealthy\x12\x16\n" +
+	"\x06leader\x18\x06 \x01(\bR\x06leader\x12!\n" +
+	"\fhealth_error\x18\a \x01(\tR\vhealthError\"\x82\x02\n" +
+	" EtcdMemberRemoveOperationRequest\x12(\n" +
+	"\x10target_node_name\x18\x01 \x01(\tR\x0etargetNodeName\x12(\n" +
+	"\x10target_member_id\x18\x02 \x01(\tR\x0etargetMemberId\x12&\n" +
+	"\x0ftarget_peer_url\x18\x03 \x01(\tR\rtargetPeerUrl\x12.\n" +
+	"\x13expected_cluster_id\x18\x04 \x01(\tR\x11expectedClusterId\x122\n" +
+	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\xc5\x03\n" +
 	"\x15ValidateConfigRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -4491,11 +4823,12 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
 	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\"0\n" +
 	"\x10ShutdownAccepted\x12\x1c\n" +
-	"\tscheduled\x18\x01 \x01(\bR\tscheduled2\x98\n" +
+	"\tscheduled\x18\x01 \x01(\bR\tscheduled2\xe9\n" +
 	"\n" +
 	"\n" +
 	"KatlcAgent\x12O\n" +
-	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12E\n" +
+	"\rGetNodeStatus\x12#.katl.agent.v1.GetNodeStatusRequest\x1a\x19.katl.agent.v1.NodeStatus\x12O\n" +
+	"\rGetEtcdStatus\x12#.katl.agent.v1.GetEtcdStatusRequest\x1a\x19.katl.agent.v1.EtcdStatus\x12E\n" +
 	"\x06Reboot\x12\x1c.katl.agent.v1.RebootRequest\x1a\x1d.katl.agent.v1.RebootAccepted\x12K\n" +
 	"\bShutdown\x12\x1e.katl.agent.v1.ShutdownRequest\x1a\x1f.katl.agent.v1.ShutdownAccepted\x12]\n" +
 	"\x0eValidateConfig\x12$.katl.agent.v1.ValidateConfigRequest\x1a%.katl.agent.v1.ConfigValidationResult\x12Z\n" +
@@ -4522,7 +4855,7 @@ func file_internal_katlc_agentapi_agent_proto_rawDescGZIP() []byte {
 	return file_internal_katlc_agentapi_agent_proto_rawDescData
 }
 
-var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_internal_katlc_agentapi_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*GetNodeStatusRequest)(nil),                      // 0: katl.agent.v1.GetNodeStatusRequest
 	(*NodeStatus)(nil),                                // 1: katl.agent.v1.NodeStatus
@@ -4533,40 +4866,44 @@ var file_internal_katlc_agentapi_agent_proto_goTypes = []any{
 	(*SubmitOperationRequest)(nil),                    // 6: katl.agent.v1.SubmitOperationRequest
 	(*BootstrapOperationRequest)(nil),                 // 7: katl.agent.v1.BootstrapOperationRequest
 	(*WorkerJoinMaterial)(nil),                        // 8: katl.agent.v1.WorkerJoinMaterial
-	(*ValidateConfigRequest)(nil),                     // 9: katl.agent.v1.ValidateConfigRequest
-	(*ConfigValidationResult)(nil),                    // 10: katl.agent.v1.ConfigValidationResult
-	(*GenerationApplyRequest)(nil),                    // 11: katl.agent.v1.GenerationApplyRequest
-	(*ConfigApplyOperationRequest)(nil),               // 12: katl.agent.v1.ConfigApplyOperationRequest
-	(*KubeadmControlPlaneConfigOperationRequest)(nil), // 13: katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
-	(*KubernetesSysextUpdateOperationRequest)(nil),    // 14: katl.agent.v1.KubernetesSysextUpdateOperationRequest
-	(*DestructiveResetOperationRequest)(nil),          // 15: katl.agent.v1.DestructiveResetOperationRequest
-	(*HostUpgradeOperationRequest)(nil),               // 16: katl.agent.v1.HostUpgradeOperationRequest
-	(*StageHostUpgradeArtifactRequest)(nil),           // 17: katl.agent.v1.StageHostUpgradeArtifactRequest
-	(*HostUpgradeArtifactStaged)(nil),                 // 18: katl.agent.v1.HostUpgradeArtifactStaged
-	(*CreateWorkerJoinMaterialRequest)(nil),           // 19: katl.agent.v1.CreateWorkerJoinMaterialRequest
-	(*CreateWorkerJoinMaterialResponse)(nil),          // 20: katl.agent.v1.CreateWorkerJoinMaterialResponse
-	(*OperationAccepted)(nil),                         // 21: katl.agent.v1.OperationAccepted
-	(*GetOperationRequest)(nil),                       // 22: katl.agent.v1.GetOperationRequest
-	(*ListOperationsRequest)(nil),                     // 23: katl.agent.v1.ListOperationsRequest
-	(*ListOperationsResponse)(nil),                    // 24: katl.agent.v1.ListOperationsResponse
-	(*OperationStatus)(nil),                           // 25: katl.agent.v1.OperationStatus
-	(*DiagnosticArtifact)(nil),                        // 26: katl.agent.v1.DiagnosticArtifact
-	(*OperationInvocation)(nil),                       // 27: katl.agent.v1.OperationInvocation
-	(*WatchOperationRequest)(nil),                     // 28: katl.agent.v1.WatchOperationRequest
-	(*OperationEvent)(nil),                            // 29: katl.agent.v1.OperationEvent
-	(*ListGenerationsRequest)(nil),                    // 30: katl.agent.v1.ListGenerationsRequest
-	(*ListGenerationsResponse)(nil),                   // 31: katl.agent.v1.ListGenerationsResponse
-	(*GetGenerationRequest)(nil),                      // 32: katl.agent.v1.GetGenerationRequest
-	(*Generation)(nil),                                // 33: katl.agent.v1.Generation
-	(*ExtensionRef)(nil),                              // 34: katl.agent.v1.ExtensionRef
-	(*GeneratedConfext)(nil),                          // 35: katl.agent.v1.GeneratedConfext
-	(*ConfigApplyStatus)(nil),                         // 36: katl.agent.v1.ConfigApplyStatus
-	(*ConfigApplyDomainAction)(nil),                   // 37: katl.agent.v1.ConfigApplyDomainAction
-	(*ConfigApplyEffect)(nil),                         // 38: katl.agent.v1.ConfigApplyEffect
-	(*RebootRequest)(nil),                             // 39: katl.agent.v1.RebootRequest
-	(*RebootAccepted)(nil),                            // 40: katl.agent.v1.RebootAccepted
-	(*ShutdownRequest)(nil),                           // 41: katl.agent.v1.ShutdownRequest
-	(*ShutdownAccepted)(nil),                          // 42: katl.agent.v1.ShutdownAccepted
+	(*GetEtcdStatusRequest)(nil),                      // 9: katl.agent.v1.GetEtcdStatusRequest
+	(*EtcdStatus)(nil),                                // 10: katl.agent.v1.EtcdStatus
+	(*EtcdMember)(nil),                                // 11: katl.agent.v1.EtcdMember
+	(*EtcdMemberRemoveOperationRequest)(nil),          // 12: katl.agent.v1.EtcdMemberRemoveOperationRequest
+	(*ValidateConfigRequest)(nil),                     // 13: katl.agent.v1.ValidateConfigRequest
+	(*ConfigValidationResult)(nil),                    // 14: katl.agent.v1.ConfigValidationResult
+	(*GenerationApplyRequest)(nil),                    // 15: katl.agent.v1.GenerationApplyRequest
+	(*ConfigApplyOperationRequest)(nil),               // 16: katl.agent.v1.ConfigApplyOperationRequest
+	(*KubeadmControlPlaneConfigOperationRequest)(nil), // 17: katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
+	(*KubernetesSysextUpdateOperationRequest)(nil),    // 18: katl.agent.v1.KubernetesSysextUpdateOperationRequest
+	(*DestructiveResetOperationRequest)(nil),          // 19: katl.agent.v1.DestructiveResetOperationRequest
+	(*HostUpgradeOperationRequest)(nil),               // 20: katl.agent.v1.HostUpgradeOperationRequest
+	(*StageHostUpgradeArtifactRequest)(nil),           // 21: katl.agent.v1.StageHostUpgradeArtifactRequest
+	(*HostUpgradeArtifactStaged)(nil),                 // 22: katl.agent.v1.HostUpgradeArtifactStaged
+	(*CreateWorkerJoinMaterialRequest)(nil),           // 23: katl.agent.v1.CreateWorkerJoinMaterialRequest
+	(*CreateWorkerJoinMaterialResponse)(nil),          // 24: katl.agent.v1.CreateWorkerJoinMaterialResponse
+	(*OperationAccepted)(nil),                         // 25: katl.agent.v1.OperationAccepted
+	(*GetOperationRequest)(nil),                       // 26: katl.agent.v1.GetOperationRequest
+	(*ListOperationsRequest)(nil),                     // 27: katl.agent.v1.ListOperationsRequest
+	(*ListOperationsResponse)(nil),                    // 28: katl.agent.v1.ListOperationsResponse
+	(*OperationStatus)(nil),                           // 29: katl.agent.v1.OperationStatus
+	(*DiagnosticArtifact)(nil),                        // 30: katl.agent.v1.DiagnosticArtifact
+	(*OperationInvocation)(nil),                       // 31: katl.agent.v1.OperationInvocation
+	(*WatchOperationRequest)(nil),                     // 32: katl.agent.v1.WatchOperationRequest
+	(*OperationEvent)(nil),                            // 33: katl.agent.v1.OperationEvent
+	(*ListGenerationsRequest)(nil),                    // 34: katl.agent.v1.ListGenerationsRequest
+	(*ListGenerationsResponse)(nil),                   // 35: katl.agent.v1.ListGenerationsResponse
+	(*GetGenerationRequest)(nil),                      // 36: katl.agent.v1.GetGenerationRequest
+	(*Generation)(nil),                                // 37: katl.agent.v1.Generation
+	(*ExtensionRef)(nil),                              // 38: katl.agent.v1.ExtensionRef
+	(*GeneratedConfext)(nil),                          // 39: katl.agent.v1.GeneratedConfext
+	(*ConfigApplyStatus)(nil),                         // 40: katl.agent.v1.ConfigApplyStatus
+	(*ConfigApplyDomainAction)(nil),                   // 41: katl.agent.v1.ConfigApplyDomainAction
+	(*ConfigApplyEffect)(nil),                         // 42: katl.agent.v1.ConfigApplyEffect
+	(*RebootRequest)(nil),                             // 43: katl.agent.v1.RebootRequest
+	(*RebootAccepted)(nil),                            // 44: katl.agent.v1.RebootAccepted
+	(*ShutdownRequest)(nil),                           // 45: katl.agent.v1.ShutdownRequest
+	(*ShutdownAccepted)(nil),                          // 46: katl.agent.v1.ShutdownAccepted
 }
 var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	3,  // 0: katl.agent.v1.NodeStatus.control_plane_endpoint:type_name -> katl.agent.v1.ControlPlaneEndpointStatus
@@ -4574,59 +4911,63 @@ var file_internal_katlc_agentapi_agent_proto_depIdxs = []int32{
 	4,  // 2: katl.agent.v1.ControlPlaneEndpointStatus.peers:type_name -> katl.agent.v1.ControlPlaneEndpointPeerStatus
 	5,  // 3: katl.agent.v1.ControlPlaneEndpointStatus.route_exchange:type_name -> katl.agent.v1.ControlPlaneEndpointRouteExchangeStatus
 	7,  // 4: katl.agent.v1.SubmitOperationRequest.bootstrap:type_name -> katl.agent.v1.BootstrapOperationRequest
-	12, // 5: katl.agent.v1.SubmitOperationRequest.config_apply:type_name -> katl.agent.v1.ConfigApplyOperationRequest
-	14, // 6: katl.agent.v1.SubmitOperationRequest.kubernetes_sysext_update:type_name -> katl.agent.v1.KubernetesSysextUpdateOperationRequest
-	15, // 7: katl.agent.v1.SubmitOperationRequest.destructive_reset:type_name -> katl.agent.v1.DestructiveResetOperationRequest
-	16, // 8: katl.agent.v1.SubmitOperationRequest.host_upgrade:type_name -> katl.agent.v1.HostUpgradeOperationRequest
-	13, // 9: katl.agent.v1.SubmitOperationRequest.kubeadm_control_plane_config:type_name -> katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
-	8,  // 10: katl.agent.v1.BootstrapOperationRequest.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
-	8,  // 11: katl.agent.v1.CreateWorkerJoinMaterialResponse.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
-	25, // 12: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
-	25, // 13: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
-	26, // 14: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	27, // 15: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
-	36, // 16: katl.agent.v1.OperationStatus.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
-	25, // 17: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
-	26, // 18: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
-	33, // 19: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
-	34, // 20: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
-	35, // 21: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
-	36, // 22: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
-	37, // 23: katl.agent.v1.ConfigApplyStatus.domain_actions:type_name -> katl.agent.v1.ConfigApplyDomainAction
-	38, // 24: katl.agent.v1.ConfigApplyDomainAction.effects:type_name -> katl.agent.v1.ConfigApplyEffect
-	0,  // 25: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
-	39, // 26: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
-	41, // 27: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
-	9,  // 28: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
-	11, // 29: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	11, // 30: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
-	17, // 31: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:input_type -> katl.agent.v1.StageHostUpgradeArtifactRequest
-	6,  // 32: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
-	19, // 33: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
-	22, // 34: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
-	23, // 35: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
-	28, // 36: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
-	30, // 37: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
-	32, // 38: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
-	1,  // 39: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
-	40, // 40: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
-	42, // 41: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
-	10, // 42: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
-	21, // 43: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
-	21, // 44: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
-	18, // 45: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:output_type -> katl.agent.v1.HostUpgradeArtifactStaged
-	21, // 46: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
-	20, // 47: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
-	25, // 48: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
-	24, // 49: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
-	29, // 50: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
-	31, // 51: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
-	33, // 52: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
-	39, // [39:53] is the sub-list for method output_type
-	25, // [25:39] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	16, // 5: katl.agent.v1.SubmitOperationRequest.config_apply:type_name -> katl.agent.v1.ConfigApplyOperationRequest
+	18, // 6: katl.agent.v1.SubmitOperationRequest.kubernetes_sysext_update:type_name -> katl.agent.v1.KubernetesSysextUpdateOperationRequest
+	19, // 7: katl.agent.v1.SubmitOperationRequest.destructive_reset:type_name -> katl.agent.v1.DestructiveResetOperationRequest
+	20, // 8: katl.agent.v1.SubmitOperationRequest.host_upgrade:type_name -> katl.agent.v1.HostUpgradeOperationRequest
+	17, // 9: katl.agent.v1.SubmitOperationRequest.kubeadm_control_plane_config:type_name -> katl.agent.v1.KubeadmControlPlaneConfigOperationRequest
+	12, // 10: katl.agent.v1.SubmitOperationRequest.etcd_member_remove:type_name -> katl.agent.v1.EtcdMemberRemoveOperationRequest
+	8,  // 11: katl.agent.v1.BootstrapOperationRequest.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
+	11, // 12: katl.agent.v1.EtcdStatus.members:type_name -> katl.agent.v1.EtcdMember
+	8,  // 13: katl.agent.v1.CreateWorkerJoinMaterialResponse.worker_join_material:type_name -> katl.agent.v1.WorkerJoinMaterial
+	29, // 14: katl.agent.v1.OperationAccepted.initial_status:type_name -> katl.agent.v1.OperationStatus
+	29, // 15: katl.agent.v1.ListOperationsResponse.operations:type_name -> katl.agent.v1.OperationStatus
+	30, // 16: katl.agent.v1.OperationStatus.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	31, // 17: katl.agent.v1.OperationStatus.invocations:type_name -> katl.agent.v1.OperationInvocation
+	40, // 18: katl.agent.v1.OperationStatus.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
+	29, // 19: katl.agent.v1.OperationEvent.status:type_name -> katl.agent.v1.OperationStatus
+	30, // 20: katl.agent.v1.OperationEvent.diagnostics:type_name -> katl.agent.v1.DiagnosticArtifact
+	37, // 21: katl.agent.v1.ListGenerationsResponse.generations:type_name -> katl.agent.v1.Generation
+	38, // 22: katl.agent.v1.Generation.sysexts:type_name -> katl.agent.v1.ExtensionRef
+	39, // 23: katl.agent.v1.Generation.confexts:type_name -> katl.agent.v1.GeneratedConfext
+	40, // 24: katl.agent.v1.Generation.config_apply:type_name -> katl.agent.v1.ConfigApplyStatus
+	41, // 25: katl.agent.v1.ConfigApplyStatus.domain_actions:type_name -> katl.agent.v1.ConfigApplyDomainAction
+	42, // 26: katl.agent.v1.ConfigApplyDomainAction.effects:type_name -> katl.agent.v1.ConfigApplyEffect
+	0,  // 27: katl.agent.v1.KatlcAgent.GetNodeStatus:input_type -> katl.agent.v1.GetNodeStatusRequest
+	9,  // 28: katl.agent.v1.KatlcAgent.GetEtcdStatus:input_type -> katl.agent.v1.GetEtcdStatusRequest
+	43, // 29: katl.agent.v1.KatlcAgent.Reboot:input_type -> katl.agent.v1.RebootRequest
+	45, // 30: katl.agent.v1.KatlcAgent.Shutdown:input_type -> katl.agent.v1.ShutdownRequest
+	13, // 31: katl.agent.v1.KatlcAgent.ValidateConfig:input_type -> katl.agent.v1.ValidateConfigRequest
+	15, // 32: katl.agent.v1.KatlcAgent.ApplyGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	15, // 33: katl.agent.v1.KatlcAgent.StageGeneration:input_type -> katl.agent.v1.GenerationApplyRequest
+	21, // 34: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:input_type -> katl.agent.v1.StageHostUpgradeArtifactRequest
+	6,  // 35: katl.agent.v1.KatlcAgent.SubmitOperation:input_type -> katl.agent.v1.SubmitOperationRequest
+	23, // 36: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:input_type -> katl.agent.v1.CreateWorkerJoinMaterialRequest
+	26, // 37: katl.agent.v1.KatlcAgent.GetOperation:input_type -> katl.agent.v1.GetOperationRequest
+	27, // 38: katl.agent.v1.KatlcAgent.ListOperations:input_type -> katl.agent.v1.ListOperationsRequest
+	32, // 39: katl.agent.v1.KatlcAgent.WatchOperation:input_type -> katl.agent.v1.WatchOperationRequest
+	34, // 40: katl.agent.v1.KatlcAgent.ListGenerations:input_type -> katl.agent.v1.ListGenerationsRequest
+	36, // 41: katl.agent.v1.KatlcAgent.GetGeneration:input_type -> katl.agent.v1.GetGenerationRequest
+	1,  // 42: katl.agent.v1.KatlcAgent.GetNodeStatus:output_type -> katl.agent.v1.NodeStatus
+	10, // 43: katl.agent.v1.KatlcAgent.GetEtcdStatus:output_type -> katl.agent.v1.EtcdStatus
+	44, // 44: katl.agent.v1.KatlcAgent.Reboot:output_type -> katl.agent.v1.RebootAccepted
+	46, // 45: katl.agent.v1.KatlcAgent.Shutdown:output_type -> katl.agent.v1.ShutdownAccepted
+	14, // 46: katl.agent.v1.KatlcAgent.ValidateConfig:output_type -> katl.agent.v1.ConfigValidationResult
+	25, // 47: katl.agent.v1.KatlcAgent.ApplyGeneration:output_type -> katl.agent.v1.OperationAccepted
+	25, // 48: katl.agent.v1.KatlcAgent.StageGeneration:output_type -> katl.agent.v1.OperationAccepted
+	22, // 49: katl.agent.v1.KatlcAgent.StageHostUpgradeArtifact:output_type -> katl.agent.v1.HostUpgradeArtifactStaged
+	25, // 50: katl.agent.v1.KatlcAgent.SubmitOperation:output_type -> katl.agent.v1.OperationAccepted
+	24, // 51: katl.agent.v1.KatlcAgent.CreateWorkerJoinMaterial:output_type -> katl.agent.v1.CreateWorkerJoinMaterialResponse
+	29, // 52: katl.agent.v1.KatlcAgent.GetOperation:output_type -> katl.agent.v1.OperationStatus
+	28, // 53: katl.agent.v1.KatlcAgent.ListOperations:output_type -> katl.agent.v1.ListOperationsResponse
+	33, // 54: katl.agent.v1.KatlcAgent.WatchOperation:output_type -> katl.agent.v1.OperationEvent
+	35, // 55: katl.agent.v1.KatlcAgent.ListGenerations:output_type -> katl.agent.v1.ListGenerationsResponse
+	37, // 56: katl.agent.v1.KatlcAgent.GetGeneration:output_type -> katl.agent.v1.Generation
+	42, // [42:57] is the sub-list for method output_type
+	27, // [27:42] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_internal_katlc_agentapi_agent_proto_init() }
@@ -4640,7 +4981,7 @@ func file_internal_katlc_agentapi_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_katlc_agentapi_agent_proto_rawDesc), len(file_internal_katlc_agentapi_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   43,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/katl-dev/katl/internal/katlc/agentapi;agentapi";
 
 service KatlcAgent {
   rpc GetNodeStatus(GetNodeStatusRequest) returns (NodeStatus);
+  rpc GetEtcdStatus(GetEtcdStatusRequest) returns (EtcdStatus);
   rpc Reboot(RebootRequest) returns (RebootAccepted);
   rpc Shutdown(ShutdownRequest) returns (ShutdownAccepted);
   rpc ValidateConfig(ValidateConfigRequest) returns (ConfigValidationResult);
@@ -98,6 +99,7 @@ message SubmitOperationRequest {
   DestructiveResetOperationRequest destructive_reset = 15;
   HostUpgradeOperationRequest host_upgrade = 16;
   KubeadmControlPlaneConfigOperationRequest kubeadm_control_plane_config = 17;
+  EtcdMemberRemoveOperationRequest etcd_member_remove = 18;
 }
 
 message BootstrapOperationRequest {
@@ -113,12 +115,42 @@ message BootstrapOperationRequest {
   WorkerJoinMaterial worker_join_material = 10;
   string kubernetes_bundle_source = 11;
   string kubernetes_bundle_ref = 12;
+  bool existing_cluster_join = 13;
 }
 
 message WorkerJoinMaterial {
   repeated string join_argv = 1;
   string expires_at = 2;
   bytes discovery_kubeconfig = 3;
+}
+
+message GetEtcdStatusRequest {}
+
+message EtcdStatus {
+  string cluster_id = 1;
+  string local_member_id = 2;
+  string leader_id = 3;
+  repeated EtcdMember members = 4;
+  uint32 quorum = 5;
+  uint32 healthy_members = 6;
+}
+
+message EtcdMember {
+  string id = 1;
+  string name = 2;
+  repeated string peer_urls = 3;
+  repeated string client_urls = 4;
+  bool healthy = 5;
+  bool leader = 6;
+  string health_error = 7;
+}
+
+message EtcdMemberRemoveOperationRequest {
+  string target_node_name = 1;
+  string target_member_id = 2;
+  string target_peer_url = 3;
+  string expected_cluster_id = 4;
+  uint32 expected_member_count = 5;
 }
 
 message ValidateConfigRequest {

--- a/internal/katlc/agentapi/agent_grpc.pb.go
+++ b/internal/katlc/agentapi/agent_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	KatlcAgent_GetNodeStatus_FullMethodName            = "/katl.agent.v1.KatlcAgent/GetNodeStatus"
+	KatlcAgent_GetEtcdStatus_FullMethodName            = "/katl.agent.v1.KatlcAgent/GetEtcdStatus"
 	KatlcAgent_Reboot_FullMethodName                   = "/katl.agent.v1.KatlcAgent/Reboot"
 	KatlcAgent_Shutdown_FullMethodName                 = "/katl.agent.v1.KatlcAgent/Shutdown"
 	KatlcAgent_ValidateConfig_FullMethodName           = "/katl.agent.v1.KatlcAgent/ValidateConfig"
@@ -40,6 +41,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type KatlcAgentClient interface {
 	GetNodeStatus(ctx context.Context, in *GetNodeStatusRequest, opts ...grpc.CallOption) (*NodeStatus, error)
+	GetEtcdStatus(ctx context.Context, in *GetEtcdStatusRequest, opts ...grpc.CallOption) (*EtcdStatus, error)
 	Reboot(ctx context.Context, in *RebootRequest, opts ...grpc.CallOption) (*RebootAccepted, error)
 	Shutdown(ctx context.Context, in *ShutdownRequest, opts ...grpc.CallOption) (*ShutdownAccepted, error)
 	ValidateConfig(ctx context.Context, in *ValidateConfigRequest, opts ...grpc.CallOption) (*ConfigValidationResult, error)
@@ -67,6 +69,16 @@ func (c *katlcAgentClient) GetNodeStatus(ctx context.Context, in *GetNodeStatusR
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NodeStatus)
 	err := c.cc.Invoke(ctx, KatlcAgent_GetNodeStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *katlcAgentClient) GetEtcdStatus(ctx context.Context, in *GetEtcdStatusRequest, opts ...grpc.CallOption) (*EtcdStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EtcdStatus)
+	err := c.cc.Invoke(ctx, KatlcAgent_GetEtcdStatus_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -220,6 +232,7 @@ func (c *katlcAgentClient) GetGeneration(ctx context.Context, in *GetGenerationR
 // for forward compatibility.
 type KatlcAgentServer interface {
 	GetNodeStatus(context.Context, *GetNodeStatusRequest) (*NodeStatus, error)
+	GetEtcdStatus(context.Context, *GetEtcdStatusRequest) (*EtcdStatus, error)
 	Reboot(context.Context, *RebootRequest) (*RebootAccepted, error)
 	Shutdown(context.Context, *ShutdownRequest) (*ShutdownAccepted, error)
 	ValidateConfig(context.Context, *ValidateConfigRequest) (*ConfigValidationResult, error)
@@ -245,6 +258,9 @@ type UnimplementedKatlcAgentServer struct{}
 
 func (UnimplementedKatlcAgentServer) GetNodeStatus(context.Context, *GetNodeStatusRequest) (*NodeStatus, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNodeStatus not implemented")
+}
+func (UnimplementedKatlcAgentServer) GetEtcdStatus(context.Context, *GetEtcdStatusRequest) (*EtcdStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetEtcdStatus not implemented")
 }
 func (UnimplementedKatlcAgentServer) Reboot(context.Context, *RebootRequest) (*RebootAccepted, error) {
 	return nil, status.Error(codes.Unimplemented, "method Reboot not implemented")
@@ -320,6 +336,24 @@ func _KatlcAgent_GetNodeStatus_Handler(srv interface{}, ctx context.Context, dec
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(KatlcAgentServer).GetNodeStatus(ctx, req.(*GetNodeStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _KatlcAgent_GetEtcdStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetEtcdStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KatlcAgentServer).GetEtcdStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KatlcAgent_GetEtcdStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KatlcAgentServer).GetEtcdStatus(ctx, req.(*GetEtcdStatusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -550,6 +584,10 @@ var KatlcAgent_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetNodeStatus",
 			Handler:    _KatlcAgent_GetNodeStatus_Handler,
+		},
+		{
+			MethodName: "GetEtcdStatus",
+			Handler:    _KatlcAgent_GetEtcdStatus_Handler,
 		},
 		{
 			MethodName: "Reboot",

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/bootstrap/readiness"
 	"github.com/katl-dev/katl/internal/installer/artifact"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/kubeadmplan"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	"github.com/katl-dev/katl/internal/installer/sysextcatalog"
@@ -40,6 +41,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"gopkg.in/yaml.v3"
 )
@@ -70,16 +72,31 @@ func TestInstalledRuntimeThreeControlPlaneV01WorkloadProof(t *testing.T) {
 	_ = vmtest.RequireWorld(t)
 }
 
+func TestInstalledRuntimeThreeControlPlaneReplacementSmoke(t *testing.T) {
+	if run, ok := threeControlPlaneWorldSmokeRun(t, "installed-runtime-three-control-plane-replacement", false); ok {
+		run.ReplacementProof = true
+		runThreeControlPlaneStackedEtcdSmoke(t, run)
+		return
+	}
+
+	options := vmtest.DefaultOptions()
+	if !options.Enabled {
+		t.Skip("set -katl.vmtest.run or KATL_VMTEST_RUN=1 to run three-control-plane replacement smoke")
+	}
+	_ = vmtest.RequireWorld(t)
+}
+
 type threeControlPlaneSmokeRun struct {
-	WorldScenario *vmtest.WorldScenario
-	Options       vmtest.Options
-	Runner        vmtest.Runner
-	Scenario      vmtest.Scenario
-	Result        vmtest.Result
-	Inputs        threeControlPlaneSmokeInputs
-	LibvirtURI    string
-	Network       string
-	WorkloadProof bool
+	WorldScenario    *vmtest.WorldScenario
+	Options          vmtest.Options
+	Runner           vmtest.Runner
+	Scenario         vmtest.Scenario
+	Result           vmtest.Result
+	Inputs           threeControlPlaneSmokeInputs
+	LibvirtURI       string
+	Network          string
+	WorkloadProof    bool
+	ReplacementProof bool
 }
 
 func threeControlPlaneWorldSmokeRun(t *testing.T, scenarioName string, workloadProof bool) (threeControlPlaneSmokeRun, bool) {
@@ -116,8 +133,18 @@ func planThreeControlPlaneWorldSmokeRun(world vmtest.World, repo, scenarioName, 
 		return threeControlPlaneSmokeRun{}, err
 	}
 	run := threeControlPlaneSmokeRun{WorldScenario: scenario}
+	_, sshAuthorizedKey, err := ensureWorldSSHKey(world)
+	if err != nil {
+		_ = scenario.WriteSetupFailure(err)
+		return run, err
+	}
 	nodes := make(map[string]vmtest.InstalledRuntimeWorldNode, 3)
 	buildRoots := publishedRuntimeBuildRoots(world, repo)
+	cp3Published, err := vmtest.FindPublishedFirstInstallRuntimeFixtureInBuildRoots(buildRoots, vmtest.NodeSpec{Name: "cp-3", Role: vmtest.ControlPlane})
+	if err != nil {
+		_ = scenario.WriteSetupFailure(err)
+		return run, err
+	}
 	for _, name := range []string{"cp-1", "cp-2", "cp-3"} {
 		node, err := vmtest.AddPublishedInstalledRuntimeNodeFromBuildRoots(scenario, buildRoots, vmtest.NodeSpec{Name: name, Role: vmtest.ControlPlane})
 		if err != nil {
@@ -172,6 +199,8 @@ func planThreeControlPlaneWorldSmokeRun(world vmtest.World, repo, scenarioName, 
 			CP3Metadata:       nodes["cp-3"].Config.NodeMetadata,
 			CP3Address:        nodes["cp-3"].Node.Address,
 			CP3MAC:            nodes["cp-3"].Node.MACAddress,
+			CP3Install:        firstInstallProvenanceFromPublished(cp3Published),
+			SSHAuthorizedKey:  sshAuthorizedKey,
 			KubernetesVersion: firstString(kubernetesVersion, "v1.36.1"),
 			WorldProvenance:   multiNodeWorldProvenanceForSpecs(world, repo, threeControlPlaneWorldRuntimeSpecs()),
 		},
@@ -405,7 +434,336 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 			t.Fatal(err)
 		}
 	}
+	if smoke.ReplacementProof {
+		replacedNodes, err := runThreeControlPlaneReplacementProof(t, ctx, smoke, result, nodes, addresses, kubeconfigPath, kubernetesBundle, etcdReport)
+		if err != nil {
+			collectKubectlDiagnostics(kubeconfigPath, result.RunDir)
+			collectTwoNodeDiagnostics("", nodes...)
+			finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+			t.Fatalf("control-plane replacement proof failed: %v", err)
+		}
+		nodes = replacedNodes
+		defer stopNode(t, nodeByName(replacedNodes, "cp-3"))
+	}
 	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
+}
+
+func runThreeControlPlaneReplacementProof(t *testing.T, ctx context.Context, smoke threeControlPlaneSmokeRun, result vmtest.Result, nodes []vmtest.RunningInstalledRuntimeNode, addresses map[string]string, kubeconfigPath string, bundle threeControlPlaneKubernetesPayloadBundle, before threeControlPlaneEtcdReport) ([]vmtest.RunningInstalledRuntimeNode, error) {
+	t.Helper()
+	dir := filepath.Join(result.RunDir, "control-plane-replacement")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nodes, err
+	}
+	configPath := filepath.Join(dir, "cluster.katlcfg")
+	if err := writeThreeControlPlaneReplacementConfig(filepath.Join(dir, "cluster.yaml"), configPath, addresses, smoke.Inputs.SSHAuthorizedKey, smoke.Inputs.KubernetesVersion, bundle.Ref); err != nil {
+		return nodes, err
+	}
+	cp1 := nodeByName(nodes, "cp-1")
+	cp2 := nodeByName(nodes, "cp-2")
+	cp3 := nodeByName(nodes, "cp-3")
+	if cp1.Name == "" || cp2.Name == "" || cp3.Name == "" {
+		return nodes, errors.New("replacement proof requires cp-1, cp-2, and cp-3")
+	}
+	beforeStatus, err := readLiveEtcdStatus(ctx, "cp-1", addresses["cp-1"])
+	if err != nil {
+		return nodes, fmt.Errorf("inspect etcd before replacement: %w", err)
+	}
+	oldMember := etcdStatusMember(beforeStatus, "cp-3")
+	if oldMember == nil {
+		return nodes, errors.New("cp-3 etcd member is missing before replacement")
+	}
+	oldMachineID, err := readNodeFileWithRetry(ctx, cp3, "/var/lib/katl/identity/machine-id", 4<<10, time.Minute)
+	if err != nil {
+		return nodes, fmt.Errorf("read cp-3 machine identity before replacement: %w", err)
+	}
+	cp3Overlay, err := bootOverlayPath(cp3)
+	if err != nil {
+		return nodes, err
+	}
+
+	var wipeStdout, wipeStderr bytes.Buffer
+	err = runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{
+		"node", "wipe", "cp-3",
+		"--config", configPath,
+		"--kubeconfig", kubeconfigPath,
+		"--timeout", "10m",
+		"--output", "json",
+	}, &wipeStdout, &wipeStderr)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-node-wipe.stdout"), wipeStdout.Bytes(), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-node-wipe.stderr"), wipeStderr.Bytes(), 0o600)
+	if err != nil {
+		return nodes, fmt.Errorf("wipe cp-3: %w: %s", err, wipeStderr.String())
+	}
+	var wipeReport struct {
+		KubernetesCleanup string `json:"kubernetesCleanup"`
+		EtcdCleanup       string `json:"etcdCleanup"`
+		EtcdCoordinator   string `json:"etcdCoordinator"`
+		EtcdMember        string `json:"etcdMemberID"`
+		Nodes             []struct {
+			Node     string `json:"node"`
+			Terminal bool   `json:"terminal"`
+			Result   string `json:"result"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(wipeStdout.Bytes(), &wipeReport); err != nil {
+		return nodes, fmt.Errorf("decode cp-3 wipe report: %w", err)
+	}
+	if wipeReport.KubernetesCleanup != "succeeded" || wipeReport.EtcdCleanup != "succeeded" ||
+		wipeReport.EtcdCoordinator == "" || !strings.EqualFold(wipeReport.EtcdMember, oldMember.GetId()) ||
+		len(wipeReport.Nodes) != 1 || wipeReport.Nodes[0].Node != "cp-3" ||
+		!wipeReport.Nodes[0].Terminal || wipeReport.Nodes[0].Result != operation.ResultSucceeded {
+		return nodes, fmt.Errorf("cp-3 wipe report is incomplete: %#v", wipeReport)
+	}
+	if err := cp3.WaitForPoweroff(ctx); err != nil {
+		return nodes, fmt.Errorf("wait for wiped cp-3 poweroff: %w", err)
+	}
+	afterRemoval, err := readLiveEtcdStatus(ctx, "cp-1", addresses["cp-1"])
+	if err != nil {
+		return nodes, fmt.Errorf("inspect etcd after cp-3 removal: %w", err)
+	}
+	if afterRemoval.GetClusterId() != beforeStatus.GetClusterId() || len(afterRemoval.GetMembers()) != 2 || etcdStatusMember(afterRemoval, "cp-3") != nil {
+		return nodes, fmt.Errorf("etcd did not converge to two surviving members: %s", afterRemoval.String())
+	}
+	if output, err := kubectlOutput(ctx, kubeconfigPath, "get", "node", "cp-3"); err == nil {
+		return nodes, fmt.Errorf("cp-3 Kubernetes Node still exists after wipe: %s", output)
+	}
+	stopNode(t, cp3)
+
+	reinstallRunner := vmtest.NewRunner(vmtest.Options{
+		Enabled:   true,
+		StateRoot: filepath.Join(dir, "reinstall-vm-runs"),
+		Keep:      vmtest.KeepAlways,
+		KVM:       smoke.Options.KVM,
+		Missing:   vmtest.MissingFails,
+	})
+	reinstallRun := operationBackedSmokeRun{
+		Options:    smoke.Options,
+		LibvirtURI: smoke.LibvirtURI,
+		Network:    smoke.Network,
+	}
+	reinstallResult, err := runWipeReinstallNode(ctx, reinstallRun, reinstallRunner, "cp-3", cp3Overlay, smoke.Inputs.CP3Install, smoke.Inputs.CP3MAC)
+	if err != nil {
+		return nodes, fmt.Errorf("reinstall cp-3: %w", err)
+	}
+	reinstalledDisk, err := firstInstallResultDisk(reinstallResult)
+	if err != nil {
+		return nodes, err
+	}
+	postRunner := vmtest.NewRunner(vmtest.Options{
+		Enabled:   true,
+		StateRoot: filepath.Join(dir, "post-reinstall-vm-runs"),
+		Keep:      vmtest.KeepFailed,
+		KVM:       smoke.Options.KVM,
+		Missing:   vmtest.MissingFails,
+	})
+	postResult, err := postRunner.Plan(vmtest.Scenario{Name: "post-control-plane-replacement"})
+	if err != nil {
+		return nodes, err
+	}
+	postResult.Started = time.Now().UTC()
+	reinstalledCP3, err := vmtest.StartInstalledRuntimeNode(ctx, postResult, threeControlPlaneNodeConfigForRun(
+		smoke, "cp-3", reinstalledDisk, reinstallResult.Artifacts.InstalledESP, "", smoke.Inputs.CP3Metadata, vmtest.DiskQCOW2, smoke.Inputs.CP3MAC, 0,
+	), vmtest.VMRunner{})
+	if err != nil {
+		return nodes, fmt.Errorf("start reinstalled cp-3: %w", err)
+	}
+	keepReinstalled := false
+	defer func() {
+		if !keepReinstalled {
+			stopNode(t, reinstalledCP3)
+		}
+	}()
+	newMachineID, err := readNodeFileWithRetry(ctx, reinstalledCP3, "/var/lib/katl/identity/machine-id", 4<<10, time.Minute)
+	if err != nil {
+		return nodes, fmt.Errorf("read reinstalled cp-3 machine identity: %w", err)
+	}
+	if strings.TrimSpace(string(newMachineID)) == strings.TrimSpace(string(oldMachineID)) {
+		return nodes, errors.New("reinstalled cp-3 preserved the old machine identity")
+	}
+	if err := assertNoRunIdentity(ctx, reinstalledCP3); err != nil {
+		return nodes, fmt.Errorf("reinstalled cp-3 retained runtime identity: %w", err)
+	}
+	status, err := readAgentNodeStatus(ctx, "cp-3", addresses["cp-3"])
+	if err != nil {
+		return nodes, fmt.Errorf("read reinstalled cp-3 status: %w", err)
+	}
+	if got := status.GetKubernetes().GetState(); got != "not-configured" {
+		return nodes, fmt.Errorf("reinstalled cp-3 Kubernetes state = %q, want not-configured", got)
+	}
+	replacedNodes := []vmtest.RunningInstalledRuntimeNode{cp1, cp2, reinstalledCP3}
+	if err := installKubernetesBundleCA(ctx, reinstalledCP3, bundle); err != nil {
+		return nodes, fmt.Errorf("install Kubernetes bundle CA on reinstalled cp-3: %w", err)
+	}
+	if _, err := stageThreeControlPlaneCNIFixtures(ctx, katlRepoRoot(t), replacedNodes, addresses); err != nil {
+		return nodes, fmt.Errorf("stage replacement CNI fixtures: %w", err)
+	}
+	if _, err := stageKubernetesImageFixtures(ctx, katlRepoRoot(t), smoke.Inputs.KubernetesVersion, reinstalledCP3); err != nil {
+		return nodes, fmt.Errorf("stage replacement Kubernetes images: %w", err)
+	}
+
+	var applyStdout, applyStderr bytes.Buffer
+	err = runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"cluster", "apply", "--config", configPath}, &applyStdout, &applyStderr)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-cluster-apply.stdout"), applyStdout.Bytes(), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-cluster-apply.stderr"), applyStderr.Bytes(), 0o600)
+	if err != nil {
+		return nodes, fmt.Errorf("apply cluster config to replacement: %w: %s", err, applyStderr.String())
+	}
+	var applyReport struct {
+		Joined []string `json:"joined"`
+		Result string   `json:"result"`
+	}
+	if err := json.Unmarshal(applyStdout.Bytes(), &applyReport); err != nil {
+		return nodes, fmt.Errorf("decode replacement apply report: %w", err)
+	}
+	if applyReport.Result != operation.ResultSucceeded || !reflect.DeepEqual(applyReport.Joined, []string{"cp-3"}) {
+		return nodes, fmt.Errorf("replacement apply report = %#v", applyReport)
+	}
+	if _, err := waitForKubectlNodes(ctx, kubeconfigPath, filepath.Join(dir, "kubectl-after-replacement.txt"), 5*time.Minute, "node/cp-1", "node/cp-2", "node/cp-3"); err != nil {
+		return nodes, fmt.Errorf("wait for replacement Kubernetes node: %w", err)
+	}
+	if err := waitForAgentKubernetesReady(ctx, replacedNodes, addresses, 3*time.Minute); err != nil {
+		return nodes, err
+	}
+	afterJoin, err := readLiveEtcdStatus(ctx, "cp-1", addresses["cp-1"])
+	if err != nil {
+		return nodes, fmt.Errorf("inspect etcd after replacement join: %w", err)
+	}
+	newMember := etcdStatusMember(afterJoin, "cp-3")
+	if afterJoin.GetClusterId() != beforeStatus.GetClusterId() || len(afterJoin.GetMembers()) != 3 ||
+		newMember == nil || strings.EqualFold(newMember.GetId(), oldMember.GetId()) ||
+		afterJoin.GetHealthyMembers() != 3 {
+		return nodes, fmt.Errorf("replacement etcd membership is invalid: before=%s after=%s", beforeStatus.String(), afterJoin.String())
+	}
+	_, joinRecord, err := collectOperationEvidence(ctx, reinstalledCP3, filepath.Join(dir, "cp-3-operation"), "bootstrap-join-control-plane")
+	if err != nil {
+		return nodes, fmt.Errorf("collect replacement join evidence: %w", err)
+	}
+	if joinRecord.BootstrapRequest == nil || !joinRecord.BootstrapRequest.ExistingClusterJoin {
+		return nodes, fmt.Errorf("replacement join did not record existing-cluster intent: %#v", joinRecord.BootstrapRequest)
+	}
+	postReport, err := verifyThreeControlPlaneEtcdAt(ctx, filepath.Join(dir, "etcd-transcripts"), replacedNodes, "/var/lib/etcd/katl-snapshots/after-control-plane-replacement.db")
+	if err != nil {
+		return nodes, fmt.Errorf("verify etcd after replacement: %w", err)
+	}
+	if postReport.Health.Quorum != before.Health.Quorum {
+		return nodes, fmt.Errorf("replacement etcd quorum = %d, want %d", postReport.Health.Quorum, before.Health.Quorum)
+	}
+
+	var repeatStdout, repeatStderr bytes.Buffer
+	err = runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"cluster", "apply", "--config", configPath}, &repeatStdout, &repeatStderr)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-cluster-apply-repeat.stdout"), repeatStdout.Bytes(), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "katlctl-cluster-apply-repeat.stderr"), repeatStderr.Bytes(), 0o600)
+	if err != nil {
+		return nodes, fmt.Errorf("repeat cluster apply after replacement: %w: %s", err, repeatStderr.String())
+	}
+	applyReport = struct {
+		Joined []string `json:"joined"`
+		Result string   `json:"result"`
+	}{}
+	if err := json.Unmarshal(repeatStdout.Bytes(), &applyReport); err != nil {
+		return nodes, fmt.Errorf("decode repeated apply report: %w", err)
+	}
+	if applyReport.Result != operation.ResultSucceeded || len(applyReport.Joined) != 0 {
+		return nodes, fmt.Errorf("repeated apply report = %#v", applyReport)
+	}
+	keepReinstalled = true
+	return replacedNodes, nil
+}
+
+func writeThreeControlPlaneReplacementConfig(sourcePath, bundlePath string, addresses map[string]string, sshAuthorizedKey, kubernetesVersion, kubernetesBundle string) error {
+	source := `apiVersion: config.katl.dev/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: replacement-vmtest
+spec:
+  controlPlaneEndpoint:
+    host: ` + addresses["cp-1"] + `
+    port: 6443
+  kubernetes:
+    version: ` + kubernetesVersion + `
+  defaults:
+    identity:
+      ssh:
+        authorizedKeys:
+          - ` + sshAuthorizedKey + `
+    networkd:
+      files:
+        - name: 80-katl-vmtest-dhcp.network
+          content: |
+            [Match]
+            Name=en*
+
+            [Network]
+            DHCP=yes
+
+            [DHCPv4]
+            ClientIdentifier=mac
+            UseHostname=no
+
+            [DHCPv6]
+            UseHostname=no
+  nodes:
+`
+	for _, name := range []string{"cp-1", "cp-2", "cp-3"} {
+		source += `    - name: ` + name + `
+      controlPlane: true
+      install:
+        targetDisk:
+          byID: /dev/disk/by-id/virtio-katl-root
+      bootstrap:
+        address: ` + addresses[name] + `
+`
+	}
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		return err
+	}
+	_, err := configbundle.WriteArchive(bundlePath, configbundle.BuildRequest{
+		SourcePath:     sourcePath,
+		KatlctlVersion: "vmtest",
+		KatlctlCommit:  "vmtest",
+		CreatedBy:      "three-control-plane replacement vmtest",
+		Planning:       configbundle.PlanningInputs{KubernetesBundle: kubernetesBundle},
+	})
+	return err
+}
+
+func readAgentNodeStatus(ctx context.Context, name, address string) (*agentapi.NodeStatus, error) {
+	connector := cluster.TCPAgentConnector{DialTimeout: 5 * time.Second}
+	conn, err := connector.Connect(ctx, inventory.PlannedNode{
+		Name: name, Address: address, Access: inventory.Access{Method: "agent"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+}
+
+func readLiveEtcdStatus(ctx context.Context, name, address string) (*agentapi.EtcdStatus, error) {
+	connector := cluster.TCPAgentConnector{DialTimeout: 5 * time.Second}
+	conn, err := connector.Connect(ctx, inventory.PlannedNode{
+		Name: name, Address: address, Access: inventory.Access{Method: "agent"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	client, ok := conn.Client.(interface {
+		GetEtcdStatus(context.Context, *agentapi.GetEtcdStatusRequest, ...grpc.CallOption) (*agentapi.EtcdStatus, error)
+	})
+	if !ok {
+		return nil, errors.New("katlc agent does not support etcd status")
+	}
+	return client.GetEtcdStatus(ctx, &agentapi.GetEtcdStatusRequest{})
+}
+
+func etcdStatusMember(status *agentapi.EtcdStatus, name string) *agentapi.EtcdMember {
+	for _, member := range status.GetMembers() {
+		if member.GetName() == name {
+			return member
+		}
+	}
+	return nil
 }
 
 func waitForAgentKubernetesReady(ctx context.Context, nodes []vmtest.RunningInstalledRuntimeNode, addresses map[string]string, timeout time.Duration) error {
@@ -806,6 +1164,8 @@ type threeControlPlaneSmokeInputs struct {
 	CP3Metadata       string
 	CP3Address        string
 	CP3MAC            string
+	CP3Install        firstInstallProvenance
+	SSHAuthorizedKey  string
 	KubernetesVersion string
 	WorldProvenance   multiNodeWorldProvenancePaths
 }
@@ -850,8 +1210,8 @@ func threeControlPlaneNodeConfigForRun(run threeControlPlaneSmokeRun, name, disk
 
 func stageThreeControlPlaneKubernetesPayloadBundles(repo string, result vmtest.Result, selectedVersion string) (threeControlPlaneKubernetesPayloadBundle, error) {
 	selectedVersion = firstString(strings.TrimSpace(selectedVersion), "v1.36.1")
-	if selectedVersion != "v1.36.0" && selectedVersion != "v1.36.1" {
-		return threeControlPlaneKubernetesPayloadBundle{}, fmt.Errorf("three-control-plane bundle proof supports v1.36.0 or v1.36.1, got %q", selectedVersion)
+	if _, err := kubernetesImageReferences(selectedVersion); err != nil {
+		return threeControlPlaneKubernetesPayloadBundle{}, fmt.Errorf("three-control-plane bundle proof does not support %q: %w", selectedVersion, err)
 	}
 	artifactPath := filepath.Join(repo, "_build/mkosi/katl-kubernetes.raw")
 	baseMetadataPath := filepath.Join(repo, "_build/mkosi/katl-kubernetes.raw.json")

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/operation"
 	"github.com/katl-dev/katl/internal/installer/persistedrecord"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/kubernetesrelease"
 	"github.com/katl-dev/katl/internal/vmtest"
 	vmtestpb "github.com/katl-dev/katl/internal/vmtest/proto"
 )
@@ -2128,10 +2129,12 @@ func ensureKubernetesImageFixture(ctx context.Context, repo, kubernetesVersion s
 }
 
 func kubernetesImageReferences(kubernetesVersion string) ([]string, error) {
-	switch kubernetesVersion {
-	case "v1.36.0", "v1.36.1":
-	default:
-		return nil, fmt.Errorf("Kubernetes VM image fixtures do not define kubeadm images for %s", kubernetesVersion)
+	supported, err := kubernetesrelease.DefaultSupportedVersions()
+	if err != nil {
+		return nil, fmt.Errorf("load supported Kubernetes versions: %w", err)
+	}
+	if _, err := supported.Select(kubernetesVersion); err != nil {
+		return nil, fmt.Errorf("Kubernetes VM image fixtures do not define kubeadm images for %s: %w", kubernetesVersion, err)
 	}
 	return []string{
 		"registry.k8s.io/kube-apiserver:" + kubernetesVersion,
@@ -4365,7 +4368,12 @@ func TestTwoNodeHostToolPrereqsUseSelectedKubectl(t *testing.T) {
 }
 
 func TestKubernetesImageReferencesMatchSupportedKubeadmVersions(t *testing.T) {
-	for _, version := range []string{"v1.36.0", "v1.36.1"} {
+	supported, err := kubernetesrelease.DefaultSupportedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, selected := range supported.Versions {
+		version := selected.PayloadVersion
 		images, err := kubernetesImageReferences(version)
 		if err != nil {
 			t.Fatalf("kubernetesImageReferences(%q) error = %v", version, err)


### PR DESCRIPTION
## Summary

- make one whole-cluster apply join a freshly reinstalled control-plane node without rerunning bootstrap
- integrate clean wipe and explicit stale etcd-member recovery with identity and quorum safeguards
- keep replacement joins on the selected healthy coordinator, tolerate same-version payload rebuilds, and preserve node configuration across host upgrades

## Why

Control-plane replacement exposed several coupled gaps: mixed fresh/ready lifecycle state was rejected, kubeadm could follow the stable VIP before the replacement was able to advertise it, stale etcd members had no bounded maintenance path, and legacy host upgrades could omit the generation-owned node manifest.

## Validation

A three-control-plane physical lab completed both clean and unclean replacement journeys while preserving the etcd cluster identity and API availability. The focused libvirt replacement and host-upgrade/rollback journeys also passed.
