### PR TITLE
config: report public validation paths

### DIFF
--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -758,11 +758,113 @@ func TestConfigValidateReportsNestedFieldPath(t *testing.T) {
 	}
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "spec.nodes[0].install.systemDisk.unsupportedSelector: field is not supported") {
+	if err == nil || !strings.Contains(err.Error(), "spec.nodes[\"cp-1\"].install.systemDisk.unsupportedSelector: field is not supported") {
 		t.Fatalf("run() error = %v, want nested field path", err)
 	}
 	if stdout.Len() != 0 || stderr.Len() != 0 {
 		t.Fatalf("stdout=%q stderr=%q, want empty", stdout.String(), stderr.String())
+	}
+}
+
+func TestConfigValidateReportsOnlyPublicNodePaths(t *testing.T) {
+	base := configBundleSource()
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "system disk selector",
+			source: strings.Replace(base,
+				"          byID: /dev/disk/by-id/ata-cp-root",
+				"          byID: /dev/disk/by-id/ata-cp-root\n          serial: duplicate-identity", 1),
+			want: `spec.nodes["cp-1"].install.systemDisk must set exactly one of byID, wwn, or serial`,
+		},
+		{
+			name: "storage selector",
+			source: strings.Replace(base, "      install:\n", `      storage:
+        disks:
+          - name: data
+            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-data
+              partition:
+                partUUID: 11111111-2222-3333-4444-555555555555
+            filesystem: xfs
+      install:
+`, 1),
+			want: `spec.nodes["cp-1"].storage.disks[0].selector must set exactly one of disk or partition`,
+		},
+		{
+			name: "sysfs path",
+			source: strings.Replace(base, "      install:\n", `      hostConfiguration:
+        sysfs:
+          - path: relative/path
+            value: enabled
+      install:
+`, 1),
+			want: `spec.nodes["cp-1"].hostConfiguration.sysfs[0].path "relative/path" must be a normalized path below /sys`,
+		},
+		{
+			name: "file set notification",
+			source: strings.Replace(base, "      install:\n", `      hostConfiguration:
+        fileSets:
+          service:
+            files:
+              - path: /etc/example.conf
+                content: enabled
+            onChange:
+              systemd:
+                - unit: example.service
+                  action: restart
+      install:
+`, 1),
+			want: `spec.nodes["cp-1"].hostConfiguration.fileSets["service"].onChange.systemd[0].action "restart" is unsupported`,
+		},
+		{
+			name: "Kubernetes taint",
+			source: strings.Replace(base, "      install:\n", `      kubernetes:
+        taints:
+          - key: dedicated
+            effect: RestartAlways
+      install:
+`, 1),
+			want: `spec.nodes["cp-1"].kubernetes.taints[0].effect "RestartAlways" is unsupported`,
+		},
+		{
+			name: "system extension configuration file",
+			source: strings.Replace(base, "      install:\n", `      systemExtensions:
+        - name: tools
+          bundle: registry.example/tools:v1
+          configuration:
+            files:
+              - path: relative.conf
+                content: enabled
+      install:
+`, 1),
+			want: `spec.nodes["cp-1"].systemExtensions[0].configuration.files[0].path: "relative.conf" must be absolute`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
+			if err := os.WriteFile(sourcePath, []byte(tt.source), 0o644); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			var stdout, stderr bytes.Buffer
+			err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("run() error = %v, want %q", err, tt.want)
+			}
+			for _, internal := range []string{"targetDisk", "install.volumes", ".sets[", ".notify.", ".sysfs[0].name", "node.bootstrap"} {
+				if strings.Contains(err.Error(), internal) {
+					t.Fatalf("run() error exposes internal path %q: %v", internal, err)
+				}
+			}
+			if stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Fatalf("stdout=%q stderr=%q, want empty", stdout.String(), stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -350,6 +350,9 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 		}
 		planning.KubernetesBundle = selection.Bundle
 	}
+	if err := validateResolvedSourceNodes(source); err != nil {
+		return nil, Result{}, err
+	}
 	config, err := LowerSource(source, planning)
 	if err != nil {
 		return nil, Result{}, err
@@ -359,7 +362,7 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 		KubeadmConfigs: kubeadmConfigs,
 	})
 	if err != nil {
-		return nil, Result{}, err
+		return nil, Result{}, publicClusterPlanError(source, err)
 	}
 	members, manifest, err := buildMembers(source, normalized, sourceDigest, plan, kubeadmConfigs, extensionBundles, request)
 	if err != nil {
@@ -459,14 +462,14 @@ func LowerSource(source SourceConfig, planning PlanningInputs) (clusterplan.Conf
 	}
 	nodes := make([]clusterplan.Node, 0, len(source.Spec.Nodes))
 	hasControlPlane := false
-	for _, node := range source.Spec.Nodes {
+	for i, node := range source.Spec.Nodes {
 		role := sourceNodeRole(node)
 		if role == inventory.RoleControlPlane {
 			hasControlPlane = true
 		}
 		resolved, err := mergeSourceNodeLayer(source.Spec.Defaults, sourceNodeLayer(node))
 		if err != nil {
-			return clusterplan.Config{}, fmt.Errorf("spec.nodes[%q]: %w", node.Name, err)
+			return clusterplan.Config{}, fmt.Errorf("%s: %w", sourceNodePath(node, i), err)
 		}
 		layer := lowerNodeLayer(resolved)
 		layer.Bootstrap.Address = strings.TrimSpace(node.Management.Address)
@@ -495,6 +498,19 @@ func LowerSource(source SourceConfig, planning PlanningInputs) (clusterplan.Conf
 			Nodes:                nodes,
 		},
 	}, nil
+}
+
+func validateResolvedSourceNodes(source SourceConfig) error {
+	for i, node := range source.Spec.Nodes {
+		resolved, err := mergeSourceNodeLayer(source.Spec.Defaults, sourceNodeLayer(node))
+		if err != nil {
+			return fmt.Errorf("%s: %w", sourceNodePath(node, i), err)
+		}
+		if err := validateResolvedSourceNode(sourceNodePath(node, i), resolved); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func lowerKubernetesSelection(source SourceConfig, bundle string) (clusterplan.KubernetesSelection, error) {
@@ -588,6 +604,21 @@ func defaultSource(source SourceConfig) SourceConfig {
 
 func normalizeSource(source SourceConfig) (SourceConfig, error) {
 	source = defaultSource(source)
+	seenNodes := make(map[string]struct{}, len(source.Spec.Nodes))
+	for i, node := range source.Spec.Nodes {
+		name := strings.TrimSpace(node.Name)
+		path := sourceNodePath(node, i)
+		if name == "" {
+			return SourceConfig{}, fmt.Errorf("%s.name is required", path)
+		}
+		if !manifest.ValidHostname(name) {
+			return SourceConfig{}, fmt.Errorf("%s.name %q must be a single DNS-style label", path, node.Name)
+		}
+		if _, exists := seenNodes[name]; exists {
+			return SourceConfig{}, fmt.Errorf("%s.name %q duplicates another node", path, name)
+		}
+		seenNodes[name] = struct{}{}
+	}
 	if strings.TrimSpace(source.Spec.Defaults.Kubernetes.Address) != "" {
 		return SourceConfig{}, fmt.Errorf("spec.defaults.kubernetes.address is not allowed; Kubernetes address must be set per node")
 	}
@@ -597,41 +628,42 @@ func normalizeSource(source SourceConfig) (SourceConfig, error) {
 		}
 	}
 	for i := range source.Spec.Nodes {
+		path := sourceNodePath(source.Spec.Nodes[i], i)
 		address, err := manifest.NormalizeKubernetesAddress(source.Spec.Nodes[i].Kubernetes.Address)
 		if err != nil {
-			return SourceConfig{}, fmt.Errorf("spec.nodes[%d].kubernetes.address: %w", i, err)
+			return SourceConfig{}, fmt.Errorf("%s.kubernetes.address: %w", path, err)
 		}
 		source.Spec.Nodes[i].Kubernetes.Address = address
 		if source.Spec.Nodes[i].Kernel != nil {
 			if err := manifest.ValidateKernelConfig(*lowerKernelConfig(source.Spec.Nodes[i].Kernel)); err != nil {
-				return SourceConfig{}, fmt.Errorf("spec.nodes[%d].kernel: %w", i, err)
+				return SourceConfig{}, fmt.Errorf("%s.kernel: %w", path, err)
 			}
 		}
 	}
-	if err := manifest.ValidateHostConfiguration(lowerHostConfiguration(source.Spec.Defaults.HostConfiguration), true); err != nil {
-		return SourceConfig{}, fmt.Errorf("spec.defaults.hostConfiguration: %w", err)
+	if err := validateSourceHostConfiguration("spec.defaults.hostConfiguration", source.Spec.Defaults.HostConfiguration); err != nil {
+		return SourceConfig{}, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := manifest.ValidateHostConfiguration(lowerHostConfiguration(source.Spec.Nodes[i].HostConfiguration), true); err != nil {
-			return SourceConfig{}, fmt.Errorf("spec.nodes[%d].hostConfiguration: %w", i, err)
+		if err := validateSourceHostConfiguration(sourceNodePath(source.Spec.Nodes[i], i)+".hostConfiguration", source.Spec.Nodes[i].HostConfiguration); err != nil {
+			return SourceConfig{}, err
 		}
 	}
-	if err := manifest.ValidateSystemExtensions(lowerSystemExtensions(source.Spec.Defaults.SystemExtensions), true); err != nil {
-		return SourceConfig{}, fmt.Errorf("spec.defaults.systemExtensions: %w", err)
+	if err := validateSourceSystemExtensions("spec.defaults.systemExtensions", source.Spec.Defaults.SystemExtensions); err != nil {
+		return SourceConfig{}, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := manifest.ValidateSystemExtensions(lowerSystemExtensions(source.Spec.Nodes[i].SystemExtensions), true); err != nil {
-			return SourceConfig{}, fmt.Errorf("spec.nodes[%d].systemExtensions: %w", i, err)
+		if err := validateSourceSystemExtensions(sourceNodePath(source.Spec.Nodes[i], i)+".systemExtensions", source.Spec.Nodes[i].SystemExtensions); err != nil {
+			return SourceConfig{}, err
 		}
 	}
 	if err := validateDefaultSystemDisk(source.Spec.Defaults.Install.SystemDisk); err != nil {
 		return SourceConfig{}, fmt.Errorf("spec.defaults.install.systemDisk: %w", err)
 	}
-	if err := validateSourceStorageDisks("spec.defaults.storage.disks", source.Spec.Defaults.Storage.Disks); err != nil {
+	if err := validateSourceStorageDisks("spec.defaults.storage.disks", source.Spec.Defaults.Storage.Disks, false); err != nil {
 		return SourceConfig{}, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := validateSourceStorageDisks(fmt.Sprintf("spec.nodes[%d].storage.disks", i), source.Spec.Nodes[i].Storage.Disks); err != nil {
+		if err := validateSourceStorageDisks(sourceNodePath(source.Spec.Nodes[i], i)+".storage.disks", source.Spec.Nodes[i].Storage.Disks, false); err != nil {
 			return SourceConfig{}, err
 		}
 	}
@@ -686,7 +718,7 @@ func resolveHostConfigurationSources(sourceRoot string, source SourceConfig) (So
 		return SourceConfig{}, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := resolve(fmt.Sprintf("spec.nodes[%d].hostConfiguration", i), &source.Spec.Nodes[i].HostConfiguration); err != nil {
+		if err := resolve(sourceNodePath(source.Spec.Nodes[i], i)+".hostConfiguration", &source.Spec.Nodes[i].HostConfiguration); err != nil {
 			return SourceConfig{}, err
 		}
 	}
@@ -734,11 +766,18 @@ func resolveHostConfigurationSources(sourceRoot string, source SourceConfig) (So
 		return SourceConfig{}, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := resolveExtensions(fmt.Sprintf("spec.nodes[%d].systemExtensions", i), &source.Spec.Nodes[i].SystemExtensions); err != nil {
+		if err := resolveExtensions(sourceNodePath(source.Spec.Nodes[i], i)+".systemExtensions", &source.Spec.Nodes[i].SystemExtensions); err != nil {
 			return SourceConfig{}, err
 		}
 	}
 	return source, nil
+}
+
+func sourceNodePath(node SourceNode, index int) string {
+	if name := strings.TrimSpace(node.Name); name != "" {
+		return fmt.Sprintf("spec.nodes[%q]", name)
+	}
+	return fmt.Sprintf("spec.nodes[%d]", index)
 }
 
 func readHostConfigurationSource(sourceRoot, source string) ([]byte, error) {

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -921,7 +921,7 @@ func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 		{
 			name: "bootstrap management block",
 			raw:  strings.Replace(validSourceConfig(), "      management:\n", "      bootstrap:\n", 1),
-			want: "spec.nodes[0].bootstrap: field is not supported",
+			want: "spec.nodes[\"cp-1\"].bootstrap: field is not supported",
 		},
 		{
 			name: "target disk defaults",
@@ -933,21 +933,21 @@ func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 			raw: strings.Replace(validSourceConfig(),
 				"      install:\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root",
 				"      install:\n        targetDisk:\n          byID: /dev/disk/by-id/ata-cp-root", 1),
-			want: "spec.nodes[0].install.targetDisk: field is not supported",
+			want: "spec.nodes[\"cp-1\"].install.targetDisk: field is not supported",
 		},
 		{
 			name: "extra disks",
 			raw: strings.Replace(validSourceConfig(),
 				"      install:\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root",
 				"      install:\n        extraDisks: []\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root", 1),
-			want: "spec.nodes[0].install.extraDisks: field is not supported",
+			want: "spec.nodes[\"cp-1\"].install.extraDisks: field is not supported",
 		},
 		{
 			name: "install volumes",
 			raw: strings.Replace(validSourceConfig(),
 				"      install:\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root",
 				"      install:\n        volumes: []\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root", 1),
-			want: "spec.nodes[0].install.volumes: field is not supported",
+			want: "spec.nodes[\"cp-1\"].install.volumes: field is not supported",
 		},
 		{
 			name: "host configuration sets",
@@ -1023,7 +1023,7 @@ func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 		{
 			name: "system role alias",
 			raw:  strings.Replace(validSourceConfig(), "      controlPlane: true\n", "      systemRole: control-plane\n", 1),
-			want: "spec.nodes[0].systemRole: field is not supported",
+			want: "spec.nodes[\"cp-1\"].systemRole: field is not supported",
 		},
 		{
 			name: "platform endpoint",
@@ -1033,17 +1033,17 @@ func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 		{
 			name: "node overrides wrapper",
 			raw:  strings.Replace(validSourceConfig(), "      install:\n", "      overrides:\n        install:\n", 1),
-			want: "spec.nodes[0].overrides: field is not supported",
+			want: "spec.nodes[\"cp-1\"].overrides: field is not supported",
 		},
 		{
 			name: "node labels alias",
 			raw:  strings.Replace(validSourceConfig(), "        labels:\n", "        nodeLabels:\n", 1),
-			want: "spec.nodes[0].kubernetes.nodeLabels: field is not supported",
+			want: "spec.nodes[\"cp-1\"].kubernetes.nodeLabels: field is not supported",
 		},
 		{
 			name: "bootstrap credentials",
 			raw:  strings.Replace(validSourceConfig(), "        address: 10.0.0.11", "        address: 10.0.0.11\n        access:\n          credentialRef: file:/tmp/token", 1),
-			want: "spec.nodes[0].management.access: field is not supported",
+			want: "spec.nodes[\"cp-1\"].management.access: field is not supported",
 		},
 		{
 			name: "kubeadm profiles",

--- a/internal/installer/configbundle/schema.go
+++ b/internal/installer/configbundle/schema.go
@@ -202,13 +202,24 @@ func validateYAMLFields(node *yaml.Node, t reflect.Type, path string) error {
 			return nil
 		}
 		for i, item := range node.Content {
-			itemPath := fmt.Sprintf("%s[%d]", path, i)
+			itemPath := sequenceItemPath(path, item, i)
 			if err := validateYAMLFields(item, t.Elem(), itemPath); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func sequenceItemPath(path string, item *yaml.Node, index int) string {
+	if path == "spec.nodes" && item.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(item.Content); i += 2 {
+			if item.Content[i].Value == "name" && strings.TrimSpace(item.Content[i+1].Value) != "" {
+				return fmt.Sprintf("%s[%q]", path, strings.TrimSpace(item.Content[i+1].Value))
+			}
+		}
+	}
+	return fmt.Sprintf("%s[%d]", path, index)
 }
 
 func joinFieldPath(parent, field string) string {

--- a/internal/installer/configbundle/source_errors.go
+++ b/internal/installer/configbundle/source_errors.go
@@ -1,0 +1,82 @@
+package configbundle
+
+import (
+	"fmt"
+	"strings"
+)
+
+func publicClusterPlanError(source SourceConfig, err error) error {
+	message := err.Error()
+	for i, node := range source.Spec.Nodes {
+		quotedName := fmt.Sprintf("%q", strings.TrimSpace(node.Name))
+		path := sourceNodePath(node, i)
+		if detail, ok := strings.CutPrefix(message, "node "+quotedName+" manifest: "); ok {
+			return fmt.Errorf("%s.%s", path, publicManifestMessage(detail))
+		}
+		if detail, ok := strings.CutPrefix(message, "node "+quotedName+": "); ok {
+			return fmt.Errorf("%s: %s", path, publicCompilerMessage(detail))
+		}
+		if detail, ok := strings.CutPrefix(message, "node "+quotedName+" "); ok {
+			return fmt.Errorf("%s.%s", path, publicNodeMessage(detail))
+		}
+	}
+	return fmt.Errorf("%s", publicCompilerMessage(message))
+}
+
+func publicManifestMessage(message string) string {
+	replacements := []struct {
+		internal string
+		public   string
+	}{
+		{"node.identity.ssh.authorizedKeys", "access.ssh.authorizedKeys"},
+		{"node.identity.hostname", "name"},
+		{"node.systemRole", "controlPlane"},
+		{"node.kernel", "kernel"},
+		{"node.systemExtensions", "systemExtensions"},
+		{"node.kubernetes.address", "kubernetes.address"},
+		{"node.bootstrap.labels", "kubernetes.labels"},
+		{"node.bootstrap.taints", "kubernetes.taints"},
+		{"node.bootstrap.nodeAddress", "management.address"},
+		{"node.bootstrap.inventoryNodeName", "name"},
+		{"node.bootstrap.clusterName", "metadata.name"},
+		{"install.targetDisk", "install.systemDisk"},
+		{"install.volumes", "storage.disks"},
+	}
+	for _, replacement := range replacements {
+		if strings.HasPrefix(message, replacement.internal) {
+			return replacement.public + strings.TrimPrefix(message, replacement.internal)
+		}
+	}
+	if detail, ok := strings.CutPrefix(message, "node.hostConfiguration: "); ok {
+		return "hostConfiguration." + publicHostConfigurationMessage(detail)
+	}
+	return publicCompilerMessage(message)
+}
+
+func publicNodeMessage(message string) string {
+	replacements := []struct {
+		internal string
+		public   string
+	}{
+		{"install.targetDisk", "install.systemDisk"},
+		{"address", "management.address"},
+		{"systemRole", "controlPlane"},
+		{"access", "management"},
+	}
+	for _, replacement := range replacements {
+		if strings.HasPrefix(message, replacement.internal) {
+			return replacement.public + strings.TrimPrefix(message, replacement.internal)
+		}
+	}
+	return publicCompilerMessage(message)
+}
+
+func publicCompilerMessage(message string) string {
+	replacer := strings.NewReplacer(
+		"spec.kubernetes.payloadVersion", "spec.kubernetes.version",
+		"spec.defaults.install.targetDisk", "spec.defaults.install.systemDisk",
+		"install.targetDisk", "install.systemDisk",
+		"install.volumes", "storage.disks",
+	)
+	return replacer.Replace(message)
+}

--- a/internal/installer/configbundle/source_layering.go
+++ b/internal/installer/configbundle/source_layering.go
@@ -382,7 +382,7 @@ func validateDefaultSystemDisk(selector *SourceDiskSelector) error {
 	return nil
 }
 
-func validateSourceStorageDisks(field string, disks Optional[[]SourceStorageDisk]) error {
+func validateSourceStorageDisks(field string, disks Optional[[]SourceStorageDisk], requireComplete bool) error {
 	values, ok := disks.Get()
 	if !ok {
 		return nil
@@ -402,8 +402,93 @@ func validateSourceStorageDisks(field string, disks Optional[[]SourceStorageDisk
 		default:
 			return fmt.Errorf("%s[%d].state must be %q or %q", field, i, manifest.SystemExtensionPresent, manifest.SystemExtensionAbsent)
 		}
+		if strings.TrimSpace(disk.State) == manifest.SystemExtensionAbsent {
+			continue
+		}
+		if disk.Selector != nil && disk.Selector.Disk != nil && disk.Selector.Partition != nil {
+			return fmt.Errorf("%s[%d].selector must set exactly one of disk or partition", field, i)
+		}
+		if !requireComplete {
+			continue
+		}
+		volume := lowerStorageDisks(supplied([]SourceStorageDisk{disk}))
+		if err := manifest.ValidateVolumes(volume); err != nil {
+			message := strings.Replace(err.Error(), "install.volumes[0]", fmt.Sprintf("%s[%d]", field, i), 1)
+			return fmt.Errorf("%s", message)
+		}
 	}
 	return nil
+}
+
+func validateResolvedSourceNode(path string, layer SourceNodeLayer) error {
+	if keys, ok := layer.Access.SSH.AuthorizedKeys.Get(); !ok || len(keys) == 0 {
+		return fmt.Errorf("%s.access.ssh.authorizedKeys must not be empty", path)
+	} else {
+		for i, key := range keys {
+			if !manifest.ValidAuthorizedKey(key) {
+				return fmt.Errorf("%s.access.ssh.authorizedKeys[%d] must be an SSH public key", path, i)
+			}
+		}
+	}
+	if layer.Install.SystemDisk == nil {
+		return fmt.Errorf("%s.install.systemDisk is required", path)
+	}
+	selected := 0
+	for _, value := range []Optional[string]{layer.Install.SystemDisk.ByID, layer.Install.SystemDisk.WWN, layer.Install.SystemDisk.Serial} {
+		if configured, ok := value.Get(); ok && strings.TrimSpace(configured) != "" {
+			selected++
+		}
+	}
+	if selected != 1 {
+		return fmt.Errorf("%s.install.systemDisk must set exactly one of byID, wwn, or serial", path)
+	}
+	if err := validateSourceStorageDisks(path+".storage.disks", layer.Storage.Disks, true); err != nil {
+		return err
+	}
+	if err := validateSourceHostConfiguration(path+".hostConfiguration", layer.HostConfiguration); err != nil {
+		return err
+	}
+	if err := validateSourceSystemExtensions(path+".systemExtensions", layer.SystemExtensions); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateSourceHostConfiguration(field string, config SourceHostConfiguration) error {
+	if err := manifest.ValidateHostConfiguration(lowerHostConfiguration(config), true); err != nil {
+		return fmt.Errorf("%s.%s", field, publicHostConfigurationMessage(err.Error()))
+	}
+	return nil
+}
+
+func publicHostConfigurationMessage(message string) string {
+	if strings.HasPrefix(message, "sysfs[") {
+		message = strings.Replace(message, "].name", "].path", 1)
+	}
+	if strings.HasPrefix(message, "sets[") {
+		message = "fileSets[" + strings.TrimPrefix(message, "sets[")
+	}
+	message = strings.ReplaceAll(message, ".notify.", ".onChange.")
+	message = strings.ReplaceAll(message, "host configuration set name", "fileSets key")
+	return message
+}
+
+func validateSourceSystemExtensions(field string, extensions Optional[[]SourceSystemExtension]) error {
+	if err := manifest.ValidateSystemExtensions(lowerSystemExtensions(extensions), true); err != nil {
+		return fmt.Errorf("%s%s", field, publicSystemExtensionsMessage(err.Error()))
+	}
+	return nil
+}
+
+func publicSystemExtensionsMessage(message string) string {
+	if index := strings.Index(message, ".configuration: sets["); index >= 0 {
+		detail := message[index+len(".configuration: sets["):]
+		if end := strings.Index(detail, "].files"); end >= 0 {
+			message = message[:index] + ".configuration.files" + detail[end+len("].files"):]
+		}
+	}
+	message = strings.ReplaceAll(message, "host configuration set name", "system extension name")
+	return message
 }
 
 func lowerSystemExtensions(extensions Optional[[]SourceSystemExtension]) []manifest.SystemExtension {

--- a/internal/installer/configbundle/system_extensions.go
+++ b/internal/installer/configbundle/system_extensions.go
@@ -55,7 +55,7 @@ func resolveSystemExtensionBundles(
 		return SourceConfig{}, nil, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := resolveEntries(fmt.Sprintf("spec.nodes[%d].systemExtensions", i), &source.Spec.Nodes[i].SystemExtensions); err != nil {
+		if err := resolveEntries(sourceNodePath(source.Spec.Nodes[i], i)+".systemExtensions", &source.Spec.Nodes[i].SystemExtensions); err != nil {
 			return SourceConfig{}, nil, err
 		}
 	}


### PR DESCRIPTION
## What changed

- report ClusterConfig validation failures with named `spec.nodes["name"]` paths and current public authoring fields
- validate effective per-node storage and configuration before lowering, including rejecting simultaneous disk and partition selectors
- translate residual compiler diagnostics for host configuration, system extensions, Kubernetes scheduling, and install storage

## Why

Source configuration was lowered into install-manifest types before all semantic validation completed. Errors therefore exposed internal field names and list indexes that did not identify the operator's node or the fields they authored.

Operators now receive actionable errors tied to the affected node and current ClusterConfig surface. Fast checks and a hands-on public `katlctl` Katldev journey passed.
