### PR TITLE
endpoint: decouple VIP from BIRD lifecycle

### DIFF
--- a/cmd/katl-endpoint-advertiser/main.go
+++ b/cmd/katl-endpoint-advertiser/main.go
@@ -78,7 +78,7 @@ func run(args []string, stderr io.Writer) error {
 			lastState = state
 		}
 		if runErr != nil {
-			return failClosed(runErr, owner, config, bgpapivip.ExecRunner{})
+			return failClosed(runErr, owner, config)
 		}
 		select {
 		case <-ctx.Done():
@@ -111,11 +111,11 @@ func loadConfig(path string) (bgpapivip.Config, error) {
 	return config, nil
 }
 
-func failClosed(runErr error, owner bgpapivip.VIPOwner, config bgpapivip.Config, runner bgpapivip.CommandRunner) error {
+func failClosed(runErr error, owner bgpapivip.VIPOwner, config bgpapivip.Config) error {
 	if runErr == nil {
 		return nil
 	}
-	return errors.Join(runErr, withdrawWith(context.Background(), owner, config, runner))
+	return errors.Join(runErr, withdrawWith(context.Background(), owner, config))
 }
 
 func withdraw(parent context.Context, configPath string) error {
@@ -123,19 +123,14 @@ func withdraw(parent context.Context, configPath string) error {
 	if err != nil {
 		return err
 	}
-	return withdrawWith(parent, bgpapivip.NetlinkVIPOwner{}, config, bgpapivip.ExecRunner{})
+	return withdrawWith(parent, bgpapivip.NetlinkVIPOwner{}, config)
 }
 
-func withdrawWith(parent context.Context, owner bgpapivip.VIPOwner, config bgpapivip.Config, runner bgpapivip.CommandRunner) error {
+func withdrawWith(parent context.Context, owner bgpapivip.VIPOwner, config bgpapivip.Config) error {
 	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
-	releaseErr := owner.SetOwned(ctx, config, false)
-	if releaseErr == nil {
-		return nil
+	if err := owner.SetOwned(ctx, config, false); err != nil {
+		return fmt.Errorf("release local endpoint address: %w", err)
 	}
-	output, stopErr := runner.Output(ctx, "systemctl", "stop", "katl-app-bird.service")
-	if stopErr != nil {
-		stopErr = fmt.Errorf("stop routing daemon after local endpoint release failed: %s", string(output))
-	}
-	return errors.Join(fmt.Errorf("release local endpoint address: %w", releaseErr), stopErr)
+	return nil
 }

--- a/cmd/katl-endpoint-advertiser/main_test.go
+++ b/cmd/katl-endpoint-advertiser/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -12,61 +11,36 @@ import (
 
 func TestWithdrawReleasesVIPWithoutStoppingBird(t *testing.T) {
 	owner := &fakeVIPOwner{owned: true}
-	runner := &fakeCommandRunner{}
-	if err := withdrawWith(context.Background(), owner, bgpapivip.Config{}, runner); err != nil {
+	if err := withdrawWith(context.Background(), owner, bgpapivip.Config{}); err != nil {
 		t.Fatal(err)
-	}
-	if len(runner.calls) != 0 {
-		t.Fatalf("fallback calls = %#v", runner.calls)
 	}
 	if owner.owned {
 		t.Fatal("withdraw retained local VIP ownership")
 	}
 }
 
-func TestWithdrawStopsDedicatedBirdWhenVIPCannotBeReleased(t *testing.T) {
+func TestWithdrawReportsVIPReleaseFailure(t *testing.T) {
 	owner := &fakeVIPOwner{owned: true, err: errors.New("netlink unavailable")}
-	runner := &fakeCommandRunner{}
-	err := withdrawWith(context.Background(), owner, bgpapivip.Config{}, runner)
+	err := withdrawWith(context.Background(), owner, bgpapivip.Config{})
 	if err == nil || !strings.Contains(err.Error(), "netlink unavailable") {
 		t.Fatalf("withdrawWith() error = %v", err)
 	}
-	want := [][]string{{"systemctl", "stop", "katl-app-bird.service"}}
-	if !reflect.DeepEqual(runner.calls, want) {
-		t.Fatalf("fallback calls = %#v, want %#v", runner.calls, want)
-	}
-}
-
-func TestWithdrawFailsWhenNeitherRouteNorDaemonCanBeStopped(t *testing.T) {
-	owner := &fakeVIPOwner{owned: true, err: errors.New("netlink unavailable")}
-	runner := &fakeCommandRunner{err: errors.New("systemctl failed"), output: []byte("access denied")}
-	err := withdrawWith(context.Background(), owner, bgpapivip.Config{}, runner)
-	if err == nil || !strings.Contains(err.Error(), "access denied") {
-		t.Fatalf("withdrawWith() error = %v", err)
+	if !owner.owned {
+		t.Fatal("failed release changed local VIP ownership")
 	}
 }
 
 func TestControllerErrorFailsClosedBeforeSystemdRestart(t *testing.T) {
 	owner := &fakeVIPOwner{owned: true}
-	runner := &fakeCommandRunner{}
 	runErr := errors.New("routing status unavailable")
 
-	err := failClosed(runErr, owner, bgpapivip.Config{}, runner)
+	err := failClosed(runErr, owner, bgpapivip.Config{})
 	if !errors.Is(err, runErr) {
 		t.Fatalf("failClosed() error = %v", err)
-	}
-	if len(runner.calls) != 0 {
-		t.Fatalf("fallback calls = %#v", runner.calls)
 	}
 	if owner.owned {
 		t.Fatal("failClosed retained local VIP ownership")
 	}
-}
-
-type fakeCommandRunner struct {
-	calls  [][]string
-	output []byte
-	err    error
 }
 
 type fakeVIPOwner struct {
@@ -84,9 +58,4 @@ func (o *fakeVIPOwner) SetOwned(_ context.Context, _ bgpapivip.Config, owned boo
 	}
 	o.owned = owned
 	return nil
-}
-
-func (r *fakeCommandRunner) Output(_ context.Context, name string, args ...string) ([]byte, error) {
-	r.calls = append(r.calls, append([]string{name}, args...))
-	return r.output, r.err
 }

--- a/docs/internal/bgp-api-vip-extension-contract.md
+++ b/docs/internal/bgp-api-vip-extension-contract.md
@@ -325,12 +325,12 @@ node role is not selected.
 
 ## Health Gate
 
-The default health target is local kube-apiserver `/readyz` reached through the
-same endpoint path that will be advertised:
+The default health target is local kube-apiserver `/readyz` reached through
+loopback:
 
 ```text
 scheme: https
-host: <endpoint.vip address>
+host: 127.0.0.1 for IPv4, ::1 for IPv6
 port: <endpoint.port>
 path: /readyz
 interval: 2s
@@ -368,15 +368,18 @@ advertisement.withdrawOnFailure
   must be true
 ```
 
-The app starts with the API VIP route withheld from all BGP export filters. When
-the VIP interface exists, generic BIRD is ready, peers are configured, and the
-local `/readyz` health gate satisfies `successThreshold`, the app enables export
-of exactly `endpoint.vip` to peers whose `allowedExportPrefixes[]` include it.
+The app starts without the API VIP address. When the VIP interface exists and
+the local `/readyz` health gate satisfies `successThreshold`, the app adds
+exactly `endpoint.vip` to that interface. BIRD observes the resulting direct
+route and exports it only to peers whose `allowedExportPrefixes[]` include it.
+Routing-daemon readiness and peer state remain diagnostics; they do not own the
+local VIP address lifecycle.
 
-If health fails for `failureThreshold`, BIRD reload fails, the selected
-generation is deactivated, or the app is stopped, the app withdraws the route.
-If withdrawal cannot be proven, status must report a recovery-required state and
-the next boot must prefer the last selected safe generation.
+If health fails for `failureThreshold`, the selected generation is deactivated,
+or the app is stopped, the app removes only its exact VIP address. It never
+stops BIRD or takes down a persistent operator routing interface. If address
+removal cannot be proven, status must report a recovery-required state and the
+next boot must prefer the last selected safe generation.
 
 ## Anycast Stance
 

--- a/docs/internal/katl-routed-control-plane-endpoint-design.md
+++ b/docs/internal/katl-routed-control-plane-endpoint-design.md
@@ -526,16 +526,15 @@ attributes without exposing the generated BIRD syntax.
 
 ## Data plane
 
-Each control-plane node owns the VIP on a Katl-generated dummy interface. The
-address exists before kubeadm so that the first local API server can accept
-connections for it. The interface alone does not cause external advertisement.
+Each control-plane node has a Katl-generated dummy interface dedicated to the
+API endpoint. The interface exists before kubeadm, but the VIP address is absent
+until the local API health gate succeeds.
 
-The routing daemon has a dedicated static route source for the VIP. It starts
-administratively disabled. Without local route exchange, its fabric export
-rule is:
+The routing daemon has a dedicated direct route source for the VIP interface.
+Without local route exchange, its fabric export rule is:
 
 ```text
-accept the exact configured VIP prefix from the Katl API route source
+accept the exact configured VIP prefix learned from the Katl API interface
 reject everything else
 ```
 
@@ -579,17 +578,18 @@ question: whether this node's kube-apiserver should receive traffic.
 The controller waits for kubeadm's API CA, then probes:
 
 ```text
-https://<vip>:<port>/readyz
+https://127.0.0.1:<port>/readyz for IPv4
+https://[::1]:<port>/readyz for IPv6
 TLS server name: controlPlaneEndpoint.host
 trust root: /etc/kubernetes/pki/ca.crt
 ```
 
 The endpoint host may be either an IP literal or a DNS name. Katl does not use
 DNS resolution as an advertisement health signal: a transient or deliberately
-external DNS view must not withdraw an otherwise healthy route. Probing the VIP
-verifies local address delivery, API listening, TLS identity, etcd-dependent
-API readiness and the endpoint port. A `200` response is healthy. Probe timing
-and thresholds are Katl-owned constants and are not configuration fields.
+external DNS view must not withdraw an otherwise healthy route. Probing
+loopback proves that this node's API is listening, presents the endpoint TLS
+identity and passes etcd-dependent readiness without following a routed VIP to
+another control plane. A `200` response is healthy.
 
 State transitions are:
 
@@ -598,16 +598,16 @@ starting -> withdrawn
 withdrawn + success threshold -> advertised
 advertised + failure threshold -> withdrawn
 maintenance requested -> withdrawn
-controller or daemon failure -> withdrawn
+controller failure -> withdrawn
+routing-daemon failure -> local VIP retained, fabric route unavailable
 ```
 
 Controller failure must fail closed. The controller's systemd unit uses an
 `ExecStopPost` withdrawal helper for clean stops and unexpected process exits.
-If the helper cannot confirm that the route source is disabled, it stops the
-dedicated routing-daemon unit so that the fabric peer sessions fall and the
-route is withdrawn. Restart always starts the route source disabled and must
-pass the health threshold again. An earlier `enable` operation can therefore
-never survive loss of the controller. VM tests must prove this after an
+The helper removes only the Katl-owned VIP address and never stops the routing
+daemon. If removal cannot be confirmed, it reports recovery-required rather
+than disrupting unrelated routing sessions. Restart removes any stale VIP
+before passing the health threshold again. VM tests must prove this after an
 ungraceful controller termination.
 
 The API VIP must not use BGP graceful restart or long-lived stale-route
@@ -688,10 +688,11 @@ Native ordering must establish:
 
 ```text
 confext and sysext activation
-  -> systemd-networkd creates the VIP
-  -> routing daemon starts withdrawn and establishes peers
+  -> systemd-networkd creates the VIP interface
+  -> routing daemon starts and establishes peers
   -> kubelet and kubeadm may start the local API
-  -> controller health gates route origination
+  -> controller health gates VIP address ownership
+  -> routing daemon observes and exports the direct VIP route
 ```
 
 Shutdown and maintenance ordering must withdraw before kubelet terminates the
@@ -853,7 +854,8 @@ Prove:
    remains reachable through another node.
 7. Losing etcd readiness withdraws the affected node.
 8. Killing the controller ungracefully withdraws the route.
-9. Killing the routing daemon removes the fabric route.
+9. Killing the routing daemon removes the fabric route without changing healthy
+   local VIP ownership.
 10. Reboot starts withdrawn and does not expose the API early.
 11. Planned maintenance withdraws before kubelet stops the API.
 12. Peer loss and peer recovery produce bounded, accurate status.

--- a/internal/installer/bgpapivip/controller.go
+++ b/internal/installer/bgpapivip/controller.go
@@ -163,9 +163,6 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 		return Status{}, err
 	}
 	c.Config = config
-	if c.Bird == nil {
-		return Status{}, fmt.Errorf("bird client is required")
-	}
 	if c.Owner == nil {
 		return Status{}, fmt.Errorf("VIP owner is required")
 	}
@@ -182,16 +179,21 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 		c.started = true
 	}
 
-	bird, birdErr := c.Bird.Status(ctx)
-	birdReady := bird.ProcessActive && bird.ControlSocketReady
+	var bird BirdRuntimeStatus
+	var birdErr error
+	if c.Bird != nil {
+		bird, birdErr = c.Bird.Status(ctx)
+	}
 	if startReleaseFailure != "" && failure == "" {
 		failure = startReleaseFailure
 	}
-	if birdErr != nil && (bird.RouteOriginated || birdReady) && failure == "" {
-		failure = inventory.Redact(birdErr.Error())
+	var routingFailure string
+	birdReady := bird.ProcessActive && bird.ControlSocketReady
+	if birdErr != nil && (bird.RouteOriginated || birdReady) {
+		routingFailure = inventory.Redact(birdErr.Error())
 	}
-	if bird.FailureReason != "" && (bird.RouteOriginated || birdReady) && failure == "" {
-		failure = inventory.Redact(bird.FailureReason)
+	if bird.FailureReason != "" && (bird.RouteOriginated || birdReady) && routingFailure == "" {
+		routingFailure = inventory.Redact(bird.FailureReason)
 	}
 	interfaceReady := true
 	if c.Interface != nil {
@@ -212,7 +214,7 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 	}
 	c.lastHealth = health.CheckedAt.UTC()
 
-	dependenciesReady := birdErr == nil && bird.FailureReason == "" && bird.ProcessActive && bird.ControlSocketReady && interfaceReady && ownerReady
+	dependenciesReady := startReleaseFailure == "" && interfaceReady && ownerReady
 	if health.Healthy && dependenciesReady {
 		c.successCount++
 		c.failureCount = 0
@@ -246,13 +248,17 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 			}
 		} else {
 			localVIPOwned = desiredOwned
-			refreshed, refreshErr := c.Bird.Status(ctx)
-			if refreshErr != nil {
-				if failure == "" {
-					failure = inventory.Redact(refreshErr.Error())
-				}
-			} else {
+			if c.Bird != nil {
+				refreshed, refreshErr := c.Bird.Status(ctx)
 				bird = refreshed
+				refreshedReady := refreshed.ProcessActive && refreshed.ControlSocketReady
+				if refreshErr != nil && (refreshed.RouteOriginated || refreshedReady) {
+					if routingFailure == "" {
+						routingFailure = inventory.Redact(refreshErr.Error())
+					}
+				} else if refreshed.FailureReason != "" && (refreshed.RouteOriginated || refreshedReady) && routingFailure == "" {
+					routingFailure = inventory.Redact(refreshed.FailureReason)
+				}
 			}
 		}
 	}
@@ -260,7 +266,11 @@ func (c *Controller) RunOnce(ctx context.Context) (Status, error) {
 	if localVIPOwned && !bird.RouteOriginated && withdrawReason == "" {
 		withdrawReason = "waiting-for-route-advertisement"
 	}
-	status := c.status(config, health, bird, interfaceReady, localVIPOwned, withdrawReason, failure, now)
+	statusFailure := failure
+	if statusFailure == "" {
+		statusFailure = routingFailure
+	}
+	status := c.status(config, health, bird, interfaceReady, localVIPOwned, withdrawReason, statusFailure, now)
 	if err := c.write(ctx, status); err != nil {
 		return status, err
 	}
@@ -276,40 +286,46 @@ func (c *Controller) Stop(ctx context.Context) (Status, error) {
 		return Status{}, err
 	}
 	c.Config = config
-	if c.Bird == nil {
-		return Status{}, fmt.Errorf("bird client is required")
-	}
 	if c.Owner == nil {
 		return Status{}, fmt.Errorf("VIP owner is required")
 	}
 	now := c.now()
-	failure := ""
+	var lifecycleFailure string
 	c.started = true
 	localVIPOwned, ownerErr := c.Owner.Owned(ctx, config)
-	if ownerErr != nil && failure == "" {
-		failure = inventory.Redact(ownerErr.Error())
+	if ownerErr != nil {
+		lifecycleFailure = inventory.Redact(ownerErr.Error())
 	}
 	if localVIPOwned {
 		if err := c.Owner.SetOwned(ctx, config, false); err != nil {
-			if failure == "" {
-				failure = inventory.Redact(err.Error())
+			if lifecycleFailure == "" {
+				lifecycleFailure = inventory.Redact(err.Error())
 			}
 		} else {
 			localVIPOwned = false
 		}
 	}
-	bird, err := c.Bird.Status(ctx)
-	if err != nil && failure == "" {
-		failure = inventory.Redact(err.Error())
+	var bird BirdRuntimeStatus
+	var routingFailure string
+	if c.Bird != nil {
+		var err error
+		bird, err = c.Bird.Status(ctx)
+		if err != nil {
+			routingFailure = inventory.Redact(err.Error())
+		}
 	}
 	c.observeRouteTransition(bird.RouteOriginated, now)
 	health := HealthResult{Healthy: false, CheckedAt: now}
-	status := c.status(config, health, bird, true, localVIPOwned, "service-stop", failure, now)
+	statusFailure := lifecycleFailure
+	if statusFailure == "" {
+		statusFailure = routingFailure
+	}
+	status := c.status(config, health, bird, true, localVIPOwned, "service-stop", statusFailure, now)
 	if err := c.write(ctx, status); err != nil {
 		return status, err
 	}
-	if failure != "" {
-		return status, fmt.Errorf("%s", failure)
+	if lifecycleFailure != "" {
+		return status, fmt.Errorf("%s", lifecycleFailure)
 	}
 	return status, nil
 }

--- a/internal/installer/bgpapivip/controller_test.go
+++ b/internal/installer/bgpapivip/controller_test.go
@@ -121,6 +121,23 @@ func TestControllerReportsUnavailableAPIAsHealthStateNotRuntimeFailure(t *testin
 	}
 }
 
+func TestControllerOwnsVIPWithoutRoutingObserver(t *testing.T) {
+	controller := testController(nil, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
+	controller.Bird = nil
+	controller.Config.Health.SuccessThreshold = 1
+
+	status, err := controller.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if !status.LocalVIPOwned || status.AdvertisementState != AdvertisementWithdrawn || status.WithdrawReason != "waiting-for-route-advertisement" {
+		t.Fatalf("status = %#v", status)
+	}
+	if status.RecoveryRequired || status.FailureReason != "" {
+		t.Fatalf("missing optional routing observer required recovery: %#v", status)
+	}
+}
+
 func TestControllerRestartStartsWithdrawnBeforeAdvertising(t *testing.T) {
 	bird := &fakeBird{status: readyBirdStatus()}
 	bird.status.RouteOriginated = true
@@ -175,7 +192,24 @@ func TestControllerStopWithdrawsAndWritesDurableStatus(t *testing.T) {
 	}
 }
 
-func TestControllerStatusRedactsBirdFailuresAndPeerState(t *testing.T) {
+func TestControllerStopReleasesVIPWhenBirdIsUnavailable(t *testing.T) {
+	bird := &fakeBird{statusErr: errors.New("bird control socket unavailable")}
+	controller := testController(bird, fakeHealth{})
+	controller.Owner.(*fakeVIPOwner).owned = true
+
+	status, err := controller.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("Stop() error = %v, want routing observation failure to remain non-fatal", err)
+	}
+	if status.LocalVIPOwned {
+		t.Fatalf("Stop() retained local VIP: %#v", status)
+	}
+	if !status.RecoveryRequired || !strings.Contains(status.FailureReason, "control socket unavailable") {
+		t.Fatalf("Stop() did not report routing observation failure: %#v", status)
+	}
+}
+
+func TestControllerKeepsHealthyVIPWhileReportingRedactedBirdFailure(t *testing.T) {
 	bird := &fakeBird{
 		status: BirdRuntimeStatus{
 			ProcessActive:      true,
@@ -196,11 +230,14 @@ func TestControllerStatusRedactsBirdFailuresAndPeerState(t *testing.T) {
 	controller := testController(bird, fakeHealth{result: HealthResult{Healthy: true, StatusCode: 200}})
 	controller.Config.Health.SuccessThreshold = 1
 	status, err := controller.RunOnce(context.Background())
-	if err == nil || strings.Contains(err.Error(), "top-secret") {
-		t.Fatalf("RunOnce() error = %v, want redacted bird failure", err)
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v, want routing failure reported without disrupting VIP lifecycle", err)
 	}
 	if strings.Contains(status.FailureReason, "top-secret") || !strings.Contains(status.FailureReason, "[REDACTED]") {
 		t.Fatalf("status leaked failure: %#v", status.FailureReason)
+	}
+	if !status.LocalVIPOwned {
+		t.Fatalf("routing observation failure withdrew healthy local VIP: %#v", status)
 	}
 	if len(status.PeerSummary) != 1 || strings.Contains(status.PeerSummary[0].FailureCategory, "peer-secret") {
 		t.Fatalf("peer summary leaked secret: %#v", status.PeerSummary)
@@ -221,7 +258,7 @@ func TestControllerReturnsVIPAcquisitionFailureAndKeepsWithdrawn(t *testing.T) {
 	}
 }
 
-func TestControllerRetriesWhileBirdControlSocketStarts(t *testing.T) {
+func TestControllerOwnsHealthyVIPWhileBirdControlSocketStarts(t *testing.T) {
 	bird := &fakeBird{
 		status: BirdRuntimeStatus{
 			ReadinessState: "not-ready",
@@ -234,15 +271,18 @@ func TestControllerRetriesWhileBirdControlSocketStarts(t *testing.T) {
 
 	status, err := controller.RunOnce(context.Background())
 	if err != nil {
-		t.Fatalf("startup RunOnce() error = %v, want dependency wait", err)
+		t.Fatalf("startup RunOnce() error = %v, want routing observation reported without disrupting VIP lifecycle", err)
 	}
-	if status.AdvertisementState != AdvertisementWithdrawn || status.WithdrawReason != "dependency-not-ready" {
+	if status.AdvertisementState != AdvertisementWithdrawn || status.WithdrawReason != "waiting-for-route-advertisement" {
 		t.Fatalf("startup status = %#v", status)
 	}
 	if status.RecoveryRequired || status.FailureReason != "" {
-		t.Fatalf("startup socket wait requires recovery: %#v", status)
+		t.Fatalf("startup socket wait required manual recovery: %#v", status)
 	}
-	if got, want := bird.advertisements, []bool{false}; !reflect.DeepEqual(got, want) {
+	if !status.LocalVIPOwned {
+		t.Fatalf("startup socket wait withdrew healthy local VIP: %#v", status)
+	}
+	if got, want := bird.advertisements, []bool{false, true}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("startup advertisements = %#v, want %#v", got, want)
 	}
 
@@ -394,12 +434,17 @@ type fakeBird struct {
 }
 
 func (b *fakeBird) Status(context.Context) (BirdRuntimeStatus, error) {
+	if b.status.ProcessActive && b.status.ControlSocketReady && b.status.FailureReason == "" && len(b.advertisements) > 0 {
+		b.status.RouteOriginated = b.advertisements[len(b.advertisements)-1]
+	}
 	return b.status, b.statusErr
 }
 
 func (b *fakeBird) observeVIP(enabled bool) {
 	b.advertisements = append(b.advertisements, enabled)
-	b.status.RouteOriginated = enabled
+	if !enabled || (b.status.ProcessActive && b.status.ControlSocketReady && b.status.FailureReason == "") {
+		b.status.RouteOriginated = enabled
+	}
 	if b.events != nil {
 		event := "route-withdraw"
 		if enabled {

--- a/internal/scriptstest/endpoint_advertiser_sysext_test.go
+++ b/internal/scriptstest/endpoint_advertiser_sysext_test.go
@@ -36,7 +36,7 @@ func TestEndpointAdvertiserSysextOnlyStartsBirdForManagedVIP(t *testing.T) {
 
 	appUnit := read("mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service")
 	for _, want := range []string{
-		"Requires=katl-app-bird.service",
+		"Wants=katl-app-bird.service",
 		"After=katl-app-bird.service",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml",
 		"ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled",

--- a/internal/vmtest/scenarios/bgp_api_vip_vmtest_test.go
+++ b/internal/vmtest/scenarios/bgp_api_vip_vmtest_test.go
@@ -699,8 +699,11 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, c
 	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp2.Result.IPAddress, true, 20*time.Second); err != nil {
 		return fmt.Errorf("healthy peer route was disrupted: %w", err)
 	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "is-active", "--quiet", "katl-app-bird.service"}); err != nil {
+		return fmt.Errorf("local API failure disrupted the node routing daemon: %w", err)
+	}
 	proof.APIFailureWithdrawn = true
-	proof.Checks = append(proof.Checks, "local API failure withdrew only the failed control plane path")
+	proof.Checks = append(proof.Checks, "local API failure withdrew only the failed control plane path and retained BIRD")
 	status, err := waitForEndpointStatus(ctx, cp, func(status bgpapivip.Status) bool {
 		return status.HealthState == bgpapivip.HealthUnhealthy &&
 			!status.LocalVIPOwned &&
@@ -743,8 +746,11 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, c
 	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, false, 20*time.Second); err != nil {
 		return fmt.Errorf("ungraceful controller death did not withdraw route: %w", err)
 	}
+	if err := assertGuestCommand(ctx, cp, []string{"systemctl", "is-active", "--quiet", "katl-app-bird.service"}); err != nil {
+		return fmt.Errorf("endpoint-controller death disrupted the node routing daemon: %w", err)
+	}
 	proof.ControllerKillWithdrawn = true
-	proof.Checks = append(proof.Checks, "ungraceful controller death failed closed")
+	proof.Checks = append(proof.Checks, "ungraceful controller death failed closed without stopping BIRD")
 	if err := setVMTestRestartPolicy(ctx, cp, "katl-app-bgp-api-vip.service", "always"); err != nil {
 		return err
 	}
@@ -767,8 +773,15 @@ func runRealRoutedEndpointProof(ctx context.Context, result vmtest.Result, cp, c
 	if _, err := waitForRouterRouteVia(ctx, router, routedEndpointProofVIP, cp.Result.IPAddress, false, 20*time.Second); err != nil {
 		return fmt.Errorf("routing daemon death did not remove route: %w", err)
 	}
+	if _, err := waitForEndpointStatus(ctx, cp, func(status bgpapivip.Status) bool {
+		return status.HealthState == bgpapivip.HealthHealthy &&
+			status.LocalVIPOwned &&
+			!status.BirdProcessActive
+	}, 20*time.Second); err != nil {
+		return fmt.Errorf("routing daemon death disrupted healthy VIP ownership: %w", err)
+	}
 	proof.RoutingDaemonKillRemoved = true
-	proof.Checks = append(proof.Checks, "routing-daemon death removed the fabric route")
+	proof.Checks = append(proof.Checks, "routing-daemon death removed the fabric route without changing healthy VIP ownership")
 	return nil
 }
 

--- a/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service
+++ b/mkosi.profiles/endpoint-advertiser-sysext/katl-app-bgp-api-vip.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Katl routed control-plane endpoint
 Documentation=https://katl.dev
-Requires=katl-app-bird.service
+Wants=katl-app-bird.service
 After=katl-app-bird.service
 ConditionPathExists=/etc/katl/apps/bgp-api-vip/config.yaml
 ConditionPathExists=/etc/katl/apps/bgp-api-vip/advertisement-enabled


### PR DESCRIPTION
## Summary

- make local API readiness own only the exact netlink VIP address
- keep BIRD running and treat its state as routing diagnostics
- prove API, advertiser, and routing-daemon failures independently in the routed VM journey

## Why

The endpoint service hard-required BIRD and used stopping the routing daemon as
a withdrawal fallback. That conflated API VIP health with the node's broader
routing lifecycle and could disrupt unrelated operator-managed sessions.
