### PR TITLE
storage: restrict defaults to safe policy

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -224,6 +224,12 @@ exactly one whole disk or one existing partition, and Katl derives both the GPT
 label `u-<name>` and mount path `/var/mnt/<name>`; operators cannot choose
 another location.
 
+Defaults may share non-identifying storage policy such as `minSizeMiB`, the
+filesystem, and `wipe: false`. Stable disk or partition identity and
+`wipe: true` must be set on the concrete node volume; Katl rejects them under
+`spec.defaults` so one inherited value cannot select or erase storage across
+the cluster.
+
 A disk-backed entry with `wipe: true` authorizes Katl to reinitialize the
 selected disk. Katl uses `systemd-repart` to create and format its
 convention-labelled partition:

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -50,6 +50,13 @@ and `state: absent` removes it. Structured disk selectors compose by supplied
 field so a common size constraint can be combined with a node-specific durable
 identifier.
 
+Storage defaults are policy, never target identity or destructive authority.
+They may carry fields such as `minSizeMiB`, `filesystem`, and explicit
+`wipe: false`. Katl rejects default `byID`, `wwn`, `serial`, every partition
+selector (including the convention-derived empty selector), `partUUID`,
+`filesystemUUID`, and `wipe: true`. Those choices must appear on the concrete
+node volume that they affect.
+
 ## Supported Shape
 
 ```yaml

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -659,6 +659,9 @@ func normalizeSource(source SourceConfig) (SourceConfig, error) {
 	if err := validateDefaultSystemDisk(source.Spec.Defaults.Install.SystemDisk); err != nil {
 		return SourceConfig{}, fmt.Errorf("spec.defaults.install.systemDisk: %w", err)
 	}
+	if err := validateDefaultStorageDisks(source.Spec.Defaults.Storage.Disks); err != nil {
+		return SourceConfig{}, err
+	}
 	if err := validateSourceStorageDisks("spec.defaults.storage.disks", source.Spec.Defaults.Storage.Disks, false); err != nil {
 		return SourceConfig{}, err
 	}

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -148,7 +148,7 @@ spec:
             disk:
               minSizeMiB: 1024
           filesystem: btrfs
-          wipe: true
+          wipe: false
         - name: scratch
           selector:
             disk:
@@ -208,6 +208,7 @@ spec:
             selector:
               disk:
                 byID: /dev/disk/by-id/overridden-data
+            wipe: true
           - name: scratch
             state: absent
       kubernetes:
@@ -892,6 +893,41 @@ func TestBuildArchiveRejectsUnsafeDiskDefaults(t *testing.T) {
 	}
 }
 
+func TestBuildArchiveRejectsUnsafeStorageDefaults(t *testing.T) {
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+		want        string
+	}{
+		{name: "by ID", old: "              minSizeMiB: 1024\n", replacement: "              byID: /dev/disk/by-id/shared-data\n", want: "spec.defaults.storage.disks[0].selector.disk.byID identifies a target"},
+		{name: "WWN", old: "              minSizeMiB: 1024\n", replacement: "              wwn: shared-data\n", want: "spec.defaults.storage.disks[0].selector.disk.wwn identifies a target"},
+		{name: "serial", old: "              minSizeMiB: 1024\n", replacement: "              serial: shared-data\n", want: "spec.defaults.storage.disks[0].selector.disk.serial identifies a target"},
+		{name: "partition by ID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              byID: /dev/disk/by-id/shared-data-part1\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
+		{name: "partition UUID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              partUUID: 01234567-89ab-cdef-0123-456789abcdef\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
+		{name: "filesystem UUID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              filesystemUUID: shared-data\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
+		{name: "convention partition", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition: {}\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
+		{name: "wipe", old: "          filesystem: xfs\n", replacement: "          filesystem: xfs\n          wipe: true\n", want: "spec.defaults.storage.disks[0].wipe must not be true"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := strings.Replace(validSourceConfig(), test.old, test.replacement, 1)
+			_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("BuildArchive() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestBuildArchiveAcceptsSafeStorageDefaultsAndNodeAuthority(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), "          filesystem: xfs\n", "          filesystem: xfs\n          wipe: false\n", 1)
+	source = strings.Replace(source, "                byID: /dev/disk/by-id/ata-cp-data\n", "                byID: /dev/disk/by-id/ata-cp-data\n            wipe: true\n", 1)
+	if _, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)}); err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+}
+
 func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1392,7 +1428,7 @@ spec:
         - name: data
           selector:
             disk:
-              byID: /dev/disk/by-id/ata-data
+              minSizeMiB: 1024
           filesystem: xfs
     access:
       ssh:
@@ -1417,6 +1453,12 @@ spec:
       install:
         systemDisk:
           byID: /dev/disk/by-id/ata-cp-root
+      storage:
+        disks:
+          - name: data
+            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
       kubernetes:
         labels:
           katl.dev/zone: rack-a
@@ -1429,6 +1471,12 @@ spec:
       install:
         systemDisk:
           byID: /dev/disk/by-id/ata-worker-root
+      storage:
+        disks:
+          - name: data
+            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-worker-data
       kubernetes:
         labels:
           katl.dev/pool: workers

--- a/internal/installer/configbundle/schema_test.go
+++ b/internal/installer/configbundle/schema_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 func TestSourceSchemaAcceptsConfigsAcceptedByKatl(t *testing.T) {
-	partitionBacked := strings.Replace(validSourceConfig(), `          selector:
-            disk:
-              byID: /dev/disk/by-id/ata-data
-`, `          selector:
-            partition: {}
+	partitionBacked := strings.Replace(validSourceConfig(), `            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
+`, `            selector:
+              partition: {}
 `, 1)
 	zeroDefaults := strings.Replace(validSourceConfig(), "    port: 6443\n", "    port: 0\n", 1)
 	zeroDefaults = strings.Replace(zeroDefaults, "    version: v1.36.1\n", `    version: ""
@@ -21,16 +21,8 @@ func TestSourceSchemaAcceptsConfigsAcceptedByKatl(t *testing.T) {
 	zeroDefaults = strings.Replace(zeroDefaults, "              content: |\n", `              mode: 0
               content: |
 `, 1)
-	clearedIdentity := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/zone: rack-a\n", `      storage:
-        disks:
-          - name: data
-            selector:
-              disk:
-                byID: ""
+	clearedIdentity := strings.Replace(validSourceConfig(), "                byID: /dev/disk/by-id/ata-cp-data\n", `                byID: ""
                 serial: data-for-cp-1
-      kubernetes:
-        labels:
-          katl.dev/zone: rack-a
 `, 1)
 
 	schema := newSourceSchemaValidator(t)
@@ -62,13 +54,13 @@ func TestSourceSchemaRejectsSemanticErrors(t *testing.T) {
 	}{
 		{
 			name: "disk and partition",
-			source: strings.Replace(validSourceConfig(), `          selector:
-            disk:
-              byID: /dev/disk/by-id/ata-data
-`, `          selector:
-            disk:
-              byID: /dev/disk/by-id/ata-data
-            partition: {}
+			source: strings.Replace(validSourceConfig(), `            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
+`, `            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
+              partition: {}
 `, 1),
 		},
 		{

--- a/internal/installer/configbundle/source_layering.go
+++ b/internal/installer/configbundle/source_layering.go
@@ -382,6 +382,41 @@ func validateDefaultSystemDisk(selector *SourceDiskSelector) error {
 	return nil
 }
 
+func validateDefaultStorageDisks(disks Optional[[]SourceStorageDisk]) error {
+	values, ok := disks.Get()
+	if !ok {
+		return nil
+	}
+	for i, volume := range values {
+		field := fmt.Sprintf("spec.defaults.storage.disks[%d]", i)
+		if wipe, supplied := volume.Wipe.Get(); supplied && wipe {
+			return fmt.Errorf("%s.wipe must not be true in defaults; set destructive authority on a concrete node volume", field)
+		}
+		if volume.Selector == nil {
+			continue
+		}
+		if volume.Selector.Partition != nil {
+			return fmt.Errorf("%s.selector.partition identifies a target and must be set on a concrete node volume", field)
+		}
+		if volume.Selector.Disk == nil {
+			continue
+		}
+		for _, identity := range []struct {
+			name  string
+			value Optional[string]
+		}{
+			{name: "byID", value: volume.Selector.Disk.ByID},
+			{name: "wwn", value: volume.Selector.Disk.WWN},
+			{name: "serial", value: volume.Selector.Disk.Serial},
+		} {
+			if configured, supplied := identity.value.Get(); supplied && strings.TrimSpace(configured) != "" {
+				return fmt.Errorf("%s.selector.disk.%s identifies a target and must be set on a concrete node volume", field, identity.name)
+			}
+		}
+	}
+	return nil
+}
+
 func validateSourceStorageDisks(field string, disks Optional[[]SourceStorageDisk], requireComplete bool) error {
 	values, ok := disks.Get()
 	if !ok {


### PR DESCRIPTION
## What changed

- restrict storage defaults to non-identifying policy such as minimum size and filesystem
- require stable disk or partition selectors and `wipe: true` on the concrete node volume
- document the safe layering contract and recovery guidance

## Why

Storage defaults previously allowed one inherited selector or destructive flag to target devices across the cluster. Validation now keeps target identity and destructive authority scoped to the affected node.
