### PR TITLE
lifecycle: enforce explicit node transitions

### DIFF
--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -31,7 +31,20 @@ var kubeadmConfigNow = func() time.Time { return time.Now().UTC() }
 
 func newClusterApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
 	opts := kubeadmControlPlaneConfigOptions{}
-	cmd := &cobra.Command{Use: "apply", Short: "Apply the complete ClusterConfig to a running cluster", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error { return runClusterApply(ctx, opts, stdout, stderr) }}
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply the complete ClusterConfig to a running cluster",
+		Long: `Apply the complete ClusterConfig to the nodes it lists.
+
+Omitting a node stops targeting it but never drains, deletes, powers off, or
+wipes that node. Use 'katlctl node wipe NODE --config CURRENT --plan' while the
+node is still listed before an intentional removal, rename, replacement, or
+role change. Enrolled node renames and role changes are refused here.`,
+		Args: cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return runClusterApply(ctx, opts, stdout, stderr)
+		},
+	}
 	f := cmd.Flags()
 	f.StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	f.StringVar(&opts.inventoryPath, "inventory", "", "advanced cluster inventory")
@@ -452,6 +465,10 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			_ = conn.Close()
 			return activatedClusterConfig{}, fmt.Errorf("status %s before cluster config apply: %w", node.Name, err)
 		}
+		if err := validateClusterNodeLifecycle(node, status); err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, err
+		}
 		validation, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion: operation.APIVersion, Kind: "ValidateConfigRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
 			Actor: "katlctl cluster apply", ExpectedMachineId: status.MachineId, ApplyMode: generation.ApplyModeAuto,
@@ -463,7 +480,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		}
 		if !validation.Accepted {
 			_ = conn.Close()
-			return activatedClusterConfig{}, fmt.Errorf("node %s rejected cluster config: %s", node.Name, firstNonEmpty(validation.FailureReason, strings.Join(validation.Diagnostics, "; ")))
+			return activatedClusterConfig{}, fmt.Errorf("node %s rejected cluster config: %s", node.Name, clusterConfigRejection(node.Name, validation))
 		}
 		if err := clusterApplyProgress(opts.progress, "phase=config-validation node=%s status=succeeded", node.Name); err != nil {
 			_ = conn.Close()
@@ -635,6 +652,49 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		joinNodes:       joinNodes,
 		joinCoordinator: joinCoordinator,
 	}, nil
+}
+
+func validateClusterNodeLifecycle(node inventory.Node, status *agentapi.NodeStatus) error {
+	kubernetes := status.GetKubernetes()
+	if kubernetes == nil || strings.TrimSpace(kubernetes.GetState()) == "" || strings.TrimSpace(kubernetes.GetState()) == "not-configured" {
+		return nil
+	}
+	observedName := strings.TrimSpace(kubernetes.GetNodeName())
+	if observedName != "" && observedName != node.Name {
+		return fmt.Errorf(
+			"refusing cluster apply for node %q at %s: the host is enrolled in Kubernetes as %q; enrolled node rename is unsupported; restore spec.nodes[].name to %q, or plan 'katlctl node wipe %s --config <previous-config> --plan' before reinstalling it with the new name; no node was wiped",
+			node.Name, node.Address, observedName, observedName, observedName,
+		)
+	}
+	observedRole := strings.TrimSpace(kubernetes.GetRole())
+	if observedRole != "" && observedRole != string(node.SystemRole) {
+		return fmt.Errorf(
+			"refusing cluster apply for node %q: desired role is %q but the enrolled Kubernetes role is %q; role changes require 'katlctl node wipe %s --config <current-config> --plan', reinstall with the desired role, then cluster apply; no node was wiped",
+			node.Name, node.SystemRole, observedRole, node.Name,
+		)
+	}
+	return nil
+}
+
+func clusterConfigRejection(node string, validation *agentapi.ConfigValidationResult) string {
+	if validation == nil {
+		return "node returned an empty validation result"
+	}
+	diagnostics := strings.TrimSpace(strings.Join(validation.Diagnostics, "; "))
+	if strings.Contains(diagnostics, configapply.DomainSystemRole+":") {
+		diagnostics += fmt.Sprintf(
+			"; keep the node in its current config and plan 'katlctl node wipe %s --config <current-config> --plan', then reinstall it with the desired role and retry; no node was wiped",
+			node,
+		)
+	}
+	failure := strings.TrimSpace(validation.FailureReason)
+	if diagnostics == "" {
+		return firstNonEmpty(failure, "configuration was rejected without a diagnostic")
+	}
+	if failure == "" || (strings.HasPrefix(failure, "config apply ") && strings.Contains(failure, " request rejected for ")) {
+		return diagnostics
+	}
+	return failure + "; " + diagnostics
 }
 
 func containsKubernetesConfigDomain(domains []string) bool {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -346,6 +346,84 @@ func TestActivateClusterConfigPlansOneFreshReplacementNode(t *testing.T) {
 	}
 }
 
+func TestActivateClusterConfigRefusesEnrolledNameAndRoleChangesBeforeValidation(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		kubernetes *agentapi.KubernetesStatus
+		want       []string
+	}{
+		{
+			name:       "rename",
+			kubernetes: &agentapi.KubernetesStatus{State: "ready", NodeName: "cp-old", Role: "control-plane"},
+			want:       []string{`enrolled in Kubernetes as "cp-old"`, "enrolled node rename is unsupported", "katlctl node wipe cp-old", "no node was wiped"},
+		},
+		{
+			name:       "role change",
+			kubernetes: &agentapi.KubernetesStatus{State: "ready", NodeName: "cp-1", Role: "worker"},
+			want:       []string{`desired role is "control-plane"`, `enrolled Kubernetes role is "worker"`, "role changes require", "no node was wiped"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			configPath := writeClusterConfig(t)
+			client := &fakeKatlcAgentClient{
+				nodeStatus: &agentapi.NodeStatus{
+					MachineId:           "machine-cp-1",
+					CurrentGenerationId: "generation-1",
+					Kubernetes:          test.kubernetes,
+				},
+				validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live", NoChanges: true},
+			}
+			previousDial := dialKatlcAgent
+			defer func() { dialKatlcAgent = previousDial }()
+			dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+				if endpoint != "10.0.0.11:9443" {
+					t.Fatalf("endpoint = %q", endpoint)
+				}
+				return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+			}
+
+			_, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, []inventory.Node{{
+				Name: "cp-1", Address: "10.0.0.11", SystemRole: inventory.RoleControlPlane, KubeadmConfig: inventory.KubeadmConfig{Ref: "control-plane"},
+			}})
+			if err == nil {
+				t.Fatal("activateClusterConfig() accepted an enrolled lifecycle change")
+			}
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("activateClusterConfig() error = %q, want %q", err, want)
+				}
+			}
+			if client.validateRequest != nil || len(client.submitRequests) != 0 {
+				t.Fatalf("lifecycle refusal reached validation or mutation: validate=%#v submit=%#v", client.validateRequest, client.submitRequests)
+			}
+		})
+	}
+}
+
+func TestValidateClusterNodeLifecycleAllowsFreshReplacement(t *testing.T) {
+	err := validateClusterNodeLifecycle(inventory.Node{Name: "cp-1", Address: "10.0.0.11", SystemRole: inventory.RoleControlPlane}, &agentapi.NodeStatus{
+		Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"},
+	})
+	if err != nil {
+		t.Fatalf("validateClusterNodeLifecycle() error = %v", err)
+	}
+}
+
+func TestClusterConfigRejectionExplainsRoleChangeRecovery(t *testing.T) {
+	message := clusterConfigRejection("katldev", &agentapi.ConfigValidationResult{
+		FailureReason: "config apply auto request rejected for 1 domain(s)",
+		Diagnostics:   []string{"system-role: rejected: domain requires wipe-reinstall"},
+	})
+	for _, want := range []string{"system-role: rejected", "katlctl node wipe katldev", "reinstall it with the desired role", "no node was wiped"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("clusterConfigRejection() = %q, want %q", message, want)
+		}
+	}
+	if strings.Contains(message, "request rejected for 1 domain") {
+		t.Fatalf("clusterConfigRejection() retained generic failure: %q", message)
+	}
+}
+
 func TestRunClusterApplyRefreshesReplacementGenerationAfterJoin(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -245,6 +245,16 @@ persistent node intent and is reconciled by supported configuration workflows.
 Kubernetes version changes are handled by the Kubernetes upgrade workflow
 rather than ordinary node configuration apply.
 
+The node list is not destructive reconciliation authority. Omitting a node
+stops targeting it and preserves its host, Kubernetes membership, etcd
+membership, partitions, filesystems, and data. Removal, enrolled rename,
+replacement, and role change use the explicit node wipe/reinstall workflow so
+the affected node is named and Kubernetes or etcd membership is handled before
+any node-local reset. Cluster apply refuses an enrolled name or role mismatch;
+one fresh same-name replacement may join at a time after the explicit wipe and
+reinstall workflow. An unenrolled hostname change remains an ordinary
+next-boot configuration change.
+
 ## Rejected Flexibility
 
 Katl v1alpha1 rejects aliases and speculative mechanisms including:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -21,6 +21,7 @@ networks.
 | Kubeadm cluster has no CNI | Install Cilium without mutating the host generation | [Run Cilium on KatlOS](cilium.md) |
 | Installed node | Inspect or reboot one host | [Access installed nodes](access.md#routine-host-management) |
 | Installed or bootstrapped node | Change supported runtime configuration | [Apply node configuration](configure-nodes.md) |
+| Node list, name, role, or hardware is changing | Review the supported transition and explicit refusal/recovery path | [Node lifecycle matrix](configure-nodes.md#node-lifecycle-matrix) |
 | Healthy installed node | Stage a new KatlOS release | [Upgrade a KatlOS host](upgrade-host.md) |
 | One control plane is being replaced | Preserve the healthy cluster and rejoin one fresh node | [Wipe and reinstall](wipe-reinstall.md#plan-one-node-replacement) |
 | Cluster is intentionally being discarded | Reset boot state and reinstall | [Wipe and reinstall](wipe-reinstall.md) |

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -26,6 +26,37 @@ mutation and then reconciles every affected Kubernetes component online. A
 Kubernetes configuration change never falls back to next-boot application or
 requires a host reboot.
 
+## Node Lifecycle Matrix
+
+`spec.nodes` is both the install inventory and the set of nodes targeted by
+`katlctl cluster apply`. Editing the list is not authority to mutate a node that
+is no longer listed. In particular, omission never drains a Kubernetes Node,
+removes an etcd member, powers off a host, changes partitions, formats storage,
+or wipes KatlOS.
+
+| Desired change | `cluster apply` behavior | Supported operator path |
+| --- | --- | --- |
+| Reorder nodes or change ordinary supported fields | Applies by stable node name | Run `katlctl cluster apply --config ./cluster.yaml` |
+| Add one installed, unenrolled node | Joins one fresh node at a time using a ready control plane | Install the new named node, add it to the config, then run `cluster apply` |
+| Replace hardware while keeping the node name and role | Joins the fresh replacement; it never wipes the old host implicitly | While the old node is still listed, run `katlctl node wipe NAME --config ./cluster.yaml --plan`, execute the reviewed wipe with the required kubeconfig, reinstall the replacement, then run `cluster apply` |
+| Remove a node from the cluster | Omission only stops Katl targeting; the old node and its data are preserved | Keep the node listed while planning and executing `katlctl node wipe NAME --config ./cluster.yaml --plan`; remove the entry only after the explicit Kubernetes/etcd-aware wipe succeeds |
+| Rename an unenrolled installed node | Stages the hostname through normal next-boot configuration | Apply, reboot, verify the new hostname, and only then bootstrap Kubernetes |
+| Rename an enrolled node | Refused before any node mutation | Keep the old name, or explicitly wipe it under the old config and reinstall it as a new node |
+| Change `controlPlane` / node role | Refused as an operation-only change | Explicitly wipe the named node, reinstall it with the desired role, then join it through `cluster apply` |
+| Change only `management.address` | Changes workstation targeting only | Verify the new address reaches the same node; no node generation or Kubernetes state changes |
+
+Removing one entry and adding another is never inferred to be a rename. It is a
+preserved omitted node plus a distinct addition until the operator completes
+the explicit removal/reinstall workflow. If an entry was removed too early,
+put it back with its old name and address, inspect its current status, and run
+the appropriate wipe plan. Do not reinstall merely to make the config match;
+preserve and diagnose the existing node first.
+
+The wipe workflow is intentionally separate because it names the affected
+node, proves Kubernetes and stacked-etcd removal where required, reports what
+disk state is preserved, and stops before installer formatting. See
+[Wipe and reinstall KatlOS](wipe-reinstall.md#plan-one-node-replacement).
+
 ## Configure Kernel Arguments
 
 Set `kernel.commandLine` under defaults or a concrete node:


### PR DESCRIPTION
## Summary

- publish the supported lifecycle matrix for adding, removing, renaming, replacing, and changing the role of a node
- refuse enrolled Kubernetes name or role mismatches before cluster configuration validation or mutation
- preserve omission as non-destructive stop-targeting behavior and keep the explicit wipe/reinstall replacement workflow
- surface an actionable node-scoped wipe plan when ordinary apply rejects a role transition

## Why

Node-list edits previously relied on behavior spread across configuration apply and wipe/reinstall documentation. That made omission and identity transitions ambiguous, and a rejected role change could lose its recovery guidance behind a generic validation message.
