### PR TITLE
config: generate accurate ClusterConfig schema

### DIFF
--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -1093,12 +1093,7 @@ func TestSourceSchemaExposesAuthoringContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SourceSchema() error = %v", err)
 	}
-	var document struct {
-		ID   string `json:"$id"`
-		Defs map[string]struct {
-			Properties map[string]json.RawMessage `json:"properties"`
-		} `json:"$defs"`
-	}
+	var document sourceSchema
 	if err := json.Unmarshal(data, &document); err != nil {
 		t.Fatalf("decode schema: %v", err)
 	}
@@ -1132,11 +1127,23 @@ func TestSourceSchemaExposesAuthoringContract(t *testing.T) {
 		[]string{"architecture", "artifactVersion", "bundleManifestDigest", "ociManifestDigest", "payloadVersion", "payloads", "supportedRuntimeInterfaces"})
 	assertSchemaFields(t, document.Defs, "controlplaneendpoint.BGP", []string{"routeExchanges"}, []string{"routeExchange"})
 	assertSchemaFields(t, document.Defs, "controlplaneendpoint.PrefixEnvelope", []string{"exactPrefixLength"}, []string{"prefixLength"})
+	assertSchemaRequired(t, document.Defs, "configbundle.SourceSpec", "nodes")
+	assertSchemaRequired(t, document.Defs, "configbundle.SourceNode", "name")
+	assertSchemaRequired(t, document.Defs, "configbundle.SourceHostConfigurationSysfsSetting", "path", "value")
+	if selector := document.Defs["configbundle.SourceVolumeSelector"]; len(selector.OneOf) != 2 {
+		t.Fatalf("volume selector oneOf branches = %d, want 2", len(selector.OneOf))
+	}
+	filesystem := document.Defs["configbundle.SourceStorageDisk"].Properties["filesystem"]
+	if !slices.Equal(filesystem.Enum, []any{"xfs", "ext4", "btrfs"}) || filesystem.Description == "" {
+		t.Fatalf("filesystem schema = %#v", filesystem)
+	}
+	port := document.Defs["controlplaneendpoint.Config"].Properties["port"]
+	if port.Minimum == nil || *port.Minimum != 0 || port.Maximum == nil || *port.Maximum != 65535 || port.Default != float64(6443) {
+		t.Fatalf("control-plane port schema = %#v", port)
+	}
 }
 
-func assertSchemaFields(t *testing.T, definitions map[string]struct {
-	Properties map[string]json.RawMessage `json:"properties"`
-}, definition string, present, absent []string) {
+func assertSchemaFields(t *testing.T, definitions map[string]schemaObject, definition string, present, absent []string) {
 	t.Helper()
 	properties := definitions[definition].Properties
 	for _, field := range present {
@@ -1147,6 +1154,15 @@ func assertSchemaFields(t *testing.T, definitions map[string]struct {
 	for _, field := range absent {
 		if _, ok := properties[field]; ok {
 			t.Fatalf("%s schema exposes removed %q", definition, field)
+		}
+	}
+}
+
+func assertSchemaRequired(t *testing.T, definitions map[string]schemaObject, definition string, required ...string) {
+	t.Helper()
+	for _, field := range required {
+		if !slices.Contains(definitions[definition].Required, field) {
+			t.Fatalf("%s schema does not require %q: %v", definition, field, definitions[definition].Required)
 		}
 	}
 }

--- a/internal/installer/configbundle/schema.go
+++ b/internal/installer/configbundle/schema.go
@@ -13,23 +13,37 @@ import (
 const SourceSchemaID = "https://katl.dev/schemas/config.katl.dev/v1alpha1/cluster-config.json"
 
 type sourceSchema struct {
-	Schema string                  `json:"$schema"`
-	ID     string                  `json:"$id"`
-	Title  string                  `json:"title"`
-	Ref    string                  `json:"$ref"`
-	Defs   map[string]schemaObject `json:"$defs"`
+	Schema      string                  `json:"$schema"`
+	ID          string                  `json:"$id"`
+	Title       string                  `json:"title"`
+	Description string                  `json:"description"`
+	Ref         string                  `json:"$ref"`
+	Defs        map[string]schemaObject `json:"$defs"`
 }
 
 type schemaObject struct {
 	Ref                  string                  `json:"$ref,omitempty"`
 	Type                 string                  `json:"type,omitempty"`
-	Const                string                  `json:"const,omitempty"`
-	Enum                 []string                `json:"enum,omitempty"`
+	Const                any                     `json:"const,omitempty"`
+	Enum                 []any                   `json:"enum,omitempty"`
+	Description          string                  `json:"description,omitempty"`
+	Default              any                     `json:"default,omitempty"`
 	Properties           map[string]schemaObject `json:"properties,omitempty"`
 	Required             []string                `json:"required,omitempty"`
 	AdditionalProperties any                     `json:"additionalProperties,omitempty"`
+	PropertyNames        *schemaObject           `json:"propertyNames,omitempty"`
 	Items                *schemaObject           `json:"items,omitempty"`
-	Minimum              *int                    `json:"minimum,omitempty"`
+	MinItems             *int                    `json:"minItems,omitempty"`
+	MaxItems             *int                    `json:"maxItems,omitempty"`
+	MinLength            *int                    `json:"minLength,omitempty"`
+	MaxLength            *int                    `json:"maxLength,omitempty"`
+	Pattern              string                  `json:"pattern,omitempty"`
+	Format               string                  `json:"format,omitempty"`
+	Minimum              *int64                  `json:"minimum,omitempty"`
+	Maximum              *int64                  `json:"maximum,omitempty"`
+	OneOf                []schemaObject          `json:"oneOf,omitempty"`
+	AnyOf                []schemaObject          `json:"anyOf,omitempty"`
+	Not                  *schemaObject           `json:"not,omitempty"`
 }
 
 // SourceSchema returns the JSON Schema for the ClusterConfig accepted by this
@@ -40,11 +54,12 @@ func SourceSchema() ([]byte, error) {
 	root := reflect.TypeOf(SourceConfig{})
 	builder.schemaFor(root)
 	document := sourceSchema{
-		Schema: "https://json-schema.org/draft/2020-12/schema",
-		ID:     SourceSchemaID,
-		Title:  APIVersion + " " + Kind,
-		Ref:    "#/$defs/" + schemaTypeName(root),
-		Defs:   builder.defs,
+		Schema:      "https://json-schema.org/draft/2020-12/schema",
+		ID:          SourceSchemaID,
+		Title:       APIVersion + " " + Kind,
+		Description: "Katl cluster intent compiled into per-node install and runtime configuration.",
+		Ref:         "#/$defs/" + schemaTypeName(root),
+		Defs:        builder.defs,
 	}
 	data, err := json.MarshalIndent(document, "", "  ")
 	if err != nil {
@@ -77,7 +92,7 @@ func (builder *schemaBuilder) schemaFor(t reflect.Type) schemaObject {
 		var required []string
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
-			name, _, visible := yamlField(field)
+			name, omitEmpty, visible := yamlField(field)
 			if !visible {
 				continue
 			}
@@ -89,17 +104,22 @@ func (builder *schemaBuilder) schemaFor(t reflect.Type) schemaObject {
 				case "kind":
 					property = schemaObject{Type: "string", Const: Kind}
 				}
+			}
+			rule := sourceSchemaFieldRule(t, name)
+			property = applySchemaFieldRule(property, rule)
+			if !omitEmpty || rule.Required {
 				required = append(required, name)
 			}
 			properties[name] = property
 		}
 		sort.Strings(required)
-		builder.defs[name] = schemaObject{
+		object := schemaObject{
 			Type:                 "object",
 			Properties:           properties,
 			Required:             required,
 			AdditionalProperties: false,
 		}
+		builder.defs[name] = applySchemaTypeRule(object, sourceSchemaTypeRule(t))
 		return ref
 	case reflect.Slice, reflect.Array:
 		items := builder.schemaFor(t.Elem())
@@ -112,7 +132,7 @@ func (builder *schemaBuilder) schemaFor(t reflect.Type) schemaObject {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return schemaObject{Type: "integer"}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		zero := 0
+		zero := int64(0)
 		return schemaObject{Type: "integer", Minimum: &zero}
 	case reflect.Float32, reflect.Float64:
 		return schemaObject{Type: "number"}

--- a/internal/installer/configbundle/schema_rules.go
+++ b/internal/installer/configbundle/schema_rules.go
@@ -1,0 +1,354 @@
+package configbundle
+
+import "reflect"
+
+type schemaFieldRule struct {
+	Required      bool
+	Description   string
+	Default       any
+	Enum          []any
+	MinItems      *int
+	MaxItems      *int
+	MinLength     *int
+	MaxLength     *int
+	Pattern       string
+	Format        string
+	Minimum       *int64
+	Maximum       *int64
+	PropertyNames *schemaObject
+}
+
+type schemaTypeRule struct {
+	OneOf []schemaObject
+}
+
+func applySchemaFieldRule(schema schemaObject, rule schemaFieldRule) schemaObject {
+	schema.Description = rule.Description
+	schema.Default = rule.Default
+	schema.Enum = rule.Enum
+	schema.MinItems = rule.MinItems
+	schema.MaxItems = rule.MaxItems
+	schema.MinLength = rule.MinLength
+	schema.MaxLength = rule.MaxLength
+	schema.Pattern = rule.Pattern
+	schema.Format = rule.Format
+	if rule.Minimum != nil {
+		schema.Minimum = rule.Minimum
+	}
+	if rule.Maximum != nil {
+		schema.Maximum = rule.Maximum
+	}
+	schema.PropertyNames = rule.PropertyNames
+	return schema
+}
+
+func applySchemaTypeRule(schema schemaObject, rule schemaTypeRule) schemaObject {
+	schema.OneOf = rule.OneOf
+	return schema
+}
+
+func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
+	key := schemaTypeName(t) + "." + field
+	switch key {
+	case "configbundle.SourceConfig.apiVersion":
+		return description("API version of this ClusterConfig document.")
+	case "configbundle.SourceConfig.kind":
+		return description("Document kind; always ClusterConfig.")
+	case "configbundle.SourceConfig.metadata":
+		return description("Cluster identity.")
+	case "configbundle.SourceConfig.spec":
+		return description("Cluster-wide defaults and explicit node intent.")
+	case "configbundle.Metadata.name":
+		return stringRule("Stable cluster name.", "", 1, 0)
+	case "configbundle.SourceSpec.controlPlaneEndpoint":
+		return description("Stable Kubernetes API endpoint and optional Katl-managed advertisement.")
+	case "configbundle.SourceSpec.kubernetes":
+		return description("Cluster-wide Kubernetes version and optional native kubeadm input.")
+	case "configbundle.SourceSpec.defaults":
+		return description("Non-identifying values inherited by every node unless overridden.")
+	case "configbundle.SourceSpec.nodes":
+		return arrayRule("Explicit nodes managed as members of this cluster.", 1)
+	case "configbundle.SourceNode.name":
+		return stringRule("Stable node name and default hostname.", dnsLabelPattern, 1, 63)
+	case "configbundle.SourceNode.controlPlane":
+		return schemaFieldRule{Description: "Whether this node is a Kubernetes control-plane member.", Default: false}
+	case "configbundle.SourceNode.access", "configbundle.SourceNodeLayer.access":
+		return description("Operator SSH access installed on the node.")
+	case "configbundle.SourceNode.kernel", "configbundle.SourceNodeLayer.kernel":
+		return description("Kernel command-line options owned by the operator.")
+	case "configbundle.SourceNode.hostConfiguration", "configbundle.SourceNodeLayer.hostConfiguration":
+		return description("Native host sysfs settings and named file sets.")
+	case "configbundle.SourceNode.systemExtensions", "configbundle.SourceNodeLayer.systemExtensions":
+		return description("Named system-extension bundles and their bounded configuration.")
+	case "configbundle.SourceNode.install", "configbundle.SourceNodeLayer.install":
+		return description("System disk selection constraints.")
+	case "configbundle.SourceNode.storage", "configbundle.SourceNodeLayer.storage":
+		return description("Persistent data volumes layered by name.")
+	case "configbundle.SourceNode.kubernetes", "configbundle.SourceNodeLayer.kubernetes":
+		return description("Per-node Kubernetes address, labels, and taints.")
+	case "configbundle.SourceNode.management":
+		return description("Workstation targeting used by katlctl; not persisted node state.")
+	case "configbundle.SourceManagementLayer.address":
+		return stringRule("Address used by katlctl to reach this node.", "", 1, 0)
+	case "configbundle.SourceAccess.ssh":
+		return description("SSH authorized-key configuration.")
+	case "configbundle.SourceSSHAccess.authorizedKeys":
+		return description("OpenSSH public keys authorized for operator access; an empty node list clears inherited keys.")
+	case "configbundle.SourceKernelConfig.commandLine":
+		return description("Complete kernel command-line option list; an empty node list clears inherited options.")
+	case "configbundle.SourceHostConfiguration.sysfs":
+		return description("Complete ordered sysfs setting list; an empty node list clears inherited settings.")
+	case "configbundle.SourceHostConfiguration.fileSets":
+		return mapRule("Named native /etc file sets; an empty node map clears inherited sets.", dnsLabelPattern)
+	case "configbundle.SourceHostConfigurationSysfsSetting.path":
+		return stringRule("Normalized writable path below /sys.", `^/sys/`, 6, 0)
+	case "configbundle.SourceHostConfigurationSysfsSetting.value":
+		return stringRule("Non-empty single-line value written at boot.", `^[^\r\n]+$`, 1, 0)
+	case "configbundle.SourceHostConfigurationFileSet.state":
+		return enumRule("Whether Katl manages or removes this named file set.", "present", "", "present", "absent")
+	case "configbundle.SourceHostConfigurationFileSet.files":
+		return description("Files owned by this set when present.")
+	case "configbundle.SourceHostConfigurationFileSet.onChange":
+		return description("Bounded systemd notifications after this set changes.")
+	case "configbundle.SourceSystemExtension.name":
+		return stringRule("Stable extension name used for layering and status.", dnsLabelPattern, 1, 63)
+	case "configbundle.SourceSystemExtension.state":
+		return enumRule("Whether the extension is present or removed.", "present", "", "present", "absent")
+	case "configbundle.SourceSystemExtension.bundle":
+		return stringRule("OCI bundle reference including registry, repository, and tag.", "", 1, 0)
+	case "configbundle.SourceSystemExtension.configuration":
+		return description("Files consumed by the selected extension.")
+	case "configbundle.SourceSystemExtension.units":
+		return description("Systemd units and drop-ins activated with the extension.")
+	case "configbundle.SourceInstallLayer.systemDisk":
+		return description("System disk selector. Defaults may provide only non-identifying size policy; each effective node requires one stable identity.")
+	case "configbundle.SourceStorageLayer.disks":
+		return description("Named whole-disk or partition-backed volumes.")
+	case "configbundle.SourceStorageDisk.name":
+		return stringRule("Volume name used to derive its GPT label and /var/mnt path.", dnsLabelPattern, 1, 63)
+	case "configbundle.SourceStorageDisk.state":
+		return enumRule("Whether Katl manages or stops managing this volume.", "present", "", "present", "absent")
+	case "configbundle.SourceStorageDisk.selector":
+		return description("Exactly one whole-disk or partition selector.")
+	case "configbundle.SourceStorageDisk.filesystem":
+		return enumRule("Filesystem required on the selected target.", nil, "xfs", "ext4", "btrfs")
+	case "configbundle.SourceStorageDisk.wipe":
+		return schemaFieldRule{Description: "Whether provisioning may format the selected target.", Default: false}
+	case "configbundle.SourceVolumeSelector.disk":
+		return description("Select a safe whole disk.")
+	case "configbundle.SourceVolumeSelector.partition":
+		return description("Select an existing partition; an empty object uses the u-{volume-name} GPT label convention.")
+	case "configbundle.SourceDiskSelector.byID":
+		return stringRule("Absolute stable /dev/disk/by-id path; an empty value clears an inherited identity.", `^(?:|/dev/disk/by-id/[^/]+)$`, 0, 0)
+	case "configbundle.SourceDiskSelector.wwn":
+		return description("Stable device world-wide name; an empty value clears an inherited identity.")
+	case "configbundle.SourceDiskSelector.serial":
+		return description("Stable device serial number; an empty value clears an inherited identity.")
+	case "configbundle.SourceDiskSelector.minSizeMiB":
+		return integerRule("Minimum acceptable device size in MiB.", 0, 0)
+	case "configbundle.SourcePartitionSelector.byID":
+		return stringRule("Absolute stable partition /dev/disk/by-id path; an empty value clears an inherited identity.", `^(?:|/dev/disk/by-id/[^/]+)$`, 0, 0)
+	case "configbundle.SourcePartitionSelector.partUUID":
+		return schemaFieldRule{Description: "GPT partition UUID; an empty value clears an inherited identity.", Pattern: `^(?:|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})$`}
+	case "configbundle.SourcePartitionSelector.filesystemUUID":
+		return description("Existing filesystem UUID; an empty value clears an inherited identity.")
+	case "configbundle.SourceKubernetesCluster.version":
+		return schemaFieldRule{Description: "Exact Kubernetes patch version compiled into the cluster.", Default: DefaultKubernetesVersion, Pattern: `^(?:|v[0-9]+\.[0-9]+\.[0-9]+)$`}
+	case "configbundle.SourceKubernetesCluster.kubeadm":
+		return description("Optional native kubeadm configuration and patches.")
+	case "configbundle.SourceKubeadmInput.configFile":
+		return schemaFieldRule{Required: true, Description: "Relative path to the multi-document kubeadm configuration file.", MinLength: intPointer(1)}
+	case "configbundle.SourceKubeadmInput.patchesDir":
+		return stringRule("Optional relative directory containing kubeadm patches.", "", 1, 0)
+	case "configbundle.SourceKubernetesLayer.address":
+		return stringRule("Literal unicast IP used as the Kubernetes node address.", "", 2, 0)
+	case "configbundle.SourceKubernetesLayer.labels":
+		return mapRule("Kubernetes labels merged by key; an empty node map clears inherited labels.", kubernetesLabelKeyPattern)
+	case "configbundle.SourceKubernetesLayer.taints":
+		return description("Complete Kubernetes taint list; an empty node list clears inherited taints.")
+	case "controlplaneendpoint.Config.host":
+		return stringRule("Stable Kubernetes API DNS name or IP address.", "", 1, 253)
+	case "controlplaneendpoint.Config.port":
+		return integerDefaultRule("Kubernetes API port; zero selects the default.", 0, 65535, 6443)
+	case "controlplaneendpoint.Config.advertisement":
+		return description("Optional Katl-managed routed API endpoint advertisement.")
+	case "controlplaneendpoint.Advertisement.vip":
+		return schemaFieldRule{Description: "Bare routed IPv4 API address.", Format: "ipv4"}
+	case "controlplaneendpoint.Advertisement.bgp":
+		return description("BGP peers and optional route exchanges.")
+	case "controlplaneendpoint.BGP.localASN":
+		return integerRule("Local BGP autonomous system number.", 1, 4294967294)
+	case "controlplaneendpoint.BGP.peers":
+		return arrayRule("BGP peers receiving the API route.", 1)
+	case "controlplaneendpoint.BGP.routeExchanges":
+		return description("Optional bounded route-exchange listeners.")
+	case "controlplaneendpoint.Peer.address":
+		return schemaFieldRule{Description: "Usable peer IPv4 address.", Format: "ipv4"}
+	case "controlplaneendpoint.Peer.asn":
+		return integerRule("Peer autonomous system number.", 1, 4294967294)
+	case "controlplaneendpoint.RouteExchange.name":
+		return stringRule("DNS-label-style route exchange name.", dnsLabelPattern, 1, 63)
+	case "controlplaneendpoint.RouteExchange.listenPort":
+		return integerDefaultRule("BGP listener port; zero selects 179 when one exchange exists.", 0, 65535, 179)
+	case "controlplaneendpoint.RouteExchange.peerASN":
+		return integerRule("Expected peer autonomous system number; zero selects localASN.", 0, 4294967294)
+	case "controlplaneendpoint.RouteExchange.exportToFabric":
+		return description("IPv4 prefix envelopes eligible for export.")
+	case "controlplaneendpoint.PrefixEnvelope.cidr":
+		return schemaFieldRule{Description: "IPv4 CIDR eligible for export.", Pattern: `^[0-9.]+/[0-9]{1,2}$`}
+	case "controlplaneendpoint.PrefixEnvelope.exactPrefixLength":
+		return integerRule("Optional exact exported prefix length.", 0, 32)
+	case "manifest.HostConfigurationFile.path":
+		return stringRule("Normalized file path below /etc.", `^/etc/`, 6, 0)
+	case "manifest.HostConfigurationFile.content":
+		return description("Inline UTF-8 file content, mutually exclusive with source.")
+	case "manifest.HostConfigurationFile.source":
+		return stringRule("Relative source file path, mutually exclusive with content.", "", 1, 0)
+	case "manifest.HostConfigurationFile.mode":
+		return schemaFieldRule{Description: "File mode; zero selects 0644, or set 0600, 0640, or 0644.", Default: 420, Enum: []any{0, 384, 416, 420}}
+	case "manifest.HostConfigurationNotifications.systemd":
+		return description("Systemd units notified after files change.")
+	case "manifest.HostConfigurationSystemdNotification.unit":
+		return stringRule("Single systemd unit name.", systemdUnitPattern, 1, 255)
+	case "manifest.HostConfigurationSystemdNotification.action":
+		return enumRule("Bounded non-disruptive systemd action.", nil, "reload", "try-reload-or-restart", "try-restart")
+	case "manifest.SystemExtensionConfiguration.files":
+		return description("Files delivered to the extension configuration namespace.")
+	case "manifest.SystemExtensionUnit.name":
+		return stringRule("Single systemd unit name owned by the extension.", systemdUnitPattern, 1, 255)
+	case "manifest.SystemExtensionUnit.enable":
+		return schemaFieldRule{Description: "Enable the unit in the generated configuration.", Default: false}
+	case "manifest.SystemExtensionUnit.requiredForBootHealth":
+		return schemaFieldRule{Description: "Require the unit to be healthy before boot succeeds.", Default: false}
+	case "manifest.SystemExtensionUnit.dropIns":
+		return description("Named systemd drop-ins for this unit.")
+	case "manifest.SystemExtensionUnitDropIn.name":
+		return schemaFieldRule{Description: "Safe basename ending in .conf.", Pattern: `^[^/]+\.conf$`, MinLength: intPointer(6)}
+	case "manifest.SystemExtensionUnitDropIn.content":
+		return description("Inline UTF-8 drop-in content, mutually exclusive with source.")
+	case "manifest.SystemExtensionUnitDropIn.source":
+		return stringRule("Relative source file path, mutually exclusive with content.", "", 1, 0)
+	case "manifest.NodeTaint.key":
+		return stringRule("Kubernetes taint key.", kubernetesLabelKeyPattern, 1, 253)
+	case "manifest.NodeTaint.value":
+		return schemaFieldRule{Description: "Optional Kubernetes taint value.", MaxLength: intPointer(63)}
+	case "manifest.NodeTaint.effect":
+		return enumRule("Kubernetes scheduling effect.", nil, "NoSchedule", "PreferNoSchedule", "NoExecute")
+	default:
+		return schemaFieldRule{}
+	}
+}
+
+func sourceSchemaTypeRule(t reflect.Type) schemaTypeRule {
+	switch schemaTypeName(t) {
+	case "configbundle.SourceVolumeSelector":
+		return schemaTypeRule{OneOf: exactlyOneRequired("disk", "partition")}
+	case "configbundle.SourceDiskSelector":
+		return schemaTypeRule{OneOf: atMostOneRequired("byID", "wwn", "serial")}
+	case "configbundle.SourcePartitionSelector":
+		return schemaTypeRule{OneOf: atMostOneRequired("byID", "partUUID", "filesystemUUID")}
+	case "manifest.HostConfigurationFile":
+		return schemaTypeRule{OneOf: exactlyOneRequired("content", "source")}
+	case "manifest.SystemExtensionUnitDropIn":
+		return schemaTypeRule{OneOf: exactlyOneRequired("content", "source")}
+	default:
+		return schemaTypeRule{}
+	}
+}
+
+func exactlyOneRequired(first, second string) []schemaObject {
+	return []schemaObject{
+		{Required: []string{first}, Not: &schemaObject{Required: []string{second}}},
+		{Required: []string{second}, Not: &schemaObject{Required: []string{first}}},
+	}
+}
+
+func atMostOneRequired(fields ...string) []schemaObject {
+	nonEmpty := make([]schemaObject, len(fields))
+	for i, field := range fields {
+		nonEmpty[i] = nonEmptyRequired(field)
+	}
+	branches := []schemaObject{{Not: &schemaObject{AnyOf: nonEmpty}}}
+	for i, field := range fields {
+		others := make([]schemaObject, 0, len(fields)-1)
+		for j := range fields {
+			if i != j {
+				others = append(others, nonEmpty[j])
+			}
+		}
+		branches = append(branches, schemaObject{
+			Required:   []string{field},
+			Properties: nonEmpty[i].Properties,
+			Not:        &schemaObject{AnyOf: others},
+		})
+	}
+	return branches
+}
+
+func nonEmptyRequired(field string) schemaObject {
+	return schemaObject{
+		Required: []string{field},
+		Properties: map[string]schemaObject{
+			field: {Not: &schemaObject{Const: ""}},
+		},
+	}
+}
+
+const (
+	dnsLabelPattern           = `^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`
+	kubernetesLabelKeyPattern = `^(?:[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?/)?[A-Za-z0-9](?:[-A-Za-z0-9_.]*[A-Za-z0-9])?$`
+	systemdUnitPattern        = `^[A-Za-z0-9][A-Za-z0-9:_.@-]*\.(?:service|socket|target|timer|path|mount|automount|slice|scope|device|swap)$`
+)
+
+func description(value string) schemaFieldRule {
+	return schemaFieldRule{Description: value}
+}
+
+func stringRule(description, pattern string, minLength, maxLength int) schemaFieldRule {
+	rule := schemaFieldRule{Description: description, Pattern: pattern}
+	if minLength > 0 {
+		rule.MinLength = intPointer(minLength)
+	}
+	if maxLength > 0 {
+		rule.MaxLength = intPointer(maxLength)
+	}
+	return rule
+}
+
+func enumRule(description string, defaultValue any, values ...string) schemaFieldRule {
+	enums := make([]any, len(values))
+	for i, value := range values {
+		enums[i] = value
+	}
+	return schemaFieldRule{Description: description, Default: defaultValue, Enum: enums}
+}
+
+func integerRule(description string, minimum, maximum int64) schemaFieldRule {
+	rule := schemaFieldRule{Description: description, Minimum: int64Pointer(minimum)}
+	if maximum > 0 {
+		rule.Maximum = int64Pointer(maximum)
+	}
+	return rule
+}
+
+func integerDefaultRule(description string, minimum, maximum int64, defaultValue int) schemaFieldRule {
+	rule := integerRule(description, minimum, maximum)
+	rule.Default = defaultValue
+	return rule
+}
+
+func arrayRule(description string, minItems int) schemaFieldRule {
+	return schemaFieldRule{Description: description, MinItems: intPointer(minItems)}
+}
+
+func mapRule(description, keyPattern string) schemaFieldRule {
+	return schemaFieldRule{Description: description, PropertyNames: &schemaObject{Pattern: keyPattern}}
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}

--- a/internal/installer/configbundle/schema_test.go
+++ b/internal/installer/configbundle/schema_test.go
@@ -1,0 +1,121 @@
+package configbundle
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSourceSchemaAcceptsConfigsAcceptedByKatl(t *testing.T) {
+	partitionBacked := strings.Replace(validSourceConfig(), `          selector:
+            disk:
+              byID: /dev/disk/by-id/ata-data
+`, `          selector:
+            partition: {}
+`, 1)
+	zeroDefaults := strings.Replace(validSourceConfig(), "    port: 6443\n", "    port: 0\n", 1)
+	zeroDefaults = strings.Replace(zeroDefaults, "    version: v1.36.1\n", `    version: ""
+`, 1)
+	zeroDefaults = strings.Replace(zeroDefaults, "          files:\n", `          state: ""
+          files:
+`, 1)
+	zeroDefaults = strings.Replace(zeroDefaults, "              content: |\n", `              mode: 0
+              content: |
+`, 1)
+	clearedIdentity := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/zone: rack-a\n", `      storage:
+        disks:
+          - name: data
+            selector:
+              disk:
+                byID: ""
+                serial: data-for-cp-1
+      kubernetes:
+        labels:
+          katl.dev/zone: rack-a
+`, 1)
+
+	schema := newSourceSchemaValidator(t)
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "whole disk", source: validSourceConfig()},
+		{name: "convention partition", source: partitionBacked},
+		{name: "explicit default values", source: zeroDefaults},
+		{name: "clear inherited identity", source: clearedIdentity},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := schema.Validate(sourceSchemaValue(t, test.source)); err != nil {
+				t.Fatalf("schema rejected valid ClusterConfig: %v", err)
+			}
+			if _, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, test.source)}); err != nil {
+				t.Fatalf("BuildArchive() rejected schema-valid ClusterConfig: %v", err)
+			}
+		})
+	}
+}
+
+func TestSourceSchemaRejectsSemanticErrors(t *testing.T) {
+	schema := newSourceSchemaValidator(t)
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "disk and partition",
+			source: strings.Replace(validSourceConfig(), `          selector:
+            disk:
+              byID: /dev/disk/by-id/ata-data
+`, `          selector:
+            disk:
+              byID: /dev/disk/by-id/ata-data
+            partition: {}
+`, 1),
+		},
+		{
+			name: "multiple disk identities",
+			source: strings.Replace(validSourceConfig(), "          byID: /dev/disk/by-id/ata-cp-root\n", `          byID: /dev/disk/by-id/ata-cp-root
+          serial: duplicate-identity
+`, 1),
+		},
+		{
+			name:   "unsupported filesystem",
+			source: strings.Replace(validSourceConfig(), "          filesystem: xfs\n", "          filesystem: zfs\n", 1),
+		},
+		{
+			name:   "port out of range",
+			source: strings.Replace(validSourceConfig(), "    port: 6443\n", "    port: 65536\n", 1),
+		},
+		{
+			name:   "missing node name",
+			source: strings.Replace(validSourceConfig(), "    - name: worker-1\n", "    - controlPlane: false\n", 1),
+		},
+		{
+			name: "missing nested sysfs value",
+			source: strings.Replace(validSourceConfig(), "    hostConfiguration:\n", `    hostConfiguration:
+      sysfs:
+        - path: /sys/module/printk/parameters/time
+`, 1),
+		},
+		{
+			name: "file content and source",
+			source: strings.Replace(validSourceConfig(), `            - path: /etc/systemd/network/10-common.network
+              content: |
+                [Match]
+                Name=enp1s0
+
+                [Network]
+                DHCP=yes
+`, `            - path: /etc/example
+              content: inline
+              source: example.conf
+`, 1),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := schema.Validate(sourceSchemaValue(t, test.source)); err == nil {
+				t.Fatal("schema accepted semantically invalid ClusterConfig")
+			}
+		})
+	}
+}

--- a/internal/installer/configbundle/schema_validator_test.go
+++ b/internal/installer/configbundle/schema_validator_test.go
@@ -1,0 +1,267 @@
+package configbundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net"
+	"regexp"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+type sourceSchemaValidator struct {
+	document map[string]any
+}
+
+func newSourceSchemaValidator(t *testing.T) sourceSchemaValidator {
+	t.Helper()
+	data, err := SourceSchema()
+	if err != nil {
+		t.Fatalf("SourceSchema() error = %v", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("decode source schema: %v", err)
+	}
+	return sourceSchemaValidator{document: document}
+}
+
+func (validator sourceSchemaValidator) Validate(value any) error {
+	return validator.validate(validator.document, value, "$")
+}
+
+func sourceSchemaValue(t *testing.T, source string) any {
+	t.Helper()
+	var value any
+	if err := yaml.Unmarshal([]byte(source), &value); err != nil {
+		t.Fatalf("decode source YAML: %v", err)
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encode source JSON: %v", err)
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("decode source JSON: %v", err)
+	}
+	return value
+}
+
+func (validator sourceSchemaValidator) validate(schema map[string]any, value any, path string) error {
+	if ref, ok := schema["$ref"].(string); ok {
+		const prefix = "#/$defs/"
+		if !strings.HasPrefix(ref, prefix) {
+			return fmt.Errorf("%s: unsupported schema reference %q", path, ref)
+		}
+		definitions := validator.document["$defs"].(map[string]any)
+		definition, ok := definitions[strings.TrimPrefix(ref, prefix)].(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s: unresolved schema reference %q", path, ref)
+		}
+		if err := validator.validate(definition, value, path); err != nil {
+			return err
+		}
+	}
+	if expected, exists := schema["const"]; exists && !equalJSON(expected, value) {
+		return fmt.Errorf("%s: value does not equal const", path)
+	}
+	if enums, ok := schema["enum"].([]any); ok {
+		matched := false
+		for _, candidate := range enums {
+			matched = matched || equalJSON(candidate, value)
+		}
+		if !matched {
+			return fmt.Errorf("%s: value is not in enum", path)
+		}
+	}
+	if err := validator.validateCombinations(schema, value, path); err != nil {
+		return err
+	}
+	typeName, _ := schema["type"].(string)
+	if typeName == "" && hasObjectKeywords(schema) {
+		if object, ok := value.(map[string]any); ok {
+			return validator.validateObject(schema, object, path)
+		}
+	}
+	switch typeName {
+	case "object":
+		object, ok := value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s: value is not an object", path)
+		}
+		return validator.validateObject(schema, object, path)
+	case "array":
+		array, ok := value.([]any)
+		if !ok {
+			return fmt.Errorf("%s: value is not an array", path)
+		}
+		return validator.validateArray(schema, array, path)
+	case "string":
+		text, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("%s: value is not a string", path)
+		}
+		return validateSchemaString(schema, text, path)
+	case "integer":
+		number, ok := value.(float64)
+		if !ok || math.Trunc(number) != number {
+			return fmt.Errorf("%s: value is not an integer", path)
+		}
+		return validateSchemaNumber(schema, number, path)
+	case "number":
+		number, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("%s: value is not a number", path)
+		}
+		return validateSchemaNumber(schema, number, path)
+	case "boolean":
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("%s: value is not a boolean", path)
+		}
+	}
+	return nil
+}
+
+func hasObjectKeywords(schema map[string]any) bool {
+	for _, keyword := range []string{"properties", "required", "additionalProperties", "propertyNames"} {
+		if _, ok := schema[keyword]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (validator sourceSchemaValidator) validateCombinations(schema map[string]any, value any, path string) error {
+	if alternatives, ok := schema["oneOf"].([]any); ok {
+		matches := 0
+		for _, alternative := range alternatives {
+			if validator.validate(alternative.(map[string]any), value, path) == nil {
+				matches++
+			}
+		}
+		if matches != 1 {
+			return fmt.Errorf("%s: value matches %d oneOf branches", path, matches)
+		}
+	}
+	if alternatives, ok := schema["anyOf"].([]any); ok {
+		for _, alternative := range alternatives {
+			if validator.validate(alternative.(map[string]any), value, path) == nil {
+				return nil
+			}
+		}
+		return fmt.Errorf("%s: value does not match anyOf", path)
+	}
+	if excluded, ok := schema["not"].(map[string]any); ok && validator.validate(excluded, value, path) == nil {
+		return fmt.Errorf("%s: value matches excluded schema", path)
+	}
+	return nil
+}
+
+func (validator sourceSchemaValidator) validateObject(schema map[string]any, object map[string]any, path string) error {
+	for _, field := range stringsFromJSON(schema["required"]) {
+		if _, ok := object[field]; !ok {
+			return fmt.Errorf("%s.%s: required property is missing", path, field)
+		}
+	}
+	properties, _ := schema["properties"].(map[string]any)
+	for field, value := range object {
+		property, known := properties[field].(map[string]any)
+		if known {
+			if err := validator.validate(property, value, path+"."+field); err != nil {
+				return err
+			}
+			continue
+		}
+		switch additional := schema["additionalProperties"].(type) {
+		case bool:
+			if !additional {
+				return fmt.Errorf("%s.%s: additional property is not allowed", path, field)
+			}
+		case map[string]any:
+			if err := validator.validate(additional, value, path+"."+field); err != nil {
+				return err
+			}
+		}
+	}
+	if names, ok := schema["propertyNames"].(map[string]any); ok {
+		for field := range object {
+			if err := validator.validate(names, field, path+"."+field); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (validator sourceSchemaValidator) validateArray(schema map[string]any, array []any, path string) error {
+	if minimum, ok := schema["minItems"].(float64); ok && len(array) < int(minimum) {
+		return fmt.Errorf("%s: array is too short", path)
+	}
+	if maximum, ok := schema["maxItems"].(float64); ok && len(array) > int(maximum) {
+		return fmt.Errorf("%s: array is too long", path)
+	}
+	items, _ := schema["items"].(map[string]any)
+	for i, value := range array {
+		if err := validator.validate(items, value, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSchemaString(schema map[string]any, value, path string) error {
+	length := utf8.RuneCountInString(value)
+	if minimum, ok := schema["minLength"].(float64); ok && length < int(minimum) {
+		return fmt.Errorf("%s: string is too short", path)
+	}
+	if maximum, ok := schema["maxLength"].(float64); ok && length > int(maximum) {
+		return fmt.Errorf("%s: string is too long", path)
+	}
+	if pattern, ok := schema["pattern"].(string); ok {
+		pattern = strings.ReplaceAll(pattern, "?:", "")
+		matched, err := regexp.MatchString(pattern, value)
+		if err != nil || !matched {
+			return fmt.Errorf("%s: string does not match pattern", path)
+		}
+	}
+	switch schema["format"] {
+	case "ipv4":
+		if address := net.ParseIP(value); address == nil || address.To4() == nil {
+			return fmt.Errorf("%s: string is not IPv4", path)
+		}
+	case "uuid":
+		matched, _ := regexp.MatchString(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`, value)
+		if !matched {
+			return fmt.Errorf("%s: string is not a UUID", path)
+		}
+	}
+	return nil
+}
+
+func validateSchemaNumber(schema map[string]any, value float64, path string) error {
+	if minimum, ok := schema["minimum"].(float64); ok && value < minimum {
+		return fmt.Errorf("%s: number is below minimum", path)
+	}
+	if maximum, ok := schema["maximum"].(float64); ok && value > maximum {
+		return fmt.Errorf("%s: number is above maximum", path)
+	}
+	return nil
+}
+
+func stringsFromJSON(value any) []string {
+	items, _ := value.([]any)
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.(string))
+	}
+	return result
+}
+
+func equalJSON(left, right any) bool {
+	leftJSON, _ := json.Marshal(left)
+	rightJSON, _ := json.Marshal(right)
+	return string(leftJSON) == string(rightJSON)
+}


### PR DESCRIPTION
## Summary

- generate nested required fields, enums, defaults, ranges, descriptions, and map-key constraints for the public ClusterConfig schema
- express disk/partition and content/source exclusivity, including stable-identity selection that preserves explicit clearing
- add conformance coverage proving representative schema-valid documents compile and semantic errors are rejected

## Why

The reflection-only schema described Go shapes but omitted much of the public authoring contract. Editors and JSON Schema validators could therefore accept ambiguous or incomplete configuration that Katl rejected later during compilation.
