### PR TITLE
boot: include firmware and CPU microcode

### DIFF
--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/katl-dev/katl/internal/firmware"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -107,6 +108,20 @@ func run(args []string, stdout, stderr io.Writer, environ []string) error {
 		return runWriteRuntimeRoot(args, stdout, stderr, cfg)
 	case "write-runtime-uki":
 		return runWriteRuntimeUKI(args, stdout, stderr, cfg)
+	case "normalize-installer-firmware":
+		return runNormalizeInstallerFirmware(args, stdout, stderr, cfg, envMap(environ))
+	case "split-initrd":
+		return runSplitInitrd(args, stdout, stderr, cfg)
+	case "join-initrd":
+		return runJoinInitrd(args, stdout, stderr, cfg)
+	case "verify-initrd":
+		return runVerifyInitrd(args, stdout, stderr, cfg)
+	case "verify-uki-initrd":
+		return runVerifyUKIInitrd(args, stdout, stderr, cfg)
+	case "verify-firmware-packages":
+		return runVerifyFirmwarePackages(args, stdout, stderr, cfg)
+	case "verify-module-firmware":
+		return runVerifyModuleFirmware(args, stdout, stderr, cfg)
 	case "write-kubernetes-sysext":
 		return runWriteKubernetesSysext(args, stdout, stderr, cfg)
 	case "write-kubernetes-sysext-from-log":
@@ -133,6 +148,13 @@ const usage = `Usage: katl-mkosi-artifacts [write [INDEX]]
        katl-mkosi-artifacts path KIND [INDEX]
        katl-mkosi-artifacts write-runtime-root --artifact PATH
        katl-mkosi-artifacts write-runtime-uki --artifact PATH --runtime-artifact PATH --runtime-sha256 SHA --kernel-version VERSION
+       katl-mkosi-artifacts normalize-installer-firmware [--uki PATH] [--initrd PATH]
+       katl-mkosi-artifacts split-initrd --input PATH --early PATH --initramfs PATH
+       katl-mkosi-artifacts join-initrd --early PATH --initramfs PATH --output PATH
+       katl-mkosi-artifacts verify-initrd --input PATH
+       katl-mkosi-artifacts verify-uki-initrd --uki PATH [--initrd PATH]
+       katl-mkosi-artifacts verify-firmware-packages --kind installer|runtime --inventory PATH
+       katl-mkosi-artifacts verify-module-firmware --root PATH
        katl-mkosi-artifacts write-kubernetes-sysext --artifact PATH --payload-version VERSION --kubeadm-version VERSION --kubelet-version VERSION --kubectl-version VERSION --cri-tools-version VERSION --ethtool-version VERSION --socat-version VERSION
        katl-mkosi-artifacts write-kubernetes-sysext-from-log --artifact PATH --log PATH --repo-id ID --repo-base-url URL --repo-minor MINOR
        katl-mkosi-artifacts write-endpoint-advertiser-sysext --artifact PATH --log PATH --runtime-artifact PATH --runtime-metadata PATH
@@ -158,9 +180,12 @@ type config struct {
 	InstallerUKI         string
 	InstallerKernel      string
 	InstallerInitrd      string
+	InstallerPackages    string
 	InstallerISO         string
 	InstallerISOExplicit bool
 	RuntimeUKI           string
+	RuntimeInitrd        string
+	RuntimePackages      string
 	RuntimeUKIMetadata   string
 	RuntimeUKIChecksum   string
 	RuntimeRoot          string
@@ -197,9 +222,12 @@ func configFromEnv(env map[string]string, repo string) (config, error) {
 		InstallerUKI:         envPath(env, repo, "KATL_INSTALLER_UKI", filepath.Join(buildDir, "katl-installer.efi")),
 		InstallerKernel:      envPath(env, repo, "KATL_INSTALLER_KERNEL", filepath.Join(buildDir, "katl-installer.vmlinuz")),
 		InstallerInitrd:      envPath(env, repo, "KATL_INSTALLER_INITRD", filepath.Join(buildDir, "katl-installer.initrd")),
+		InstallerPackages:    envPath(env, repo, "KATL_INSTALLER_PACKAGE_SET", filepath.Join(buildDir, "katl-installer.packages.tsv")),
 		InstallerISO:         installerISO,
 		InstallerISOExplicit: installerISOExplicit,
 		RuntimeUKI:           runtimeUKI,
+		RuntimeInitrd:        envPath(env, repo, "KATL_RUNTIME_INITRD", filepath.Join(buildDir, "katl-runtime-root.initrd")),
+		RuntimePackages:      envPath(env, repo, "KATL_RUNTIME_PACKAGE_SET", filepath.Join(buildDir, "katl-runtime.packages.tsv")),
 		RuntimeUKIMetadata:   envPath(env, repo, "KATL_RUNTIME_UKI_METADATA", runtimeUKI+".json"),
 		RuntimeUKIChecksum:   envPath(env, repo, "KATL_RUNTIME_UKI_CHECKSUM", runtimeUKI+".sha256"),
 		RuntimeRoot:          runtimeRoot,
@@ -262,28 +290,32 @@ type bootMetadata struct {
 	InstallerInterface       string   `json:"installerInterface"`
 	DefaultKernelCommandLine []string `json:"defaultKernelCommandLine"`
 	SupportedInputModes      []string `json:"supportedInputModes"`
+	PackageInventorySHA256   string   `json:"packageInventorySHA256,omitempty"`
+	EarlyMicrocodeSHA256     string   `json:"earlyMicrocodeSHA256,omitempty"`
 }
 
 type localMetadata struct {
-	Name              string            `json:"name"`
-	Kind              string            `json:"kind"`
-	Format            string            `json:"format"`
-	Path              string            `json:"path"`
-	SizeBytes         int64             `json:"sizeBytes"`
-	SHA256            string            `json:"sha256"`
-	Compression       string            `json:"compression,omitempty"`
-	Generation        string            `json:"generation,omitempty"`
-	Version           string            `json:"version,omitempty"`
-	PayloadVersion    string            `json:"payloadVersion,omitempty"`
-	Architecture      string            `json:"architecture"`
-	SourceRepo        *sourceRepo       `json:"sourceRepo,omitempty"`
-	PackageVersions   map[string]string `json:"packageVersions,omitempty"`
-	RuntimeInterface  string            `json:"runtimeInterface"`
-	CompatibleBoot    *bootCompat       `json:"compatibleBoot,omitempty"`
-	CompatibleRuntime *runtimeCompat    `json:"compatibleRuntime,omitempty"`
-	KernelVersion     string            `json:"kernelVersion,omitempty"`
-	KernelCommandLine []string          `json:"kernelCommandLine,omitempty"`
-	Created           string            `json:"created"`
+	Name                   string            `json:"name"`
+	Kind                   string            `json:"kind"`
+	Format                 string            `json:"format"`
+	Path                   string            `json:"path"`
+	SizeBytes              int64             `json:"sizeBytes"`
+	SHA256                 string            `json:"sha256"`
+	Compression            string            `json:"compression,omitempty"`
+	Generation             string            `json:"generation,omitempty"`
+	Version                string            `json:"version,omitempty"`
+	PayloadVersion         string            `json:"payloadVersion,omitempty"`
+	Architecture           string            `json:"architecture"`
+	SourceRepo             *sourceRepo       `json:"sourceRepo,omitempty"`
+	PackageVersions        map[string]string `json:"packageVersions,omitempty"`
+	RuntimeInterface       string            `json:"runtimeInterface"`
+	CompatibleBoot         *bootCompat       `json:"compatibleBoot,omitempty"`
+	CompatibleRuntime      *runtimeCompat    `json:"compatibleRuntime,omitempty"`
+	KernelVersion          string            `json:"kernelVersion,omitempty"`
+	KernelCommandLine      []string          `json:"kernelCommandLine,omitempty"`
+	PackageInventorySHA256 string            `json:"packageInventorySHA256,omitempty"`
+	EarlyMicrocodeSHA256   string            `json:"earlyMicrocodeSHA256,omitempty"`
+	Created                string            `json:"created"`
 }
 
 type bootCompat struct {
@@ -377,6 +409,10 @@ func runWriteRuntimeRoot(args []string, stdout, stderr io.Writer, cfg config) er
 	}
 
 	artifactPath := absPath(cfg.RepoRoot, *artifact)
+	packageDigest, err := packageInventoryDigest("runtime", cfg.RuntimePackages)
+	if err != nil {
+		return err
+	}
 	size, digest, err := fileInfo(artifactPath)
 	if err != nil {
 		return err
@@ -401,7 +437,8 @@ func runWriteRuntimeRoot(args []string, stdout, stderr io.Writer, cfg config) er
 			RuntimeInterface:  "katl-runtime-1",
 			KernelCommandLine: runtimeKernelCommandLine(),
 		},
-		Created: cfg.CreatedAt,
+		PackageInventorySHA256: packageDigest,
+		Created:                cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
 		return err
@@ -432,6 +469,21 @@ func runWriteRuntimeUKI(args []string, stdout, stderr io.Writer, cfg config) err
 
 	artifactPath := absPath(cfg.RepoRoot, *artifact)
 	runtimePath := absPath(cfg.RepoRoot, *runtimeArtifact)
+	packageDigest, err := packageInventoryDigest("runtime", cfg.RuntimePackages)
+	if err != nil {
+		return err
+	}
+	earlyDigest := ""
+	if packageDigest != "" {
+		if !fileExists(cfg.RuntimeInitrd) {
+			return fmt.Errorf("runtime initrd not found for firmware metadata: %s", cfg.RuntimeInitrd)
+		}
+		report, verifyErr := firmware.VerifyUKIInitrd(artifactPath, cfg.RuntimeInitrd)
+		if verifyErr != nil {
+			return fmt.Errorf("verify runtime firmware metadata: %w", verifyErr)
+		}
+		earlyDigest = report.EarlySHA256
+	}
 	size, digest, err := fileInfo(artifactPath)
 	if err != nil {
 		return err
@@ -454,14 +506,184 @@ func runWriteRuntimeUKI(args []string, stdout, stderr io.Writer, cfg config) err
 			ArtifactPath:   filepath.Base(runtimePath),
 			ArtifactSHA256: *runtimeSHA,
 		},
-		KernelVersion:     *kernelVersion,
-		KernelCommandLine: runtimeKernelCommandLine(),
-		Created:           cfg.CreatedAt,
+		KernelVersion:          *kernelVersion,
+		KernelCommandLine:      runtimeKernelCommandLine(),
+		PackageInventorySHA256: packageDigest,
+		EarlyMicrocodeSHA256:   earlyDigest,
+		Created:                cfg.CreatedAt,
 	}
 	if err := writeJSON(metadataPath(artifactPath), metadata, cfg.RepoRoot); err != nil {
 		return err
 	}
 	fmt.Fprintln(stdout, digest)
+	return nil
+}
+
+func runNormalizeInstallerFirmware(args []string, stdout, stderr io.Writer, cfg config, env map[string]string) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts normalize-installer-firmware", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	uki := flags.String("uki", cfg.InstallerUKI, "installer UKI artifact")
+	initrd := flags.String("initrd", cfg.InstallerInitrd, "loose installer initrd artifact")
+	ukify := flags.String("ukify", envDefault(env, "KATL_UKIFY", "ukify"), "ukify executable")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if err := firmware.NormalizeInstaller(absPath(cfg.RepoRoot, *uki), absPath(cfg.RepoRoot, *initrd), *ukify); err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, "installer firmware normalized")
+	return nil
+}
+
+func runSplitInitrd(args []string, stdout, stderr io.Writer, cfg config) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts split-initrd", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	input := flags.String("input", "", "combined initrd input")
+	early := flags.String("early", "", "early microcode cpio output")
+	initramfs := flags.String("initramfs", "", "normal initramfs output")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*input) == "" || strings.TrimSpace(*early) == "" || strings.TrimSpace(*initramfs) == "" {
+		return fmt.Errorf("--input, --early, and --initramfs are required")
+	}
+	report, err := firmware.WriteSplit(
+		absPath(cfg.RepoRoot, *input),
+		absPath(cfg.RepoRoot, *early),
+		absPath(cfg.RepoRoot, *initramfs),
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "earlyMicrocodeSHA256=%s\n", report.EarlySHA256)
+	return nil
+}
+
+func runJoinInitrd(args []string, stdout, stderr io.Writer, cfg config) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts join-initrd", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	early := flags.String("early", "", "early microcode cpio input")
+	initramfs := flags.String("initramfs", "", "normal initramfs input")
+	output := flags.String("output", "", "combined initrd output")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*early) == "" || strings.TrimSpace(*initramfs) == "" || strings.TrimSpace(*output) == "" {
+		return fmt.Errorf("--early, --initramfs, and --output are required")
+	}
+	report, err := firmware.WriteJoined(
+		absPath(cfg.RepoRoot, *early),
+		absPath(cfg.RepoRoot, *initramfs),
+		absPath(cfg.RepoRoot, *output),
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "earlyMicrocodeSHA256=%s\n", report.EarlySHA256)
+	return nil
+}
+
+func runVerifyInitrd(args []string, stdout, stderr io.Writer, cfg config) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts verify-initrd", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	input := flags.String("input", "", "combined initrd input")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*input) == "" {
+		return fmt.Errorf("--input is required")
+	}
+	data, err := os.ReadFile(absPath(cfg.RepoRoot, *input))
+	if err != nil {
+		return err
+	}
+	report, err := firmware.SplitEarlyInitrd(data)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "earlyMicrocodeSHA256=%s vendors=Intel,AMD\n", report.EarlySHA256)
+	return nil
+}
+
+func runVerifyUKIInitrd(args []string, stdout, stderr io.Writer, cfg config) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts verify-uki-initrd", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	uki := flags.String("uki", "", "UKI artifact")
+	initrd := flags.String("initrd", "", "matching loose initrd")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*uki) == "" {
+		return fmt.Errorf("--uki is required")
+	}
+	initrdPath := ""
+	if strings.TrimSpace(*initrd) != "" {
+		initrdPath = absPath(cfg.RepoRoot, *initrd)
+	}
+	report, err := firmware.VerifyUKIInitrd(absPath(cfg.RepoRoot, *uki), initrdPath)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "earlyMicrocodeSHA256=%s vendors=Intel,AMD\n", report.EarlySHA256)
+	return nil
+}
+
+func runVerifyFirmwarePackages(args []string, stdout, stderr io.Writer, cfg config) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts verify-firmware-packages", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	kind := flags.String("kind", "", "artifact kind: installer or runtime")
+	inventory := flags.String("inventory", "", "resolved package inventory")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*kind) == "" || strings.TrimSpace(*inventory) == "" {
+		return fmt.Errorf("--kind and --inventory are required")
+	}
+	packages, err := firmware.VerifyPackageInventory(*kind, absPath(cfg.RepoRoot, *inventory))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "firmwarePackages=%d kind=%s\n", len(packages), *kind)
+	return nil
+}
+
+func runVerifyModuleFirmware(args []string, stdout, stderr io.Writer, cfg config) error {
+	flags := flag.NewFlagSet("katl-mkosi-artifacts verify-module-firmware", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", "", "extracted initramfs root")
+	modinfo := flags.String("modinfo", "modinfo", "modinfo executable")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*root) == "" {
+		return fmt.Errorf("--root is required")
+	}
+	modules, requirements, err := firmware.VerifyInstallerModuleFirmware(absPath(cfg.RepoRoot, *root), *modinfo)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "modules=%d firmwareRequirements=%d\n", modules, requirements)
 	return nil
 }
 
@@ -1311,6 +1533,31 @@ func writeRuntimeIndex(indexPath string, cfg config) error {
 }
 
 func writeBootMetadata(role, format, artifactPath, created string, cfg config) error {
+	packageDigest, err := packageInventoryDigest("installer", cfg.InstallerPackages)
+	if err != nil {
+		return err
+	}
+	earlyDigest := ""
+	if packageDigest != "" {
+		switch role {
+		case "installer-uki":
+			report, verifyErr := firmware.VerifyUKIInitrd(artifactPath, cfg.InstallerInitrd)
+			if verifyErr != nil {
+				return fmt.Errorf("verify installer UKI firmware metadata: %w", verifyErr)
+			}
+			earlyDigest = report.EarlySHA256
+		case "installer-initrd":
+			data, readErr := os.ReadFile(artifactPath)
+			if readErr != nil {
+				return fmt.Errorf("read installer initrd firmware metadata: %w", readErr)
+			}
+			report, verifyErr := firmware.SplitEarlyInitrd(data)
+			if verifyErr != nil {
+				return fmt.Errorf("verify installer initrd firmware metadata: %w", verifyErr)
+			}
+			earlyDigest = report.EarlySHA256
+		}
+	}
 	size, digest, err := fileInfo(artifactPath)
 	if err != nil {
 		return err
@@ -1335,6 +1582,8 @@ func writeBootMetadata(role, format, artifactPath, created string, cfg config) e
 		InstallerInterface:       cfg.InstallerInterface,
 		DefaultKernelCommandLine: []string{"console=ttyS0,115200n8", "console=tty0", "systemd.getty_auto=no", "systemd.log_target=console", "loglevel=6"},
 		SupportedInputModes:      []string{"pxe-preseed", "local-handoff", "offline-media"},
+		PackageInventorySHA256:   packageDigest,
+		EarlyMicrocodeSHA256:     earlyDigest,
 	}
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
@@ -1347,9 +1596,23 @@ func writeBootMetadata(role, format, artifactPath, created string, cfg config) e
 	return nil
 }
 
+func packageInventoryDigest(kind, path string) (string, error) {
+	if !fileExists(path) {
+		return "", nil
+	}
+	if _, err := firmware.VerifyPackageInventory(kind, path); err != nil {
+		return "", err
+	}
+	_, digest, err := fileInfo(path)
+	if err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
 func installerBootCompression(role string) string {
 	if role == "installer-initrd" {
-		return "zstd"
+		return "early-cpio+zstd"
 	}
 	return ""
 }

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -52,6 +52,7 @@ func TestWriteAndPath(t *testing.T) {
 		"KATL_INSTALLER_UKI=" + installerUKI,
 		"KATL_INSTALLER_KERNEL=" + installerKernel,
 		"KATL_INSTALLER_INITRD=" + installerInitrd,
+		"KATL_INSTALLER_PACKAGE_SET=" + filepath.Join(workDir, "missing-installer-packages.tsv"),
 		"KATL_INSTALLER_ISO=" + installerISO,
 		"KATL_RUNTIME_UKI=" + runtimeUKI,
 		"KATL_RUNTIME_UKI_METADATA=" + runtimeUKI + ".json",
@@ -107,7 +108,7 @@ func TestWriteAndPath(t *testing.T) {
 		t.Fatalf("installer UKI compression = %q, want empty outer compression", metadata.Compression)
 	}
 	readTestJSON(t, installerInitrd+".json", &metadata)
-	if metadata.ArtifactRole != "installer-initrd" || metadata.Compression != "zstd" {
+	if metadata.ArtifactRole != "installer-initrd" || metadata.Compression != "early-cpio+zstd" {
 		t.Fatalf("installer initrd metadata = %#v", metadata)
 	}
 	readTestJSON(t, installerISO+".json", &metadata)
@@ -140,6 +141,7 @@ func TestWriteInstallerArtifactsDoesNotRequireRuntime(t *testing.T) {
 		"KATL_INSTALLER_UKI=" + installerUKI,
 		"KATL_INSTALLER_KERNEL=" + installerKernel,
 		"KATL_INSTALLER_INITRD=" + installerInitrd,
+		"KATL_INSTALLER_PACKAGE_SET=" + filepath.Join(workDir, "missing-installer-packages.tsv"),
 	})
 	if err != nil {
 		t.Fatalf("write installer artifacts error = %v", err)
@@ -335,6 +337,8 @@ func TestMetadataWriters(t *testing.T) {
 		"KATL_BUILD_COMMIT=test-build",
 		"KATL_VERSION=0.1.0",
 		"KATL_ARCHITECTURE=x86_64",
+		"KATL_RUNTIME_INITRD=" + filepath.Join(workDir, "missing-runtime.initrd"),
+		"KATL_RUNTIME_PACKAGE_SET=" + filepath.Join(workDir, "missing-runtime-packages.tsv"),
 	}
 
 	var stdout bytes.Buffer

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -320,8 +320,10 @@ install and upgrade SquashFS images, and the installer UKI, kernel, initrd, and
 UEFI-bootable ISO variants, each with
 adjacent JSON metadata and SHA-256 files. The ISO embeds the matching KatlOS
 install image and its metadata, so it is the primary self-contained install
-artifact. The installer initrd is zstd-compressed inside both the loose initrd
-and UKI; its metadata records that compression while filenames remain stable.
+artifact. The installer initrd contains an uncompressed early CPU microcode
+archive followed by the zstd-compressed normal initramfs inside both the loose
+initrd and UKI; its metadata records that combined format while filenames remain
+stable.
 It remains generic because node identity, disk selection, network,
 and bootstrap configuration are supplied separately at boot. The loose
 installer and install-image artifacts remain available for PXE deployments.

--- a/docs/internal/adrs/adr-013-firmware-and-cpu-microcode-support.md
+++ b/docs/internal/adrs/adr-013-firmware-and-cpu-microcode-support.md
@@ -1,6 +1,6 @@
 # ADR-013: KatlOS includes common firmware and CPU microcode
 
-Status: proposed.
+Status: accepted.
 
 Date: 2026-07-25.
 

--- a/docs/internal/v0.1-kernel-firmware-support-policy.md
+++ b/docs/internal/v0.1-kernel-firmware-support-policy.md
@@ -51,32 +51,17 @@ of a selected storage or input driver; they are not an installer support claim.
 
 ## Firmware And Licensing
 
-Firmware support is separate from module support. Current package inventories include
-`kernel-core`, `kernel-modules`, and `kernel-modules-core`, but they do not yet
-prove any firmware or CPU microcode package is present. `katl-dty.16.2.7` must
-turn this policy into artifact checks and either add the required redistributable
-firmware packages or record a release-blocking exception.
+Firmware and CPU microcode support is defined by
+[ADR-013](adrs/adr-013-firmware-and-cpu-microcode-support.md), which supersedes
+the earlier provisional firmware portions of this policy. KatlOS includes
+redistributable Fedora-packaged Intel and AMD CPU microcode, common device
+firmware, and the firmware families required by the retained in-tree Intel and
+AMD GPU drivers. These inputs are versioned and rolled back with the immutable
+runtime generation.
 
-The intended v0.1 policy is:
-
-- Redistributable Fedora-packaged firmware needed by required in-box classes is
-  allowed and should be included when the package license permits redistribution
-  in KatlOS artifacts.
-- GPU firmware needed by `amdgpu`, `i915`, or `xe` is expected out of box when
-  Fedora ships it under redistributable terms.
-- CPU microcode is allowed only through normal redistributable distro packages;
-  if redistribution or artifact constraints are unclear, v0.1 must document the
-  omission rather than silently imply coverage.
-- Proprietary or out-of-tree driver stacks are not v0.1 in-box support.
-  Examples include NVIDIA proprietary modules, Broadcom `wl`, DKMS-delivered
-  drivers, vendor side-loaded kernel modules, and ZFS kernel modules.
-- Highly specialized firmware or drivers can be future node extension or
-  operator-managed territory only after a separate design defines trust,
-  licensing, update, and rollback behavior.
-
-If a required class cannot be supported because Fedora packaging splits firmware
-in a way KatlOS cannot redistribute, the release notes and artifact checks must
-say that directly. Absence must be explicit.
+Proprietary, out-of-tree, user-supplied, and specialized firmware remains
+outside the v0.1 in-box boundary unless a separate decision defines its
+licensing, trust, compatibility, lifecycle, and verification contracts.
 
 ## Pruning Rules
 

--- a/internal/firmware/initrd.go
+++ b/internal/firmware/initrd.go
@@ -1,0 +1,437 @@
+package firmware
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const newcHeaderSize = 110
+
+var zstdMagic = []byte{0x28, 0xb5, 0x2f, 0xfd}
+
+var ErrSectionNotFound = errors.New("PE section not found")
+
+type EarlyInitrd struct {
+	Early       []byte
+	Initramfs   []byte
+	Entries     []string
+	EarlySHA256 string
+}
+
+func SplitEarlyInitrd(data []byte) (EarlyInitrd, error) {
+	entries, archiveEnd, err := parseEarlyCPIO(data)
+	if err != nil {
+		return EarlyInitrd{}, err
+	}
+	payloadStart := archiveEnd
+	for payloadStart < len(data) && data[payloadStart] == 0 {
+		payloadStart++
+	}
+	if payloadStart+len(zstdMagic) > len(data) || !bytes.Equal(data[payloadStart:payloadStart+len(zstdMagic)], zstdMagic) {
+		return EarlyInitrd{}, fmt.Errorf("early CPU microcode archive is not followed by a zstd initramfs")
+	}
+	if err := requireMicrocodeVendors(entries); err != nil {
+		return EarlyInitrd{}, err
+	}
+	early := slices.Clone(data[:payloadStart])
+	initramfs := slices.Clone(data[payloadStart:])
+	sum := sha256.Sum256(early)
+	return EarlyInitrd{
+		Early:       early,
+		Initramfs:   initramfs,
+		Entries:     entries,
+		EarlySHA256: hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+func VerifyEarlyArchive(data []byte) ([]string, error) {
+	entries, archiveEnd, err := parseEarlyCPIO(data)
+	if err != nil {
+		return nil, err
+	}
+	for _, value := range data[archiveEnd:] {
+		if value != 0 {
+			return nil, fmt.Errorf("early CPU microcode input contains data after its cpio archive")
+		}
+	}
+	if err := requireMicrocodeVendors(entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func JoinEarlyInitrd(early, initramfs []byte) ([]byte, error) {
+	if _, err := VerifyEarlyArchive(early); err != nil {
+		return nil, err
+	}
+	if len(initramfs) < len(zstdMagic) || !bytes.Equal(initramfs[:len(zstdMagic)], zstdMagic) {
+		return nil, fmt.Errorf("normal initramfs is not zstd-compressed")
+	}
+	combined := make([]byte, 0, len(early)+len(initramfs))
+	combined = append(combined, early...)
+	combined = append(combined, initramfs...)
+	if _, err := SplitEarlyInitrd(combined); err != nil {
+		return nil, fmt.Errorf("verify combined initrd: %w", err)
+	}
+	return combined, nil
+}
+
+func VerifyUKIInitrd(ukiPath, initrdPath string) (EarlyInitrd, error) {
+	embedded, err := readPESection(ukiPath, ".initrd")
+	if err != nil {
+		return EarlyInitrd{}, fmt.Errorf("read UKI initrd: %w", err)
+	}
+	if _, err := readPESection(ukiPath, ".ucode"); err == nil {
+		return EarlyInitrd{}, fmt.Errorf("UKI keeps CPU microcode in a separate .ucode section instead of the leading initrd archive")
+	} else if !errors.Is(err, ErrSectionNotFound) {
+		return EarlyInitrd{}, fmt.Errorf("inspect UKI microcode section: %w", err)
+	}
+	report, err := SplitEarlyInitrd(embedded)
+	if err != nil {
+		return EarlyInitrd{}, fmt.Errorf("verify UKI initrd: %w", err)
+	}
+	if strings.TrimSpace(initrdPath) == "" {
+		return report, nil
+	}
+	loose, err := os.ReadFile(initrdPath)
+	if err != nil {
+		return EarlyInitrd{}, fmt.Errorf("read loose initrd %s: %w", initrdPath, err)
+	}
+	if !bytes.Equal(embedded, loose) {
+		return EarlyInitrd{}, fmt.Errorf("UKI initrd does not match loose initrd %s", initrdPath)
+	}
+	return report, nil
+}
+
+func NormalizeInstaller(ukiPath, initrdPath, ukify string) error {
+	if _, err := os.Stat(ukiPath); err != nil {
+		return fmt.Errorf("stat installer UKI %s: %w", ukiPath, err)
+	}
+	if _, err := os.Stat(initrdPath); err != nil {
+		return fmt.Errorf("stat installer initrd %s: %w", initrdPath, err)
+	}
+	microcode, err := readPESection(ukiPath, ".ucode")
+	if errors.Is(err, ErrSectionNotFound) {
+		_, verifyErr := VerifyUKIInitrd(ukiPath, initrdPath)
+		return verifyErr
+	}
+	if err != nil {
+		return fmt.Errorf("read installer UKI microcode: %w", err)
+	}
+	normal, err := readPESection(ukiPath, ".initrd")
+	if err != nil {
+		return fmt.Errorf("read installer UKI initrd: %w", err)
+	}
+	combined, err := JoinEarlyInitrd(microcode, normal)
+	if err != nil {
+		return fmt.Errorf("combine installer microcode and initramfs: %w", err)
+	}
+	linux, err := readPESection(ukiPath, ".linux")
+	if err != nil {
+		return fmt.Errorf("read installer UKI kernel: %w", err)
+	}
+	osRelease, err := readPESection(ukiPath, ".osrel")
+	if err != nil {
+		return fmt.Errorf("read installer UKI os-release: %w", err)
+	}
+	cmdline, err := readPESection(ukiPath, ".cmdline")
+	if err != nil {
+		return fmt.Errorf("read installer UKI command line: %w", err)
+	}
+	uname, err := readPESection(ukiPath, ".uname")
+	if err != nil {
+		return fmt.Errorf("read installer UKI kernel version: %w", err)
+	}
+
+	dir := filepath.Dir(ukiPath)
+	work, err := os.MkdirTemp(dir, ".katl-installer-uki-")
+	if err != nil {
+		return fmt.Errorf("create installer UKI work directory: %w", err)
+	}
+	defer os.RemoveAll(work)
+	write := func(name string, data []byte) (string, error) {
+		path := filepath.Join(work, name)
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	linuxPath, err := write("linux", linux)
+	if err != nil {
+		return fmt.Errorf("write installer kernel input: %w", err)
+	}
+	initrdPathTmp, err := write("initrd", combined)
+	if err != nil {
+		return fmt.Errorf("write installer initrd input: %w", err)
+	}
+	osReleasePath, err := write("os-release", osRelease)
+	if err != nil {
+		return fmt.Errorf("write installer os-release input: %w", err)
+	}
+	cmdlinePath, err := write("cmdline", cmdline)
+	if err != nil {
+		return fmt.Errorf("write installer command-line input: %w", err)
+	}
+	outputPath := filepath.Join(work, "installer.efi")
+	if strings.TrimSpace(ukify) == "" {
+		ukify = "ukify"
+	}
+	version := strings.Trim(string(uname), "\x00\r\n ")
+	if version == "" {
+		return fmt.Errorf("installer UKI kernel version is empty")
+	}
+	output, err := exec.Command(
+		ukify,
+		"build",
+		"--linux", linuxPath,
+		"--initrd", initrdPathTmp,
+		"--os-release", "@"+osReleasePath,
+		"--cmdline", "@"+cmdlinePath,
+		"--uname", version,
+		"--output", outputPath,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("rebuild installer UKI: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	if _, err := VerifyUKIInitrd(outputPath, initrdPathTmp); err != nil {
+		return fmt.Errorf("verify rebuilt installer UKI: %w", err)
+	}
+	ukiInfo, err := os.Stat(ukiPath)
+	if err != nil {
+		return fmt.Errorf("stat installer UKI mode: %w", err)
+	}
+	initrdInfo, err := os.Stat(initrdPath)
+	if err != nil {
+		return fmt.Errorf("stat installer initrd mode: %w", err)
+	}
+	if err := os.Chmod(outputPath, ukiInfo.Mode().Perm()); err != nil {
+		return fmt.Errorf("set rebuilt installer UKI mode: %w", err)
+	}
+	if err := writeAtomic(initrdPath, combined, initrdInfo.Mode().Perm()); err != nil {
+		return err
+	}
+	if err := os.Rename(outputPath, ukiPath); err != nil {
+		return fmt.Errorf("replace installer UKI: %w", err)
+	}
+	_, err = VerifyUKIInitrd(ukiPath, initrdPath)
+	return err
+}
+
+func WriteSplit(input, earlyPath, initramfsPath string) (EarlyInitrd, error) {
+	data, err := os.ReadFile(input)
+	if err != nil {
+		return EarlyInitrd{}, fmt.Errorf("read initrd %s: %w", input, err)
+	}
+	report, err := SplitEarlyInitrd(data)
+	if err != nil {
+		return EarlyInitrd{}, err
+	}
+	if err := writeAtomic(earlyPath, report.Early, 0o644); err != nil {
+		return EarlyInitrd{}, err
+	}
+	if err := writeAtomic(initramfsPath, report.Initramfs, 0o644); err != nil {
+		return EarlyInitrd{}, err
+	}
+	return report, nil
+}
+
+func WriteJoined(earlyPath, initramfsPath, outputPath string) (EarlyInitrd, error) {
+	early, err := os.ReadFile(earlyPath)
+	if err != nil {
+		return EarlyInitrd{}, fmt.Errorf("read early microcode archive %s: %w", earlyPath, err)
+	}
+	initramfs, err := os.ReadFile(initramfsPath)
+	if err != nil {
+		return EarlyInitrd{}, fmt.Errorf("read normal initramfs %s: %w", initramfsPath, err)
+	}
+	combined, err := JoinEarlyInitrd(early, initramfs)
+	if err != nil {
+		return EarlyInitrd{}, err
+	}
+	if err := writeAtomic(outputPath, combined, 0o644); err != nil {
+		return EarlyInitrd{}, err
+	}
+	return SplitEarlyInitrd(combined)
+}
+
+func parseEarlyCPIO(data []byte) ([]string, int, error) {
+	if len(data) < newcHeaderSize || (string(data[:6]) != "070701" && string(data[:6]) != "070702") {
+		return nil, 0, fmt.Errorf("initrd does not start with an uncompressed early cpio archive")
+	}
+	var entries []string
+	offset := 0
+	for {
+		if offset+newcHeaderSize > len(data) {
+			return nil, 0, fmt.Errorf("early cpio header is truncated at byte %d", offset)
+		}
+		header := data[offset : offset+newcHeaderSize]
+		if string(header[:6]) != "070701" && string(header[:6]) != "070702" {
+			return nil, 0, fmt.Errorf("invalid early cpio header magic at byte %d", offset)
+		}
+		fileSize, err := parseHexField(header[54:62])
+		if err != nil {
+			return nil, 0, fmt.Errorf("parse early cpio file size at byte %d: %w", offset, err)
+		}
+		nameSize, err := parseHexField(header[94:102])
+		if err != nil {
+			return nil, 0, fmt.Errorf("parse early cpio name size at byte %d: %w", offset, err)
+		}
+		if nameSize == 0 {
+			return nil, 0, fmt.Errorf("early cpio entry at byte %d has an empty name", offset)
+		}
+		nameStart := offset + newcHeaderSize
+		nameEnd, ok := checkedEnd(nameStart, nameSize, len(data))
+		if !ok {
+			return nil, 0, fmt.Errorf("early cpio entry name is truncated at byte %d", offset)
+		}
+		nameBytes := data[nameStart:nameEnd]
+		if nameBytes[len(nameBytes)-1] != 0 {
+			return nil, 0, fmt.Errorf("early cpio entry name is not NUL-terminated at byte %d", offset)
+		}
+		name := strings.TrimPrefix(string(nameBytes[:len(nameBytes)-1]), "./")
+		dataStart := align4(nameEnd)
+		dataEnd, ok := checkedEnd(dataStart, fileSize, len(data))
+		if !ok {
+			return nil, 0, fmt.Errorf("early cpio entry %q is truncated", name)
+		}
+		offset = align4(dataEnd)
+		if offset > len(data) {
+			return nil, 0, fmt.Errorf("early cpio entry %q padding is truncated", name)
+		}
+		if name == "TRAILER!!!" {
+			sort.Strings(entries)
+			return entries, offset, nil
+		}
+		entries = append(entries, name)
+	}
+}
+
+func parseHexField(value []byte) (uint64, error) {
+	number, err := strconv.ParseUint(string(value), 16, 64)
+	if err != nil {
+		return 0, err
+	}
+	return number, nil
+}
+
+func checkedEnd(start int, size uint64, limit int) (int, bool) {
+	if size > uint64(limit) || uint64(start)+size > uint64(limit) {
+		return 0, false
+	}
+	return start + int(size), true
+}
+
+func align4(value int) int {
+	return (value + 3) &^ 3
+}
+
+func requireMicrocodeVendors(entries []string) error {
+	present := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		present[entry] = true
+	}
+	for _, capability := range []struct {
+		path   string
+		vendor string
+	}{
+		{"kernel/x86/microcode/GenuineIntel.bin", "Intel"},
+		{"kernel/x86/microcode/AuthenticAMD.bin", "AMD"},
+	} {
+		if !present[capability.path] {
+			return fmt.Errorf("%s early CPU microcode capability is missing: expected /%s in the leading cpio archive", capability.vendor, capability.path)
+		}
+	}
+	return nil
+}
+
+func readPESection(path, name string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	var dos [64]byte
+	if _, err := file.ReadAt(dos[:], 0); err != nil {
+		return nil, fmt.Errorf("read DOS header: %w", err)
+	}
+	peOffset := int64(binary.LittleEndian.Uint32(dos[0x3c:0x40]))
+	var header [24]byte
+	if _, err := file.ReadAt(header[:], peOffset); err != nil {
+		return nil, fmt.Errorf("read PE header: %w", err)
+	}
+	if !bytes.Equal(header[:4], []byte{'P', 'E', 0, 0}) {
+		return nil, fmt.Errorf("invalid PE signature")
+	}
+	sectionCount := int(binary.LittleEndian.Uint16(header[6:8]))
+	optionalSize := int64(binary.LittleEndian.Uint16(header[20:22]))
+	sectionOffset := peOffset + int64(len(header)) + optionalSize
+	for index := range sectionCount {
+		var section [40]byte
+		offset := sectionOffset + int64(index*len(section))
+		if _, err := file.ReadAt(section[:], offset); err != nil {
+			return nil, fmt.Errorf("read PE section header %d: %w", index, err)
+		}
+		sectionName := string(bytes.TrimRight(section[:8], "\x00"))
+		if sectionName != name {
+			continue
+		}
+		virtualSize := int64(binary.LittleEndian.Uint32(section[8:12]))
+		rawSize := int64(binary.LittleEndian.Uint32(section[16:20]))
+		rawOffset := int64(binary.LittleEndian.Uint32(section[20:24]))
+		size := rawSize
+		if virtualSize > 0 && virtualSize <= rawSize {
+			size = virtualSize
+		}
+		if size < 0 || rawOffset < 0 || rawOffset+size > info.Size() {
+			return nil, fmt.Errorf("PE section %s points outside the file", name)
+		}
+		data := make([]byte, size)
+		if _, err := file.ReadAt(data, rawOffset); err != nil {
+			return nil, fmt.Errorf("read PE section %s: %w", name, err)
+		}
+		return data, nil
+	}
+	return nil, fmt.Errorf("%w: %s", ErrSectionNotFound, name)
+}
+
+func writeAtomic(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s directory: %w", path, err)
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".")
+	if err != nil {
+		return fmt.Errorf("create temporary %s: %w", path, err)
+	}
+	tmp := file.Name()
+	defer os.Remove(tmp)
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write temporary %s: %w", path, err)
+	}
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("set temporary %s mode: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary %s: %w", path, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/firmware/initrd_test.go
+++ b/internal/firmware/initrd_test.go
@@ -1,0 +1,130 @@
+package firmware
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSplitEarlyInitrd(t *testing.T) {
+	early := testCPIO(t, map[string][]byte{
+		"early_cpio":                            nil,
+		"kernel/x86/microcode/AuthenticAMD.bin": []byte("amd"),
+		"kernel/x86/microcode/GenuineIntel.bin": []byte("intel"),
+	})
+	early = append(early, make([]byte, (512-len(early)%512)%512)...)
+	normal := append(slices.Clone(zstdMagic), []byte("normal")...)
+	combined := append(slices.Clone(early), normal...)
+	report, err := SplitEarlyInitrd(combined)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(report.Early, early) || !bytes.Equal(report.Initramfs, normal) {
+		t.Fatalf("split initrd lengths = early %d normal %d, want %d and %d", len(report.Early), len(report.Initramfs), len(early), len(normal))
+	}
+	if report.EarlySHA256 == "" {
+		t.Fatal("early microcode digest is empty")
+	}
+}
+
+func TestSplitEarlyInitrdRejectsMissingVendor(t *testing.T) {
+	early := testCPIO(t, map[string][]byte{
+		"kernel/x86/microcode/GenuineIntel.bin": []byte("intel"),
+	})
+	combined := append(early, zstdMagic...)
+	_, err := SplitEarlyInitrd(combined)
+	if err == nil || !strings.Contains(err.Error(), "AMD early CPU microcode capability is missing") {
+		t.Fatalf("SplitEarlyInitrd() error = %v", err)
+	}
+}
+
+func TestSplitEarlyInitrdRejectsMicrocodeInNormalInitramfs(t *testing.T) {
+	normal := append(slices.Clone(zstdMagic), []byte("microcode")...)
+	_, err := SplitEarlyInitrd(normal)
+	if err == nil || !strings.Contains(err.Error(), "does not start with an uncompressed early cpio archive") {
+		t.Fatalf("SplitEarlyInitrd() error = %v", err)
+	}
+}
+
+func TestVerifyPackageInventory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packages.tsv")
+	content := strings.Join([]string{
+		"linux-firmware\t20260622-1.fc44.noarch",
+		"microcode_ctl\t2:2.1-74.fc44.x86_64",
+		"amd-ucode-firmware\t20260622-1.fc44.noarch",
+		"intel-gpu-firmware\t20260622-1.fc44.noarch",
+		"amd-gpu-firmware\t20260622-1.fc44.noarch",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	packages, err := VerifyPackageInventory("runtime", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packages["microcode_ctl"] != "2:2.1-74.fc44.x86_64" {
+		t.Fatalf("microcode_ctl = %q", packages["microcode_ctl"])
+	}
+}
+
+func TestVerifyPackageInventoryReportsCapability(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packages.tsv")
+	if err := os.WriteFile(path, []byte("linux-firmware\t1.noarch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := VerifyPackageInventory("installer", path)
+	if err == nil || !strings.Contains(err.Error(), "Intel CPU microcode capability is missing") || !strings.Contains(err.Error(), "microcode_ctl") {
+		t.Fatalf("VerifyPackageInventory() error = %v", err)
+	}
+}
+
+func testCPIO(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	names = append(names, "TRAILER!!!")
+	for index, name := range names {
+		data := files[name]
+		header := "070701" +
+			hexField(uint64(index+1)) +
+			hexField(0o100644) +
+			hexField(0) +
+			hexField(0) +
+			hexField(1) +
+			hexField(0) +
+			hexField(uint64(len(data))) +
+			hexField(0) +
+			hexField(0) +
+			hexField(0) +
+			hexField(0) +
+			hexField(uint64(len(name)+1)) +
+			hexField(0)
+		if len(header) != newcHeaderSize {
+			t.Fatalf("header length = %d", len(header))
+		}
+		out.WriteString(header)
+		out.WriteString(name)
+		out.WriteByte(0)
+		for out.Len()%4 != 0 {
+			out.WriteByte(0)
+		}
+		out.Write(data)
+		for out.Len()%4 != 0 {
+			out.WriteByte(0)
+		}
+	}
+	return out.Bytes()
+}
+
+func hexField(value uint64) string {
+	return fmt.Sprintf("%08x", value)
+}

--- a/internal/firmware/modules.go
+++ b/internal/firmware/modules.go
@@ -1,0 +1,156 @@
+package firmware
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var installerFirmwareModuleFamilies = []string{
+	"drivers/ata/",
+	"drivers/block/",
+	"drivers/hv/",
+	"drivers/md/",
+	"drivers/message/",
+	"drivers/net/ethernet/",
+	"drivers/net/hyperv/",
+	"drivers/net/mdio/",
+	"drivers/net/phy/",
+	"drivers/net/virtio_net",
+	"drivers/net/vmxnet3/",
+	"drivers/nvme/",
+	"drivers/scsi/",
+	"drivers/usb/host/",
+	"drivers/usb/storage/",
+	"drivers/vhost/",
+	"drivers/virtio/",
+}
+
+func VerifyInstallerModuleFirmware(root, modinfo string) (int, int, error) {
+	if strings.TrimSpace(modinfo) == "" {
+		modinfo = "modinfo"
+	}
+	moduleRoot := filepath.Join(root, "usr", "lib", "modules")
+	firmwareRoot := filepath.Join(root, "usr", "lib", "firmware")
+	var modules []string
+	if err := filepath.WalkDir(moduleRoot, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !isKernelModule(entry.Name()) {
+			return nil
+		}
+		relative, err := filepath.Rel(moduleRoot, path)
+		if err != nil {
+			return err
+		}
+		if !installerFirmwareModule(relative) {
+			return nil
+		}
+		modules = append(modules, path)
+		return nil
+	}); err != nil {
+		return 0, 0, fmt.Errorf("walk installer kernel modules: %w", err)
+	}
+	sort.Strings(modules)
+	requirements := make(map[string][]string)
+	for _, module := range modules {
+		output, err := exec.Command(modinfo, "-F", "firmware", module).CombinedOutput()
+		if err != nil {
+			return len(modules), len(requirements), fmt.Errorf("inspect firmware requirements for %s: %w: %s", filepath.Base(module), err, strings.TrimSpace(string(output)))
+		}
+		for _, line := range strings.Split(string(output), "\n") {
+			requirement := strings.TrimSpace(line)
+			if requirement == "" {
+				continue
+			}
+			requirements[requirement] = append(requirements[requirement], module)
+		}
+	}
+	names := make([]string, 0, len(requirements))
+	for name := range requirements {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var missing []string
+	for _, name := range names {
+		if err := validateFirmwarePath(name); err != nil {
+			return len(modules), len(requirements), err
+		}
+		present, err := firmwarePresent(firmwareRoot, name)
+		if err != nil {
+			return len(modules), len(requirements), err
+		}
+		if !present {
+			missing = append(missing, fmt.Sprintf(
+				"%s requires %s",
+				filepath.Base(requirements[name][0]),
+				name,
+			))
+		}
+	}
+	if len(missing) > 0 {
+		return len(modules), len(requirements), fmt.Errorf(
+			"claimed installer drivers are missing firmware from the same initrd:\n- %s",
+			strings.Join(missing, "\n- "),
+		)
+	}
+	return len(modules), len(requirements), nil
+}
+
+func installerFirmwareModule(path string) bool {
+	path = filepath.ToSlash(path)
+	kernelAt := strings.Index(path, "/kernel/")
+	if kernelAt < 0 {
+		return false
+	}
+	path = path[kernelAt+len("/kernel/"):]
+	for _, family := range installerFirmwareModuleFamilies {
+		if strings.HasPrefix(path, family) {
+			return true
+		}
+	}
+	return false
+}
+
+func isKernelModule(name string) bool {
+	for _, suffix := range []string{".ko", ".ko.gz", ".ko.xz", ".ko.zst"} {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateFirmwarePath(path string) error {
+	if filepath.IsAbs(path) || filepath.Clean(path) != path || strings.HasPrefix(path, ".."+string(filepath.Separator)) || path == ".." {
+		return fmt.Errorf("kernel module reported unsafe firmware path %q", path)
+	}
+	return nil
+}
+
+func firmwarePresent(root, requirement string) (bool, error) {
+	for _, suffix := range []string{"", ".xz", ".zst", ".gz"} {
+		candidate := filepath.Join(root, requirement+suffix)
+		if strings.ContainsAny(requirement, "*?[") {
+			matches, err := filepath.Glob(candidate)
+			if err != nil {
+				return false, fmt.Errorf("match firmware requirement %q: %w", requirement, err)
+			}
+			if len(matches) > 0 {
+				return true, nil
+			}
+			continue
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return true, nil
+		} else if !os.IsNotExist(err) {
+			return false, fmt.Errorf("stat firmware %s: %w", candidate, err)
+		}
+	}
+	return false, nil
+}

--- a/internal/firmware/packages.go
+++ b/internal/firmware/packages.go
@@ -1,0 +1,62 @@
+package firmware
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type PackageCapability struct {
+	Name       string
+	Capability string
+}
+
+var packageCapabilities = map[string][]PackageCapability{
+	"installer": {
+		{Name: "linux-firmware", Capability: "general redistributable device firmware"},
+		{Name: "microcode_ctl", Capability: "Intel CPU microcode"},
+		{Name: "amd-ucode-firmware", Capability: "AMD CPU microcode"},
+	},
+	"runtime": {
+		{Name: "linux-firmware", Capability: "general redistributable device firmware"},
+		{Name: "microcode_ctl", Capability: "Intel CPU microcode"},
+		{Name: "amd-ucode-firmware", Capability: "AMD CPU microcode"},
+		{Name: "intel-gpu-firmware", Capability: "Intel i915 and xe GPU firmware"},
+		{Name: "amd-gpu-firmware", Capability: "AMD amdgpu firmware"},
+	},
+}
+
+func VerifyPackageInventory(kind, path string) (map[string]string, error) {
+	required, ok := packageCapabilities[kind]
+	if !ok {
+		return nil, fmt.Errorf("unsupported firmware package inventory kind %q", kind)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s package inventory %s: %w", kind, path, err)
+	}
+	defer file.Close()
+	packages := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 2)
+		if len(fields) != 2 || strings.TrimSpace(fields[0]) == "" || strings.TrimSpace(fields[1]) == "" {
+			return nil, fmt.Errorf("%s package inventory has malformed line %q", kind, line)
+		}
+		packages[fields[0]] = fields[1]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read %s package inventory: %w", kind, err)
+	}
+	for _, capability := range required {
+		if strings.TrimSpace(packages[capability.Name]) == "" {
+			return nil, fmt.Errorf("%s %s capability is missing: expected package %s in %s", kind, capability.Capability, capability.Name, path)
+		}
+	}
+	return packages, nil
+}

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -2,11 +2,11 @@
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
   "recipeScope": "kubernetes-bundle-v1",
-  "recipeDigest": "sha256:5e26ccbc9d5e687b7a642dceb7e50624bf74ab58820092ca3adafd447964342b",
+  "recipeDigest": "sha256:239aaede1675d8996eead1938d3d8756a829c64c2938d74738dd891f9fbdf440",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 31,
+      "artifactRevision": 32,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -16,7 +16,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 29,
+      "artifactRevision": 30,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -26,7 +26,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 28,
+      "artifactRevision": 29,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -36,7 +36,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 28,
+      "artifactRevision": 29,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/mkosi_artifacts_test.go
+++ b/internal/scriptstest/mkosi_artifacts_test.go
@@ -50,6 +50,7 @@ func TestMkosiArtifactsWriteProducesValidJSON(t *testing.T) {
 		"KATL_INSTALLER_UKI="+installerUKI,
 		"KATL_INSTALLER_KERNEL="+installerKernel,
 		"KATL_INSTALLER_INITRD="+installerInitrd,
+		"KATL_INSTALLER_PACKAGE_SET="+filepath.Join(workDir, "missing-installer-packages.tsv"),
 		"KATL_INSTALLER_ISO="+installerISO,
 		"KATL_RUNTIME_UKI="+runtimeUKI,
 		"KATL_RUNTIME_UKI_METADATA="+runtimeUKI+".json",

--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -8,20 +8,20 @@ import (
 	"testing"
 )
 
-func TestRuntimeInitrdIncludesLibseccomp(t *testing.T) {
+func TestRuntimeInitrdPackagingPreservesEarlyMicrocode(t *testing.T) {
 	wrapper, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts", "mkosi"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	text := string(wrapper)
-	for _, want := range []string{
-		`"$root/usr/lib64/libseccomp.so.2"`,
-		"cpio --null --create --append --format=newc",
-		`zstd -q --ultra -22 -f "$initrd_raw" -o "$runtime_initrd"`,
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("runtime artifact packaging does not append libseccomp to the initrd: missing %q", want)
-		}
+	splitAt := strings.Index(text, "mkosi_artifacts split-initrd")
+	repackAt := strings.Index(text, "cpio --null --create --append --format=newc")
+	joinAt := strings.Index(text, "mkosi_artifacts join-initrd")
+	if splitAt < 0 || repackAt < 0 || joinAt < 0 || splitAt >= repackAt || repackAt >= joinAt {
+		t.Fatal("runtime initrd packaging must preserve early microcode around normal initramfs changes")
+	}
+	if !strings.Contains(text, `"$root/usr/lib64/libseccomp.so.2"`) {
+		t.Fatal("runtime initrd packaging must include libseccomp for the runtime switch-root helper")
 	}
 }
 
@@ -32,7 +32,7 @@ func TestRuntimeBootInputsArePublishedBeforeInitrdPackaging(t *testing.T) {
 	}
 	text := string(wrapper)
 	publish := `cp --reflink=auto "$kernel_source" "$runtime_kernel"`
-	packageInitrd := `zstd -q -d -c "$runtime_initrd"`
+	packageInitrd := `mkosi_artifacts split-initrd`
 	publishAt := strings.Index(text, publish)
 	packageAt := strings.Index(text, packageInitrd)
 	if publishAt < 0 || packageAt < 0 || publishAt >= packageAt {

--- a/internal/vmtest/first_install.go
+++ b/internal/vmtest/first_install.go
@@ -109,6 +109,9 @@ func RunFirstInstall(ctx context.Context, runner Runner, scenario Scenario, conf
 		config.Installer.Expect = installedSignal
 		config.Installer.VM.Expect = installedSignal
 		config.Installer.DiskFirst = true
+		if config.Installer.VM.SerialIdleTimeout == 0 {
+			config.Installer.VM.SerialIdleTimeout = -1
+		}
 	}
 	if config.GuestHandoff {
 		preseed, err := writeGuestHandoffSeedMedia(ctx, result, config, manifest)

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -13,6 +13,10 @@ Packages=
         # Boot stack and initrd userspace.
         kernel-core
         kernel-modules
+        # Generic Intel/AMD CPU microcode and firmware for retained early drivers.
+        linux-firmware
+        microcode_ctl
+        amd-ucode-firmware
         systemd
         systemd-boot-unsigned
         systemd-udev
@@ -67,6 +71,17 @@ KernelModules=
         /fs/udf/
         /fs/xfs/
         /lib/
+        # Specialized and obsolete devices whose firmware is outside the
+        # generic installer support policy.
+        -/drivers/net/ethernet/mellanox/mlxsw/*
+        -/drivers/net/ethernet/netronome/nfp/*
+        -/drivers/net/ethernet/qlogic/qed/*
+        -/drivers/net/ethernet/qlogic/qede/*
+        -/drivers/net/ethernet/sun/cassini
+        -/drivers/net/ethernet/tehuti/tn40xx
+        -/drivers/scsi/qedf/*
+        -/drivers/scsi/qedi/*
+        -/drivers/scsi/wd719x
 # Remove unsupported operator entrypoints and package-manager metadata that
 # arrive through retained Fedora packages.
 RemoveFiles=

--- a/mkosi.profiles/runtime/mkosi.conf
+++ b/mkosi.profiles/runtime/mkosi.conf
@@ -9,6 +9,13 @@ Packages=
         # Runtime boot, kernel modules, and initramfs tooling.
         kernel-core
         kernel-modules
+        # Common redistributable firmware and generic Intel/AMD CPU microcode.
+        linux-firmware
+        microcode_ctl
+        amd-ucode-firmware
+        # Runtime GPU firmware for the retained in-tree driver families.
+        intel-gpu-firmware
+        amd-gpu-firmware
         wireless-regdb
         dracut
         systemd

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -4,6 +4,9 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 artifact="${1:-$repo_root/_build/mkosi/katl-installer.efi}"
 initrd="${KATL_INSTALLER_INITRD:-${artifact%.efi}.initrd}"
+packages="${KATL_INSTALLER_PACKAGE_SET:-$repo_root/_build/mkosi/katl-installer.packages.tsv}"
+artifact_metadata="${artifact}.json"
+initrd_metadata="${initrd}.json"
 
 fail() {
     echo "error: $*" >&2
@@ -15,17 +18,62 @@ need() {
 }
 
 need cpio
+need go
 need grep
+need jq
+need modinfo
+need sha256sum
 need ukify
 need zstd
 
 [[ -f "$artifact" ]] || fail "installer UKI not found: $artifact"
 [[ -f "$initrd" ]] || fail "installer initrd not found: $initrd"
+[[ -f "$packages" ]] || fail "installer package inventory not found: $packages"
+[[ -f "$artifact_metadata" ]] || fail "installer UKI metadata not found: $artifact_metadata"
+[[ -f "$initrd_metadata" ]] || fail "installer initrd metadata not found: $initrd_metadata"
 
 work="$(mktemp -d "${TMPDIR:-/tmp}/katl-installer-check.XXXXXX")"
-trap 'rm -rf "$work"' EXIT
+cleanup() {
+    chmod -R u+w "$work" 2>/dev/null || true
+    rm -rf "$work"
+}
+trap cleanup EXIT
+early_cpio="$work/early.cpio"
+normal_initrd="$work/normal.initrd"
 initrd_cpio="$work/installer.cpio"
-zstd -q -d -c "$initrd" >"$initrd_cpio" || fail "decompress installer initrd failed"
+GOCACHE="${GOCACHE:-$repo_root/_build/go-cache}" \
+    go run "$repo_root/cmd/katl-mkosi-artifacts" verify-firmware-packages \
+    --kind installer \
+    --inventory "$packages" >/dev/null ||
+    fail "verify installer firmware package capabilities failed"
+firmware_report="$(GOCACHE="${GOCACHE:-$repo_root/_build/go-cache}" \
+    go run "$repo_root/cmd/katl-mkosi-artifacts" verify-uki-initrd \
+    --uki "$artifact" \
+    --initrd "$initrd")" ||
+    fail "verify installer UKI early CPU microcode failed"
+early_sha="${firmware_report#earlyMicrocodeSHA256=}"
+early_sha="${early_sha%% *}"
+package_sha="$(sha256sum "$packages" | awk '{print $1}')"
+jq -e --arg early "$early_sha" --arg packages "$package_sha" \
+    '.artifactRole == "installer-uki"
+      and .earlyMicrocodeSHA256 == $early
+      and .packageInventorySHA256 == $packages' \
+    "$artifact_metadata" >/dev/null ||
+    fail "installer UKI metadata does not bind the firmware package inventory and early microcode"
+jq -e --arg early "$early_sha" --arg packages "$package_sha" \
+    '.artifactRole == "installer-initrd"
+      and .compression == "early-cpio+zstd"
+      and .earlyMicrocodeSHA256 == $early
+      and .packageInventorySHA256 == $packages' \
+    "$initrd_metadata" >/dev/null ||
+    fail "installer initrd metadata does not bind the firmware package inventory and early microcode"
+GOCACHE="${GOCACHE:-$repo_root/_build/go-cache}" \
+    go run "$repo_root/cmd/katl-mkosi-artifacts" split-initrd \
+    --input "$initrd" \
+    --early "$early_cpio" \
+    --initramfs "$normal_initrd" >/dev/null ||
+    fail "split installer early CPU microcode and normal initramfs failed"
+zstd -q -d -c "$normal_initrd" >"$initrd_cpio" || fail "decompress installer initrd failed"
 
 inspect="$(ukify inspect "$artifact")" || fail "inspect installer UKI failed"
 grep -Fq '.linux:' <<<"$inspect" || fail "installer UKI missing .linux section"
@@ -43,6 +91,21 @@ fi
 if grep -Eq '^usr/lib/modules/[^/]+/(System\.map|vmlinuz)$' <<<"$initrd_list"; then
     fail "installer initrd contains duplicate kernel build artifacts"
 fi
+initrd_root="$work/root"
+mkdir -p "$initrd_root"
+(
+    cd "$initrd_root"
+    cpio -id --quiet --no-absolute-filenames <"$initrd_cpio"
+) || fail "extract installer initrd for firmware verification failed"
+if find "$initrd_root/usr/lib/modules" -type f \
+    \( -name 'i915.ko*' -o -name 'xe.ko*' -o -name 'amdgpu.ko*' \) \
+    -print -quit | grep -q .; then
+    fail "installer initrd unexpectedly contains runtime GPU drivers"
+fi
+GOCACHE="${GOCACHE:-$repo_root/_build/go-cache}" \
+    go run "$repo_root/cmd/katl-mkosi-artifacts" verify-module-firmware \
+    --root "$initrd_root" >/dev/null ||
+    fail "verify installer driver firmware co-location failed"
 
 has_path() {
     local path="${1#/}"

--- a/scripts/check-runtime-boot-asset
+++ b/scripts/check-runtime-boot-asset
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 artifact="${1:-_build/mkosi/katl-runtime.efi}"
 metadata="${artifact}.json"
 checksum="${artifact}.sha256"
+initrd="${KATL_RUNTIME_INITRD:-$(dirname "$artifact")/katl-runtime-root.initrd}"
+packages="${KATL_RUNTIME_PACKAGE_SET:-$(dirname "$artifact")/katl-runtime.packages.tsv}"
 
 fail() {
     echo "error: $*" >&2
@@ -15,6 +18,7 @@ need() {
 }
 
 need jq
+need go
 need grep
 need sha256sum
 need stat
@@ -22,13 +26,25 @@ need stat
 [[ -f "$artifact" ]] || fail "artifact not found: $artifact"
 [[ -f "$metadata" ]] || fail "metadata not found: $metadata"
 [[ -f "$checksum" ]] || fail "checksum not found: $checksum"
+[[ -f "$initrd" ]] || fail "runtime initrd not found: $initrd"
+[[ -f "$packages" ]] || fail "runtime package inventory not found: $packages"
 
 (cd "$(dirname "$artifact")" && sha256sum -c "$(basename "$checksum")")
 
 size="$(stat -c %s "$artifact")"
 sha256="$(sha256sum "$artifact" | awk '{print $1}')"
+package_sha="$(sha256sum "$packages" | awk '{print $1}')"
+firmware_report="$(GOCACHE="${GOCACHE:-$repo_root/_build/go-cache}" \
+    go run "$repo_root/cmd/katl-mkosi-artifacts" verify-uki-initrd \
+    --uki "$artifact" \
+    --initrd "$initrd")" ||
+    fail "runtime UKI early CPU microcode verification failed"
+early_sha="${firmware_report#earlyMicrocodeSHA256=}"
+early_sha="${early_sha%% *}"
 jq -e \
     --arg sha "$sha256" \
+    --arg early "$early_sha" \
+    --arg packages "$package_sha" \
     --argjson size "$size" \
     '.name == "runtime-uki"
       and .kind == "runtime-uki"
@@ -38,9 +54,11 @@ jq -e \
       and .compatibleRuntime.artifactPath == "katl-runtime-root.squashfs"
       and ((.kernelCommandLine // []) | index("rootfstype=squashfs") != null)
       and ((.kernelCommandLine // []) | index("ro") != null)
+      and .earlyMicrocodeSHA256 == $early
+      and .packageInventorySHA256 == $packages
       and .sizeBytes == $size
       and .sha256 == $sha' "$metadata" >/dev/null ||
-    fail "runtime UKI metadata does not match artifact"
+    fail "runtime UKI metadata does not match artifact or firmware inputs"
 
 if command -v ukify >/dev/null 2>&1; then
     inspection="$(ukify inspect "$artifact")"

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 artifact="${1:-_build/mkosi/katl-runtime-root.squashfs}"
 metadata="${artifact}.json"
 checksum="${artifact}.sha256"
+packages="${KATL_RUNTIME_PACKAGE_SET:-$(dirname "$artifact")/katl-runtime.packages.tsv}"
 
 fail() {
     echo "error: $*" >&2
@@ -56,7 +58,7 @@ links_to() {
 }
 
 check_kernel_support() {
-    local module_index versions version builtin module_count firmware_index firmware_count
+    local module_index versions version builtin module_count firmware_index firmware_count module_root
     module_index="$(unsquashfs -ll "$artifact" usr/lib/modules)" || fail "inspect /usr/lib/modules failed"
     versions="$(
         sed -n 's#.*squashfs-root/usr/lib/modules/\([^/[:space:]]*\).*#\1#p' <<<"$module_index" |
@@ -94,9 +96,20 @@ check_kernel_support() {
         ip_vs_wrr \
         ip_vs_sh \
         virtio_net \
-        virtio_blk
+        virtio_blk \
+        i915 \
+        xe \
+        amdgpu
     do
         require_module "$name"
+    done
+
+    module_root="$work/runtime-modules"
+    unsquashfs -no-progress -d "$module_root" "$artifact" usr/lib/modules >/dev/null ||
+        fail "extract runtime kernel modules failed"
+    for name in i915 xe amdgpu; do
+        modinfo -b "$module_root/usr" -k "$version" "$name" >/dev/null ||
+            fail "runtime artifact-local modinfo failed for $name"
     done
 
     firmware_index="$(unsquashfs -ll "$artifact" usr/lib/firmware 2>/dev/null || true)"
@@ -105,12 +118,21 @@ check_kernel_support() {
     )"
     printf "runtime kernel modules: version=%s module_files=%s required=%s\n" \
         "$version" "$module_count" \
-        "br_netfilter,nf_conntrack,overlay,ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,virtio_net,virtio_blk"
+        "br_netfilter,nf_conntrack,overlay,ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,virtio_net,virtio_blk,i915,xe,amdgpu"
     if [[ "${firmware_count:-0}" -eq 0 ]]; then
         echo "runtime firmware inventory: none; this artifact does not claim firmware-backed hardware support"
     else
         printf "runtime firmware inventory: files=%s\n" "$firmware_count"
     fi
+}
+
+require_firmware_family() {
+    local family="$1"
+    local capability="$2"
+    local output
+    output="$(unsquashfs -ll "$artifact" "usr/lib/firmware/$family" 2>/dev/null || true)"
+    grep -Eq "squashfs-root/usr/lib/firmware/$family/.+" <<<"$output" ||
+        fail "runtime $capability capability is missing: expected firmware family /usr/lib/firmware/$family"
 }
 
 root_locked() {
@@ -122,8 +144,10 @@ root_locked() {
 }
 
 need awk
+need go
 need grep
 need jq
+need modinfo
 need sha256sum
 need stat
 need unsquashfs
@@ -131,15 +155,27 @@ need unsquashfs
 [[ -f "$artifact" ]] || fail "artifact not found: $artifact"
 [[ -f "$metadata" ]] || fail "metadata not found: $metadata"
 [[ -f "$checksum" ]] || fail "checksum not found: $checksum"
+[[ -f "$packages" ]] || fail "runtime package inventory not found: $packages"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/katl-runtime-check.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+GOCACHE="${GOCACHE:-$repo_root/_build/go-cache}" \
+    go run "$repo_root/cmd/katl-mkosi-artifacts" verify-firmware-packages \
+    --kind runtime \
+    --inventory "$packages" >/dev/null ||
+    fail "verify runtime firmware package capabilities failed"
 
 (cd "$(dirname "$artifact")" && sha256sum -c "$(basename "$checksum")")
 
 size="$(stat -c %s "$artifact")"
 sha256="$(sha256sum "$artifact" | awk '{print $1}')"
+package_sha="$(sha256sum "$packages" | awk '{print $1}')"
 runtime_version="$(jq -r '.version // empty' "$metadata")"
 [[ -n "$runtime_version" ]] || fail "runtime root metadata version is missing"
 jq -e \
     --arg sha "$sha256" \
+    --arg packages "$package_sha" \
     --argjson size "$size" \
     '.name == "runtime-root"
       and .kind == "runtime-root"
@@ -149,9 +185,10 @@ jq -e \
       and .compatibleBoot.kind == "uki"
       and ((.compatibleBoot.kernelCommandLine // []) | index("rootfstype=squashfs") != null)
       and ((.compatibleBoot.kernelCommandLine // []) | index("ro") != null)
+      and .packageInventorySHA256 == $packages
       and .sizeBytes == $size
       and .sha256 == $sha' "$metadata" >/dev/null ||
-    fail "runtime root metadata does not match artifact"
+    fail "runtime root metadata does not match artifact or firmware package inventory"
 
 runtime_inventory="$(unsquashfs -ll "$artifact")" || fail "list runtime root failed"
 if grep -Eiq 'squashfs-root/[^[:space:]]*(vmtest|vm-test)' <<<"$runtime_inventory"; then
@@ -257,6 +294,11 @@ file_has /usr/lib/tmpfiles.d/katl-state.conf "d /var/lib/katl/kubernetes/cni/net
 links_to /opt/cni/bin /var/lib/katl/kubernetes/cni/bin
 links_to /etc/cni/net.d /var/lib/katl/kubernetes/cni/net.d
 check_kernel_support
+require_firmware_family intel-ucode "Intel CPU microcode"
+require_firmware_family amd-ucode "AMD CPU microcode"
+require_firmware_family i915 "Intel i915 GPU firmware"
+require_firmware_family xe "Intel xe GPU firmware"
+require_firmware_family amdgpu "AMD amdgpu firmware"
 
 for path in \
     /usr/bin/mkosi \

--- a/scripts/mkosi
+++ b/scripts/mkosi
@@ -671,6 +671,10 @@ if [[ "$runtime" == direct ]]; then
     fi
     if [[ "$status" -eq 0 && -n "$installer_package_set" ]]; then
         GOCACHE="${GOCACHE:-$TMPDIR/katl-go-cache}" \
+            go run ./cmd/katl-mkosi-artifacts normalize-installer-firmware >/dev/null || status=1
+    fi
+    if [[ "$status" -eq 0 && -n "$installer_package_set" ]]; then
+        GOCACHE="${GOCACHE:-$TMPDIR/katl-go-cache}" \
             go run ./cmd/katl-mkosi-artifacts write-installer-artifacts >/dev/null || status=1
     fi
     if [[ "$status" -eq 0 && -n "$cache_target" ]]; then
@@ -764,6 +768,11 @@ set +e
             status=1
         fi
     fi
+    if [[ "$status" -eq 0 && -n "${KATL_INSTALLER_PACKAGE_SET:-}" ]]; then
+        if ! mkosi_artifacts normalize-installer-firmware >/dev/null; then
+            status=1
+        fi
+    fi
     if [[ "$status" -eq 0 && "${KATL_EMIT_RUNTIME_ARTIFACT:-0}" == 1 ]]; then
         root=_build/mkosi/katl-runtime-root
         artifact=_build/mkosi/katl-runtime-root.squashfs
@@ -802,15 +811,23 @@ set +e
                     status=1
                 else
                     initrd_overlay=$(mktemp -d)
+                    initrd_early=$(mktemp)
+                    initrd_regular=$(mktemp)
                     initrd_raw=$(mktemp)
                     mkdir -p "$initrd_overlay/usr/lib64"
-                    if ! cp -a \
+                    if ! mkosi_artifacts split-initrd \
+                        --input "$runtime_initrd" \
+                        --early "$initrd_early" \
+                        --initramfs "$initrd_regular" >/dev/null; then
+                        echo "error: split runtime early microcode and normal initramfs" >&2
+                        status=1
+                    elif ! cp -a \
                         "$root/usr/lib64/libseccomp.so.2" \
                         "$root/usr/lib64/libseccomp.so.2."* \
                         "$initrd_overlay/usr/lib64/"; then
                         echo "error: stage runtime initrd libseccomp overlay" >&2
                         status=1
-                    elif ! zstd -q -d -c "$runtime_initrd" >"$initrd_raw"; then
+                    elif ! zstd -q -d -c "$initrd_regular" >"$initrd_raw"; then
                         echo "error: decompress runtime initrd" >&2
                         status=1
                     elif ! (
@@ -821,11 +838,17 @@ set +e
                     ); then
                         echo "error: append runtime initrd libseccomp overlay" >&2
                         status=1
-                    elif ! zstd -q --ultra -22 -f "$initrd_raw" -o "$runtime_initrd"; then
+                    elif ! zstd -q --ultra -22 -f "$initrd_raw" -o "$initrd_regular"; then
                         echo "error: recompress runtime initrd" >&2
                         status=1
+                    elif ! mkosi_artifacts join-initrd \
+                        --early "$initrd_early" \
+                        --initramfs "$initrd_regular" \
+                        --output "$runtime_initrd" >/dev/null; then
+                        echo "error: restore runtime early microcode before normal initramfs" >&2
+                        status=1
                     fi
-                    rm -rf "$initrd_overlay" "$initrd_raw"
+                    rm -rf "$initrd_overlay" "$initrd_early" "$initrd_regular" "$initrd_raw"
                     ukify_args=(
                         build
                         --linux "$runtime_kernel"
@@ -839,6 +862,10 @@ set +e
                         ukify_args+=(--stub /usr/lib/systemd/boot/efi/linuxx64.efi.stub)
                     fi
                     if [[ "$status" -eq 0 ]] && ! ukify "${ukify_args[@]}"; then
+                        status=1
+                    elif [[ "$status" -eq 0 ]] && ! mkosi_artifacts verify-uki-initrd \
+                        --uki "$boot_artifact" \
+                        --initrd "$runtime_initrd" >/dev/null; then
                         status=1
                     fi
                 fi


### PR DESCRIPTION
## What changed

- Include redistributable Intel and AMD CPU microcode plus common device and GPU firmware in immutable installer and runtime artifacts.
- Preserve and verify ordered early microcode archives in loose initrds and UKIs.
- Bind firmware package inventories and early microcode digests into artifact metadata, with capability-focused release checks.

## Why

KatlOS retained the relevant in-tree kernel drivers but did not guarantee their firmware or early CPU microcode was present in the same generation. This makes the kernel, firmware, and rollback unit coherent without exposing Fedora package selection to operators.

## Impact

Generic x86-64 artifacts support both Intel and AMD systems through the existing install, upgrade, and rollback workflows. Clean release artifacts passed content verification, first-install VM boot, and a persistent `katlctl` install/reboot journey.
