### PR TITLE
kubernetes: select exact node address

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -175,12 +175,18 @@ spec:
           byID: /dev/disk/by-id/ata-KATL_CP_1_ROOT
       bootstrap:
         address: 192.0.2.11
+      # Optional on multihomed nodes; this is Kubernetes identity, not the
+      # operator-reachable bootstrap address.
+      kubernetes:
+        address: 10.254.1.1
     - name: worker-1
       install:
         targetDisk:
           byID: /dev/disk/by-id/ata-KATL_WORKER_1_ROOT
       bootstrap:
         address: 192.0.2.21
+      kubernetes:
+        address: 10.254.1.3
 ```
 
 When no native kubeadm file is supplied, Katl's generated kubeadm profile keeps
@@ -194,6 +200,13 @@ Kubernetes version itself. ClusterConfig does not expose KatlOS or Kubernetes
 image URLs, credentials, named kubeadm profiles, node classes, or other
 compiler mechanisms. An advanced `systemExtensions` entry may select an
 operator-owned native software bundle by OCI reference as described below.
+
+On a multihomed node, set the optional exact `nodes[].kubernetes.address`.
+Katl uses it for kubelet `--node-ip` and the kubeadm local API advertise address
+during both init and control-plane join. It is deliberately one literal IP,
+not a subnet-selection policy. Omit it for normal single-uplink nodes. The
+separate `bootstrap.address` remains the management address used by `katlctl`
+and may be different.
 
 `kernel.commandLine` adds operator-owned arguments to the installed kernel
 command line. It may be set under `spec.defaults` or on a concrete node; a

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -112,6 +112,8 @@ spec:
         targetDisk:
           byID: /dev/disk/by-id/ata-KATL_CP_1_ROOT
       kubernetes:
+        # Optional exact address used for this node's Kubernetes identity.
+        address: 10.254.1.1
         labels:
           topology.kubernetes.io/zone: rack-a
         taints: []
@@ -125,6 +127,15 @@ initial Kubernetes bootstrap, and an optional initial workstation context.
 It need not be a permanent node identity, but it must remain reachable through
 those steps. For DHCP nodes, use a reservation or update the workstation
 saved context when the address changes.
+
+`nodes[].kubernetes.address` is an optional exact IP address for Kubernetes on
+a multihomed node. Katl supplies it to kubelet as `--node-ip`, to kubeadm init
+as `InitConfiguration.localAPIEndpoint.advertiseAddress`, and to control-plane
+join as `JoinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress`.
+It must be a literal unicast IPv4 or IPv6 address; hostnames and CIDR selectors
+are rejected. Omit it on ordinary single-uplink nodes to retain kubeadm and
+kubelet automatic address selection. The value is node-specific and cannot be
+set under `spec.defaults`.
 
 `controlPlane: true` is the only public role choice. Omission or `false` means
 worker, and at least one node must set it to true. Katl derives its internal
@@ -175,7 +186,9 @@ and embeds into the compiled bundle. Katl supplies missing role documents, the
 selected Kubernetes version, the containerd CRI socket, safe rendered paths,
 and dynamic bootstrap credentials. It rejects unsupported API kinds, unsafe
 host paths, symlinks, traversal, and a kubeadm version that conflicts with
-`spec.kubernetes.version`.
+`spec.kubernetes.version`. Kubelet `node-ip` and the init/join local API
+advertise address are also Katl-owned and must be expressed through
+`nodes[].kubernetes.address`.
 
 ## Runtime Planning
 
@@ -192,6 +205,11 @@ state. Normal config apply may stage and report that state, but making a running
 cluster match it requires the dedicated kubeadm-aware operation. Native input
 acceptance does not imply that every kubeadm change has a supported live
 transition.
+
+Changing `nodes[].kubernetes.address` on an already installed node is a
+node-identity migration. Normal config apply keeps the requested field visible
+but refuses the change with a kubeadm-aware operation requirement; set the
+address in the ClusterConfig used for installation.
 
 Disk installation fields are consumed by installation and are not runtime
 configuration. Kubernetes version changes are handled by the Kubernetes

--- a/docs/internal/kubeadm-config-input-design.md
+++ b/docs/internal/kubeadm-config-input-design.md
@@ -74,6 +74,11 @@ Operator-authored kubeadm YAML omits values already owned by Katl:
   conflicting authored value is rejected.
 - The selected endpoint hostname is added once to
   `ClusterConfiguration.apiServer.certSANs`.
+- kubelet `node-ip`, `InitConfiguration.localAPIEndpoint.advertiseAddress`,
+  and control-plane join
+  `JoinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress` come from
+  the optional exact `nodes[].kubernetes.address`; conflicting native values
+  are rejected.
 - `InitConfiguration` and `JoinConfiguration`
   `nodeRegistration.criSocket` default to containerd.
 - `InitConfiguration.nodeRegistration.taints` defaults to `[]`; node taints

--- a/docs/internal/schemas/install-manifest-v1alpha1.schema.json
+++ b/docs/internal/schemas/install-manifest-v1alpha1.schema.json
@@ -340,6 +340,17 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "address": {
+          "type": "string",
+          "anyOf": [
+            {
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            }
+          ]
+        },
         "kubeadm": {
           "$ref": "#/$defs/kubeadmReference"
         }

--- a/internal/bootstrap/cluster/cluster.go
+++ b/internal/bootstrap/cluster/cluster.go
@@ -1420,6 +1420,11 @@ func synthesizeJoinConfig(initDoc map[string]any) map[string]any {
 	if patches, ok := initDoc["patches"].(map[string]any); ok {
 		doc["patches"] = patches
 	}
+	if localAPIEndpoint, ok := initDoc["localAPIEndpoint"].(map[string]any); ok {
+		doc["controlPlane"] = map[string]any{
+			"localAPIEndpoint": localAPIEndpoint,
+		}
+	}
 	return doc
 }
 

--- a/internal/bootstrap/cluster/cluster_test.go
+++ b/internal/bootstrap/cluster/cluster_test.go
@@ -1690,6 +1690,35 @@ patches:
 	}
 }
 
+func TestRenderControlPlaneJoinCarriesLocalAPIEndpoint(t *testing.T) {
+	base := []byte(`apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 10.254.1.3
+nodeRegistration:
+  kubeletExtraArgs:
+    - name: node-ip
+      value: 10.254.1.3
+`)
+	material := JoinMaterial{Argv: []string{
+		"kubeadm", "join", "api.katl.test:6443",
+		"--token", "abcdef.0123456789abcdef",
+		"--discovery-token-ca-cert-hash", testDiscoveryHash,
+		"--control-plane",
+		"--certificate-key", strings.Repeat("a", 64),
+	}}
+	rendered, err := RenderControlPlaneJoinConfig(base, material)
+	if err != nil {
+		t.Fatalf("RenderControlPlaneJoinConfig() error = %v", err)
+	}
+	text := string(rendered)
+	for _, want := range []string{"advertiseAddress: 10.254.1.3", "name: node-ip", "value: 10.254.1.3"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("rendered join config missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
 func TestRenderControlPlaneJoinUsesEphemeralFileDiscovery(t *testing.T) {
 	base := []byte(`apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration

--- a/internal/installer/cluster_intent.go
+++ b/internal/installer/cluster_intent.go
@@ -56,6 +56,7 @@ type ClusterIntentInventory struct {
 
 type ClusterIntentKubernetes struct {
 	PayloadVersion string `json:"payloadVersion,omitempty"`
+	Address        string `json:"address,omitempty"`
 	SysextPath     string `json:"sysextPath,omitempty"`
 	SysextSHA256   string `json:"sysextSHA256,omitempty"`
 	SysextSize     uint64 `json:"sysextSizeBytes,omitempty"`
@@ -214,6 +215,7 @@ func BuildClusterIntent(request ClusterIntentRequest) (ClusterIntent, error) {
 		},
 		Kubernetes: ClusterIntentKubernetes{
 			PayloadVersion: strings.TrimSpace(request.KubernetesVersion),
+			Address:        strings.TrimSpace(request.Manifest.Node.Kubernetes.Address),
 		},
 		Source:             ClusterIntentSource{RequestDigest: strings.TrimSpace(request.RequestDigest)},
 		RequestDigest:      strings.TrimSpace(request.RequestDigest),
@@ -243,6 +245,10 @@ func BuildClusterIntent(request ClusterIntentRequest) (ClusterIntent, error) {
 	config, ok := request.KubeadmConfigs[ref]
 	if !ok {
 		return ClusterIntent{}, fmt.Errorf("node.kubernetes.kubeadm.configRef %q was not resolved", ref)
+	}
+	config, err := kubeadmconfig.WithNodeAddress(config, request.Manifest.Node.Kubernetes.Address)
+	if err != nil {
+		return ClusterIntent{}, err
 	}
 	intentValue, err := configdomain.KubeadmIntent(config)
 	if err != nil {
@@ -285,6 +291,10 @@ func writeClusterKubeadmInput(root string, intent ClusterIntent, configs map[str
 	plan, ok := configs[ref]
 	if !ok {
 		return fmt.Errorf("cluster intent kubeadm configRef %q was not resolved", ref)
+	}
+	plan, err := kubeadmconfig.WithNodeAddress(plan, intent.Kubernetes.Address)
+	if err != nil {
+		return err
 	}
 	dir, err := StoredKubeadmInputDir(root, ref)
 	if err != nil {

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -245,6 +245,7 @@ func compileNode(config Config, name string, role inventory.SystemRole, layer No
 			SystemExtensions:     append([]manifest.SystemExtension(nil), layer.SystemExtensions...),
 			ControlPlaneEndpoint: managedEndpoint,
 			Kubernetes: manifest.KubernetesConfig{
+				Address: strings.TrimSpace(layer.Kubernetes.Address),
 				Kubeadm: manifest.KubeadmReference{ConfigRef: layer.Kubernetes.KubeadmConfigRef},
 			},
 			Bootstrap: &manifest.BootstrapIntent{
@@ -372,6 +373,9 @@ func copyLabels(labels map[string]string) map[string]string {
 func validateSharedLayer(path string, layer NodeLayer) error {
 	if layer.Install.TargetDisk != nil {
 		return fmt.Errorf("%s.install.targetDisk is not allowed; target disk identity must be set per node", path)
+	}
+	if strings.TrimSpace(layer.Kubernetes.Address) != "" {
+		return fmt.Errorf("%s.kubernetes.address is not allowed; Kubernetes address must be set per node", path)
 	}
 	if layer.Install.TargetDiskDefaults != nil {
 		if err := validateTargetDiskDefaults(*layer.Install.TargetDiskDefaults); err != nil {

--- a/internal/installer/clusterplan/merge.go
+++ b/internal/installer/clusterplan/merge.go
@@ -57,6 +57,9 @@ func mergeLayer(base, next NodeLayer) (NodeLayer, error) {
 		return NodeLayer{}, err
 	}
 	out.Install.ExtraDisks = extra
+	if strings.TrimSpace(next.Kubernetes.Address) != "" {
+		out.Kubernetes.Address = strings.TrimSpace(next.Kubernetes.Address)
+	}
 	if strings.TrimSpace(next.Kubernetes.KubeadmConfigRef) != "" {
 		out.Kubernetes.KubeadmConfigRef = strings.TrimSpace(next.Kubernetes.KubeadmConfigRef)
 	}

--- a/internal/installer/clusterplan/types.go
+++ b/internal/installer/clusterplan/types.go
@@ -66,6 +66,7 @@ type InstallLayer struct {
 }
 
 type KubernetesLayer struct {
+	Address          string               `yaml:"address,omitempty" json:"address,omitempty"`
 	KubeadmConfigRef string               `yaml:"kubeadmConfigRef,omitempty" json:"kubeadmConfigRef,omitempty"`
 	NodeLabels       map[string]string    `yaml:"nodeLabels,omitempty" json:"nodeLabels,omitempty"`
 	NodeTaints       []manifest.NodeTaint `yaml:"nodeTaints,omitempty" json:"nodeTaints,omitempty"`

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -683,11 +683,15 @@ func applyOverlay(node *manifest.NodeConfig, overlay NodeOverlay, kubernetesInit
 		}
 	}
 	if overlay.Kubernetes != nil {
-		changed := node.Kubernetes != *overlay.Kubernetes
+		addressChanged := node.Kubernetes.Address != overlay.Kubernetes.Address
+		configChanged := node.Kubernetes.Kubeadm != overlay.Kubernetes.Kubeadm
 		node.Kubernetes = *overlay.Kubernetes
-		if changed {
+		if configChanged {
 			domains.add(DomainSelectedKubeadmConfig)
 			domains.add(DomainBootstrapNodeMetadata)
+		}
+		if addressChanged {
+			domains.add(DomainKubeletNodeIdentity)
 		}
 	}
 	if overlay.ControlPlaneEndpointSet && !reflect.DeepEqual(node.ControlPlaneEndpoint, overlay.ControlPlaneEndpoint) {

--- a/internal/installer/configapply/runtime_apply_test.go
+++ b/internal/installer/configapply/runtime_apply_test.go
@@ -205,6 +205,30 @@ func TestControlPlaneEndpointApplyClassification(t *testing.T) {
 	}
 }
 
+func TestKubernetesAddressApplyClassification(t *testing.T) {
+	current := baseManifest()
+	desired := current.Node.Kubernetes
+	desired.Address = "10.254.1.1"
+	request := trustedBundleRequest(t.TempDir(), TrustedBundleRequest{
+		ApplyMode:       generation.ApplyModeAuto,
+		CurrentManifest: current,
+		NodeOverrides: map[string]NodeOverlay{
+			"cp-1": {Kubernetes: &desired},
+		},
+	})
+	_, changes, _, err := mergeRuntimeConfig(request)
+	if err != nil {
+		t.Fatalf("mergeRuntimeConfig() error = %v", err)
+	}
+	if len(changes) != 1 || changes[0].Domain != DomainKubeletNodeIdentity {
+		t.Fatalf("changes = %#v, want %q", changes, DomainKubeletNodeIdentity)
+	}
+	decision, err := Plan(request.ApplyMode, changes)
+	if err == nil || len(decision.Diagnostics) != 1 || decision.Diagnostics[0].RequiredOperation != "kubeadm-aware operation" {
+		t.Fatalf("Plan() error = %v, decision = %#v", err, decision)
+	}
+}
+
 func TestEndpointRoutingImpactNamesExchangeAndExportChanges(t *testing.T) {
 	before := managedEndpoint("192.0.2.1")
 	before.Advertisement.BGP.RouteExchange = []controlplaneendpoint.RouteExchange{{

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -127,8 +127,9 @@ type SourceKubeadmInput struct {
 }
 
 type SourceKubernetesLayer struct {
-	Labels map[string]string    `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Taints []manifest.NodeTaint `yaml:"taints,omitempty" json:"taints,omitempty"`
+	Address string               `yaml:"address,omitempty" json:"address,omitempty"`
+	Labels  map[string]string    `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Taints  []manifest.NodeTaint `yaml:"taints,omitempty" json:"taints,omitempty"`
 }
 
 type BundleManifest struct {
@@ -462,6 +463,7 @@ func lowerNodeLayer(layer SourceNodeLayer) clusterplan.NodeLayer {
 			ExtraDisks:         append([]manifest.ExtraDisk(nil), layer.Install.ExtraDisks...),
 		},
 		Kubernetes: clusterplan.KubernetesLayer{
+			Address:    strings.TrimSpace(layer.Kubernetes.Address),
 			NodeLabels: copyLabels(layer.Kubernetes.Labels),
 			NodeTaints: append([]manifest.NodeTaint(nil), layer.Kubernetes.Taints...),
 		},
@@ -514,12 +516,20 @@ func defaultSource(source SourceConfig) SourceConfig {
 
 func normalizeSource(source SourceConfig) (SourceConfig, error) {
 	source = defaultSource(source)
+	if strings.TrimSpace(source.Spec.Defaults.Kubernetes.Address) != "" {
+		return SourceConfig{}, fmt.Errorf("spec.defaults.kubernetes.address is not allowed; Kubernetes address must be set per node")
+	}
 	if source.Spec.Defaults.Kernel != nil {
 		if err := manifest.ValidateKernelConfig(*source.Spec.Defaults.Kernel); err != nil {
 			return SourceConfig{}, fmt.Errorf("spec.defaults.kernel: %w", err)
 		}
 	}
 	for i := range source.Spec.Nodes {
+		address, err := manifest.NormalizeKubernetesAddress(source.Spec.Nodes[i].Kubernetes.Address)
+		if err != nil {
+			return SourceConfig{}, fmt.Errorf("spec.nodes[%d].kubernetes.address: %w", i, err)
+		}
+		source.Spec.Nodes[i].Kubernetes.Address = address
 		if source.Spec.Nodes[i].Kernel != nil {
 			if err := manifest.ValidateKernelConfig(*source.Spec.Nodes[i].Kernel); err != nil {
 				return SourceConfig{}, fmt.Errorf("spec.nodes[%d].kernel: %w", i, err)
@@ -896,6 +906,10 @@ func addNodeKubeadmInputs(members *[]member, descriptors *[]Descriptor, node clu
 	if !ok {
 		return nil, fmt.Errorf("node %s kubeadm config %q was not resolved", node.Name, ref)
 	}
+	plan, err := kubeadmconfig.WithNodeAddress(plan, node.InstallManifest.Node.Kubernetes.Address)
+	if err != nil {
+		return nil, fmt.Errorf("node %s kubeadm config %q: %w", node.Name, ref, err)
+	}
 	var out []Descriptor
 	files := append([]kubeadmconfig.File{plan.Config}, plan.Patches...)
 	for _, file := range files {
@@ -1003,7 +1017,7 @@ func addBytes(members *[]member, descriptors *[]Descriptor, role, node, mediaTyp
 		FileName:    fileName,
 		Annotations: annotations,
 	}
-	*members = append(*members, member{descriptor: desc, data: append([]byte(nil), data...)})
+	*members = append(*members, member{descriptor: desc, data: slices.Clone(data)})
 	*descriptors = append(*descriptors, desc)
 	return desc
 }

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -287,6 +287,65 @@ shutdownGracePeriod: 45s
 	}
 }
 
+func TestBuildArchiveRendersExactKubernetesAddressPerNode(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/zone: rack-a", "      kubernetes:\n        address: 10.254.1.1\n        labels:\n          katl.dev/zone: rack-a", 1)
+	source = strings.Replace(source, "      kubernetes:\n        labels:\n          katl.dev/pool: workers", "      kubernetes:\n        address: 10.254.1.3\n        labels:\n          katl.dev/pool: workers", 1)
+	archive, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+
+	controlPlane, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode(control-plane) error = %v", err)
+	}
+	cpDocuments, err := decodeKubeadmDocuments(controlPlane.KubeadmConfigs["control-plane"].Config.Content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	init := kubeadmDocument(cpDocuments, "InitConfiguration")
+	if got := nestedString(init, "localAPIEndpoint", "advertiseAddress"); got != "10.254.1.1" {
+		t.Fatalf("control-plane advertiseAddress = %q", got)
+	}
+	if got := kubeletNodeIP(init); got != "10.254.1.1" {
+		t.Fatalf("control-plane kubelet node-ip = %q", got)
+	}
+
+	worker, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "worker-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode(worker) error = %v", err)
+	}
+	workerDocuments, err := decodeKubeadmDocuments(worker.KubeadmConfigs["worker"].Config.Content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := kubeletNodeIP(kubeadmDocument(workerDocuments, "JoinConfiguration")); got != "10.254.1.3" {
+		t.Fatalf("worker kubelet node-ip = %q", got)
+	}
+}
+
+func TestBuildArchiveLeavesKubernetesAddressAutomaticWhenOmitted(t *testing.T) {
+	archive, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, validSourceConfig())})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	controlPlane, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode() error = %v", err)
+	}
+	documents, err := decodeKubeadmDocuments(controlPlane.KubeadmConfigs["control-plane"].Config.Content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	init := kubeadmDocument(documents, "InitConfiguration")
+	if got := nestedString(init, "localAPIEndpoint", "advertiseAddress"); got != "" {
+		t.Fatalf("advertiseAddress = %q, want automatic selection", got)
+	}
+	if got := kubeletNodeIP(init); got != "" {
+		t.Fatalf("kubelet node-ip = %q, want automatic selection", got)
+	}
+}
+
 func TestBuildArchiveRejectsConflictingKatlOwnedKubeadmValues(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -329,6 +388,36 @@ volumePluginDir: other
 `,
 			want: "volumePluginDir must be",
 		},
+		{
+			name: "kubelet node IP",
+			config: `apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    - name: node-ip
+      value: 10.254.1.1
+`,
+			want: "node-ip is supplied from nodes[].kubernetes.address",
+		},
+		{
+			name: "local API advertise address",
+			config: `apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: 10.254.1.1
+`,
+			want: "advertiseAddress is supplied from nodes[].kubernetes.address",
+		},
+		{
+			name: "join local API advertise address",
+			config: `apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+controlPlane:
+  localAPIEndpoint:
+    advertiseAddress: 10.254.1.3
+`,
+			want: "advertiseAddress is supplied from nodes[].kubernetes.address",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -342,6 +431,22 @@ volumePluginDir: other
 				t.Fatalf("BuildArchive() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildArchiveRejectsInvalidKubernetesAddress(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/zone: rack-a", "      kubernetes:\n        address: 10.254.1.0/31\n        labels:\n          katl.dev/zone: rack-a", 1)
+	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+	if err == nil || !strings.Contains(err.Error(), "must be a literal unicast IP address") {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+}
+
+func TestBuildArchiveRequiresKubernetesAddressPerNode(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), "  defaults:\n", "  defaults:\n    kubernetes:\n      address: 10.254.1.1\n", 1)
+	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+	if err == nil || !strings.Contains(err.Error(), "must be set per node") {
+		t.Fatalf("BuildArchive() error = %v", err)
 	}
 }
 
@@ -969,6 +1074,38 @@ func nativeFile(files []confext.NativeEtcFile, path string) *confext.NativeEtcFi
 		}
 	}
 	return nil
+}
+
+func kubeadmDocument(documents []map[string]any, kind string) map[string]any {
+	for _, document := range documents {
+		if document["kind"] == kind {
+			return document
+		}
+	}
+	return nil
+}
+
+func nestedString(document map[string]any, path ...string) string {
+	var value any = document
+	for _, segment := range path {
+		mapping, _ := value.(map[string]any)
+		value = mapping[segment]
+	}
+	text, _ := value.(string)
+	return text
+}
+
+func kubeletNodeIP(document map[string]any) string {
+	registration, _ := document["nodeRegistration"].(map[string]any)
+	arguments, _ := registration["kubeletExtraArgs"].([]any)
+	for _, raw := range arguments {
+		argument, _ := raw.(map[string]any)
+		if argument["name"] == "node-ip" {
+			value, _ := argument["value"].(string)
+			return value
+		}
+	}
+	return ""
 }
 
 const testSSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example"

--- a/internal/installer/configbundle/kubeadm.go
+++ b/internal/installer/configbundle/kubeadm.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	kubeadmCRISocket = "unix:///run/containerd/containerd.sock"
+	kubeadmCRISocket      = "unix:///run/containerd/containerd.sock"
+	kubeletNodeIPArgument = "node-ip"
 )
 
 type kubeadmSourceInput struct {
@@ -71,6 +72,9 @@ func splitKubeadmPlans(input kubeadmconfig.Plan, kubernetesVersion string) (map[
 		kind, _ := document["kind"].(string)
 		if _, exists := byKind[kind]; exists {
 			return nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile contains duplicate %s documents", kind)
+		}
+		if err := rejectManagedNodeAddress(document); err != nil {
+			return nil, fmt.Errorf("spec.kubernetes.kubeadm.configFile document %d: %w", index+1, err)
 		}
 		if kind == "JoinConfiguration" {
 			if _, controlPlane := document["controlPlane"]; controlPlane {
@@ -137,6 +141,44 @@ func splitKubeadmPlans(input kubeadmconfig.Plan, kubernetesVersion string) (map[
 		plans[role.name] = plan
 	}
 	return plans, nil
+}
+
+func rejectManagedNodeAddress(document map[string]any) error {
+	kind, _ := document["kind"].(string)
+	if kind != "InitConfiguration" && kind != "JoinConfiguration" {
+		return nil
+	}
+	if nodeRegistration, ok := document["nodeRegistration"].(map[string]any); ok {
+		switch extraArgs := nodeRegistration["kubeletExtraArgs"].(type) {
+		case map[string]any:
+			if _, exists := extraArgs[kubeletNodeIPArgument]; exists {
+				return fmt.Errorf("%s nodeRegistration.kubeletExtraArgs node-ip is supplied from nodes[].kubernetes.address", kind)
+			}
+		case []any:
+			for _, raw := range extraArgs {
+				argument, _ := raw.(map[string]any)
+				name, _ := argument["name"].(string)
+				if strings.TrimSpace(name) == kubeletNodeIPArgument {
+					return fmt.Errorf("%s nodeRegistration.kubeletExtraArgs node-ip is supplied from nodes[].kubernetes.address", kind)
+				}
+			}
+		}
+	}
+	if kind == "InitConfiguration" {
+		if endpoint, ok := document["localAPIEndpoint"].(map[string]any); ok {
+			if value, exists := endpoint["advertiseAddress"]; exists && strings.TrimSpace(fmt.Sprint(value)) != "" {
+				return fmt.Errorf("InitConfiguration localAPIEndpoint.advertiseAddress is supplied from nodes[].kubernetes.address")
+			}
+		}
+	}
+	if controlPlane, ok := document["controlPlane"].(map[string]any); ok {
+		if endpoint, ok := controlPlane["localAPIEndpoint"].(map[string]any); ok {
+			if value, exists := endpoint["advertiseAddress"]; exists && strings.TrimSpace(fmt.Sprint(value)) != "" {
+				return fmt.Errorf("JoinConfiguration controlPlane.localAPIEndpoint.advertiseAddress is supplied from nodes[].kubernetes.address")
+			}
+		}
+	}
+	return nil
 }
 
 func defaultKubeadmDocuments() (map[string]map[string]any, error) {

--- a/internal/installer/configdomain/configdomain.go
+++ b/internal/installer/configdomain/configdomain.go
@@ -77,6 +77,10 @@ func NativeEtcFiles(request RenderRequest) ([]confext.NativeEtcFile, error) {
 		if !ok {
 			return nil, fmt.Errorf("node.kubernetes.kubeadm.configRef %q was not resolved", ref)
 		}
+		config, err = kubeadmconfig.WithNodeAddress(config, request.Manifest.Node.Kubernetes.Address)
+		if err != nil {
+			return nil, err
+		}
 		if config.Name != ref {
 			return nil, fmt.Errorf("node.kubernetes.kubeadm.configRef %q resolved to KubeadmConfig %q", ref, config.Name)
 		}
@@ -297,6 +301,7 @@ type nodeMetadataKubeadm struct {
 type nodeMetadataKubernetes struct {
 	PayloadVersion string `json:"payloadVersion,omitempty"`
 	ActivationPath string `json:"activationPath,omitempty"`
+	Address        string `json:"address,omitempty"`
 }
 
 func nodeMetadataFile(installManifest manifest.Manifest, config *kubeadmconfig.Plan, kubernetesVersion string, kubernetesActivationPath string) (confext.NativeEtcFile, error) {
@@ -310,6 +315,7 @@ func nodeMetadataFile(installManifest manifest.Manifest, config *kubeadmconfig.P
 		Kubernetes: nodeMetadataKubernetes{
 			PayloadVersion: kubernetesVersion,
 			ActivationPath: kubernetesActivationPath,
+			Address:        installManifest.Node.Kubernetes.Address,
 		},
 	}
 	if config != nil {

--- a/internal/installer/kubeadmconfig/node_address.go
+++ b/internal/installer/kubeadmconfig/node_address.go
@@ -1,0 +1,163 @@
+package kubeadmconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const kubeletNodeIPArgument = "node-ip"
+
+// WithNodeAddress returns a node-specific kubeadm plan. Kubeadm persists
+// nodeRegistration.kubeletExtraArgs into kubeadm-flags.env, so one source of
+// node identity configures both kubelet and the local API endpoint.
+func WithNodeAddress(plan Plan, address string) (Plan, error) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return clonePlan(plan), nil
+	}
+	documents, err := decodeDocuments(plan.Config.Content)
+	if err != nil {
+		return Plan{}, fmt.Errorf("decode KubeadmConfig %q for node address: %w", plan.Name, err)
+	}
+	for _, document := range documents {
+		kind, _ := document["kind"].(string)
+		switch kind {
+		case "InitConfiguration", "JoinConfiguration":
+			if err := setKubeletNodeIP(document, address); err != nil {
+				return Plan{}, fmt.Errorf("KubeadmConfig %q %s: %w", plan.Name, kind, err)
+			}
+		}
+		switch kind {
+		case "InitConfiguration":
+			if err := setAdvertiseAddress(childMapping(document, "localAPIEndpoint"), address); err != nil {
+				return Plan{}, fmt.Errorf("KubeadmConfig %q InitConfiguration: %w", plan.Name, err)
+			}
+		case "JoinConfiguration":
+			controlPlane, ok := document["controlPlane"].(map[string]any)
+			if !ok || controlPlane == nil {
+				continue
+			}
+			if err := setAdvertiseAddress(childMapping(controlPlane, "localAPIEndpoint"), address); err != nil {
+				return Plan{}, fmt.Errorf("KubeadmConfig %q JoinConfiguration.controlPlane: %w", plan.Name, err)
+			}
+		}
+	}
+	content, err := encodeDocuments(documents)
+	if err != nil {
+		return Plan{}, fmt.Errorf("encode KubeadmConfig %q for node address: %w", plan.Name, err)
+	}
+	files := []File{{
+		SourcePath: plan.Config.SourcePath,
+		RenderPath: plan.Config.RenderPath,
+		Content:    content,
+		Mode:       plan.Config.Mode,
+	}}
+	for _, patch := range plan.Patches {
+		copy := patch
+		copy.Content = slices.Clone(patch.Content)
+		files = append(files, copy)
+	}
+	rendered, err := PlanFromRenderedFiles(plan.Name, files)
+	if err != nil {
+		return Plan{}, fmt.Errorf("validate KubeadmConfig %q with node address: %w", plan.Name, err)
+	}
+	return rendered, nil
+}
+
+func clonePlan(plan Plan) Plan {
+	out := plan
+	out.Config.Content = slices.Clone(plan.Config.Content)
+	out.Patches = slices.Clone(plan.Patches)
+	for i := range out.Patches {
+		out.Patches[i].Content = slices.Clone(plan.Patches[i].Content)
+	}
+	out.Documents = slices.Clone(plan.Documents)
+	return out
+}
+
+func decodeDocuments(data []byte) ([]map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var documents []map[string]any
+	for {
+		document := map[string]any{}
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			return documents, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(document) > 0 {
+			documents = append(documents, document)
+		}
+	}
+}
+
+func encodeDocuments(documents []map[string]any) ([]byte, error) {
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	for _, document := range documents {
+		if err := encoder.Encode(document); err != nil {
+			_ = encoder.Close()
+			return nil, err
+		}
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func setKubeletNodeIP(document map[string]any, address string) error {
+	nodeRegistration := childMapping(document, "nodeRegistration")
+	extraArgs, ok := nodeRegistration["kubeletExtraArgs"].([]any)
+	if nodeRegistration["kubeletExtraArgs"] != nil && !ok {
+		return fmt.Errorf("nodeRegistration.kubeletExtraArgs must use the kubeadm v1beta4 argument list")
+	}
+	for _, raw := range extraArgs {
+		argument, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := argument["name"].(string)
+		if strings.TrimSpace(name) != kubeletNodeIPArgument {
+			continue
+		}
+		value := strings.TrimSpace(fmt.Sprint(argument["value"]))
+		if value != address {
+			return fmt.Errorf("nodeRegistration.kubeletExtraArgs node-ip %q conflicts with node Kubernetes address %q", value, address)
+		}
+		return nil
+	}
+	nodeRegistration["kubeletExtraArgs"] = append(extraArgs, map[string]any{
+		"name":  kubeletNodeIPArgument,
+		"value": address,
+	})
+	document["nodeRegistration"] = nodeRegistration
+	return nil
+}
+
+func setAdvertiseAddress(localAPIEndpoint map[string]any, address string) error {
+	configured := strings.TrimSpace(fmt.Sprint(localAPIEndpoint["advertiseAddress"]))
+	if configured != "" && configured != "<nil>" && configured != address {
+		return fmt.Errorf("localAPIEndpoint.advertiseAddress %q conflicts with node Kubernetes address %q", configured, address)
+	}
+	localAPIEndpoint["advertiseAddress"] = address
+	return nil
+}
+
+func childMapping(parent map[string]any, key string) map[string]any {
+	child, _ := parent[key].(map[string]any)
+	if child == nil {
+		child = map[string]any{}
+		parent[key] = child
+	}
+	return child
+}

--- a/internal/installer/manifest/manifest.go
+++ b/internal/installer/manifest/manifest.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/netip"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -208,6 +209,7 @@ type SystemExtensionPayloadRef struct {
 }
 
 type KubernetesConfig struct {
+	Address string           `json:"address,omitempty" yaml:"address,omitempty"`
 	Kubeadm KubeadmReference `json:"kubeadm,omitempty" yaml:"kubeadm,omitempty"`
 }
 
@@ -390,6 +392,9 @@ func ValidateWithOptions(manifest Manifest, options ValidateOptions) error {
 	if err := ValidateSystemExtensions(manifest.Node.SystemExtensions, false); err != nil {
 		return fmt.Errorf("node.systemExtensions: %w", err)
 	}
+	if _, err := NormalizeKubernetesAddress(manifest.Node.Kubernetes.Address); err != nil {
+		return fmt.Errorf("node.kubernetes.address: %w", err)
+	}
 	if err := validateNameRef("node.kubernetes.kubeadm.configRef", manifest.Node.Kubernetes.Kubeadm.ConfigRef); err != nil {
 		return err
 	}
@@ -429,6 +434,18 @@ func ValidateWithOptions(manifest Manifest, options ValidateOptions) error {
 		}
 	}
 	return nil
+}
+
+func NormalizeKubernetesAddress(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	address, err := netip.ParseAddr(value)
+	if err != nil || address.Zone() != "" || !address.IsGlobalUnicast() {
+		return "", fmt.Errorf("%q must be a literal unicast IP address", value)
+	}
+	return address.String(), nil
 }
 
 func ValidateKernelConfig(config KernelConfig) error {

--- a/internal/installer/manifest/manifest_test.go
+++ b/internal/installer/manifest/manifest_test.go
@@ -24,6 +24,20 @@ func TestDecodeAcceptsMinimal(t *testing.T) {
 	}
 }
 
+func TestNormalizeKubernetesAddress(t *testing.T) {
+	for _, address := range []string{"10.254.1.1", "fd00::1"} {
+		got, err := NormalizeKubernetesAddress(address)
+		if err != nil || got != address {
+			t.Fatalf("NormalizeKubernetesAddress(%q) = %q, %v", address, got, err)
+		}
+	}
+	for _, address := range []string{"10.254.1.0/31", "node.example", "0.0.0.0", "224.0.0.1", "::1"} {
+		if _, err := NormalizeKubernetesAddress(address); err == nil {
+			t.Fatalf("NormalizeKubernetesAddress(%q) error = nil", address)
+		}
+	}
+}
+
 func TestDecodeUsesDefaultKatlosImage(t *testing.T) {
 	input := `apiVersion: install.katl.dev/v1alpha1
 kind: InstallManifest

--- a/internal/katlc/config/validate.go
+++ b/internal/katlc/config/validate.go
@@ -339,6 +339,10 @@ func validateKubernetes(node *yaml.Node, path string, options Options, result *R
 	}
 	for _, pair := range mappingPairsWithPath(node, path) {
 		switch pair.key {
+		case "address":
+			if _, err := manifest.NormalizeKubernetesAddress(scalarValue(pair.value)); err != nil {
+				result.add("invalid-kubernetes-address", pair.path, err.Error())
+			}
 		case "kubeadm":
 			validateKubeadm(pair.value, pair.path, options, result)
 		default:


### PR DESCRIPTION
Adds optional per-node `nodes[].kubernetes.address` for multihomed nodes and carries it through install and runtime configuration.

Katl now supplies the exact address to kubelet `--node-ip`, kubeadm init's local API endpoint, and control-plane join's local API endpoint. Omission keeps automatic address selection, native kubeadm conflicts are rejected, and `bootstrap.address` remains management reachability only.

The gap was that kubeadm and kubelet independently selected interfaces even when operators needed a stable fabric address. The change was validated through the three-control-plane VM scenario and a persistent public-interface install/bootstrap journey.
