### PR TITLE
ci: validate Kubernetes bundles before merge

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -149,9 +149,10 @@ jobs:
           fi
           matrix="$(go run ./cmd/katl-kubernetes-release "${args[@]}")"
 
+          publish=false
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             publish=true
-          else
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             publish="$DISPATCH_PUBLISH"
           fi
           if [[ "$publish" != "true" && "$publish" != "false" ]]; then

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -2,11 +2,11 @@
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
   "recipeScope": "kubernetes-bundle-v1",
-  "recipeDigest": "sha256:74ccff769e33c395a02486895ad5201bef572785d712b49cad90f18f17131f44",
+  "recipeDigest": "sha256:835c6c772ebb97f0d849101470e4cd5c4425f72617913a3cbd334406671b67da",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 33,
+      "artifactRevision": 34,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -16,7 +16,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 31,
+      "artifactRevision": 32,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -26,7 +26,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 30,
+      "artifactRevision": 31,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -36,7 +36,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 30,
+      "artifactRevision": 31,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",


### PR DESCRIPTION
Make Kubernetes bundle producer runs validation-only on pull requests while preserving publication on main and explicit manual dispatches. Advance the immutable bundle revisions for the changed recipe. This closes the gap that allowed the artifact publication regression from 11f275d to reach main without building the affected Kubernetes bundles first.