### PR TITLE
installer: verify extra disk filesystem support

### DIFF
--- a/cmd/katl-mkosi-artifacts/main.go
+++ b/cmd/katl-mkosi-artifacts/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/katl-dev/katl/internal/firmware"
+	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	"gopkg.in/yaml.v3"
 )
@@ -1600,8 +1601,14 @@ func packageInventoryDigest(kind, path string) (string, error) {
 	if !fileExists(path) {
 		return "", nil
 	}
-	if _, err := firmware.VerifyPackageInventory(kind, path); err != nil {
+	packages, err := firmware.VerifyPackageInventory(kind, path)
+	if err != nil {
 		return "", err
+	}
+	if kind == "installer" {
+		if err := disk.VerifyInstallerFilesystemPackages(packages); err != nil {
+			return "", err
+		}
 	}
 	_, digest, err := fileInfo(path)
 	if err != nil {

--- a/cmd/katl-mkosi-artifacts/main_test.go
+++ b/cmd/katl-mkosi-artifacts/main_test.go
@@ -26,6 +26,24 @@ func TestBuildTimestamp(t *testing.T) {
 	}
 }
 
+func TestPackageInventoryDigestRejectsMissingExtraDiskFormatter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packages.tsv")
+	content := strings.Join([]string{
+		"linux-firmware\t1.noarch",
+		"microcode_ctl\t2.x86_64",
+		"amd-ucode-firmware\t1.noarch",
+		"e2fsprogs\t1.x86_64",
+		"xfsprogs\t1.x86_64",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := packageInventoryDigest("installer", path)
+	if err == nil || !strings.Contains(err.Error(), "btrfs") || !strings.Contains(err.Error(), "btrfs-progs") {
+		t.Fatalf("packageInventoryDigest() error = %v", err)
+	}
+}
+
 func TestWriteAndPath(t *testing.T) {
 	repo := testRepoRoot(t)
 	workDir := testWorkDir(t, repo)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -204,6 +204,26 @@ would override its root, immutable-runtime, generation identity, or recovery
 policy. Image-required and Katl-owned arguments remain internal and are always
 carried alongside the configured additions.
 
+Additional whole disks may be configured under a node's
+`install.extraDisks`. The supported and journey-verified filesystems are
+`ext4`, `xfs`, and `btrfs`. Katl derives the mount location as
+`/var/lib/katl/mnt/<name>`; operators cannot choose another path. Set
+`wipe: true` to authorize formatting that selected disk. With `wipe: false`,
+the disk must already contain the requested filesystem and Katl preserves its
+data:
+
+```yaml
+install:
+  targetDisk:
+    byID: /dev/disk/by-id/ata-KATL_WORKER_1_ROOT
+  extraDisks:
+    - name: data
+      selector:
+        byID: /dev/disk/by-id/ata-KATL_WORKER_1_DATA
+      filesystem: btrfs
+      wipe: true
+```
+
 For a routed endpoint advertised by Katl, add the VIP and fabric peers. Katl
 then installs and runs the endpoint advertiser only on control-plane nodes;
 external endpoints and workers do not run BIRD:

--- a/docs/internal/installer-runtime-design.md
+++ b/docs/internal/installer-runtime-design.md
@@ -430,10 +430,10 @@ SSH and identity
 extra disks
   selectors must not resolve to the target root disk or its partitions; names
   must be unique and Katl derives each mount path as
-  /var/lib/katl/mnt/<name>; wipe=false requires an existing filesystem matching
-  the requested type and preserves it, while wipe=true authorizes formatting
-  only that selected extra disk; custom mount paths and mount options are
-  deferred
+  /var/lib/katl/mnt/<name>; supported filesystems are ext4, xfs, and btrfs;
+  wipe=false requires an existing filesystem matching the requested type and
+  preserves it, while wipe=true authorizes formatting only that selected extra
+  disk; custom mount paths and mount options are deferred
 ```
 
 Runtime first-boot seed material may configure:

--- a/docs/internal/schemas/install-manifest-v1alpha1.schema.json
+++ b/docs/internal/schemas/install-manifest-v1alpha1.schema.json
@@ -229,7 +229,8 @@
         "filesystem": {
           "enum": [
             "ext4",
-            "xfs"
+            "xfs",
+            "btrfs"
           ]
         },
         "wipe": {

--- a/docs/internal/v0.1-kernel-firmware-support-policy.md
+++ b/docs/internal/v0.1-kernel-firmware-support-policy.md
@@ -21,7 +21,8 @@ The v0.1 installer and runtime images must keep in-box support for:
   proof is OVMF on KVM/libvirt.
 - The installed KatlOS disk layout: GPT, vfat ESP and XBOOTLDR where present,
   SquashFS immutable root slots, ext4 state partitions, ext4 etcd partitions,
-  and extra data disks using the schema-supported `ext4` or `xfs` filesystems.
+  and extra data disks using the schema-supported `ext4`, `xfs`, or `btrfs`
+  filesystems.
 - Loop devices for mounting the KatlOS image bundled inside installation media;
   the installer loads `loop` explicitly before installation starts.
 - Common block storage controllers and virtual disks, including NVMe, AHCI/SATA,

--- a/docs/internal/writable-state-layout.md
+++ b/docs/internal/writable-state-layout.md
@@ -30,7 +30,8 @@ generation state.
 contain the requested filesystem, and Katl mounts it without wiping or
 formatting it. A blank disk or filesystem mismatch fails planning with guidance
 to set `wipe: true` if reformatting is intended. `wipe: true` wipes and formats
-only the selected extra disk.
+only the selected extra disk. The supported extra-disk filesystems are `ext4`,
+`xfs`, and `btrfs`.
 
 ## Etcd Data Placement
 

--- a/internal/installer/disk/layout.go
+++ b/internal/installer/disk/layout.go
@@ -238,7 +238,7 @@ func planExtraDisks(facts HardwareFacts, target BlockDevice, requests []ExtraDis
 		if filesystem == "" {
 			filesystem = "ext4"
 		}
-		if filesystem != "ext4" && filesystem != "xfs" {
+		if !IsSupportedExtraDiskFilesystem(filesystem) {
 			return nil, fmt.Errorf("extra disk %q filesystem %q is unsupported", request.Name, filesystem)
 		}
 		if !request.Wipe {
@@ -261,6 +261,35 @@ func planExtraDisks(facts HardwareFacts, target BlockDevice, requests []ExtraDis
 	}
 
 	return plans, nil
+}
+
+func IsSupportedExtraDiskFilesystem(filesystem string) bool {
+	for _, capability := range extraDiskFilesystemCapabilities {
+		if capability.Filesystem == filesystem {
+			return true
+		}
+	}
+	return false
+}
+
+type extraDiskFilesystemCapability struct {
+	Filesystem       string
+	FormatterPackage string
+}
+
+var extraDiskFilesystemCapabilities = []extraDiskFilesystemCapability{
+	{Filesystem: "ext4", FormatterPackage: "e2fsprogs"},
+	{Filesystem: "xfs", FormatterPackage: "xfsprogs"},
+	{Filesystem: "btrfs", FormatterPackage: "btrfs-progs"},
+}
+
+func VerifyInstallerFilesystemPackages(packages map[string]string) error {
+	for _, capability := range extraDiskFilesystemCapabilities {
+		if packages[capability.FormatterPackage] == "" {
+			return fmt.Errorf("installer %s extra-disk formatting capability is missing: expected package %s", capability.Filesystem, capability.FormatterPackage)
+		}
+	}
+	return nil
 }
 
 func persistentDevicePath(device BlockDevice, selector discovery.TargetDiskSelector) (string, error) {

--- a/internal/installer/disk/layout_test.go
+++ b/internal/installer/disk/layout_test.go
@@ -198,6 +198,21 @@ func TestPlanDiskLayoutReusesOnlyMatchingExtraDiskFilesystem(t *testing.T) {
 	}
 }
 
+func TestVerifyInstallerFilesystemPackages(t *testing.T) {
+	packages := map[string]string{
+		"e2fsprogs": "1.x86_64",
+		"xfsprogs":  "1.x86_64",
+	}
+	err := VerifyInstallerFilesystemPackages(packages)
+	if err == nil || !strings.Contains(err.Error(), "btrfs") || !strings.Contains(err.Error(), "btrfs-progs") {
+		t.Fatalf("VerifyInstallerFilesystemPackages() error = %v", err)
+	}
+	packages["btrfs-progs"] = "1.x86_64"
+	if err := VerifyInstallerFilesystemPackages(packages); err != nil {
+		t.Fatalf("VerifyInstallerFilesystemPackages() error = %v", err)
+	}
+}
+
 func assertPartition(t *testing.T, plan DiskLayoutPlan, name, label string, sizeMiB uint64, remaining bool) PartitionPlan {
 	t.Helper()
 

--- a/internal/installer/manifest/manifest.go
+++ b/internal/installer/manifest/manifest.go
@@ -384,11 +384,10 @@ func ValidateWithOptions(manifest Manifest, options ValidateOptions) error {
 		if err := validateDiskSelector(fmt.Sprintf("install.extraDisks[%d].selector", i), extra.Selector); err != nil {
 			return err
 		}
-		switch extra.Filesystem {
-		case "ext4", "xfs":
-		case "":
+		switch {
+		case extra.Filesystem == "":
 			return fmt.Errorf("install.extraDisks[%d].filesystem is required", i)
-		default:
+		case !disk.IsSupportedExtraDiskFilesystem(extra.Filesystem):
 			return fmt.Errorf("install.extraDisks[%d].filesystem %q is unsupported", i, extra.Filesystem)
 		}
 	}

--- a/internal/installer/manifest/manifest_test.go
+++ b/internal/installer/manifest/manifest_test.go
@@ -195,14 +195,14 @@ func TestDecodeAcceptsExtraDisks(t *testing.T) {
 				{
 					"name": "data",
 					"selector": {"byID": "/dev/disk/by-id/ata-data"},
-					"filesystem": "xfs",
+					"filesystem": "btrfs",
 					"wipe": true
 				}
 			]`)))
 	if err != nil {
 		t.Fatalf("Decode() error = %v", err)
 	}
-	if len(manifest.Install.ExtraDisks) != 1 || manifest.Install.ExtraDisks[0].Name != "data" {
+	if len(manifest.Install.ExtraDisks) != 1 || manifest.Install.ExtraDisks[0].Name != "data" || manifest.Install.ExtraDisks[0].Filesystem != "btrfs" {
 		t.Fatalf("extra disks = %#v", manifest.Install.ExtraDisks)
 	}
 }

--- a/internal/kubernetesrelease/supported-versions.json
+++ b/internal/kubernetesrelease/supported-versions.json
@@ -2,11 +2,11 @@
   "apiVersion": "katl.dev/v1alpha1",
   "kind": "KubernetesSupportedVersions",
   "recipeScope": "kubernetes-bundle-v1",
-  "recipeDigest": "sha256:f10d06beb068b55425817e43d7cedfdcfc71d626ecdbbd309ba079ccd8dbd7ca",
+  "recipeDigest": "sha256:2768122d9c78ae80a1f9c1be4d69356be34d3f879ac8f7763647c1b1acd80e4c",
   "versions": [
     {
       "payloadVersion": "v1.36.0",
-      "artifactRevision": 36,
+      "artifactRevision": 37,
       "packages": {
         "kubeadm": "0:1.36.0-150500.1.1",
         "kubelet": "0:1.36.0-150500.1.1",
@@ -16,7 +16,7 @@
     },
     {
       "payloadVersion": "v1.36.1",
-      "artifactRevision": 34,
+      "artifactRevision": 35,
       "packages": {
         "kubeadm": "0:1.36.1-150500.1.1",
         "kubelet": "0:1.36.1-150500.1.1",
@@ -26,7 +26,7 @@
     },
     {
       "payloadVersion": "v1.36.2",
-      "artifactRevision": 33,
+      "artifactRevision": 34,
       "packages": {
         "kubeadm": "0:1.36.2-150500.2.1",
         "kubelet": "0:1.36.2-150500.2.1",
@@ -36,7 +36,7 @@
     },
     {
       "payloadVersion": "v1.36.3",
-      "artifactRevision": 33,
+      "artifactRevision": 34,
       "packages": {
         "kubeadm": "0:1.36.3-150500.1.1",
         "kubelet": "0:1.36.3-150500.1.1",

--- a/mkosi.profiles/installer-image/mkosi.conf
+++ b/mkosi.profiles/installer-image/mkosi.conf
@@ -31,6 +31,8 @@ Packages=
         parted
         iproute
         e2fsprogs
+        xfsprogs
+        btrfs-progs
         dosfstools
         coreutils
         bash
@@ -63,6 +65,7 @@ KernelModules=
         /drivers/virtio/
         /drivers/video/
         /fs/ext4/
+        /fs/btrfs/
         /fs/fat/
         /fs/isofs/
         /fs/nls/nls_cp437


### PR DESCRIPTION
Packages XFS and Btrfs formatting support in the installer and exposes Btrfs alongside ext4 and XFS for managed extra disks.

The schema previously advertised XFS while the installer omitted its formatter, so a valid request could fail only after installation began. The filesystem allowlist is now shared across validation and planning, and installer artifact metadata generation fails when any supported formatter package is missing.

Operators can use ext4, XFS, or Btrfs at Katl-controlled /var/lib/katl/mnt/<name> paths with documented wipe and preservation semantics. The generated Kubernetes recipe revision is advanced because installer image inputs changed.