### PR TITLE
cluster: retain desired kubeadm state

### DIFF
--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -402,6 +402,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		noChanges         bool
 		acceptedApplyMode string
 		changedDomains    []string
+		components        []string
 	}
 	prepared := make([]preparedInput, 0, len(nodes))
 	components := map[string]bool{}
@@ -417,14 +418,15 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		if !ok {
 			return activatedClusterConfig{}, fmt.Errorf("selected kubeadm input %q for %s is missing", node.KubeadmConfig.Ref, node.Name)
 		}
+		var nodeComponents []string
 		for _, document := range plan.Documents {
 			switch document.Kind {
 			case "ClusterConfiguration":
-				components["control-plane"] = true
+				nodeComponents = append(nodeComponents, "control-plane")
 			case "KubeletConfiguration":
-				components["kubelet"] = true
+				nodeComponents = append(nodeComponents, "kubelet")
 			case "KubeProxyConfiguration":
-				components["kube-proxy"] = true
+				nodeComponents = append(nodeComponents, "kube-proxy")
 			}
 		}
 		configYAML, err := configapply.RenderNodeConfigurationChange(configapply.RenderNodeRequest{
@@ -434,7 +436,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		if err != nil {
 			return activatedClusterConfig{}, fmt.Errorf("render cluster config for %s: %w", node.Name, err)
 		}
-		prepared = append(prepared, preparedInput{node: node, configYAML: configYAML})
+		prepared = append(prepared, preparedInput{node: node, configYAML: configYAML, components: nodeComponents})
 	}
 	result := make(map[string]string, len(nodes))
 	for i := range prepared {
@@ -473,6 +475,11 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		input.acceptedApplyMode = validation.AcceptedApplyMode
 		input.changedDomains = append([]string(nil), validation.ChangedDomains...)
 		_ = conn.Close()
+		if containsKubernetesConfigDomain(validation.ChangedDomains) {
+			for _, component := range input.components {
+				components[component] = true
+			}
+		}
 		if validation.NoChanges {
 			if len(validation.Diagnostics) > 0 {
 				return activatedClusterConfig{}, fmt.Errorf("node %s configuration files match, but runtime state is not current: %s", node.Name, strings.Join(validation.Diagnostics, "; "))
@@ -501,6 +508,13 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 	}
 	preBootstrap := len(prepared) > 0 && notConfigured == len(prepared)
 	joinCoordinator := ""
+	if preBootstrap {
+		for _, input := range prepared {
+			for _, component := range input.components {
+				components[component] = true
+			}
+		}
+	}
 	if notConfigured > 0 && !preBootstrap {
 		if notConfigured != 1 {
 			return activatedClusterConfig{}, fmt.Errorf(
@@ -535,6 +549,14 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 				"cluster has one fresh node but no ready control plane can coordinate its join (%s)",
 				strings.Join(kubernetesStates, ", "),
 			)
+		}
+		for _, input := range prepared {
+			if input.kubernetesState != "not-configured" {
+				continue
+			}
+			for _, component := range input.components {
+				components[component] = true
+			}
 		}
 	}
 

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -80,8 +80,12 @@ func TestRunClusterApplyReconcilesWholeConfigAndAllKubernetesComponents(t *testi
 	configPath := writeClusterConfig(t)
 	var stdout, stderr bytes.Buffer
 	client := &fakeKatlcAgentClient{
-		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
-		validateResult:  &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
+		nodeStatus: &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
+		validateResult: &agentapi.ConfigValidationResult{
+			Accepted:          true,
+			AcceptedApplyMode: "live",
+			ChangedDomains:    []string{configapply.DomainKubeadmConfig},
+		},
 		submitAccepted:  &agentapi.OperationAccepted{OperationId: "operation-1", RequestDigest: strings.Repeat("e", 64)},
 		operationStatus: &agentapi.OperationStatus{OperationId: "operation-1", Terminal: true, Result: operation.ResultSucceeded},
 		generation: &agentapi.Generation{
@@ -208,6 +212,69 @@ func TestRunClusterApplySkipsKubernetesComponentsBeforeBootstrap(t *testing.T) {
 	}
 	if len(client.submitRequests) != 0 {
 		t.Fatalf("pre-bootstrap no-op submitted mutations: %#v", client.submitRequests)
+	}
+}
+
+func TestRunClusterApplyStagesPostBootstrapHostOnlyChangeAndRepeatsWithoutKubeadm(t *testing.T) {
+	configPath := writeClusterConfig(t)
+	client := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-1",
+			CurrentGenerationId: "generation-1",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "ready"},
+		},
+		validateResult: &agentapi.ConfigValidationResult{
+			Accepted:          true,
+			AcceptedApplyMode: generation.ApplyModeNextBoot,
+			ChangedDomains:    []string{configapply.DomainHostConfiguration},
+		},
+		submitAccepted: &agentapi.OperationAccepted{OperationId: "stage-cp-1", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{
+			OperationId:           "stage-cp-1",
+			CandidateGenerationId: "cluster-config-42",
+			Terminal:              true,
+			Result:                operation.ResultSucceeded,
+		},
+	}
+	previousDial := dialKatlcAgent
+	previousNow := kubeadmConfigNow
+	defer func() {
+		dialKatlcAgent = previousDial
+		kubeadmConfigNow = previousNow
+	}()
+	dialKatlcAgent = func(context.Context, string) (katlcAgentConnection, error) {
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+	kubeadmConfigNow = func() time.Time { return time.Unix(0, 42).UTC() }
+
+	var stdout, stderr bytes.Buffer
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{`"rebootRequired":true`, `"stagedNodes":["cp-1"]`, `"kubernetes":{}`} {
+		if !strings.Contains(stdout.String(), required) {
+			t.Fatalf("staged stdout = %s, missing %s", stdout.String(), required)
+		}
+	}
+	if len(client.submitRequests) != 1 || client.submitRequests[0].OperationKind != "generation-stage" {
+		t.Fatalf("staged submit requests = %#v, want one generation-stage", client.submitRequests)
+	}
+	if client.generationRequest != nil || strings.Contains(stderr.String(), "component=control-plane status=started") || strings.Contains(stderr.String(), "component=kubelet status=started") {
+		t.Fatalf("host-only stage reconciled Kubernetes: generation=%#v progress=%s", client.generationRequest, stderr.String())
+	}
+
+	client.nodeStatus.CurrentGenerationId = "cluster-config-42"
+	client.validateResult = &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: generation.ApplyModeLive, NoChanges: true}
+	stdout.Reset()
+	stderr.Reset()
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), `"kubernetes":{}`) || strings.Contains(stdout.String(), `"rebootRequired"`) {
+		t.Fatalf("repeat stdout = %s", stdout.String())
+	}
+	if len(client.submitRequests) != 1 || client.generationRequest != nil {
+		t.Fatalf("repeat apply mutated state: submits=%#v generation=%#v", client.submitRequests, client.generationRequest)
 	}
 }
 
@@ -410,8 +477,14 @@ func TestActivateClusterConfigDiscoversKubeProxyPhase(t *testing.T) {
 		t.Fatal(err)
 	}
 	client := &fakeKatlcAgentClient{
-		nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
-		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+		nodeStatus: &agentapi.NodeStatus{MachineId: "machine-cp-1", CurrentGenerationId: "generation-1"},
+		validateResult: &agentapi.ConfigValidationResult{
+			Accepted:          true,
+			AcceptedApplyMode: "live",
+			ChangedDomains:    []string{configapply.DomainKubeadmConfig},
+		},
+		submitAccepted:  &agentapi.OperationAccepted{OperationId: "stage-cp-1", RequestDigest: strings.Repeat("e", 64)},
+		operationStatus: &agentapi.OperationStatus{OperationId: "stage-cp-1", Terminal: true, Result: operation.ResultSucceeded},
 	}
 	previousDial := dialKatlcAgent
 	defer func() { dialKatlcAgent = previousDial }()

--- a/internal/installer/bootstrapruntime/prepare.go
+++ b/internal/installer/bootstrapruntime/prepare.go
@@ -20,7 +20,9 @@ import (
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/bootstrapplan"
 	"github.com/katl-dev/katl/internal/installer/confext"
+	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 )
 
 type Result struct {
@@ -140,6 +142,26 @@ func Prepare(root string, plan bootstrapplan.Plan, now time.Time) (Result, error
 	}
 	if err := generation.WriteRecord(metadataPath, next); err != nil {
 		return Result{}, err
+	}
+	desiredFiles, _, err := readStoredKubeadmInput(root, plan.RuntimeInputs.KubeadmInput)
+	if err != nil {
+		return Result{}, err
+	}
+	kubeadmFiles := make([]kubeadmconfig.File, 0, len(desiredFiles))
+	for _, input := range desiredFiles {
+		kubeadmFiles = append(kubeadmFiles, kubeadmconfig.File{
+			RenderPath: input.RenderPath,
+			Content:    input.Content,
+			Mode:       input.Mode,
+		})
+	}
+	kubeadmRef := strings.TrimSpace(plan.RuntimeInputs.KubeadmInput.ConfigRef)
+	kubeadmPlan, err := kubeadmconfig.PlanFromRenderedFiles(kubeadmRef, kubeadmFiles)
+	if err != nil {
+		return Result{}, fmt.Errorf("preserve desired kubeadm input: %w", err)
+	}
+	if err := configapply.WriteGenerationKubeadmConfig(root, candidate, kubeadmRef, kubeadmPlan); err != nil {
+		return Result{}, fmt.Errorf("preserve desired kubeadm input: %w", err)
 	}
 	if err := writeLiveActivationOverride(root, candidate); err != nil {
 		return Result{}, err

--- a/internal/installer/bootstrapruntime/prepare_test.go
+++ b/internal/installer/bootstrapruntime/prepare_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/bootstrapplan"
+	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
 )
@@ -138,6 +139,13 @@ func TestPrepareMaterializesCandidateRuntimeWithoutBootDefault(t *testing.T) {
 	}
 	assertContains(t, filepath.Join(root, "var/lib/katl/generations/1/confext/etc/katl/kubeadm/control-plane/config.yaml"), "InitConfiguration")
 	assertContains(t, filepath.Join(root, "var/lib/katl/generations/1/confext/etc/katl/kubeadm/control-plane/config.yaml"), "controlPlaneEndpoint: api.katl.test:6443")
+	desiredKubeadm, sourceGeneration, err := configapply.ReadEffectiveGenerationKubeadmConfig(root, "1", "control-plane")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceGeneration != "1" || strings.Contains(string(desiredKubeadm.Config.Content), "controlPlaneEndpoint:") {
+		t.Fatalf("desired kubeadm input = source %q content:\n%s", sourceGeneration, desiredKubeadm.Config.Content)
+	}
 	assertContains(t, filepath.Join(root, "var/lib/katl/generations/1/confext/etc/katl/bootstrap-runtime.json"), `"controlPlaneEndpoint": "api.katl.test:6443"`)
 	assertContains(t, filepath.Join(root, "var/lib/katl/generations/1/confext/etc/extension-release.d/extension-release.katl-node"), "ID=katlos")
 	assertContains(t, filepath.Join(root, "var/lib/katl/generations/1/confext/etc/systemd/network/80-katl-vmtest-dhcp.network"), "DHCP=yes")

--- a/internal/installer/configapply/kubeadm_state.go
+++ b/internal/installer/configapply/kubeadm_state.go
@@ -1,0 +1,151 @@
+package configapply
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
+	"github.com/katl-dev/katl/internal/installer/persistedrecord"
+)
+
+const (
+	generationKubeadmInputDir = "kubeadm-input"
+	maxGenerationAncestry     = 256
+)
+
+func WriteGenerationKubeadmConfig(root, generationID, ref string, plan kubeadmconfig.Plan) error {
+	dir, err := generation.GenerationDir(root, generationID)
+	if err != nil {
+		return err
+	}
+	ref, err = cleanKubeadmInputRef(ref)
+	if err != nil {
+		return err
+	}
+	files := append([]kubeadmconfig.File{plan.Config}, plan.Patches...)
+	if _, err := kubeadmconfig.PlanFromRenderedFiles(ref, files); err != nil {
+		return fmt.Errorf("validate desired kubeadm input: %w", err)
+	}
+	base := filepath.Join(dir, generationKubeadmInputDir, ref)
+	for _, file := range files {
+		rel, err := kubeadmInputRelativePath(ref, file.RenderPath)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(base, rel)
+		mode := file.Mode.Perm()
+		if mode == 0 {
+			mode = 0o644
+		}
+		if err := persistedrecord.WriteFileAtomic(path, file.Content, mode); err != nil {
+			return fmt.Errorf("write desired kubeadm input %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+func ReadEffectiveGenerationKubeadmConfig(root, generationID, ref string) (kubeadmconfig.Plan, string, error) {
+	var err error
+	ref, err = cleanKubeadmInputRef(ref)
+	if err != nil {
+		return kubeadmconfig.Plan{}, "", err
+	}
+	selected := strings.TrimSpace(generationID)
+	visited := map[string]bool{}
+	for depth := 0; selected != "" && depth < maxGenerationAncestry; depth++ {
+		if visited[selected] {
+			return kubeadmconfig.Plan{}, "", fmt.Errorf("generation kubeadm input ancestry contains a cycle at %q", selected)
+		}
+		visited[selected] = true
+		plan, err := readGenerationKubeadmConfig(root, selected, ref)
+		if err == nil {
+			return plan, selected, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return kubeadmconfig.Plan{}, "", err
+		}
+		spec, _, readErr := generation.ReadGeneration(root, selected)
+		if readErr != nil {
+			return kubeadmconfig.Plan{}, "", fmt.Errorf("read generation %q while resolving its kubeadm input: %w", selected, readErr)
+		}
+		selected = strings.TrimSpace(spec.PreviousGenerationID)
+	}
+	if selected != "" {
+		return kubeadmconfig.Plan{}, "", fmt.Errorf("generation kubeadm input ancestry exceeds %d generations", maxGenerationAncestry)
+	}
+	return kubeadmconfig.Plan{}, "", fmt.Errorf("generation %q has no desired kubeadm input ancestry: %w", generationID, os.ErrNotExist)
+}
+
+func readGenerationKubeadmConfig(root, generationID, ref string) (kubeadmconfig.Plan, error) {
+	dir, err := generation.GenerationDir(root, generationID)
+	if err != nil {
+		return kubeadmconfig.Plan{}, err
+	}
+	base := filepath.Join(dir, generationKubeadmInputDir, ref)
+	var files []kubeadmconfig.File
+	if err := filepath.WalkDir(base, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("desired kubeadm input %s is not a regular file", path)
+		}
+		rel, err := filepath.Rel(base, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files = append(files, kubeadmconfig.File{
+			RenderPath: filepath.ToSlash(filepath.Join("/etc/katl/kubeadm", ref, rel)),
+			Content:    content,
+			Mode:       info.Mode().Perm(),
+		})
+		return nil
+	}); err != nil {
+		return kubeadmconfig.Plan{}, fmt.Errorf("read generation %s desired kubeadm input: %w", generationID, err)
+	}
+	plan, err := kubeadmconfig.PlanFromRenderedFiles(ref, files)
+	if err != nil {
+		return kubeadmconfig.Plan{}, fmt.Errorf("decode generation %s desired kubeadm input: %w", generationID, err)
+	}
+	return plan, nil
+}
+
+func cleanKubeadmInputRef(ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("desired kubeadm input ref is required")
+	}
+	if ref != filepath.Base(ref) || ref == "." || ref == ".." {
+		return "", fmt.Errorf("desired kubeadm input ref %q must be a single path segment", ref)
+	}
+	return ref, nil
+}
+
+func kubeadmInputRelativePath(ref, renderPath string) (string, error) {
+	base := filepath.ToSlash(filepath.Join("/etc/katl/kubeadm", ref))
+	renderPath = filepath.ToSlash(filepath.Clean("/" + strings.TrimPrefix(strings.TrimSpace(renderPath), "/")))
+	if !strings.HasPrefix(renderPath, base+"/") {
+		return "", fmt.Errorf("desired kubeadm input path %q must be under %s", renderPath, base)
+	}
+	rel := strings.TrimPrefix(renderPath, base+"/")
+	if rel == "" || rel == "." || strings.HasPrefix(rel, "../") || strings.Contains(rel, "/../") {
+		return "", fmt.Errorf("desired kubeadm input path %q escapes its generation directory", renderPath)
+	}
+	return filepath.FromSlash(rel), nil
+}

--- a/internal/installer/configapply/kubeadm_state_test.go
+++ b/internal/installer/configapply/kubeadm_state_test.go
@@ -1,0 +1,79 @@
+package configapply
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
+)
+
+func TestGenerationKubeadmConfigFollowsGenerationAncestry(t *testing.T) {
+	root := t.TempDir()
+	writeKubeadmStateGeneration(t, root, "generation-bootstrap", "")
+	writeKubeadmStateGeneration(t, root, "generation-host-config", "generation-bootstrap")
+	want := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\n"
+	plan, err := kubeadmconfig.PlanFromRenderedFiles("control-plane", []kubeadmconfig.File{{
+		RenderPath: "/etc/katl/kubeadm/control-plane/config.yaml",
+		Content:    []byte(want),
+		Mode:       0o644,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteGenerationKubeadmConfig(root, "generation-bootstrap", "control-plane", plan); err != nil {
+		t.Fatal(err)
+	}
+
+	got, source, err := ReadEffectiveGenerationKubeadmConfig(root, "generation-host-config", "control-plane")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source != "generation-bootstrap" || string(got.Config.Content) != want {
+		t.Fatalf("effective kubeadm input = source %q content %q", source, got.Config.Content)
+	}
+}
+
+func TestGenerationKubeadmConfigRejectsAncestryCycle(t *testing.T) {
+	root := t.TempDir()
+	writeKubeadmStateGeneration(t, root, "generation-a", "generation-b")
+	writeKubeadmStateGeneration(t, root, "generation-b", "generation-a")
+
+	_, _, err := ReadEffectiveGenerationKubeadmConfig(root, "generation-a", "control-plane")
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("ReadEffectiveGenerationKubeadmConfig() error = %v, want cycle", err)
+	}
+}
+
+func TestGenerationKubeadmConfigRejectsUnsafeRef(t *testing.T) {
+	_, _, err := ReadEffectiveGenerationKubeadmConfig(t.TempDir(), "generation-a", "../control-plane")
+	if err == nil || !strings.Contains(err.Error(), "single path segment") {
+		t.Fatalf("ReadEffectiveGenerationKubeadmConfig() error = %v, want unsafe ref", err)
+	}
+}
+
+func writeKubeadmStateGeneration(t *testing.T, root, id, previous string) {
+	t.Helper()
+	createdAt := time.Date(2026, 7, 24, 19, 0, 0, 0, time.UTC)
+	spec := generation.GenerationSpec{
+		APIVersion: generation.APIVersion, Kind: generation.SpecKind,
+		GenerationID: id, PreviousGenerationID: previous,
+		RuntimeVersion: "2026.7.0", CreatedAt: createdAt,
+		Root: generation.RootSelection{
+			Slot: "root-a", PartitionUUID: "aaaaaaaa-1111-2222-3333-444444444444",
+			RuntimeVersion: "2026.7.0", RuntimeInterface: "katl-runtime-1",
+			Architecture: "x86_64", RuntimeArtifactSHA256: strings.Repeat("a", 64),
+		},
+		Boot: generation.BootSelection{
+			UKIPath: "/efi/EFI/Linux/katl_2026.7.0.efi",
+		},
+	}
+	status, err := generation.NewGenerationStatus(spec, generation.CommitStateCommitted, generation.BootStateGood, generation.HealthStateHealthy, createdAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := generation.WriteGeneration(root, spec, status); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -216,6 +216,25 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
 		return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
 	}
+	kubeadmRef := strings.TrimSpace(merged.Node.Kubernetes.Kubeadm.ConfigRef)
+	if kubeadmRef != "" {
+		kubeadmPlan, ok := request.KubeadmConfigs[kubeadmRef]
+		if !ok {
+			err := fmt.Errorf("selected kubeadm config %q is missing", kubeadmRef)
+			audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
+			audit.CandidateGeneration = request.GenerationID
+			audit.AcceptedApplyMode = matrixDecision.AcceptedMode
+			auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
+			return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
+		}
+		if err := WriteGenerationKubeadmConfig(request.Root, request.GenerationID, kubeadmRef, kubeadmPlan); err != nil {
+			audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
+			audit.CandidateGeneration = request.GenerationID
+			audit.AcceptedApplyMode = matrixDecision.AcceptedMode
+			auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
+			return TrustedBundleResult{Manifest: merged, Files: files, Tree: tree, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
+		}
+	}
 	desiredSysexts, err := endpointAdvertiserSysexts(request, merged)
 	if err != nil {
 		audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -916,6 +916,11 @@ func activeGenerationKubeadmConfigs(root string, currentGenerationID string, cur
 	if ref == "" {
 		return nil, nil
 	}
+	if plan, _, err := configapply.ReadEffectiveGenerationKubeadmConfig(root, currentGenerationID, ref); err == nil {
+		return map[string]kubeadmconfig.Plan{ref: plan}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
 	generationDir, err := generation.GenerationDir(root, currentGenerationID)
 	if err != nil {
 		return nil, err

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/generation"
+	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -1640,6 +1641,43 @@ func TestActiveGenerationKubeadmConfigsPreferActiveConfext(t *testing.T) {
 	}
 	if got := string(configs[ref].Config.Content); got != active {
 		t.Fatalf("active config = %q, want %q", got, active)
+	}
+}
+
+func TestActiveGenerationKubeadmConfigsPreferDesiredInputOverBootstrapRuntime(t *testing.T) {
+	root := t.TempDir()
+	writeConfigApplyBaseState(t, root)
+	const ref = "control-plane"
+	currentManifest := manifest.Manifest{Node: manifest.NodeConfig{
+		Kubernetes: manifest.KubernetesConfig{Kubeadm: manifest.KubeadmReference{ConfigRef: ref}},
+	}}
+	confextDir := filepath.Join(root, "var/lib/katl/generations/generation-0/confext/etc/katl/kubeadm", ref)
+	if err := os.MkdirAll(confextDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	runtimeRendered := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\ncontrolPlaneEndpoint: api.katl.test:6443\n"
+	if err := os.WriteFile(filepath.Join(confextDir, "config.yaml"), []byte(runtimeRendered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desired := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\n"
+	plan, err := kubeadmconfig.PlanFromRenderedFiles(ref, []kubeadmconfig.File{{
+		RenderPath: "/etc/katl/kubeadm/control-plane/config.yaml",
+		Content:    []byte(desired),
+		Mode:       0o644,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := configapply.WriteGenerationKubeadmConfig(root, "generation-0", ref, plan); err != nil {
+		t.Fatal(err)
+	}
+
+	configs, err := activeGenerationKubeadmConfigs(root, "generation-0", currentManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(configs[ref].Config.Content); got != desired {
+		t.Fatalf("active desired config = %q, want %q", got, desired)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve operator-authored kubeadm input separately from bootstrap runtime materialization
- inherit desired kubeadm input across runtime generations
- reconcile kubeadm components only when Kubernetes desired state changes

## Root cause

Bootstrap's endpoint-specific kubeadm render was reused as desired input, so later host-only changes appeared to include a Kubernetes configuration change.