### PR TITLE
config: add boot-time host overlays

### DIFF
--- a/docs/internal/adrs/adr-011-native-host-configuration-files.md
+++ b/docs/internal/adrs/adr-011-native-host-configuration-files.md
@@ -477,6 +477,27 @@ Persisted records contain set names, paths, content digests, classifications,
 actions, results, and rollback targets. Routine status does not echo file
 content, source bytes, or low-level systemd invocation identifiers.
 
+### Bounded tmpfiles and containerd handlers
+
+Files directly below `/etc/tmpfiles.d` receive a narrower content contract than
+the full native language. Operator rules may use only exact `w` entries for
+normalized `/sys/...` paths. Mode, user, group, and age remain `-`; targets and
+arguments may not contain globs, specifiers, or escapes. Katl rejects duplicate
+write targets across sets.
+
+These rules are next-boot-only. After the selected confext is active, Katl runs
+`systemd-tmpfiles --create` for each operator file and reads every target back.
+Boot health fails when application or verification fails. This provides useful
+sysfs configuration without allowing tmpfiles delete/create types to bypass the
+host file ownership boundary.
+
+The KatlOS containerd base configuration imports
+`/etc/containerd/conf.d/*.toml`. Operators carry version-compatible TOML files
+there through the same hostConfiguration API. Overlay changes are
+next-boot-only because containerd is release-critical and is not restarted by
+a routine live apply; its normal service and boot-health semantics validate
+the resulting daemon startup.
+
 ## Install And Update Behavior
 
 The same `hostConfiguration` input is valid during first install and runtime
@@ -542,7 +563,7 @@ domains merely to reproduce their native file formats.
 This decision does not provide:
 
 ```text
-arbitrary writes outside /etc
+arbitrary files or unbounded writes outside /etc
 mutable in-place editing of the active /etc tree
 shell hooks or a general command runner
 package installation or an embedded package manager

--- a/docs/internal/kubeadm-config-input-design.md
+++ b/docs/internal/kubeadm-config-input-design.md
@@ -37,11 +37,6 @@ string inside Katl YAML:
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta4
-kind: InitConfiguration
-nodeRegistration:
-  criSocket: unix:///run/containerd/containerd.sock
----
-apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 clusterName: katl
 networking:
@@ -70,6 +65,21 @@ containerd CRI socket, and safe patch paths are supplied by Katl. Control-plane
 join material is derived from the selected init input. Tokens, discovery
 hashes, and certificate keys are injected only by the accepted bootstrap
 operation and are never read from ClusterConfig.
+
+Operator-authored kubeadm YAML omits values already owned by Katl:
+
+- `ClusterConfiguration.kubernetesVersion` comes from
+  `spec.kubernetes.version`.
+- `ClusterConfiguration.controlPlaneEndpoint` is injected for bootstrap; a
+  conflicting authored value is rejected.
+- The selected endpoint hostname is added once to
+  `ClusterConfiguration.apiServer.certSANs`.
+- `InitConfiguration` and `JoinConfiguration`
+  `nodeRegistration.criSocket` default to containerd.
+- `InitConfiguration.nodeRegistration.taints` defaults to `[]`; node taints
+  belong in ClusterConfig.
+- `KubeletConfiguration.volumePluginDir` is enforced as
+  `/var/lib/kubelet/plugins/volume/exec`.
 
 The rendered path is stable for node-local `katlc` operation wrappers:
 
@@ -198,17 +208,18 @@ only paths that are already part of the kubeadm contract or explicitly
 allowlisted for a tested scenario. Any hostPath under the denied path list must
 fail validation.
 
-`kubernetesVersion` may be omitted or set to the selected sysext version. If it
-is present and conflicts with the selected Kubernetes sysext payload version,
-validation must fail before install or runtime config activation. For first
-install, the selected payload version comes from Katl bootstrap intent and the
-exact matching Kubernetes payload bundle fetched and verified by `katlc`. Katl
-may normalize manifest `1.36.0` to kubeadm's `v1.36.0` form for comparison.
-Release compatibility resolution selects the bundle outside native kubeadm
-YAML; no catalog references or sentinel values are written into it.
+Operators should omit `kubernetesVersion`; Katl writes the version selected by
+`spec.kubernetes.version`. A redundant matching value remains valid, while a
+conflict fails before install or runtime config activation. For first install,
+the selected payload version comes from Katl bootstrap intent and the exact
+matching Kubernetes payload bundle fetched and verified by `katlc`. Release
+compatibility resolution selects the bundle outside native kubeadm YAML; no
+catalog references or sentinel values are written into it.
 
-The CRI socket should default to containerd's socket. A different CRI socket is
-deferred until Katl intentionally supports another runtime.
+The CRI socket defaults to containerd's socket and any different value is
+rejected until Katl intentionally supports another runtime. Control-plane
+registration taints are defaulted empty; users configure node taints through
+ClusterConfig rather than duplicating that intent in native kubeadm YAML.
 
 ## Rendered Files
 

--- a/docs/internal/kubernetes-sysext-delivery.md
+++ b/docs/internal/kubernetes-sysext-delivery.md
@@ -431,7 +431,7 @@ payloadVersion exactly matches resolved intent
 architecture matches the installed runtime
 supportedRuntimeInterfaces includes the runtime root interface
 Kubernetes minor and skew policy are allowed for the requested operation
-kubeadm config kubernetesVersion, when present, matches the selected payload
+kubeadm config kubernetesVersion is supplied from the selected payload
 supportedKubeadmConfigAPIFamilies covers the rendered kubeadm input
 required host prerequisites are present or planned in the candidate generation
 ```
@@ -440,8 +440,8 @@ Skew validation is operation-specific:
 
 ```text
 first bootstrap or first join
-  Exact `v1.36.x` payload selected by bundle ref is allowed when rendered
-  kubeadm input either omits kubernetesVersion or names the same exact version.
+  Exact `v1.36.x` payload selected by bundle ref is allowed. Katl supplies the
+  rendered kubeadm kubernetesVersion; redundant authored values must match.
 
 normal runtime config apply
   Kubernetes payload selection must be unchanged; any requested sysext change is

--- a/docs/internal/supported-node-config-domains.md
+++ b/docs/internal/supported-node-config-domains.md
@@ -62,6 +62,7 @@ modules-load
 tmpfiles
   required directories, modes, and ownership for Katl-managed node state
   rendered under /etc/tmpfiles.d/
+  public hostConfiguration supports bounded exact sysfs write rules
 
 mount units
   persistent state projections and extra data disk mounts
@@ -181,9 +182,10 @@ modules-load
   golden tests cover required Kubernetes/network modules
 
 tmpfiles
-  allow only Katl-managed directories and modes
-  reject files that would override host identity or kubeadm output
-  verify generated rules with systemd-tmpfiles where practical
+  keep internal directory and ownership rules limited to Katl-managed paths
+  allow public hostConfiguration only for exact w rules below /sys
+  reject destructive types, globs, specifiers, escapes, and duplicate targets
+  apply and read-back verify public sysfs writes before boot health succeeds
 
 mount units and extra disks
   derive mount points below /var/lib/katl/mnt from validated unique names
@@ -195,7 +197,10 @@ Bootstrap profile input
   allow kubelet configuration only as native kubelet documents referenced by
   the resolved KubeadmConfig
   reject denied host paths and unsafe patch directories
-  require kubernetesVersion, when present, to match the selected sysext
+  supply kubernetesVersion from spec.kubernetes.version and reject conflicts
+  default the containerd CRI socket and empty control-plane registration taints
+  enforce the writable-state kubelet volumePluginDir
+  inject controlPlaneEndpoint and its hostname certificate SAN at bootstrap
   golden tests cover init, join, kubelet configuration, patches, and selected
   sysext mismatch
 

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -83,6 +83,21 @@ spec:
               content: |
                 br_netfilter
                 vfio_pci
+
+        kernel-tunables:
+          files:
+            - path: /etc/tmpfiles.d/80-home-lab-kernel-tunables.conf
+              content: |
+                w /sys/module/printk/parameters/time - - - - N
+
+        containerd:
+          files:
+            - path: /etc/containerd/conf.d/80-home-lab.toml
+              content: |
+                version = 4
+
+                [debug]
+                  level = "warn"
 ```
 
 `source` is relative to the ClusterConfig directory and is embedded when
@@ -104,9 +119,12 @@ spec:
 ```
 
 Sysctl files with a reversible concrete-key change can apply live. Udev rules
-can reload live, but Katl does not retrigger existing devices. Module load and
-modprobe files are next-boot-only. Other permitted files are next-boot unless
-their set declares a bounded notification for an unprotected existing unit:
+can reload live, but Katl does not retrigger existing devices. Module load,
+modprobe, tmpfiles sysfs writes, and containerd overlays are next-boot-only.
+Katl runs each operator tmpfiles file and verifies the requested sysfs value
+before boot health succeeds. Containerd imports `/etc/containerd/conf.d/*.toml`
+when it starts. Other permitted files are next-boot unless their set declares a
+bounded notification for an unprotected existing unit:
 
 ```yaml
 notify:
@@ -118,7 +136,10 @@ notify:
 The accepted actions are `reload`, `try-reload-or-restart`, and `try-restart`.
 Katl rejects protected paths, duplicate path ownership, executable or writable
 modes, and attempts to notify release-critical units before rendering a
-candidate generation.
+candidate generation. Operator tmpfiles files are intentionally narrower than
+the full `tmpfiles.d` language: each non-comment line must be an exact `w` rule
+for a normalized `/sys/...` path, with `-` for mode, user, group, and age, and a
+concrete value without globs, specifiers, or escapes.
 
 ## Apply The Cluster
 

--- a/internal/bootstrap/cluster/cluster_test.go
+++ b/internal/bootstrap/cluster/cluster_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -759,6 +760,27 @@ func TestTransportRunnerRunKubeadmInitWritesEndpointConfig(t *testing.T) {
 		if !strings.Contains(uploaded, want) {
 			t.Fatalf("uploaded init config = %q, want %q", uploaded, want)
 		}
+	}
+}
+
+func TestRenderInitConfigRejectsConflictingEndpointAndDeduplicatesSAN(t *testing.T) {
+	base := []byte(`apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+controlPlaneEndpoint: old-api.katl.test:6443
+apiServer:
+  certSANs:
+    - api.katl.test
+`)
+	if _, err := RenderInitConfig(base, "api.katl.test:6443"); err == nil || !strings.Contains(err.Error(), "conflicts with cluster endpoint") {
+		t.Fatalf("RenderInitConfig() error = %v, want endpoint conflict", err)
+	}
+
+	rendered, err := RenderInitConfig(bytes.ReplaceAll(base, []byte("old-api.katl.test:6443"), []byte("api.katl.test:6443")), "api.katl.test:6443")
+	if err != nil {
+		t.Fatalf("RenderInitConfig() error = %v", err)
+	}
+	if strings.Count(string(rendered), "- api.katl.test") != 1 {
+		t.Fatalf("rendered config duplicated endpoint SAN:\n%s", rendered)
 	}
 }
 

--- a/internal/installer/configapply/host_configuration.go
+++ b/internal/installer/configapply/host_configuration.go
@@ -90,6 +90,25 @@ func planHostConfigurationChange(current, desired manifest.HostConfiguration) Ho
 				for _, assignment := range assignments {
 					plan.Effects = append(plan.Effects, plannedEffect("apply-and-verify", "sysctl "+assignment.Key))
 				}
+			case strings.HasPrefix(filePath, "/etc/tmpfiles.d/") && strings.HasSuffix(filePath, ".conf"):
+				if stagedReason == "" {
+					stagedReason = "tmpfiles sysfs writes apply and verify on next boot"
+				}
+				if file, exists := afterFiles[filePath]; exists && file.Content != nil {
+					writes, err := manifest.ParseTmpfilesSysfsWrites(*file.Content)
+					if err == nil {
+						for _, write := range writes {
+							plan.Effects = append(plan.Effects, plannedEffect("apply-and-verify", "sysfs "+write.Path))
+						}
+					}
+				}
+			case strings.HasPrefix(filePath, "/etc/containerd/conf.d/") && strings.HasSuffix(filePath, ".toml"):
+				if stagedReason == "" {
+					stagedReason = "containerd configuration overlays load on next boot"
+				}
+				if _, exists := afterFiles[filePath]; exists {
+					plan.Effects = append(plan.Effects, plannedEffect("load", "containerd configuration "+filePath))
+				}
 			case strings.HasPrefix(filePath, "/etc/udev/rules.d/") && strings.HasSuffix(filePath, ".rules"):
 				udevReload = true
 				if _, exists := afterFiles[filePath]; exists {

--- a/internal/installer/configapply/host_configuration_boot.go
+++ b/internal/installer/configapply/host_configuration_boot.go
@@ -27,6 +27,8 @@ func PlanHostConfigurationActivation(config manifest.HostConfiguration, phase st
 	notifications := map[string]string{}
 	sysctls := map[string]string{}
 	modules := map[string]struct{}{}
+	tmpfilesPaths := map[string]struct{}{}
+	tmpfilesWrites := map[string]string{}
 	udevPaths := map[string]struct{}{}
 	systemdReload := false
 
@@ -46,6 +48,14 @@ func PlanHostConfigurationActivation(config manifest.HostConfiguration, phase st
 			case strings.HasPrefix(file.Path, "/etc/modules-load.d/") && file.Content != nil:
 				for _, module := range parseModulesLoad(*file.Content) {
 					modules[module] = struct{}{}
+				}
+			case strings.HasPrefix(file.Path, "/etc/tmpfiles.d/") && strings.HasSuffix(file.Path, ".conf") && file.Content != nil:
+				writes, err := manifest.ParseTmpfilesSysfsWrites(*file.Content)
+				if err == nil {
+					tmpfilesPaths[file.Path] = struct{}{}
+					for _, write := range writes {
+						tmpfilesWrites[write.Path] = write.Value
+					}
 				}
 			case strings.HasPrefix(file.Path, "/etc/udev/rules.d/") && strings.HasSuffix(file.Path, ".rules"):
 				udevPaths[file.Path] = struct{}{}
@@ -85,6 +95,30 @@ func PlanHostConfigurationActivation(config manifest.HostConfiguration, phase st
 	if verify {
 		for _, key := range sortedKeys(sysctls) {
 			plan.addCommandWithOutput("sysctl-verify-"+key, "apply-and-verify", "sysctl "+key, sysctls[key], "/usr/sbin/sysctl", "-n", key)
+		}
+	}
+	if prepare {
+		for _, filePath := range sortedKeys(tmpfilesPaths) {
+			plan.addCommand(
+				"tmpfiles-create-"+filepath.Base(filePath),
+				"apply",
+				"tmpfiles "+filePath,
+				"systemd-tmpfiles",
+				"--create",
+				filePath,
+			)
+		}
+	}
+	if verify {
+		for _, target := range sortedKeys(tmpfilesWrites) {
+			plan.addCommandWithOutput(
+				"tmpfiles-verify-"+strings.Trim(strings.ReplaceAll(target, "/", "-"), "-"),
+				"apply-and-verify",
+				"sysfs "+target,
+				tmpfilesWrites[target],
+				"/usr/bin/cat",
+				target,
+			)
 		}
 	}
 	if prepare {

--- a/internal/installer/configapply/host_configuration_boot_test.go
+++ b/internal/installer/configapply/host_configuration_boot_test.go
@@ -54,6 +54,29 @@ func TestInspectHostConfigurationClassifiesLiveSysctlDrift(t *testing.T) {
 	}
 }
 
+func TestPlanHostConfigurationActivationAppliesAndVerifiesSysfsWrites(t *testing.T) {
+	tmpfiles := "w /sys/module/printk/parameters/time - - - - N\n"
+	config := manifest.HostConfiguration{Sets: map[string]manifest.HostConfigurationSet{
+		"kernel-tunables": {Files: []manifest.HostConfigurationFile{{
+			Path:    "/etc/tmpfiles.d/80-kernel-tunables.conf",
+			Content: &tmpfiles,
+		}}},
+	}}
+	prepare := PlanHostConfigurationActivation(config, HostConfigurationPhasePrepare)
+	if len(prepare.Commands) != 1 || strings.Join(prepare.Commands[0].Argv, " ") != "systemd-tmpfiles --create /etc/tmpfiles.d/80-kernel-tunables.conf" {
+		t.Fatalf("prepare commands = %#v", prepare.Commands)
+	}
+	verify := PlanHostConfigurationActivation(config, HostConfigurationPhaseVerify)
+	if len(verify.Commands) != 1 ||
+		strings.Join(verify.Commands[0].Argv, " ") != "/usr/bin/cat /sys/module/printk/parameters/time" ||
+		verify.Commands[0].ExpectedStdout != "N" {
+		t.Fatalf("verify commands = %#v", verify.Commands)
+	}
+	if HostConfigurationDriftIsLive(verify.Effects) {
+		t.Fatalf("sysfs drift must require next-boot reconciliation: %#v", verify.Effects)
+	}
+}
+
 func TestExecuteHostConfigurationActivationReportsEachOutcome(t *testing.T) {
 	plan := HostConfigurationActivationPlan{}
 	plan.addCommand("first", "reload", "udev rules", "/usr/bin/true")

--- a/internal/installer/configapply/host_configuration_test.go
+++ b/internal/installer/configapply/host_configuration_test.go
@@ -49,6 +49,47 @@ func TestPlanHostConfigurationStagesKernelModuleFiles(t *testing.T) {
 	}
 }
 
+func TestPlanHostConfigurationStagesBootOwnedOverlays(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    string
+		target  string
+	}{
+		{
+			name:    "tmpfiles sysfs write",
+			path:    "/etc/tmpfiles.d/80-kernel-tunables.conf",
+			content: "w /sys/module/printk/parameters/time - - - - N\n",
+			want:    "apply and verify on next boot",
+			target:  "sysfs /sys/module/printk/parameters/time",
+		},
+		{
+			name:    "containerd overlay",
+			path:    "/etc/containerd/conf.d/80-debug.toml",
+			content: "[debug]\n  level = \"warn\"\n",
+			want:    "load on next boot",
+			target:  "containerd configuration /etc/containerd/conf.d/80-debug.toml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := testHostConfiguration("example", tt.path, tt.content)
+			plan := planHostConfigurationChange(manifest.HostConfiguration{}, desired)
+			if plan.Live || !strings.Contains(plan.Message, tt.want) {
+				t.Fatalf("plan = %#v, want staged change", plan)
+			}
+			found := false
+			for _, effect := range plan.Effects {
+				found = found || effect.Target == tt.target
+			}
+			if !found {
+				t.Fatalf("effects = %#v, want target %q", plan.Effects, tt.target)
+			}
+		})
+	}
+}
+
 func TestPlanHostConfigurationUsesBoundedSystemdNotification(t *testing.T) {
 	content := "[Journal]\nSystemMaxUse=2G\n"
 	desired := manifest.HostConfiguration{Sets: map[string]manifest.HostConfigurationSet{

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -705,38 +705,48 @@ func SourceControlPlaneEndpoint(source SourceConfig) string {
 	return plan.Endpoint
 }
 
-func defaultKubeadmInitConfig(version string) string {
-	config := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n  taints: []\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nnetworking:\n  podSubnet: 10.244.0.0/16\n  serviceSubnet: 10.96.0.0/12\n"
-	if version != "" {
-		config += "kubernetesVersion: " + version + "\n"
-	}
-	return config + defaultKubeletConfig()
+func defaultKubeadmInitConfig() string {
+	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: InitConfiguration\n---\napiVersion: kubeadm.k8s.io/v1beta4\nkind: ClusterConfiguration\nnetworking:\n  podSubnet: 10.244.0.0/16\n  serviceSubnet: 10.96.0.0/12\n" + defaultKubeletConfig()
 }
 
 func defaultKubeadmJoinConfig() string {
-	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\nnodeRegistration:\n  criSocket: unix:///run/containerd/containerd.sock\n" + defaultKubeletConfig()
+	return "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\n" + defaultKubeletConfig()
 }
 
 func defaultKubeletConfig() string {
-	return "---\napiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nvolumePluginDir: /var/lib/kubelet/plugins/volume/exec\n"
+	return "---\napiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\n"
 }
 
 func defaultKubeadmConfigs(kubernetesVersion string) (map[string]kubeadmconfig.Plan, error) {
-	inputs := map[string]string{
-		"control-plane": defaultKubeadmInitConfig(kubernetesVersion),
-		"worker":        defaultKubeadmJoinConfig(),
+	documents, err := defaultKubeadmDocuments()
+	if err != nil {
+		return nil, err
 	}
-	configs := make(map[string]kubeadmconfig.Plan, len(inputs))
-	for _, name := range []string{"control-plane", "worker"} {
-		plan, err := kubeadmconfig.PlanFromRenderedFiles(name, []kubeadmconfig.File{{
-			RenderPath: "/etc/katl/kubeadm/" + name + "/config.yaml",
-			Content:    []byte(inputs[name]),
+	if err := provideKubeadmDefaults(documents, kubernetesVersion); err != nil {
+		return nil, err
+	}
+	roles := []struct {
+		name      string
+		documents []map[string]any
+	}{
+		{name: "control-plane", documents: []map[string]any{documents["InitConfiguration"], documents["ClusterConfiguration"], documents["KubeletConfiguration"]}},
+		{name: "worker", documents: []map[string]any{documents["JoinConfiguration"], documents["KubeletConfiguration"]}},
+	}
+	configs := make(map[string]kubeadmconfig.Plan, len(roles))
+	for _, role := range roles {
+		content, err := encodeKubeadmDocuments(role.documents, role.name, false)
+		if err != nil {
+			return nil, err
+		}
+		plan, err := kubeadmconfig.PlanFromRenderedFiles(role.name, []kubeadmconfig.File{{
+			RenderPath: "/etc/katl/kubeadm/" + role.name + "/config.yaml",
+			Content:    content,
 			Mode:       0o644,
 		}})
 		if err != nil {
-			return nil, fmt.Errorf("select internal kubeadm profile %s: %w", name, err)
+			return nil, fmt.Errorf("select internal kubeadm profile %s: %w", role.name, err)
 		}
-		configs[name] = plan
+		configs[role.name] = plan
 	}
 	return configs, nil
 }

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -249,7 +249,7 @@ shutdownGracePeriod: 45s
 	}
 	cp := controlPlane.KubeadmConfigs["control-plane"]
 	cpConfig := string(cp.Config.Content)
-	for _, want := range []string{"kind: InitConfiguration", "kind: ClusterConfiguration", "kubernetesVersion: v1.36.1", "name: profiling", "kind: KubeletConfiguration", "volumePluginDir: /var/lib/kubelet/plugins/volume/exec", "directory: /etc/katl/kubeadm/control-plane/patches"} {
+	for _, want := range []string{"kind: InitConfiguration", "criSocket: unix:///run/containerd/containerd.sock", "taints: []", "kind: ClusterConfiguration", "kubernetesVersion: v1.36.1", "name: profiling", "kind: KubeletConfiguration", "volumePluginDir: /var/lib/kubelet/plugins/volume/exec", "directory: /etc/katl/kubeadm/control-plane/patches"} {
 		if !strings.Contains(cpConfig, want) {
 			t.Fatalf("control-plane kubeadm input missing %q:\n%s", want, cpConfig)
 		}
@@ -283,6 +283,64 @@ shutdownGracePeriod: 45s
 	}
 	if changed.Manifest.Source.SourceDigest == result.Manifest.Source.SourceDigest {
 		t.Fatalf("source digest did not change with referenced kubeadm input: %s", changed.Manifest.Source.SourceDigest)
+	}
+}
+
+func TestBuildArchiveRejectsConflictingKatlOwnedKubeadmValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{
+			name: "Kubernetes version",
+			config: `apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: v1.35.0
+`,
+			want: "does not match spec.kubernetes.version",
+		},
+		{
+			name: "CRI socket",
+			config: `apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+nodeRegistration:
+  criSocket: unix:///run/crio/crio.sock
+`,
+			want: "nodeRegistration.criSocket must be",
+		},
+		{
+			name: "control-plane taints",
+			config: `apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+nodeRegistration:
+  taints:
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+`,
+			want: "nodeRegistration.taints must be empty",
+		},
+		{
+			name: "volume plugin directory",
+			config: `apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+volumePluginDir: other
+`,
+			want: "volumePluginDir must be",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "kubeadm.yaml"), tt.config)
+			source := strings.Replace(validSourceConfig(), "    version: v1.36.1", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml", 1)
+			sourcePath := filepath.Join(dir, "cluster.yaml")
+			writeFile(t, sourcePath, source)
+			_, _, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("BuildArchive() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/installer/configbundle/kubeadm.go
+++ b/internal/installer/configbundle/kubeadm.go
@@ -87,7 +87,7 @@ func splitKubeadmPlans(input kubeadmconfig.Plan, kubernetesVersion string) (map[
 		byKind[kind] = document
 	}
 
-	defaults, err := defaultKubeadmDocuments(kubernetesVersion)
+	defaults, err := defaultKubeadmDocuments()
 	if err != nil {
 		return nil, err
 	}
@@ -139,8 +139,8 @@ func splitKubeadmPlans(input kubeadmconfig.Plan, kubernetesVersion string) (map[
 	return plans, nil
 }
 
-func defaultKubeadmDocuments(kubernetesVersion string) (map[string]map[string]any, error) {
-	controlPlane, err := decodeKubeadmDocuments([]byte(defaultKubeadmInitConfig(kubernetesVersion)))
+func defaultKubeadmDocuments() (map[string]map[string]any, error) {
+	controlPlane, err := decodeKubeadmDocuments([]byte(defaultKubeadmInitConfig()))
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,15 @@ func provideKubeadmDefaults(documents map[string]map[string]any, kubernetesVersi
 	for _, kind := range []string{"InitConfiguration", "JoinConfiguration"} {
 		document := documents[kind]
 		nodeRegistration := childMapping(document, "nodeRegistration")
-		if value, _ := nodeRegistration["criSocket"].(string); strings.TrimSpace(value) == "" {
-			nodeRegistration["criSocket"] = kubeadmCRISocket
+		if value, _ := nodeRegistration["criSocket"].(string); strings.TrimSpace(value) != "" && value != kubeadmCRISocket {
+			return fmt.Errorf("spec.kubernetes.kubeadm.configFile %s nodeRegistration.criSocket must be %q on KatlOS", kind, kubeadmCRISocket)
+		}
+		nodeRegistration["criSocket"] = kubeadmCRISocket
+		if kind == "InitConfiguration" {
+			if taints, exists := nodeRegistration["taints"]; exists && !emptyKubeadmSequence(taints) {
+				return fmt.Errorf("spec.kubernetes.kubeadm.configFile InitConfiguration nodeRegistration.taints must be empty; configure node taints in ClusterConfig")
+			}
+			nodeRegistration["taints"] = []any{}
 		}
 		document["nodeRegistration"] = nodeRegistration
 	}
@@ -178,6 +185,14 @@ func provideKubeadmDefaults(documents map[string]map[string]any, kubernetesVersi
 	}
 	kubelet["volumePluginDir"] = kubeadmconfig.KubeletVolumePluginDir
 	return nil
+}
+
+func emptyKubeadmSequence(value any) bool {
+	if value == nil {
+		return true
+	}
+	sequence, ok := value.([]any)
+	return ok && len(sequence) == 0
 }
 
 func encodeKubeadmDocuments(documents []map[string]any, role string, hasPatches bool) ([]byte, error) {

--- a/internal/installer/generation/state.go
+++ b/internal/installer/generation/state.go
@@ -266,7 +266,7 @@ func renderHostConfigPrepareService() string {
 	return strings.Join([]string{
 		"[Unit]",
 		"Description=Prepare selected Katl native host configuration",
-		"Documentation=man:systemd-confext(8) man:sysctl.d(5) man:modules-load.d(5) man:udev(7)",
+		"Documentation=man:systemd-confext(8) man:sysctl.d(5) man:modules-load.d(5) man:tmpfiles.d(5) man:udev(7)",
 		"DefaultDependencies=no",
 		"Requires=systemd-confext.service",
 		"After=systemd-confext.service",
@@ -284,7 +284,7 @@ func renderHostConfigVerifyService() string {
 	return strings.Join([]string{
 		"[Unit]",
 		"Description=Verify selected Katl native host configuration",
-		"Documentation=man:sysctl.d(5) man:modules-load.d(5)",
+		"Documentation=man:sysctl.d(5) man:modules-load.d(5) man:tmpfiles.d(5)",
 		"DefaultDependencies=no",
 		"Requires=katl-host-config-prepare.service",
 		"After=katl-host-config-prepare.service",

--- a/internal/installer/manifest/host_configuration_test.go
+++ b/internal/installer/manifest/host_configuration_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestValidateHostConfigurationAcceptsNativeFilesAndNotifications(t *testing.T) {
 	sysctl := "net.ipv4.ip_forward = 1\n"
+	tmpfiles := "w /sys/module/printk/parameters/time - - - - N\n"
 	journal := "[Journal]\nSystemMaxUse=2G\n"
 	config := HostConfiguration{Sets: map[string]HostConfigurationSet{
 		"forwarding": {
@@ -14,6 +15,12 @@ func TestValidateHostConfigurationAcceptsNativeFilesAndNotifications(t *testing.
 				Path:    "/etc/sysctl.d/80-forwarding.conf",
 				Content: &sysctl,
 				Mode:    0o640,
+			}},
+		},
+		"kernel-tunables": {
+			Files: []HostConfigurationFile{{
+				Path:    "/etc/tmpfiles.d/80-kernel-tunables.conf",
+				Content: &tmpfiles,
 			}},
 		},
 		"journal-limits": {
@@ -29,6 +36,53 @@ func TestValidateHostConfigurationAcceptsNativeFilesAndNotifications(t *testing.
 	}}
 	if err := ValidateHostConfiguration(config, false); err != nil {
 		t.Fatalf("ValidateHostConfiguration() error = %v", err)
+	}
+}
+
+func TestValidateHostConfigurationRejectsUnsafeTmpfilesRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "destructive type", content: "r /sys/example - - - - -\n", want: "use w"},
+		{name: "host file", content: "w /etc/hostname - - - - lab\n", want: "below /sys"},
+		{name: "glob", content: "w /sys/class/net/*/mtu - - - - 9000\n", want: "must not contain globs"},
+		{name: "argument glob", content: "w /sys/example - - - - *\n", want: "argument must be a concrete value"},
+		{name: "ownership", content: "w /sys/example 0644 - - - value\n", want: "mode must be -"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := HostConfiguration{Sets: map[string]HostConfigurationSet{
+				"kernel-tunables": {Files: []HostConfigurationFile{{
+					Path:    "/etc/tmpfiles.d/80-kernel-tunables.conf",
+					Content: &tt.content,
+				}}},
+			}}
+			err := ValidateHostConfiguration(config, false)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateHostConfiguration() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateHostConfigurationRejectsDuplicateTmpfilesTargets(t *testing.T) {
+	first := "w /sys/module/printk/parameters/time - - - - N\n"
+	second := "w /sys/module/printk/parameters/time - - - - Y\n"
+	config := HostConfiguration{Sets: map[string]HostConfigurationSet{
+		"first": {Files: []HostConfigurationFile{{
+			Path:    "/etc/tmpfiles.d/80-first.conf",
+			Content: &first,
+		}}},
+		"second": {Files: []HostConfigurationFile{{
+			Path:    "/etc/tmpfiles.d/80-second.conf",
+			Content: &second,
+		}}},
+	}}
+	err := ValidateHostConfiguration(config, false)
+	if err == nil || !strings.Contains(err.Error(), "already owned") {
+		t.Fatalf("ValidateHostConfiguration() error = %v, want duplicate target rejection", err)
 	}
 }
 

--- a/internal/installer/manifest/manifest.go
+++ b/internal/installer/manifest/manifest.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
@@ -116,6 +117,11 @@ func (notifications HostConfigurationNotifications) IsZero() bool {
 type HostConfigurationSystemdNotification struct {
 	Unit   string `json:"unit" yaml:"unit"`
 	Action string `json:"action" yaml:"action"`
+}
+
+type TmpfilesSysfsWrite struct {
+	Path  string
+	Value string
 }
 
 const (
@@ -662,6 +668,7 @@ func ValidateHostConfiguration(config HostConfiguration, allowSource bool) error
 	}
 	sort.Strings(setNames)
 	paths := make(map[string]string)
+	tmpfilesTargets := make(map[string]string)
 	systemdNotifications := make(map[string]string)
 	totalBytes := 0
 	for _, name := range setNames {
@@ -715,6 +722,21 @@ func ValidateHostConfiguration(config HostConfiguration, allowSource bool) error
 					return fmt.Errorf("%s.content exceeds %d bytes", field, MaxHostConfigurationFileBytes)
 				}
 				totalBytes += len(*file.Content)
+				if strings.HasPrefix(cleaned, "/etc/tmpfiles.d/") {
+					writes, err := ParseTmpfilesSysfsWrites(*file.Content)
+					if err != nil {
+						return fmt.Errorf("%s.content: %w", field, err)
+					}
+					for _, write := range writes {
+						if owner, exists := tmpfilesTargets[write.Path]; exists {
+							return fmt.Errorf("%s.content writes %q, which is already owned by set %q", field, write.Path, owner)
+						}
+						tmpfilesTargets[write.Path] = name
+					}
+				}
+			}
+			if strings.HasPrefix(cleaned, "/etc/tmpfiles.d/") && (path.Dir(cleaned) != "/etc/tmpfiles.d" || !strings.HasSuffix(cleaned, ".conf")) {
+				return fmt.Errorf("%s.path %q must be a .conf file directly below /etc/tmpfiles.d", field, cleaned)
 			}
 			switch file.Mode {
 			case 0, 0o600, 0o640, 0o644:
@@ -736,6 +758,56 @@ func ValidateHostConfiguration(config HostConfiguration, allowSource bool) error
 		return fmt.Errorf("file content exceeds the %d-byte host configuration limit", MaxHostConfigurationTotalBytes)
 	}
 	return nil
+}
+
+// ParseTmpfilesSysfsWrites accepts the bounded tmpfiles subset Katl can apply
+// and verify without granting rules ownership of arbitrary host paths.
+func ParseTmpfilesSysfsWrites(content string) ([]TmpfilesSysfsWrite, error) {
+	var writes []TmpfilesSysfsWrite
+	seen := make(map[string]struct{})
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 7 {
+			return nil, fmt.Errorf("tmpfiles line %d must contain type, path, mode, user, group, age, and argument", lineNumber)
+		}
+		if fields[0] != "w" {
+			return nil, fmt.Errorf("tmpfiles line %d type %q is unsupported; use w for a sysfs write", lineNumber, fields[0])
+		}
+		target := fields[1]
+		if path.Clean(target) != target || !strings.HasPrefix(target, "/sys/") {
+			return nil, fmt.Errorf("tmpfiles line %d path %q must be a normalized path below /sys", lineNumber, target)
+		}
+		if strings.ContainsAny(target, "*?[]%\\") {
+			return nil, fmt.Errorf("tmpfiles line %d path %q must not contain globs, specifiers, or escapes", lineNumber, target)
+		}
+		for index, value := range fields[2:6] {
+			if value != "-" {
+				names := []string{"mode", "user", "group", "age"}
+				return nil, fmt.Errorf("tmpfiles line %d %s must be - for a sysfs write", lineNumber, names[index])
+			}
+		}
+		value := fields[6]
+		if value == "-" || strings.ContainsAny(value, "*?[]%\\\x00") {
+			return nil, fmt.Errorf("tmpfiles line %d argument must be a concrete value without globs, specifiers, or escapes", lineNumber)
+		}
+		if _, duplicate := seen[target]; duplicate {
+			return nil, fmt.Errorf("tmpfiles line %d duplicates write target %q", lineNumber, target)
+		}
+		seen[target] = struct{}{}
+		writes = append(writes, TmpfilesSysfsWrite{Path: target, Value: value})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read tmpfiles content: %w", err)
+	}
+	if len(writes) == 0 {
+		return nil, fmt.Errorf("tmpfiles content must contain at least one sysfs write")
+	}
+	return writes, nil
 }
 
 // ValidateSystemExtensions validates only the generic ownership and

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -331,10 +331,15 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/config-apply-status.json",
 		`"phase": "next-boot"`,
 		`"acceptedApplyMode": "next-boot"`,
+		`"domain": "host-configuration"`,
 		`"domain": "networkd"`,
 		`"domain": "kernel-command-line"`,
+		`"target": "sysfs /sys/module/printk/parameters/time"`,
+		`"target": "containerd configuration /etc/containerd/conf.d/80-katl-vmtest.toml"`,
 	)
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/systemd/network/20-katl-vmtest-extra-address.network", "Address=198.51.100.77/32")
+	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/tmpfiles.d/80-katl-vmtest-sysfs.conf", "w /sys/module/printk/parameters/time - - - - N")
+	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/containerd/conf.d/80-katl-vmtest.toml", "oom_score = 123")
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/boot/selection.json", `"defaultGenerationID": "`+liveGeneration+`"`, `"targetBootGenerationID": "`+stagedGeneration+`"`, `"trialGenerationID": "`+stagedGeneration+`"`, `"pendingTransactionID": "`+stagedAccepted.OperationId+`"`, `"pendingHealthValidation": true`)
 	assertGuestExists(t, ctx, guest, "/var/lib/katl/generations/"+currentGeneration+"/metadata.json")
 	assertOptionalReadlink(t, ctx, guest, "/run/extensions/katl-kubernetes.raw", beforeSysext)
@@ -362,6 +367,24 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	)
 	assertGuestAddress(t, ctx, guest, "198.51.100.77", 32)
 	assertGuestFileContains(t, ctx, guest, "/proc/cmdline", "katl.vmtest.config_apply_kernel=1")
+	if got := strings.TrimSpace(guestCommandOutput(t, ctx, guest, "effective-tmpfiles-sysfs",
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		"/usr/bin/cat", "/sys/module/printk/parameters/time",
+	)); got != "N" {
+		t.Fatalf("printk time sysfs value = %q, want N", got)
+	}
+	guestCommand(t, ctx, guest, "start-containerd-with-overlay", "systemctl", "start", "containerd.service")
+	guestCommand(t, ctx, guest, "containerd-active-after-overlay", "systemctl", "is-active", "--quiet", "containerd.service")
+	containerdPID := strings.TrimSpace(guestCommandOutput(t, ctx, guest, "containerd-main-pid", "systemctl", "show", "--property=MainPID", "--value", "containerd.service"))
+	if containerdPID == "" || containerdPID == "0" {
+		t.Fatalf("containerd MainPID = %q, want running process", containerdPID)
+	}
+	if got := strings.TrimSpace(guestCommandOutput(t, ctx, guest, "containerd-oom-score",
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		"/usr/bin/cat", "/proc/"+containerdPID+"/oom_score_adj",
+	)); got != "123" {
+		t.Fatalf("containerd oom_score_adj = %q, want imported overlay value 123", got)
+	}
 	if cmdline := readGuestFile(t, ctx, guest, "/proc/cmdline"); strings.Contains(cmdline, "katl.vmtest.initial_kernel=1") {
 		t.Fatalf("replaced initial kernel argument remained active after reboot: %s", cmdline)
 	}

--- a/internal/vmtest/testdata/config-apply/next-boot-networkd.yaml
+++ b/internal/vmtest/testdata/config-apply/next-boot-networkd.yaml
@@ -27,3 +27,16 @@ spec:
 
             [DHCPv6]
             UseHostname=no
+    hostConfiguration:
+      sets:
+        vmtest-tmpfiles:
+          files:
+            - path: /etc/tmpfiles.d/80-katl-vmtest-sysfs.conf
+              content: |
+                w /sys/module/printk/parameters/time - - - - N
+        vmtest-containerd:
+          files:
+            - path: /etc/containerd/conf.d/80-katl-vmtest.toml
+              content: |
+                version = 4
+                oom_score = 123

--- a/mkosi.profiles/runtime/mkosi.extra/etc/containerd/config.toml
+++ b/mkosi.profiles/runtime/mkosi.extra/etc/containerd/config.toml
@@ -1,4 +1,5 @@
 version = 4
+imports = ["/etc/containerd/conf.d/*.toml"]
 disabled_plugins = ["io.containerd.internal.v1.opt"]
 
 [plugins.'io.containerd.cri.v1.runtime'.containerd]

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-host-config-prepare.service
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-host-config-prepare.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Prepare selected Katl native host configuration
-Documentation=man:systemd-confext(8) man:sysctl.d(5) man:modules-load.d(5) man:udev(7)
+Documentation=man:systemd-confext(8) man:sysctl.d(5) man:modules-load.d(5) man:tmpfiles.d(5) man:udev(7)
 DefaultDependencies=no
 Requires=systemd-confext.service
 After=systemd-confext.service

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-host-config-verify.service
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/system/katl-host-config-verify.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Verify selected Katl native host configuration
-Documentation=man:sysctl.d(5) man:modules-load.d(5)
+Documentation=man:sysctl.d(5) man:modules-load.d(5) man:tmpfiles.d(5)
 DefaultDependencies=no
 Requires=katl-host-config-prepare.service
 After=katl-host-config-prepare.service

--- a/scripts/check-runtime-root
+++ b/scripts/check-runtime-root
@@ -289,6 +289,7 @@ file_has_line /usr/lib/os-release 'KATL_BASE_VERSION_ID=44'
 file_has_line /usr/lib/os-release "SYSEXT_LEVEL=katl-runtime-1"
 file_has /usr/lib/systemd/system/var.mount "What=/dev/disk/by-partlabel/KATL_STATE"
 file_has /usr/lib/systemd/system/etc-kubernetes.mount "What=/var/lib/katl/kubernetes/etc-kubernetes"
+file_has /etc/containerd/config.toml 'imports = ["/etc/containerd/conf.d/*.toml"]'
 file_has /etc/containerd/config.toml 'bin_dirs = ["/var/lib/katl/kubernetes/cni/bin", "/usr/libexec/cni"]'
 file_has /etc/containerd/config.toml 'conf_dir = "/var/lib/katl/kubernetes/cni/net.d"'
 file_has /usr/lib/tmpfiles.d/katl-state.conf "d /var/lib/katl/kubernetes/cni/bin 0755 root root -"


### PR DESCRIPTION
Adds a bounded `tmpfiles.d` host-configuration handler for exact sysfs writes,
applied and read-back verified during candidate boot. Containerd now imports
operator overlays from `/etc/containerd/conf.d/*.toml`.

Kubeadm rendering now has one source of truth for Katl-owned version, endpoint,
endpoint SAN, CRI socket, control-plane taints, and volume plugin directory
values, while rejecting conflicting authored input.

Validated through initial install, Kubernetes bootstrap, existing-node config
apply, reboot, repeat apply, and safe rejection paths in a persistent Katldev
VM.
