### PR TITLE
katldev: reserve PCI capacity for extra disks

### DIFF
--- a/cmd/katldev/installer.go
+++ b/cmd/katldev/installer.go
@@ -305,6 +305,7 @@ func (manager installerManager) create(ctx context.Context, opts installerOption
 		Network:          vmtest.VMNetworkConfig{Mode: vmtest.VMNetworkUser, MAC: mac},
 		DomainMetadata:   installerDomainMetadata,
 		PersistentSerial: true,
+		HotplugPCISlots:  3,
 	}
 	plan, err := vmtest.PlanVM(result, config)
 	if err != nil {

--- a/internal/vmtest/libvirt_vm.go
+++ b/internal/vmtest/libvirt_vm.go
@@ -61,6 +61,7 @@ type VMConfig struct {
 	Agent             AgentControlConfig
 	DomainMetadata    string
 	PersistentSerial  bool
+	HotplugPCISlots   int
 }
 
 type SerialHook struct {
@@ -999,6 +1000,7 @@ func planVM(result Result, config VMConfig, probe probe) (VMPlan, error) {
 		VSock:            vsock,
 		Metadata:         first(config.DomainMetadata, "katl/vmtest"),
 		PersistentSerial: config.PersistentSerial,
+		HotplugPCISlots:  config.HotplugPCISlots,
 	})
 	if err != nil {
 		return VMPlan{}, fmt.Errorf("marshal libvirt domain XML: %w", err)
@@ -1204,6 +1206,7 @@ type libvirtDomain struct {
 	VSock            VSockPlan
 	Metadata         string
 	PersistentSerial bool
+	HotplugPCISlots  int
 }
 
 type domainXML struct {
@@ -1258,17 +1261,24 @@ type domainFeatures struct {
 }
 
 type domainDevices struct {
-	RNG       domainRNG       `xml:"rng"`
-	Interface domainInterface `xml:"interface"`
-	Disks     []domainDisk    `xml:"disk"`
-	Serial    domainSerial    `xml:"serial"`
-	Console   domainConsole   `xml:"console"`
-	VSock     *domainVSock    `xml:"vsock,omitempty"`
+	RNG         domainRNG          `xml:"rng"`
+	Interface   domainInterface    `xml:"interface"`
+	Disks       []domainDisk       `xml:"disk"`
+	Controllers []domainController `xml:"controller,omitempty"`
+	Serial      domainSerial       `xml:"serial"`
+	Console     domainConsole      `xml:"console"`
+	VSock       *domainVSock       `xml:"vsock,omitempty"`
 }
 
 type domainRNG struct {
 	Model   string           `xml:"model,attr"`
 	Backend domainRNGBackend `xml:"backend"`
+}
+
+type domainController struct {
+	Type  string `xml:"type,attr"`
+	Index int    `xml:"index,attr"`
+	Model string `xml:"model,attr"`
 }
 
 type domainRNGBackend struct {
@@ -1532,6 +1542,28 @@ func libvirtDomainXML(domain libvirtDomain) (string, error) {
 	}
 	if domain.PersistentSerial {
 		doc.Devices.Serial.Log = &domainSerialLog{File: domain.SerialLog, Append: "on"}
+	}
+	if domain.HotplugPCISlots > 0 {
+		doc.Devices.Controllers = append(doc.Devices.Controllers, domainController{
+			Type:  "pci",
+			Model: "pcie-root",
+		})
+		rootPorts := 4 + domain.HotplugPCISlots
+		for _, disk := range domain.Disks {
+			if disk.Bus == "" || disk.Bus == "virtio" {
+				rootPorts++
+			}
+		}
+		if domain.VSock.Enabled {
+			rootPorts++
+		}
+		for index := 1; index <= rootPorts; index++ {
+			doc.Devices.Controllers = append(doc.Devices.Controllers, domainController{
+				Type:  "pci",
+				Index: index,
+				Model: "pcie-root-port",
+			})
+		}
 	}
 	for _, disk := range domain.Disks {
 		device := disk.Device

--- a/internal/vmtest/libvirt_vm_test.go
+++ b/internal/vmtest/libvirt_vm_test.go
@@ -2,6 +2,7 @@ package vmtest
 
 import (
 	"context"
+	"encoding/xml"
 	"errors"
 	"io"
 	"os"
@@ -84,6 +85,48 @@ func TestVMPlanSupportsIndependentDomainOwnershipAndPersistentSerial(t *testing.
 	if strings.Contains(plan.DomainXML, ">katl/vmtest</vmtest>") {
 		t.Fatalf("independently owned VM uses automated vmtest metadata:\n%s", plan.DomainXML)
 	}
+}
+
+func TestVMPlanReservesHotplugPCISlots(t *testing.T) {
+	result, config := vmFixture(t)
+	probe := probe{
+		lookPath: func(string) (string, error) { return "/usr/bin/virsh", nil },
+		stat:     os.Stat,
+		access:   func(string) error { return nil },
+	}
+	config.HotplugPCISlots = 1
+	plan, err := planVM(result, config, probe)
+	if err != nil {
+		t.Fatalf("planVM() error = %v", err)
+	}
+	baseline := countPCIeRootPorts(t, plan.DomainXML)
+	config.HotplugPCISlots = 4
+	plan, err = planVM(result, config, probe)
+	if err != nil {
+		t.Fatalf("planVM() error = %v", err)
+	}
+	if got := countPCIeRootPorts(t, plan.DomainXML) - baseline; got != 3 {
+		t.Fatalf("additional hotplug PCI slots = %d, want 3", got)
+	}
+}
+
+func countPCIeRootPorts(t *testing.T, domainXML string) int {
+	t.Helper()
+	var domain struct {
+		Devices struct {
+			Controllers []domainController `xml:"controller"`
+		} `xml:"devices"`
+	}
+	if err := xml.Unmarshal([]byte(domainXML), &domain); err != nil {
+		t.Fatalf("decode domain XML: %v", err)
+	}
+	var hotplugSlots int
+	for _, controller := range domain.Devices.Controllers {
+		if controller.Type == "pci" && controller.Model == "pcie-root-port" {
+			hotplugSlots++
+		}
+	}
+	return hotplugSlots
 }
 
 func TestVMLibvirtNetworkFromConfigAndEnv(t *testing.T) {


### PR DESCRIPTION
## What changed

- allow VM callers to reserve spare PCIe root-port capacity
- have katldev reserve three slots for extra virtio disks
- cover the requested-capacity contract without pinning controller addresses or ordering

## Why

Fresh persistent katldev installer domains exhausted libvirt's automatically generated PCIe root ports after the first extra disk, so attaching a second disk failed with `No more available PCI slots`.