### PR TITLE
ci: gate immutable extension publication

### DIFF
--- a/.github/workflows/system-extensions.yml
+++ b/.github/workflows/system-extensions.yml
@@ -56,6 +56,8 @@ jobs:
       KATL_MKOSI_IMAGE: localhost/katl-mkosi-builder:fedora-44-go-squashfs
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -65,6 +67,23 @@ jobs:
         run: |
           echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")" >> "$GITHUB_ENV"
           echo "KATL_BUILD_COMMIT=$GITHUB_SHA" >> "$GITHUB_ENV"
+      - name: Determine immutable publication intent
+        id: publication
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PUBLISH: ${{ inputs.publish || false }}
+        run: |
+          publish=false
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$MANUAL_PUBLISH" == "true" ]]; then
+            publish=true
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            changed="$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")"
+            if grep -Eq '^(Containerfile\.mkosi$|extensions/bird/extension\.env$|mkosi\.conf$|mkosi\.profiles/runtime/|mkosi\.profiles/system-extension-bird/|scripts/build-system-extension$|scripts/mkosi$)' <<<"$changed"; then
+              publish=true
+            fi
+          fi
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
       - name: Build and verify generic BIRD extension
         shell: bash
         run: |
@@ -88,14 +107,14 @@ jobs:
             --created-at "$created_at" \
             --sysext "_build/mkosi/katl-bird.raw"
       - name: Log in to GHCR
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+        if: ${{ steps.publication.outputs.publish == 'true' }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Publish through the common payload-bundle publisher
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+        if: ${{ steps.publication.outputs.publish == 'true' }}
         shell: bash
         run: |
           source extensions/bird/extension.env

--- a/internal/scriptstest/system_extension_workflow_test.go
+++ b/internal/scriptstest/system_extension_workflow_test.go
@@ -1,0 +1,72 @@
+package scriptstest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSystemExtensionWorkflowSeparatesValidationFromPublication(t *testing.T) {
+	repo := repoRoot(t)
+	contents, err := os.ReadFile(filepath.Join(repo, ".github", "workflows", "system-extensions.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				ID   string `yaml:"id"`
+				If   string `yaml:"if"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(contents, &workflow); err != nil {
+		t.Fatalf("parse system extension workflow: %v", err)
+	}
+
+	bird, ok := workflow.Jobs["bird"]
+	if !ok {
+		t.Fatal("system extension workflow has no bird job")
+	}
+	var decision, build string
+	var loginIf, publishIf string
+	for _, step := range bird.Steps {
+		switch step.Name {
+		case "Determine immutable publication intent":
+			if step.ID != "publication" {
+				t.Fatalf("publication decision id = %q, want publication", step.ID)
+			}
+			decision = step.Run
+		case "Build and verify generic BIRD extension":
+			build = step.Run
+		case "Log in to GHCR":
+			loginIf = step.If
+		case "Publish through the common payload-bundle publisher":
+			publishIf = step.If
+		}
+	}
+
+	for _, contract := range []string{
+		`git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA"`,
+		`extensions/bird/extension\.env`,
+		`mkosi\.profiles/system-extension-bird/`,
+		`scripts/mkosi`,
+		`echo "publish=$publish" >> "$GITHUB_OUTPUT"`,
+	} {
+		if !strings.Contains(decision, contract) {
+			t.Errorf("publication decision does not enforce %q", contract)
+		}
+	}
+	if !strings.Contains(build, "--pack-only") {
+		t.Fatal("system extension workflow must pack-validate on every triggered run")
+	}
+	const publishCondition = "${{ steps.publication.outputs.publish == 'true' }}"
+	if loginIf != publishCondition || publishIf != publishCondition {
+		t.Fatalf("publication conditions = login %q publish %q, want %q", loginIf, publishIf, publishCondition)
+	}
+}


### PR DESCRIPTION
## What changed

Keep building and pack-validating the BIRD extension whenever shared producer tooling changes, while automatically publishing only when extension or runtime artifact inputs changed. Explicit manual publication remains available.

## Why

An unrelated shared OCI-store fix retriggered the BIRD workflow with a new commit timestamp and attempted to replace the already-published immutable `v3.3.1-katl.4` tag. The publisher correctly refused it, but the workflow should not infer release intent from every validation trigger.

Immutable conflicts still catch changed extension artifacts whose version was not bumped.
