### PR TITLE
installer: mount managed extra disks after boot

### DIFF
--- a/docs/internal/initial-design.md
+++ b/docs/internal/initial-design.md
@@ -192,7 +192,7 @@ machine-id values or machine-id policy
 installer SSH override policy
 artifact trust-root or signing policy
 bootloader, loader entry, or kernel argument policy
-extra disk mount options
+extra disk mount paths or mount options
 prebuilt confext artifacts in the default path
 arbitrary `/etc` file paths
 Kubernetes-generated mutable state under /etc/kubernetes

--- a/docs/internal/installer-runtime-design.md
+++ b/docs/internal/installer-runtime-design.md
@@ -384,10 +384,9 @@ Target disk selectors must prefer stable hardware identity such as
 `/dev/sda` are not valid manifest selectors because they are not stable enough
 for destructive operations.
 
-The schema can validate required fields, value shape, safe enum values, exact
-duplicate arrays, and reserved mount path syntax. `katlos-install` must add
-semantic validation for facts that need hardware discovery or normalized path
-comparison:
+The schema can validate required fields, value shape, safe enum values, and
+exact duplicate arrays. `katlos-install` must add semantic validation for facts
+that need hardware discovery:
 
 ```text
 target disk
@@ -429,12 +428,12 @@ SSH and identity
   metadata with systemd.machine_id=
 
 extra disks
-  selectors must not resolve to the target root disk or its partitions; mount
-  paths must normalize under /srv or /var/lib/katl/extra; duplicate normalized
-  mount paths, parent/child mount conflicts, and reserved paths such as /,
-  /boot, /efi, /usr, /etc, /run, /tmp, /var, /var/lib/kubelet,
-  /var/lib/containerd, and /var/lib/etcd must be rejected; custom mount options
-  are deferred
+  selectors must not resolve to the target root disk or its partitions; names
+  must be unique and Katl derives each mount path as
+  /var/lib/katl/mnt/<name>; wipe=false requires an existing filesystem matching
+  the requested type and preserves it, while wipe=true authorizes formatting
+  only that selected extra disk; custom mount paths and mount options are
+  deferred
 ```
 
 Runtime first-boot seed material may configure:
@@ -467,7 +466,7 @@ loading the install manifest
 selecting the node config
 collecting hardware facts
 validating target disk identity and size
-validating extra disk identity, filesystem, and mount requests
+validating extra disk identity, filesystem, preservation, and mount requests
 verifying artifact signatures and digests
 building an install plan
 persisting install progress when the state partition exists

--- a/docs/internal/schemas/install-manifest-v1alpha1.schema.json
+++ b/docs/internal/schemas/install-manifest-v1alpha1.schema.json
@@ -216,12 +216,12 @@
       "required": [
         "name",
         "selector",
-        "filesystem",
-        "mount"
+        "filesystem"
       ],
       "properties": {
         "name": {
-          "$ref": "#/$defs/dnsLabel"
+          "$ref": "#/$defs/dnsLabel",
+          "description": "Name used by Katl to derive /var/lib/katl/mnt/<name>."
         },
         "selector": {
           "$ref": "#/$defs/diskSelector"
@@ -232,22 +232,10 @@
             "xfs"
           ]
         },
-        "mount": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "path"
-          ],
-          "properties": {
-            "path": {
-              "type": "string",
-              "pattern": "^/(srv|var/lib/katl/extra)/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$"
-            }
-          }
-        },
         "wipe": {
           "type": "boolean",
-          "default": false
+          "default": false,
+          "description": "When true, wipe and format this selected disk. When false, require and preserve a matching existing filesystem."
         }
       }
     },

--- a/docs/internal/supported-node-config-domains.md
+++ b/docs/internal/supported-node-config-domains.md
@@ -85,8 +85,9 @@ SSH and operator access
   no general host account, PAM, sudo, passwd, shadow, or sysusers passthrough
 
 extra disk mount requests
-  additional non-root data disks with explicit mount points and filesystem
-  policy
+  additional non-root data disks named by the operator and mounted at
+  Katl-controlled paths below /var/lib/katl/mnt
+  explicit filesystem and per-disk preservation or wipe policy
   installer plans the disk work; runtime config renders native mounts
 ```
 
@@ -185,8 +186,8 @@ tmpfiles
   verify generated rules with systemd-tmpfiles where practical
 
 mount units and extra disks
-  validate mount points, filesystem choices, and destructive-install guards
-  reject paths under /run, /usr, /boot, /efi, and /etc/kubernetes
+  derive mount points below /var/lib/katl/mnt from validated unique names
+  validate filesystem choices, preservation state, and destructive-install guards
   verify generated units with systemd-analyze verify where practical
 
 Bootstrap profile input

--- a/docs/internal/writable-state-layout.md
+++ b/docs/internal/writable-state-layout.md
@@ -18,6 +18,20 @@ systemd-gpt-auto type var only when the target disk is unambiguous
 Persistent identity must not be stored in `/run`. `/run` is only for boot-local
 activation links and service handoff state that can be regenerated from `/var`.
 
+## Extra Disk Placement
+
+Katl mounts configured non-root data disks below
+`/var/lib/katl/mnt/<extra-disk-name>`. The name is operator supplied, but the
+mount path is Katl controlled and is not part of the install configuration
+surface. This prevents an extra disk from shadowing runtime, Kubernetes, or
+generation state.
+
+`wipe: false` is the preservation path: the selected whole disk must already
+contain the requested filesystem, and Katl mounts it without wiping or
+formatting it. A blank disk or filesystem mismatch fails planning with guidance
+to set `wipe: true` if reformatting is intended. `wipe: true` wipes and formats
+only the selected extra disk.
+
 ## Etcd Data Placement
 
 The first supported path keeps etcd data at `/var/lib/etcd` on the `KATL_STATE`
@@ -55,10 +69,10 @@ validation and mount-unit coverage.
 
 Unsafe cases must be rejected rather than interpreted as etcd storage:
 
-- `install.extraDisks[].mount.path` equal to `/var/lib/etcd` or any parent or
-  child path that would shadow it.
 - Extra-disk selectors that resolve to the selected target root disk or one of
   its partitions.
+- Duplicate or invalid extra-disk names, which would collide below
+  `/var/lib/katl/mnt`.
 - Dedicated etcd partition requests without a positive size, with a filesystem
   outside the supported allowlist, or that leave less than the minimum state
   partition size.
@@ -75,6 +89,7 @@ paths for services:
 | `var.mount` | installed `KATL_STATE` partition by PARTUUID | `/var` | Required local filesystem; no `nofail`; must be active before any persistent node service starts |
 | `etc-kubernetes.mount` | `/var/lib/katl/kubernetes/etc-kubernetes` bind source | `/etc/kubernetes` | Only writable `/etc` projection in the first implementation; active after confext and before kubelet or kubeadm automation |
 | `var-lib-etcd.mount` | optional installed `KATL_ETCD` partition by PARTUUID | `/var/lib/etcd` | Generated only when a dedicated etcd partition was planned; active before kubelet, kubeadm automation, and the kubeadm-ready target |
+| `var-lib-katl-mnt-<name>.mount` | selected extra disk by durable `/dev/disk/by-id` identity | `/var/lib/katl/mnt/<name>` | Generated for each configured extra disk; active after `var.mount` through `katl-extra-disks.target` and required before boot health succeeds |
 
 No mount units are generated for `/var/lib/kubelet` or
 `/var/lib/containerd` in the default model. They are native directories on the

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -455,7 +455,6 @@ func TestCompileRejectsInvalidInput(t *testing.T) {
 					Name:       "data",
 					Selector:   manifest.DiskSelector{Serial: "different"},
 					Filesystem: "xfs",
-					Mount:      manifest.ExtraMount{Path: "/srv/data"},
 				})
 			},
 			want: "extra disk",
@@ -668,7 +667,6 @@ func validConfig() Config {
 					Name:       "data",
 					Selector:   manifest.DiskSelector{ByID: "/dev/disk/by-id/ata-data"},
 					Filesystem: "xfs",
-					Mount:      manifest.ExtraMount{Path: "/srv/data"},
 				}}},
 				Bootstrap: BootstrapLayer{Access: inventory.Access{Method: "agent", CredentialRef: "vsock:1234:10240"}},
 			},

--- a/internal/installer/clusterplan/testdata/basic.golden.json
+++ b/internal/installer/clusterplan/testdata/basic.golden.json
@@ -87,10 +87,7 @@
               "selector": {
                 "byID": "/dev/disk/by-id/ata-data"
               },
-              "filesystem": "xfs",
-              "mount": {
-                "path": "/srv/data"
-              }
+              "filesystem": "xfs"
             }
           ]
         },
@@ -211,10 +208,7 @@
               "selector": {
                 "byID": "/dev/disk/by-id/ata-data"
               },
-              "filesystem": "xfs",
-              "mount": {
-                "path": "/srv/data"
-              }
+              "filesystem": "xfs"
             }
           ]
         },

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -861,8 +861,6 @@ spec:
           selector:
             byID: /dev/disk/by-id/ata-data
           filesystem: xfs
-          mount:
-            path: /srv/data
     identity:
       ssh:
         authorizedKeys:

--- a/internal/installer/discovery/command.go
+++ b/internal/installer/discovery/command.go
@@ -189,27 +189,38 @@ func stringValue(value *string) string {
 
 func parseFindmnt(data []byte) ([]MountFact, error) {
 	var raw struct {
-		Filesystems []struct {
-			Source  string `json:"source"`
-			Target  string `json:"target"`
-			FSType  string `json:"fstype"`
-			Options string `json:"options"`
-		} `json:"filesystems"`
+		Filesystems []findmntFilesystem `json:"filesystems"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("decode findmnt json: %w", err)
 	}
 
-	mounts := make([]MountFact, 0, len(raw.Filesystems))
+	var mounts []MountFact
 	for _, filesystem := range raw.Filesystems {
-		mounts = append(mounts, MountFact{
-			Source:     filesystem.Source,
-			Target:     filesystem.Target,
-			Filesystem: filesystem.FSType,
-			Options:    splitOptions(filesystem.Options),
-		})
+		mounts = appendFindmntFilesystem(mounts, filesystem)
 	}
 	return mounts, nil
+}
+
+type findmntFilesystem struct {
+	Source   string              `json:"source"`
+	Target   string              `json:"target"`
+	FSType   string              `json:"fstype"`
+	Options  string              `json:"options"`
+	Children []findmntFilesystem `json:"children"`
+}
+
+func appendFindmntFilesystem(mounts []MountFact, filesystem findmntFilesystem) []MountFact {
+	mounts = append(mounts, MountFact{
+		Source:     filesystem.Source,
+		Target:     filesystem.Target,
+		Filesystem: filesystem.FSType,
+		Options:    splitOptions(filesystem.Options),
+	})
+	for _, child := range filesystem.Children {
+		mounts = appendFindmntFilesystem(mounts, child)
+	}
+	return mounts
 }
 
 func parseIPLinks(data []byte) ([]NICFact, error) {

--- a/internal/installer/discovery/command_test.go
+++ b/internal/installer/discovery/command_test.go
@@ -54,7 +54,15 @@ func TestCommandDiscoverySourceCollectsReadOnlyFacts(t *testing.T) {
       "source": "/dev/nvme0n1p1",
       "target": "/boot",
       "fstype": "vfat",
-      "options": "rw,nosuid,nodev"
+      "options": "rw,nosuid,nodev",
+      "children": [
+        {
+          "source": "/dev/sdb",
+          "target": "/boot/data",
+          "fstype": "ext4",
+          "options": "rw"
+        }
+      ]
     }
   ]
 }`),
@@ -106,6 +114,7 @@ func TestCommandDiscoverySourceCollectsReadOnlyFacts(t *testing.T) {
 
 	wantMounts := []MountFact{
 		{Source: "/dev/nvme0n1p1", Target: "/boot", Filesystem: "vfat", Options: []string{"rw", "nosuid", "nodev"}},
+		{Source: "/dev/sdb", Target: "/boot/data", Filesystem: "ext4", Options: []string{"rw"}},
 	}
 	if !reflect.DeepEqual(facts.Mounts, wantMounts) {
 		t.Fatalf("mounts = %#v, want %#v", facts.Mounts, wantMounts)

--- a/internal/installer/disk/executor.go
+++ b/internal/installer/disk/executor.go
@@ -213,8 +213,8 @@ func BuildDiskOperations(plan DiskLayoutPlan, targetMountPrefix string) []DiskOp
 	for _, extra := range plan.ExtraMounts {
 		if extra.Wipe {
 			operations = append(operations, DiskOperation{Name: "wipe-extra-" + extra.Name, Command: "wipefs", Args: []string{"--all", extra.DevicePath}, Destructive: true})
+			operations = append(operations, DiskOperation{Name: "format-extra-" + extra.Name, Command: "mkfs." + extra.Filesystem, Args: []string{extra.DevicePath}, Destructive: true})
 		}
-		operations = append(operations, DiskOperation{Name: "format-extra-" + extra.Name, Command: "mkfs." + extra.Filesystem, Args: []string{extra.DevicePath}, Destructive: true})
 		operations = append(operations, DiskOperation{Name: "create-mountpoint-extra-" + extra.Name, Command: "mkdir", Args: []string{"-p", targetMountPrefix + extra.MountPath}})
 		operations = append(operations, DiskOperation{Name: "mount-extra-" + extra.Name, Command: "mount", Args: []string{extra.DevicePath, targetMountPrefix + extra.MountPath}})
 	}

--- a/internal/installer/disk/executor_test.go
+++ b/internal/installer/disk/executor_test.go
@@ -57,6 +57,26 @@ func TestDiskExecutorRefusesDestructiveActionsWithoutPermission(t *testing.T) {
 	}
 }
 
+func TestDiskExecutorPreservesReusableExtraDisk(t *testing.T) {
+	plan := executorPlan()
+	plan.ExtraMounts[0].Wipe = false
+
+	result, err := (DiskExecutor{}).Execute(context.Background(), DiskExecutionRequest{
+		Plan:             plan,
+		AllowDestructive: true,
+		DryRun:           true,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if countOps(result.Operations, "format-extra-data") != 0 || countOps(result.Operations, "wipe-extra-data") != 0 {
+		t.Fatalf("preserved extra disk has destructive operations: %#v", result.Operations)
+	}
+	if countOps(result.Operations, "mount-extra-data") != 1 {
+		t.Fatalf("preserved extra disk is not mounted: %#v", result.Operations)
+	}
+}
+
 func TestDiskExecutorExecutesOperationGroups(t *testing.T) {
 	plan := executorPlan()
 	commands := &NoopCommandRunner{}
@@ -273,7 +293,7 @@ func TestValidateAppliedLayout(t *testing.T) {
 		Mounts: []MountFact{
 			{Source: "/dev/nvme0n1p1", Target: "/efi", Filesystem: "vfat"},
 			{Source: "/dev/nvme0n1p4", Target: "/var", Filesystem: "ext4"},
-			{Source: "/dev/sdb", Target: "/srv/data", Filesystem: "xfs"},
+			{Source: "/dev/sdb", Target: "/var/lib/katl/mnt/data", Filesystem: "xfs"},
 		},
 	}
 	if err := ValidateAppliedLayout(facts, plan); err != nil {
@@ -283,7 +303,7 @@ func TestValidateAppliedLayout(t *testing.T) {
 	prefixed.Mounts = []MountFact{
 		{Source: "/dev/nvme0n1p1", Target: "/target/efi", Filesystem: "vfat"},
 		{Source: "/dev/nvme0n1p4", Target: "/target/var", Filesystem: "ext4"},
-		{Source: "/dev/sdb", Target: "/target/srv/data", Filesystem: "xfs"},
+		{Source: "/dev/sdb", Target: "/target/var/lib/katl/mnt/data", Filesystem: "xfs"},
 	}
 	if err := ValidateAppliedLayoutAt(prefixed, plan, "/target"); err != nil {
 		t.Fatalf("ValidateAppliedLayoutAt() error = %v", err)
@@ -305,7 +325,7 @@ func executorPlan() DiskLayoutPlan {
 			{Name: "state", GPTLabel: GPTLabelState, Type: "var", Filesystem: "ext4", MountPath: "/var", Remaining: true},
 		},
 		ExtraMounts: []ExtraDiskPlan{
-			{Name: "data", DevicePath: "/dev/sdb", Filesystem: "xfs", MountPath: "/srv/data", Wipe: true},
+			{Name: "data", DevicePath: "/dev/sdb", Filesystem: "xfs", MountPath: "/var/lib/katl/mnt/data", Wipe: true},
 		},
 		Boot: BootTargetMetadata{RootSlot: RootSlotA, RootPartitionLabel: GPTLabelRootA},
 	}

--- a/internal/installer/disk/layout.go
+++ b/internal/installer/disk/layout.go
@@ -2,15 +2,15 @@ package disk
 
 import (
 	"fmt"
-	"path"
-	"strings"
+	"slices"
 
 	"github.com/katl-dev/katl/internal/installer/discovery"
 )
 
 const (
-	DefaultESPSizeMiB = 512
-	MinimumRootMiB    = 1024
+	DefaultESPSizeMiB  = 512
+	MinimumRootMiB     = 1024
+	ExtraDiskMountRoot = "/var/lib/katl/mnt"
 
 	GPTLabelESP      = "KATL_ESP"
 	GPTLabelXBOOTLDR = "KATL_XBOOTLDR"
@@ -62,7 +62,6 @@ type ExtraDiskRequest struct {
 	Name       string
 	Selector   TargetDiskSelector
 	Filesystem string
-	MountPath  string
 	Wipe       bool
 }
 
@@ -92,12 +91,13 @@ type PartitionPlan struct {
 }
 
 type ExtraDiskPlan struct {
-	Name       string
-	DevicePath string
-	Filesystem string
-	MountPath  string
-	Wipe       bool
-	Signatures []SignatureReport
+	Name        string
+	DevicePath  string
+	MountSource string
+	Filesystem  string
+	MountPath   string
+	Wipe        bool
+	Signatures  []SignatureReport
 }
 
 type BootTargetMetadata struct {
@@ -212,18 +212,16 @@ func planTargetPartitions(target BlockDevice, request DiskLayoutRequest) ([]Part
 }
 
 func planExtraDisks(facts HardwareFacts, target BlockDevice, requests []ExtraDiskRequest) ([]ExtraDiskPlan, error) {
-	seenMounts := make(map[string]string, len(requests))
+	seenNames := make(map[string]struct{}, len(requests))
 	plans := make([]ExtraDiskPlan, 0, len(requests))
 	for _, request := range requests {
-		mountPath, err := normalizeExtraMountPath(request.MountPath)
-		if err != nil {
-			return nil, fmt.Errorf("extra disk %q: %w", request.Name, err)
+		if err := validateExtraDiskName(request.Name); err != nil {
+			return nil, err
 		}
-		if conflictWith, ok := mountConflict(seenMounts, mountPath); ok {
-			return nil, fmt.Errorf("extra disk %q mount %s conflicts with %s", request.Name, mountPath, conflictWith)
+		if _, exists := seenNames[request.Name]; exists {
+			return nil, fmt.Errorf("extra disk name %q is duplicated", request.Name)
 		}
-		seenMounts[mountPath] = request.Name
-
+		seenNames[request.Name] = struct{}{}
 		match, err := discovery.MatchTargetDisk(facts, request.Selector)
 		if err != nil {
 			return nil, fmt.Errorf("extra disk %q: %w", request.Name, err)
@@ -231,54 +229,63 @@ func planExtraDisks(facts HardwareFacts, target BlockDevice, requests []ExtraDis
 		if match.Device.Path == target.Path {
 			return nil, fmt.Errorf("extra disk %q resolves to target root disk %s", request.Name, target.Path)
 		}
+		mountSource, err := persistentDevicePath(match.Device, request.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("extra disk %q: %w", request.Name, err)
+		}
 
 		filesystem := request.Filesystem
 		if filesystem == "" {
 			filesystem = "ext4"
 		}
+		if filesystem != "ext4" && filesystem != "xfs" {
+			return nil, fmt.Errorf("extra disk %q filesystem %q is unsupported", request.Name, filesystem)
+		}
+		if !request.Wipe {
+			switch {
+			case match.Device.FilesystemSignature == "":
+				return nil, fmt.Errorf("extra disk %q has no reusable filesystem; set wipe to true to format it as %s", request.Name, filesystem)
+			case match.Device.FilesystemSignature != filesystem:
+				return nil, fmt.Errorf("extra disk %q has filesystem %s, not requested %s; set wipe to true to reformat it", request.Name, match.Device.FilesystemSignature, filesystem)
+			}
+		}
 		plans = append(plans, ExtraDiskPlan{
-			Name:       request.Name,
-			DevicePath: match.Device.Path,
-			Filesystem: filesystem,
-			MountPath:  mountPath,
-			Wipe:       request.Wipe,
-			Signatures: match.Signatures,
+			Name:        request.Name,
+			DevicePath:  match.Device.Path,
+			MountSource: mountSource,
+			Filesystem:  filesystem,
+			MountPath:   ExtraDiskMountRoot + "/" + request.Name,
+			Wipe:        request.Wipe,
+			Signatures:  match.Signatures,
 		})
 	}
 
 	return plans, nil
 }
 
-func normalizeExtraMountPath(mountPath string) (string, error) {
-	clean := path.Clean("/" + strings.TrimPrefix(strings.TrimSpace(mountPath), "/"))
-	if clean == "." || clean == "/" {
-		return "", fmt.Errorf("mount path is required")
+func persistentDevicePath(device BlockDevice, selector discovery.TargetDiskSelector) (string, error) {
+	if selector.ByID != "" {
+		return selector.ByID, nil
 	}
-	if isReservedMountPath(clean) {
-		return "", fmt.Errorf("mount path %s is reserved", clean)
+	aliases := slices.Clone(device.ByID)
+	slices.Sort(aliases)
+	if len(aliases) == 0 {
+		return "", fmt.Errorf("selected disk %s has no durable /dev/disk/by-id path for boot-time mounting", device.Path)
 	}
-	if !strings.HasPrefix(clean, "/srv/") && !strings.HasPrefix(clean, "/var/lib/katl/extra/") {
-		return "", fmt.Errorf("mount path %s must be under /srv or /var/lib/katl/extra", clean)
-	}
-	return clean, nil
+	return aliases[0], nil
 }
 
-func isReservedMountPath(mountPath string) bool {
-	switch mountPath {
-	case "/", "/boot", "/efi", "/usr", "/etc", "/run", "/tmp", "/var", "/var/lib/kubelet", "/var/lib/containerd", "/var/lib/etcd":
-		return true
-	default:
-		return false
+func validateExtraDiskName(name string) error {
+	if name == "" {
+		return fmt.Errorf("extra disk name is required")
 	}
-}
-
-func mountConflict(seen map[string]string, candidate string) (string, bool) {
-	for existing, name := range seen {
-		if existing == candidate || strings.HasPrefix(existing, candidate+"/") || strings.HasPrefix(candidate, existing+"/") {
-			return name, true
+	for i, value := range name {
+		if value >= 'a' && value <= 'z' || value >= '0' && value <= '9' || value == '-' && i > 0 && i < len(name)-1 {
+			continue
 		}
+		return fmt.Errorf("extra disk name %q must use lowercase letters, digits, and internal dashes", name)
 	}
-	return "", false
+	return nil
 }
 
 func planBootTarget(slot RootSlot) (BootTargetMetadata, error) {

--- a/internal/installer/disk/layout_test.go
+++ b/internal/installer/disk/layout_test.go
@@ -121,7 +121,6 @@ func TestPlanDiskLayoutExtraDiskMountRequests(t *testing.T) {
 				Name:       "data",
 				Selector:   TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data"},
 				Filesystem: "xfs",
-				MountPath:  "/srv/data",
 				Wipe:       true,
 			},
 		},
@@ -134,7 +133,7 @@ func TestPlanDiskLayoutExtraDiskMountRequests(t *testing.T) {
 		t.Fatalf("extra mount count = %d, want 1", len(plan.ExtraMounts))
 	}
 	extra := plan.ExtraMounts[0]
-	if extra.DevicePath != "/dev/sdb" || extra.MountPath != "/srv/data" || extra.Filesystem != "xfs" || !extra.Wipe {
+	if extra.DevicePath != "/dev/sdb" || extra.MountSource != "/dev/disk/by-id/ata-data" || extra.MountPath != "/var/lib/katl/mnt/data" || extra.Filesystem != "xfs" || !extra.Wipe {
 		t.Fatalf("extra mount = %#v", extra)
 	}
 	if len(extra.Signatures) != 1 || extra.Signatures[0].Value != "gpt" {
@@ -142,7 +141,7 @@ func TestPlanDiskLayoutExtraDiskMountRequests(t *testing.T) {
 	}
 }
 
-func TestPlanDiskLayoutRejectsDuplicateAndUnsafeExtraMounts(t *testing.T) {
+func TestPlanDiskLayoutRejectsDuplicateExtraDiskNames(t *testing.T) {
 	facts := layoutFacts(
 		diskForLayout("/dev/nvme0n1", "/dev/disk/by-id/nvme-root", 32768),
 		diskForLayout("/dev/sdb", "/dev/disk/by-id/ata-data-a", 16384),
@@ -155,25 +154,47 @@ func TestPlanDiskLayoutRejectsDuplicateAndUnsafeExtraMounts(t *testing.T) {
 		RootB:      RootSlotRequest{SizeMiB: 4096},
 		State:      StatePartitionRequest{MinSizeMiB: 8192},
 		ExtraDisks: []ExtraDiskRequest{
-			{Name: "data-a", Selector: TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data-a"}, MountPath: "/srv/data"},
-			{Name: "data-b", Selector: TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data-b"}, MountPath: "/srv/data/cache"},
+			{Name: "data", Selector: TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data-a"}, Wipe: true},
+			{Name: "data", Selector: TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data-b"}, Wipe: true},
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), "conflicts") {
-		t.Fatalf("PlanDiskLayout() error = %v, want mount conflict", err)
+	if err == nil || !strings.Contains(err.Error(), "duplicated") {
+		t.Fatalf("PlanDiskLayout() error = %v, want duplicate name failure", err)
 	}
+}
 
-	_, err = PlanDiskLayout(facts, DiskLayoutRequest{
+func TestPlanDiskLayoutReusesOnlyMatchingExtraDiskFilesystem(t *testing.T) {
+	extra := diskForLayout("/dev/sdb", "/dev/disk/by-id/ata-data", 16384)
+	extra.FilesystemSignature = "ext4"
+	facts := layoutFacts(
+		diskForLayout("/dev/nvme0n1", "/dev/disk/by-id/nvme-root", 32768),
+		extra,
+	)
+	request := DiskLayoutRequest{
 		TargetDisk: TargetDiskSelector{ByID: "/dev/disk/by-id/nvme-root"},
 		RootA:      RootSlotRequest{SizeMiB: 4096},
 		RootB:      RootSlotRequest{SizeMiB: 4096},
 		State:      StatePartitionRequest{MinSizeMiB: 8192},
-		ExtraDisks: []ExtraDiskRequest{
-			{Name: "data-a", Selector: TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data-a"}, MountPath: "/var/lib/kubelet"},
-		},
-	})
-	if err == nil || !strings.Contains(err.Error(), "reserved") {
-		t.Fatalf("PlanDiskLayout() error = %v, want reserved mount failure", err)
+		ExtraDisks: []ExtraDiskRequest{{
+			Name:       "data",
+			Selector:   TargetDiskSelector{ByID: "/dev/disk/by-id/ata-data"},
+			Filesystem: "ext4",
+		}},
+	}
+
+	if _, err := PlanDiskLayout(facts, request); err != nil {
+		t.Fatalf("PlanDiskLayout() error = %v", err)
+	}
+
+	request.ExtraDisks[0].Filesystem = "xfs"
+	if _, err := PlanDiskLayout(facts, request); err == nil || !strings.Contains(err.Error(), "set wipe to true") {
+		t.Fatalf("PlanDiskLayout() error = %v, want safe reuse refusal", err)
+	}
+
+	facts.BlockDevices[1].FilesystemSignature = ""
+	request.ExtraDisks[0].Filesystem = "ext4"
+	if _, err := PlanDiskLayout(facts, request); err == nil || !strings.Contains(err.Error(), "set wipe to true") {
+		t.Fatalf("PlanDiskLayout() error = %v, want blank disk refusal", err)
 	}
 }
 

--- a/internal/installer/generation/state.go
+++ b/internal/installer/generation/state.go
@@ -15,6 +15,18 @@ const (
 
 type StateRequest struct {
 	PartitionUUID string
+	ExtraMounts   []ExtraMountRequest
+}
+
+type ExtraMountRequest struct {
+	Source     string
+	Path       string
+	Filesystem string
+}
+
+type ExtraMountUnit struct {
+	Name    string
+	Content string
 }
 
 type KubernetesProjectionRequest struct {
@@ -31,6 +43,8 @@ type StateAssets struct {
 	HostConfigVerify   string
 	ExtensionReload    string
 	ExtensionActivate  string
+	ExtraDisksTarget   string
+	ExtraDisksActivate string
 	KubeadmActivate    string
 	KubeadmReadyTarget string
 	BootCompleteTarget string
@@ -43,6 +57,7 @@ type StateAssets struct {
 	RuntimeStatus      string
 	AgentService       string
 	Tmpfiles           string
+	ExtraMounts        []ExtraMountUnit
 	Dirs               []StateDir
 	MountPoints        []StateDir
 }
@@ -58,6 +73,10 @@ func RenderState(request StateRequest) (StateAssets, error) {
 		return StateAssets{}, err
 	}
 	kubernetesMount, err := RenderKubernetesProjection(KubernetesProjectionRequest{})
+	if err != nil {
+		return StateAssets{}, err
+	}
+	extraMounts, extraMountPoints, err := RenderExtraMounts(request.ExtraMounts)
 	if err != nil {
 		return StateAssets{}, err
 	}
@@ -107,6 +126,8 @@ func RenderState(request StateRequest) (StateAssets, error) {
 		HostConfigVerify:   renderHostConfigVerifyService(),
 		ExtensionReload:    renderSystemExtensionReloadService(),
 		ExtensionActivate:  renderSystemExtensionActivateService(),
+		ExtraDisksTarget:   renderExtraDisksTarget(),
+		ExtraDisksActivate: renderExtraDisksActivateService(),
 		KubeadmActivate:    renderKubeadmActivateService(),
 		KubeadmReadyTarget: renderKubeadmReadyTarget(),
 		BootCompleteTarget: renderBootCompleteTarget(),
@@ -119,10 +140,78 @@ func RenderState(request StateRequest) (StateAssets, error) {
 		RuntimeStatus:      renderRuntimeStatusService(),
 		AgentService:       renderAgentService(),
 		Tmpfiles:           renderTmpfiles(dirs),
+		ExtraMounts:        extraMounts,
 		Dirs:               dirs,
-		MountPoints:        []StateDir{{Path: KubernetesTarget, Mode: 0o755}},
+		MountPoints:        append([]StateDir{{Path: KubernetesTarget, Mode: 0o755}}, extraMountPoints...),
 	}
 	return assets, nil
+}
+
+func RenderExtraMounts(requests []ExtraMountRequest) ([]ExtraMountUnit, []StateDir, error) {
+	units := make([]ExtraMountUnit, 0, len(requests))
+	mountPoints := make([]StateDir, 0, len(requests))
+	for _, request := range requests {
+		name, err := mountUnitName(request.Path)
+		if err != nil {
+			return nil, nil, err
+		}
+		source := strings.TrimSpace(request.Source)
+		if source == "" || strings.ContainsAny(source, "\r\n\x00") {
+			return nil, nil, fmt.Errorf("extra mount %s source is invalid", request.Path)
+		}
+		filesystem := strings.TrimSpace(request.Filesystem)
+		if filesystem == "" || strings.ContainsAny(filesystem, "\r\n\x00") {
+			return nil, nil, fmt.Errorf("extra mount %s filesystem is invalid", request.Path)
+		}
+		units = append(units, ExtraMountUnit{
+			Name: name,
+			Content: strings.Join([]string{
+				"[Unit]",
+				"Description=Katl managed extra disk",
+				"Documentation=man:systemd.mount(5)",
+				"Requires=var.mount",
+				"After=var.mount",
+				"Before=local-fs.target",
+				"Conflicts=umount.target",
+				"Before=umount.target",
+				"",
+				"[Mount]",
+				"What=" + source,
+				"Where=" + request.Path,
+				"Type=" + filesystem,
+				"Options=rw",
+				"",
+				"[Install]",
+				"WantedBy=local-fs.target",
+				"",
+			}, "\n"),
+		})
+		mountPoints = append(mountPoints, StateDir{Path: request.Path, Mode: 0o755})
+	}
+	return units, mountPoints, nil
+}
+
+func mountUnitName(mountPath string) (string, error) {
+	clean := path.Clean(strings.TrimSpace(mountPath))
+	if clean == "." || clean == "/" || !path.IsAbs(clean) || clean != mountPath || strings.ContainsAny(clean, "\r\n\x00") {
+		return "", fmt.Errorf("extra mount path %q is invalid", mountPath)
+	}
+	var name strings.Builder
+	for _, value := range []byte(strings.TrimPrefix(clean, "/")) {
+		switch {
+		case value == '/':
+			name.WriteByte('-')
+		case value >= 'a' && value <= 'z',
+			value >= 'A' && value <= 'Z',
+			value >= '0' && value <= '9',
+			value == '_',
+			value == '.':
+			name.WriteByte(value)
+		default:
+			fmt.Fprintf(&name, "\\x%02x", value)
+		}
+	}
+	return name.String() + ".mount", nil
 }
 
 func RenderKubernetesProjection(request KubernetesProjectionRequest) (string, error) {
@@ -263,6 +352,34 @@ func renderKubeadmReadyTarget() string {
 	}, "\n")
 }
 
+func renderExtraDisksTarget() string {
+	return strings.Join([]string{
+		"[Unit]",
+		"Description=Katl managed extra disks",
+		"Documentation=man:systemd.target(5)",
+		"",
+	}, "\n")
+}
+
+func renderExtraDisksActivateService() string {
+	return strings.Join([]string{
+		"[Unit]",
+		"Description=Activate Katl managed extra disks",
+		"Documentation=man:systemd.mount(5) man:systemd.target(5)",
+		"Requires=katl-system-extensions-reload.service",
+		"After=katl-system-extensions-reload.service",
+		"Before=katl-boot-health.service",
+		"",
+		"[Service]",
+		"Type=oneshot",
+		"RemainAfterExit=yes",
+		"StandardOutput=journal+console",
+		"SyslogIdentifier=katl-extra-disks-activate",
+		"ExecStart=/usr/bin/systemctl start katl-extra-disks.target",
+		"",
+	}, "\n")
+}
+
 func renderKubeadmActivateService() string {
 	return strings.Join([]string{
 		"[Unit]",
@@ -304,8 +421,8 @@ func renderBootHealthService() string {
 		"[Unit]",
 		"Description=Record successful Katl boot health",
 		"Documentation=man:systemd.service(5)",
-		"Requires=katl-runtime-handoff-status.service katl-system-extensions-activate.service katlc-agent.service systemd-networkd.service sshd.service",
-		"After=katl-runtime-handoff-status.service katl-system-extensions-activate.service katlc-agent.service systemd-networkd.service sshd.service",
+		"Requires=katl-runtime-handoff-status.service katl-system-extensions-activate.service katl-extra-disks-activate.service katlc-agent.service systemd-networkd.service sshd.service",
+		"After=katl-runtime-handoff-status.service katl-system-extensions-activate.service katl-extra-disks-activate.service katlc-agent.service systemd-networkd.service sshd.service",
 		"Before=katl-boot-complete.target",
 		"RequiresMountsFor=/efi /var/lib/katl",
 		"",
@@ -469,6 +586,16 @@ func WriteState(root string, request StateRequest) (StateAssets, error) {
 	if err := writeFile(root, "etc/systemd/system/etc-kubernetes.mount", assets.EtcKubernetesMount, 0o644); err != nil {
 		return StateAssets{}, err
 	}
+	for _, mount := range assets.ExtraMounts {
+		unitPath := filepath.Join("etc/systemd/system", mount.Name)
+		if err := writeFile(root, unitPath, mount.Content, 0o644); err != nil {
+			return StateAssets{}, err
+		}
+		linkPath := filepath.Join("etc/systemd/system/local-fs.target.wants", mount.Name)
+		if err := writeSymlink(root, linkPath, "../"+mount.Name); err != nil {
+			return StateAssets{}, err
+		}
+	}
 	if err := writeFile(root, "etc/systemd/system/katl-generation-activate.service", assets.GenerationActivate, 0o644); err != nil {
 		return StateAssets{}, err
 	}
@@ -482,6 +609,12 @@ func WriteState(root string, request StateRequest) (StateAssets, error) {
 		return StateAssets{}, err
 	}
 	if err := writeFile(root, "etc/systemd/system/katl-system-extensions-activate.service", assets.ExtensionActivate, 0o644); err != nil {
+		return StateAssets{}, err
+	}
+	if err := writeFile(root, "etc/systemd/system/katl-extra-disks.target", assets.ExtraDisksTarget, 0o644); err != nil {
+		return StateAssets{}, err
+	}
+	if err := writeFile(root, "etc/systemd/system/katl-extra-disks-activate.service", assets.ExtraDisksActivate, 0o644); err != nil {
 		return StateAssets{}, err
 	}
 	if err := writeFile(root, "etc/systemd/system/katl-kubeadm-activate.service", assets.KubeadmActivate, 0o644); err != nil {

--- a/internal/installer/generation/state_test.go
+++ b/internal/installer/generation/state_test.go
@@ -278,8 +278,8 @@ WantedBy=multi-user.target
 	wantHealth := `[Unit]
 Description=Record successful Katl boot health
 Documentation=man:systemd.service(5)
-Requires=katl-runtime-handoff-status.service katl-system-extensions-activate.service katlc-agent.service systemd-networkd.service sshd.service
-After=katl-runtime-handoff-status.service katl-system-extensions-activate.service katlc-agent.service systemd-networkd.service sshd.service
+Requires=katl-runtime-handoff-status.service katl-system-extensions-activate.service katl-extra-disks-activate.service katlc-agent.service systemd-networkd.service sshd.service
+After=katl-runtime-handoff-status.service katl-system-extensions-activate.service katl-extra-disks-activate.service katlc-agent.service systemd-networkd.service sshd.service
 Before=katl-boot-complete.target
 RequiresMountsFor=/efi /var/lib/katl
 
@@ -454,6 +454,8 @@ func TestRuntimeStaticStateUnits(t *testing.T) {
 	assertRepoFile(t, filepath.Join(systemdRoot, "katl-host-config-verify.service"), assets.HostConfigVerify)
 	assertRepoFile(t, filepath.Join(systemdRoot, "katl-system-extensions-reload.service"), assets.ExtensionReload)
 	assertRepoFile(t, filepath.Join(systemdRoot, "katl-system-extensions-activate.service"), assets.ExtensionActivate)
+	assertRepoFile(t, filepath.Join(systemdRoot, "katl-extra-disks.target"), assets.ExtraDisksTarget)
+	assertRepoFile(t, filepath.Join(systemdRoot, "katl-extra-disks-activate.service"), assets.ExtraDisksActivate)
 	assertRepoFile(t, filepath.Join(systemdRoot, "katl-kubeadm-activate.service"), assets.KubeadmActivate)
 	assertRepoFile(t, filepath.Join(systemdRoot, "katl-kubeadm-ready.target"), assets.KubeadmReadyTarget)
 	assertRepoFile(t, filepath.Join(systemdRoot, "katl-boot-complete.target"), assets.BootCompleteTarget)

--- a/internal/installer/install_record.go
+++ b/internal/installer/install_record.go
@@ -20,6 +20,7 @@ const (
 type InstallRecordRequest struct {
 	TargetRoot        string
 	Manifest          manifest.Manifest
+	ExtraMounts       []generation.ExtraMountRequest
 	KubeadmConfigs    map[string]kubeadmconfig.Plan
 	KubernetesVersion string
 	Record            generation.Record
@@ -50,6 +51,11 @@ func MaterializeInstallRecord(request InstallRecordRequest) (InstallRecordResult
 	if err != nil {
 		return InstallRecordResult{}, err
 	}
+	extraMountFiles, err := extraMountNativeEtcFiles(request.ExtraMounts)
+	if err != nil {
+		return InstallRecordResult{}, err
+	}
+	files = append(files, extraMountFiles...)
 
 	release, err := confextRelease(request.Record)
 	if err != nil {
@@ -105,6 +111,40 @@ func MaterializeInstallRecord(request InstallRecordRequest) (InstallRecordResult
 		Record:       record,
 		MetadataPath: metadataPath,
 	}, nil
+}
+
+func extraMountNativeEtcFiles(requests []generation.ExtraMountRequest) ([]confext.NativeEtcFile, error) {
+	units, _, err := generation.RenderExtraMounts(requests)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]confext.NativeEtcFile, 0, len(units)+1)
+	unitNames := make([]string, 0, len(units))
+	for _, unit := range units {
+		files = append(files, confext.NativeEtcFile{
+			Path:    filepath.ToSlash(filepath.Join("/etc/systemd/system", unit.Name)),
+			Content: unit.Content,
+			Mode:    0o644,
+			UID:     0,
+			GID:     0,
+		})
+		unitNames = append(unitNames, unit.Name)
+	}
+	if len(unitNames) > 0 {
+		files = append(files, confext.NativeEtcFile{
+			Path: "/etc/systemd/system/katl-extra-disks.target.d/50-mounts.conf",
+			Content: strings.Join([]string{
+				"[Unit]",
+				"Requires=" + strings.Join(unitNames, " "),
+				"After=" + strings.Join(unitNames, " "),
+				"",
+			}, "\n"),
+			Mode: 0o644,
+			UID:  0,
+			GID:  0,
+		})
+	}
+	return files, nil
 }
 
 func confextRelease(record generation.Record) (confext.ExtensionRelease, error) {

--- a/internal/installer/install_record_test.go
+++ b/internal/installer/install_record_test.go
@@ -6,8 +6,46 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
+
+func TestMaterializeInstallRecordIncludesExtraDiskMount(t *testing.T) {
+	installManifest, err := manifest.Decode(strings.NewReader(validInstallManifestForRecord()))
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	result, err := MaterializeInstallRecord(InstallRecordRequest{
+		TargetRoot: t.TempDir(),
+		Manifest:   installManifest,
+		ExtraMounts: []generation.ExtraMountRequest{{
+			Source:     "/dev/disk/by-id/virtio-katl-extra-a",
+			Path:       "/var/lib/katl/mnt/data",
+			Filesystem: "ext4",
+		}},
+		Record: *minimalRecord("2026.06.04-001"),
+		Chown:  func(string, int, int) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("MaterializeInstallRecord() error = %v", err)
+	}
+	unitPath := filepath.Join(result.Tree.ConfextDir, "etc/systemd/system/var-lib-katl-mnt-data.mount")
+	unit, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read extra disk mount unit: %v", err)
+	}
+	if !strings.Contains(string(unit), "What=/dev/disk/by-id/virtio-katl-extra-a") || !strings.Contains(string(unit), "Where=/var/lib/katl/mnt/data") {
+		t.Fatalf("extra disk mount unit:\n%s", unit)
+	}
+	enablementPath := filepath.Join(result.Tree.ConfextDir, "etc/systemd/system/katl-extra-disks.target.d/50-mounts.conf")
+	enablement, err := os.ReadFile(enablementPath)
+	if err != nil {
+		t.Fatalf("read extra disk mount enablement: %v", err)
+	}
+	if !strings.Contains(string(enablement), "Requires=var-lib-katl-mnt-data.mount") {
+		t.Fatalf("extra disk mount enablement:\n%s", enablement)
+	}
+}
 
 func TestMaterializeInstallRecordRejectsUncleanGenerationID(t *testing.T) {
 	installManifest, err := manifest.Decode(strings.NewReader(validInstallManifestForRecord()))

--- a/internal/installer/manifest/manifest.go
+++ b/internal/installer/manifest/manifest.go
@@ -218,12 +218,7 @@ type ExtraDisk struct {
 	Name       string       `json:"name" yaml:"name"`
 	Selector   DiskSelector `json:"selector" yaml:"selector"`
 	Filesystem string       `json:"filesystem" yaml:"filesystem"`
-	Mount      ExtraMount   `json:"mount" yaml:"mount"`
 	Wipe       bool         `json:"wipe,omitempty" yaml:"wipe,omitempty"`
-}
-
-type ExtraMount struct {
-	Path string `json:"path" yaml:"path"`
 }
 
 type KatlosImage struct {
@@ -374,18 +369,27 @@ func ValidateWithOptions(manifest Manifest, options ValidateOptions) error {
 			return err
 		}
 	}
+	extraDiskNames := make(map[string]struct{}, len(manifest.Install.ExtraDisks))
 	for i, extra := range manifest.Install.ExtraDisks {
-		if strings.TrimSpace(extra.Name) == "" {
+		if extra.Name == "" {
 			return fmt.Errorf("install.extraDisks[%d].name is required", i)
 		}
+		if err := validateNameRef(fmt.Sprintf("install.extraDisks[%d].name", i), extra.Name); err != nil {
+			return err
+		}
+		if _, exists := extraDiskNames[extra.Name]; exists {
+			return fmt.Errorf("install.extraDisks[%d].name %q is duplicated", i, extra.Name)
+		}
+		extraDiskNames[extra.Name] = struct{}{}
 		if err := validateDiskSelector(fmt.Sprintf("install.extraDisks[%d].selector", i), extra.Selector); err != nil {
 			return err
 		}
-		if strings.TrimSpace(extra.Filesystem) == "" {
+		switch extra.Filesystem {
+		case "ext4", "xfs":
+		case "":
 			return fmt.Errorf("install.extraDisks[%d].filesystem is required", i)
-		}
-		if strings.TrimSpace(extra.Mount.Path) == "" {
-			return fmt.Errorf("install.extraDisks[%d].mount.path is required", i)
+		default:
+			return fmt.Errorf("install.extraDisks[%d].filesystem %q is unsupported", i, extra.Filesystem)
 		}
 	}
 	return nil
@@ -1158,7 +1162,6 @@ func BuildDiskLayoutRequest(manifest Manifest, profile RootDiskProfile, runtimeR
 			Name:       extra.Name,
 			Selector:   diskSelector(extra.Selector),
 			Filesystem: extra.Filesystem,
-			MountPath:  extra.Mount.Path,
 			Wipe:       extra.Wipe,
 		})
 	}

--- a/internal/installer/manifest/manifest_test.go
+++ b/internal/installer/manifest/manifest_test.go
@@ -196,14 +196,13 @@ func TestDecodeAcceptsExtraDisks(t *testing.T) {
 					"name": "data",
 					"selector": {"byID": "/dev/disk/by-id/ata-data"},
 					"filesystem": "xfs",
-					"mount": {"path": "/srv/data"},
 					"wipe": true
 				}
 			]`)))
 	if err != nil {
 		t.Fatalf("Decode() error = %v", err)
 	}
-	if len(manifest.Install.ExtraDisks) != 1 || manifest.Install.ExtraDisks[0].Mount.Path != "/srv/data" {
+	if len(manifest.Install.ExtraDisks) != 1 || manifest.Install.ExtraDisks[0].Name != "data" {
 		t.Fatalf("extra disks = %#v", manifest.Install.ExtraDisks)
 	}
 }
@@ -610,15 +609,15 @@ func TestDecodeRejectsDeferredFields(t *testing.T) {
 		{name: "trust", manifest: manifestWithTop(`, "trust": {"roots": []}`), want: "trust"},
 		{name: "boot", manifest: manifestWithTop(`, "boot": {"efi": true}`), want: "boot"},
 		{name: "kernel args", manifest: manifestWithTop(`, "kernelArgs": ["quiet"]`), want: "kernelArgs"},
-		{name: "extra disk mount options", manifest: manifestWithInstall(`,
+		{name: "extra disk mount path", manifest: manifestWithInstall(`,
 			"extraDisks": [
 				{
 					"name": "data",
 					"selector": {"byID": "/dev/disk/by-id/ata-data"},
 					"filesystem": "xfs",
-					"mount": {"path": "/srv/data", "options": ["noatime"]}
+					"mount": {"path": "/srv/data"}
 				}
-			]`), want: "options"},
+			]`), want: "mount"},
 	}
 
 	for _, tt := range tests {
@@ -641,7 +640,6 @@ func TestBuildDiskLayoutRequestUsesKatlOwnedRootProfile(t *testing.T) {
 					"name": "data",
 					"selector": {"byID": "/dev/disk/by-id/ata-data"},
 					"filesystem": "xfs",
-					"mount": {"path": "/srv/data"},
 					"wipe": true
 				}
 			]`)))
@@ -673,7 +671,7 @@ func TestBuildDiskLayoutRequestUsesKatlOwnedRootProfile(t *testing.T) {
 	if request.InitialRootSlot != disk.RootSlotB || request.RuntimeRootSizeMiB != 4096 {
 		t.Fatalf("root profile fields = %#v", request)
 	}
-	if len(request.ExtraDisks) != 1 || request.ExtraDisks[0].Filesystem != "xfs" || request.ExtraDisks[0].MountPath != "/srv/data" || !request.ExtraDisks[0].Wipe {
+	if len(request.ExtraDisks) != 1 || request.ExtraDisks[0].Filesystem != "xfs" || !request.ExtraDisks[0].Wipe {
 		t.Fatalf("extra disks = %#v", request.ExtraDisks)
 	}
 }

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -802,6 +802,7 @@ func (installMountUnitsStep) Run(ctx context.Context, install *Context) error {
 	}
 	if _, err := generation.WriteState(install.TargetRoot, generation.StateRequest{
 		PartitionUUID: install.LoaderRecord.Root.PartitionUUID,
+		ExtraMounts:   installedExtraMounts(install),
 	}); err != nil {
 		return err
 	}
@@ -826,6 +827,7 @@ func (writeInstallRecordStep) Run(ctx context.Context, install *Context) error {
 	result, err := MaterializeInstallRecord(InstallRecordRequest{
 		TargetRoot:        install.TargetRoot,
 		Manifest:          install.Manifest,
+		ExtraMounts:       installedExtraMounts(install),
 		KubeadmConfigs:    install.KubeadmConfigs,
 		KubernetesVersion: installedKubernetesPayloadVersion(install),
 		Record:            *install.LoaderRecord,
@@ -854,6 +856,21 @@ func (writeInstallRecordStep) Run(ctx context.Context, install *Context) error {
 		return err
 	}
 	return recordStep(ctx, install, WriteInstallRecord)
+}
+
+func installedExtraMounts(install *Context) []generation.ExtraMountRequest {
+	if install.DiskLayout == nil {
+		return nil
+	}
+	extraMounts := make([]generation.ExtraMountRequest, 0, len(install.DiskLayout.ExtraMounts))
+	for _, mount := range install.DiskLayout.ExtraMounts {
+		extraMounts = append(extraMounts, generation.ExtraMountRequest{
+			Source:     mount.MountSource,
+			Path:       mount.MountPath,
+			Filesystem: mount.Filesystem,
+		})
+	}
+	return extraMounts
 }
 
 func writeInstalledManifest(targetRoot, generationID string, installManifest manifest.Manifest) error {

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -1203,8 +1203,14 @@ func TestRunnerInstallsMountUnits(t *testing.T) {
 	install := &Context{
 		TargetRoot:   targetRoot,
 		LoaderRecord: &record,
-		Commands:     &NoopCommandRunner{},
-		Store:        store,
+		DiskLayout: &disk.DiskLayoutPlan{ExtraMounts: []disk.ExtraDiskPlan{{
+			Name:        "data",
+			MountSource: "/dev/disk/by-id/virtio-katl-extra-a",
+			Filesystem:  "ext4",
+			MountPath:   "/var/lib/katl/mnt/data",
+		}}},
+		Commands: &NoopCommandRunner{},
+		Store:    store,
 	}
 
 	if err := NewRunner(Plan{installMountUnitsStep{}}, install).Run(context.Background()); err != nil {
@@ -1213,11 +1219,14 @@ func TestRunnerInstallsMountUnits(t *testing.T) {
 
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var.mount"), "What=PARTUUID=11111111-2222-3333-4444-555555555555")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/etc-kubernetes.mount"), "Where=/etc/kubernetes")
+	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var-lib-katl-mnt-data.mount"), "What=/dev/disk/by-id/virtio-katl-extra-a")
+	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var-lib-katl-mnt-data.mount"), "Where=/var/lib/katl/mnt/data")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/katl-kubeadm-ready.target"), "Requires=systemd-sysext.service systemd-confext.service containerd.service kubelet.service etc-kubernetes.mount")
 	assertMissing(t, filepath.Join(targetRoot, "etc/systemd/system/multi-user.target.wants/katl-kubeadm-ready.target"))
 	assertContains(t, filepath.Join(targetRoot, "etc/tmpfiles.d/katl-state.conf"), "d /var/lib/katl/kubernetes/etc-kubernetes 0755 root root -")
 	assertContains(t, filepath.Join(targetRoot, "etc/tmpfiles.d/katl-state.conf"), "d /var/lib/etcd 0755 root root -")
 	assertDir(t, filepath.Join(targetRoot, "etc/kubernetes"), 0o755)
+	assertDir(t, filepath.Join(targetRoot, "var/lib/katl/mnt/data"), 0o755)
 	if got := install.Completed; !reflect.DeepEqual(got, []StepID{InstallMountUnits}) {
 		t.Fatalf("completed steps = %#v", got)
 	}

--- a/internal/vmtest/first_install_world.go
+++ b/internal/vmtest/first_install_world.go
@@ -526,7 +526,6 @@ func externalConfigLiterals(manifestPath, nodeMetadataPath string) ([]string, er
 		addExternalConfigLiteral(values, disk.Selector.ByID)
 		addExternalConfigLiteral(values, disk.Selector.WWN)
 		addExternalConfigLiteral(values, disk.Selector.Serial)
-		addExternalConfigLiteral(values, disk.Mount.Path)
 	}
 	if manifest.Node.Bootstrap != nil {
 		bootstrap := manifest.Node.Bootstrap

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-boot-health.service
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-boot-health.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Record successful Katl boot health
 Documentation=man:systemd.service(5)
-Requires=katl-runtime-handoff-status.service katl-system-extensions-activate.service katlc-agent.service systemd-networkd.service sshd.service
-After=katl-runtime-handoff-status.service katl-system-extensions-activate.service katlc-agent.service systemd-networkd.service sshd.service
+Requires=katl-runtime-handoff-status.service katl-system-extensions-activate.service katl-extra-disks-activate.service katlc-agent.service systemd-networkd.service sshd.service
+After=katl-runtime-handoff-status.service katl-system-extensions-activate.service katl-extra-disks-activate.service katlc-agent.service systemd-networkd.service sshd.service
 Before=katl-boot-complete.target
 RequiresMountsFor=/efi /var/lib/katl
 

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-extra-disks-activate.service
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-extra-disks-activate.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Activate Katl managed extra disks
+Documentation=man:systemd.mount(5) man:systemd.target(5)
+Requires=katl-system-extensions-reload.service
+After=katl-system-extensions-reload.service
+Before=katl-boot-health.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+StandardOutput=journal+console
+SyslogIdentifier=katl-extra-disks-activate
+ExecStart=/usr/bin/systemctl start katl-extra-disks.target

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-extra-disks.target
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-extra-disks.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Katl managed extra disks
+Documentation=man:systemd.target(5)

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -211,6 +211,8 @@ for path in \
     /usr/lib/systemd/system/katl-generation-activate.service \
     /usr/lib/systemd/system/katl-system-extensions-reload.service \
     /usr/lib/systemd/system/katl-system-extensions-activate.service \
+    /usr/lib/systemd/system/katl-extra-disks.target \
+    /usr/lib/systemd/system/katl-extra-disks-activate.service \
     /usr/lib/systemd/system/katl-kubeadm-ready.target \
     /usr/lib/systemd/system/katl-kubeadm-activate.service \
     /usr/lib/systemd/system/katl-boot-complete.target \


### PR DESCRIPTION
## What changed
- derive extra-disk mounts at Katl-controlled paths under `/var/lib/katl/mnt/<name>`
- persist durable native mount units and activate them after generation 0 confext reload
- make configured mount success part of boot health
- preserve matching filesystems with `wipe: false`; refuse blank or mismatched disks before mutation
- retain nested `findmnt` results during installed-layout verification

## Why
The installer mounted and formatted configured extra disks only during installation. The immutable installed runtime did not activate a boot-visible mount unit, so a disk could be left unmounted while node health still reported OK. The disk executor also formatted selected extra disks even when `wipe: false`.