### PR TITLE
ci: require Kubernetes producer validation

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -2,33 +2,6 @@ name: Kubernetes Bundle Artifacts
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/kubernetes-bundles.yml
-      - Containerfile.mkosi
-      - cmd/katl-kubernetes-release/**
-      - "!cmd/katl-kubernetes-release/**/*_test.go"
-      - cmd/katl-mkosi-artifacts/**
-      - "!cmd/katl-mkosi-artifacts/**/*_test.go"
-      - cmd/katl-publish-kubernetes-sysext/**
-      - "!cmd/katl-publish-kubernetes-sysext/**/*_test.go"
-      - containers-policy.json
-      - go.mod
-      - go.sum
-      - internal/installer/artifact/artifact.go
-      - internal/installer/artifact/local.go
-      - internal/installer/payloadbundle/**
-      - internal/installer/sysextcatalog/catalog.go
-      - internal/installer/sysextcatalog/publish.go
-      - internal/installer/sysextcatalog/stage.go
-      - internal/kubernetesrelease/**
-      - "!internal/kubernetesrelease/**/*_test.go"
-      - internal/kubernetesrelease/supported-versions.json
-      - mkosi.conf
-      - mkosi.profiles/kubernetes-sysext/**
-      - mkosi.profiles/runtime/mkosi.conf
-      - mkosi.profiles/runtime/os-release.in
-      - scripts/build-kubernetes-sysext
-      - scripts/check-kubernetes-sysext
   push:
     branches:
       - main
@@ -445,6 +418,35 @@ jobs:
           name: kubernetes-compatibility-${{ env.PAYLOAD_VERSION }}
           path: _build/compatibility/*.json
           if-no-files-found: error
+
+  presubmit:
+    name: Kubernetes Bundle Presubmit
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+      - plan
+      - build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      BUILD_REQUIRED: ${{ needs.plan.outputs.build }}
+      BUILD_RESULT: ${{ needs.build.result }}
+      PLAN_RESULT: ${{ needs.plan.result }}
+    steps:
+      - name: Require successful producer validation
+        shell: bash
+        run: |
+          if [[ "$PLAN_RESULT" != "success" ]]; then
+            echo "error: Kubernetes bundle planning did not succeed: $PLAN_RESULT" >&2
+            exit 1
+          fi
+          if [[ "$BUILD_REQUIRED" == "true" && "$BUILD_RESULT" != "success" ]]; then
+            echo "error: Kubernetes bundle builds did not succeed: $BUILD_RESULT" >&2
+            exit 1
+          fi
+          if [[ "$BUILD_REQUIRED" == "false" && "$BUILD_RESULT" != "skipped" ]]; then
+            echo "error: unexpected Kubernetes bundle build result: $BUILD_RESULT" >&2
+            exit 1
+          fi
 
   compatibility:
     name: Record Published Compatibility

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -268,7 +268,10 @@ scripts/check-fast origin/main...HEAD
 The command checks all tracked Go formatting, patch whitespace, and runs the
 complete Go suite with `-count=1` so cached test results cannot hide failures.
 Changes reach `main` through pull requests after the `Format And Unit Tests`
-check passes; direct pushes are not part of the supported development loop.
+and `Kubernetes Bundle Presubmit` checks pass. The Kubernetes check is a quick
+no-op for unrelated changes and builds every affected supported bundle when
+producer inputs change. Direct pushes are not part of the supported development
+loop.
 
 It intentionally skips mkosi builds, libvirt/KVM setup, VM scenarios, and
 publishing. Run host-specific VM gates locally with `scripts/vmtest-run` on a

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -2,11 +2,11 @@
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
   "recipeScope": "kubernetes-bundle-v1",
-  "recipeDigest": "sha256:835c6c772ebb97f0d849101470e4cd5c4425f72617913a3cbd334406671b67da",
+  "recipeDigest": "sha256:1555cdbeeffef4621f81ff51ea8f9f6aaece57b529840d009b2b70b58a469dec",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 34,
+      "artifactRevision": 35,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -16,7 +16,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 32,
+      "artifactRevision": 33,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -26,7 +26,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 31,
+      "artifactRevision": 32,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -36,7 +36,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 31,
+      "artifactRevision": 32,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -18,6 +18,8 @@ func TestKubernetesBundleWorkflowLinksUpstreamRelease(t *testing.T) {
 	var workflow struct {
 		On   map[string]any `yaml:"on"`
 		Jobs map[string]struct {
+			Name  string            `yaml:"name"`
+			Needs any               `yaml:"needs"`
 			Env   map[string]string `yaml:"env"`
 			Steps []struct {
 				Name string `yaml:"name"`
@@ -28,8 +30,27 @@ func TestKubernetesBundleWorkflowLinksUpstreamRelease(t *testing.T) {
 	if err := yaml.Unmarshal(contents, &workflow); err != nil {
 		t.Fatalf("parse Kubernetes bundle workflow: %v", err)
 	}
-	if _, ok := workflow.On["pull_request"]; !ok {
-		t.Fatal("Kubernetes bundle workflow does not build relevant pull requests")
+	pullRequest, ok := workflow.On["pull_request"]
+	if !ok {
+		t.Fatal("Kubernetes bundle workflow does not validate pull requests")
+	}
+	if config, ok := pullRequest.(map[string]any); ok {
+		if _, restricted := config["paths"]; restricted {
+			t.Fatal("Kubernetes bundle presubmit is not available to every pull request")
+		}
+	}
+
+	presubmit, ok := workflow.Jobs["presubmit"]
+	if !ok {
+		t.Fatal("Kubernetes bundle workflow has no stable presubmit result")
+	}
+	if presubmit.Name != "Kubernetes Bundle Presubmit" {
+		t.Fatalf("Kubernetes bundle presubmit name = %q", presubmit.Name)
+	}
+	for _, dependency := range []string{"plan", "build"} {
+		if !hasWorkflowNeed(presubmit.Needs, dependency) {
+			t.Errorf("Kubernetes bundle presubmit does not wait for %s", dependency)
+		}
 	}
 
 	build, ok := workflow.Jobs["build"]
@@ -83,6 +104,20 @@ func TestKubernetesBundleWorkflowLinksUpstreamRelease(t *testing.T) {
 	if strings.Contains(string(contents), "oras push") || strings.Contains(string(contents), "oras cp") {
 		t.Fatal("Kubernetes workflow must not assemble or publish through a second OCI implementation")
 	}
+}
+
+func hasWorkflowNeed(value any, want string) bool {
+	switch needs := value.(type) {
+	case string:
+		return needs == want
+	case []any:
+		for _, need := range needs {
+			if need == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestPublicKubernetesBundleCheckRequiresUpstreamRelease(t *testing.T) {


### PR DESCRIPTION
Add one stable Kubernetes Bundle Presubmit result that runs on every pull request and waits for bundle planning plus every selected producer build. Unrelated changes complete as a no-op, while producer changes cannot pass until their affected immutable bundles build and verify. This makes the artifact gate suitable for main branch protection.