### PR TITLE
ci: approve required generated PR checks

### DIFF
--- a/.github/workflows/kubernetes-bundles.yml
+++ b/.github/workflows/kubernetes-bundles.yml
@@ -579,34 +579,40 @@ jobs:
               });
             }
 
-            let validationRun;
-            for (let attempt = 0; attempt < 12; attempt++) {
-              const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "fast-checks.yml",
-                branch: process.env.HEAD_BRANCH,
-                event: "pull_request",
-                per_page: 10,
-              });
-              validationRun = runs.workflow_runs.find(run =>
-                run.head_sha === process.env.HEAD_SHA
-              );
-              if (validationRun) {
-                break;
+            const validationWorkflows = [
+              "fast-checks.yml",
+              "kubernetes-bundles.yml",
+            ];
+            for (const workflowId of validationWorkflows) {
+              let validationRun;
+              for (let attempt = 0; attempt < 12; attempt++) {
+                const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  branch: process.env.HEAD_BRANCH,
+                  event: "pull_request",
+                  per_page: 10,
+                });
+                validationRun = runs.workflow_runs.find(run =>
+                  run.head_sha === process.env.HEAD_SHA
+                );
+                if (validationRun) {
+                  break;
+                }
+                await new Promise(resolve => setTimeout(resolve, 5000));
               }
-              await new Promise(resolve => setTimeout(resolve, 5000));
-            }
-            if (!validationRun) {
-              throw new Error(`Fast Checks pull_request run was not created for ${process.env.HEAD_BRANCH}@${process.env.HEAD_SHA}`);
-            }
-            if (validationRun.conclusion === "action_required") {
-              await github.request("POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve", {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: validationRun.id,
-              });
-              core.info(`Approved Fast Checks run ${validationRun.id} for generated PR #${pull.number}`);
-            } else {
-              core.info(`Fast Checks run ${validationRun.id} requires no approval (${validationRun.status}/${validationRun.conclusion || "pending"})`);
+              if (!validationRun) {
+                throw new Error(`${workflowId} pull_request run was not created for ${process.env.HEAD_BRANCH}@${process.env.HEAD_SHA}`);
+              }
+              if (validationRun.conclusion === "action_required") {
+                await github.request("POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve", {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: validationRun.id,
+                });
+                core.info(`Approved ${workflowId} run ${validationRun.id} for generated PR #${pull.number}`);
+              } else {
+                core.info(`${workflowId} run ${validationRun.id} requires no approval (${validationRun.status}/${validationRun.conclusion || "pending"})`);
+              }
             }

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -2,11 +2,11 @@
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
   "recipeScope": "kubernetes-bundle-v1",
-  "recipeDigest": "sha256:1555cdbeeffef4621f81ff51ea8f9f6aaece57b529840d009b2b70b58a469dec",
+  "recipeDigest": "sha256:f10d06beb068b55425817e43d7cedfdcfc71d626ecdbbd309ba079ccd8dbd7ca",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 35,
+      "artifactRevision": 36,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -16,7 +16,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 33,
+      "artifactRevision": 34,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -26,7 +26,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 32,
+      "artifactRevision": 33,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -36,7 +36,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 32,
+      "artifactRevision": 33,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/internal/scriptstest/kubernetes_bundle_workflow_test.go
+++ b/internal/scriptstest/kubernetes_bundle_workflow_test.go
@@ -187,6 +187,8 @@ func TestKubernetesBundleWorkflowRetiresSupersededCompatibilityPRs(t *testing.T)
 		"github.rest.pulls.update",
 		`state: "closed"`,
 		"github.rest.actions.listWorkflowRuns",
+		`"fast-checks.yml"`,
+		`"kubernetes-bundles.yml"`,
 		`run.head_sha === process.env.HEAD_SHA`,
 		`validationRun.conclusion === "action_required"`,
 		`/actions/runs/{run_id}/approve`,


### PR DESCRIPTION
## What changed

Generated Kubernetes compatibility PRs now discover and approve both required validation workflows before enabling auto-merge. The workflow contract test covers both required workflow IDs, and artifact revisions advance with the changed producer recipe.

## Why

After Kubernetes Bundle Presubmit became required, generated compatibility PRs could stall in action_required even though Fast Checks was approved automatically. Approving both workflows preserves branch protection without manual release intervention.

## Validation

- scripts/check-fast origin/main...HEAD
- go run ./cmd/katl-kubernetes-release verify-recipe