### PR TITLE
network: leave CNI routes unmanaged

### DIFF
--- a/docs/internal/v0.1-supported-image-surface.md
+++ b/docs/internal/v0.1-supported-image-surface.md
@@ -111,7 +111,7 @@ Supported runtime services and targets:
 | `containerd.service` | supported internal | Kubernetes/container runtime dependency. |
 | `kubelet.service` drop-in | supported when Kubernetes sysext is selected | rootfs owns ordering/mount integration only. |
 | `var.mount`, `etc-kubernetes.mount` | supported | persistent state and kubeadm projection. |
-| `systemd-networkd`, `systemd-resolved`, `systemd-timesyncd`, `dbus-broker` | supported platform services | configured through Katl-owned domains. |
+| `systemd-networkd`, `systemd-resolved`, `systemd-timesyncd`, `dbus-broker` | supported platform services | configured through Katl-owned domains; networkd leaves foreign routes, routing policy rules, and next hops created by Kubernetes CNI components unmanaged. |
 | `katl-vmtest-agent.service`, `katl-vmtest-debug-shell.service` | VM/test-only | gated by kernel command line; never a production API. |
 
 Unsupported runtime surface:

--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -68,6 +68,24 @@ func TestRuntimeKubernetesSysctlsSupportCNIs(t *testing.T) {
 	}
 }
 
+func TestRuntimeNetworkdLeavesKubernetesRoutesAlone(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join(repoRoot(t), "mkosi.profiles", "runtime", "mkosi.extra", "usr", "lib", "systemd", "networkd.conf.d", "10-katl-kubernetes.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(config)
+	for _, want := range []string{
+		"[Network]",
+		"ManageForeignRoutes=no",
+		"ManageForeignRoutingPolicyRules=no",
+		"ManageForeignNextHops=no",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("runtime networkd policy missing %q", want)
+		}
+	}
+}
+
 func TestRuntimeBuildExcludesVMTestSupportByDefault(t *testing.T) {
 	repo := repoRoot(t)
 	bin := filepath.Join(t.TempDir(), "bin")

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -108,6 +108,18 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 		t.Fatalf("katlc runtime smoke: %v", err)
 	}
 	assertInstalledSSHReady(t, ctx, guest)
+	networkdConfig := guestCommandOutput(t, ctx, guest, "networkd-manager-policy",
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		"/usr/bin/systemd-analyze", "cat-config", "systemd/networkd.conf",
+	)
+	if !containsAll(networkdConfig,
+		"ManageForeignRoutes=no",
+		"ManageForeignRoutingPolicyRules=no",
+		"ManageForeignNextHops=no",
+	) {
+		t.Fatalf("merged systemd-networkd configuration is missing Kubernetes route policy:\n%s", networkdConfig)
+	}
+	guestCommand(t, ctx, guest, "networkd-active", "systemctl", "is-active", "systemd-networkd.service")
 	waitGuestFileContains(t, ctx, guest, "/var/lib/katl/install/status.json", `"finalHandoff": "waiting-for-cluster-bootstrap"`)
 	defer func() {
 		if t.Failed() {

--- a/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/networkd.conf.d/10-katl-kubernetes.conf
+++ b/mkosi.profiles/runtime/mkosi.extra/usr/lib/systemd/networkd.conf.d/10-katl-kubernetes.conf
@@ -1,0 +1,4 @@
+[Network]
+ManageForeignRoutes=no
+ManageForeignRoutingPolicyRules=no
+ManageForeignNextHops=no


### PR DESCRIPTION
## Summary

- ship a Katl-owned `systemd-networkd` manager drop-in in the immutable runtime
- leave foreign routes, routing policy rules, and next hops unmanaged
- verify the effective merged policy on an installed, healthy KatlOS node

## Why

Kubernetes CNI components create and manage networking objects outside systemd-networkd. The runtime must prevent networkd from adopting or removing those objects during normal reconciliation.

This makes the ownership boundary an in-box KatlOS default rather than operator ceremony.

Validated through runtime image contract coverage, installed-runtime VM testing, and a persistent install/reboot journey.
