### PR TITLE
storage: require operation-scoped wipe authority

### DIFF
--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -27,12 +27,13 @@ const (
 )
 
 type installApplyOptions struct {
-	endpoint   string
-	configPath string
-	nodeName   string
-	noWait     bool
-	timeout    time.Duration
-	output     string
+	endpoint                           string
+	configPath                         string
+	nodeName                           string
+	destructiveStorageAcknowledgements []string
+	noWait                             bool
+	timeout                            time.Duration
+	output                             string
 }
 
 type installStatusOptions struct {
@@ -70,6 +71,7 @@ func newInstallApplyCommand(ctx context.Context, stdout, stderr io.Writer) *cobr
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "ClusterConfig YAML or Katl config bundle")
 	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "installer address or HTTP(S) base URL; overrides the selected node's bootstrap address")
 	cmd.Flags().StringVar(&opts.nodeName, "node", "", "configured node name or bootstrap address; required unless the config contains one node")
+	cmd.Flags().StringArrayVar(&opts.destructiveStorageAcknowledgements, "acknowledge-storage-wipe", nil, "authorize overwriting one non-blank node volume as NODE/VOLUME (repeatable)")
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the installer accepts the bundle")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "overall handoff and install wait timeout")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text or json")
@@ -98,6 +100,10 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	}
 	if opts.timeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
+	}
+	acknowledgements, err := normalizeDestructiveStorageAcknowledgements(opts.destructiveStorageAcknowledgements)
+	if err != nil {
+		return err
 	}
 	config, err := loadKatlConfig(opts.configPath, installApplyCreator, configbundle.PlanningInputs{})
 	if err != nil {
@@ -143,7 +149,7 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 		return fmt.Errorf("installer is not accepting config: state=%s selectedNode=%s", before.State, before.SelectedNode)
 	}
 
-	accepted, err := submitInstallBundle(waitCtx, client, endpoint, archive, selected.BundleDigest, selected.Node.Name)
+	accepted, err := submitInstallBundle(waitCtx, client, endpoint, archive, selected.BundleDigest, selected.Node.Name, acknowledgements)
 	if err != nil {
 		return err
 	}
@@ -307,7 +313,7 @@ func fetchInstallStatus(ctx context.Context, client *http.Client, endpoint strin
 	return doInstallRequest(client, req, "read installer status")
 }
 
-func submitInstallBundle(ctx context.Context, client *http.Client, endpoint string, archive []byte, digest, node string) (handoff.HandoffStatus, error) {
+func submitInstallBundle(ctx context.Context, client *http.Client, endpoint string, archive []byte, digest, node string, acknowledgements []string) (handoff.HandoffStatus, error) {
 	requestURL, err := url.Parse(endpoint + "/v1/config-bundle")
 	if err != nil {
 		return handoff.HandoffStatus{}, fmt.Errorf("create installer handoff URL: %w", err)
@@ -315,6 +321,9 @@ func submitInstallBundle(ctx context.Context, client *http.Client, endpoint stri
 	query := requestURL.Query()
 	query.Set("node", node)
 	query.Set("digest", digest)
+	for _, acknowledgement := range acknowledgements {
+		query.Add("acknowledgeStorageWipe", acknowledgement)
+	}
 	requestURL.RawQuery = query.Encode()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(archive))
 	if err != nil {

--- a/cmd/katlctl/install_test.go
+++ b/cmd/katlctl/install_test.go
@@ -446,7 +446,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(status)
 	})
 	mux.HandleFunc("POST /v1/config-bundle", func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "" || r.URL.Query().Get("node") != "cp-1" || !strings.HasPrefix(r.URL.Query().Get("digest"), "sha256:") {
+		if r.Header.Get("Authorization") != "" || r.URL.Query().Get("node") != "cp-1" || !strings.HasPrefix(r.URL.Query().Get("digest"), "sha256:") || r.URL.Query().Get("acknowledgeStorageWipe") != "cp-1/data" {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
@@ -465,6 +465,7 @@ func TestInstallApplyWaitsForRebootReady(t *testing.T) {
 		"--output", "json",
 		"--endpoint", ts.URL,
 		"--node", "cp-1",
+		"--acknowledge-storage-wipe", "cp-1/data",
 		"--timeout", "5s",
 	}, &stdout, &stderr)
 	if err != nil {

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -25,6 +25,7 @@ type kubeadmControlPlaneConfigOptions struct {
 	configPath, inventoryPath, coordinator, generationID, configName string
 	rolloutID, component                                             string
 	progress                                                         io.Writer
+	destructiveStorageAcknowledgements                               []string
 }
 
 var kubeadmConfigNow = func() time.Time { return time.Now().UTC() }
@@ -52,6 +53,7 @@ role change. Enrolled node renames and role changes are refused here.`,
 	f.StringVar(&opts.generationID, "generation", "", "active desired generation ID")
 	f.StringVar(&opts.configName, "config-name", "", "selected KubeadmConfig name")
 	f.StringVar(&opts.rolloutID, "rollout-id", "", "rollout identity")
+	f.StringArrayVar(&opts.destructiveStorageAcknowledgements, "acknowledge-storage-wipe", nil, "authorize overwriting one non-blank node volume as NODE/VOLUME (repeatable)")
 	for _, name := range []string{"inventory", "generation", "config-name", "rollout-id"} {
 		cmd.Flags().Lookup(name).Hidden = true
 	}
@@ -60,6 +62,11 @@ role change. Enrolled node renames and role changes are refused here.`,
 
 func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions, stdout, stderr io.Writer) error {
 	opts.progress = stderr
+	acknowledgements, err := normalizeDestructiveStorageAcknowledgements(opts.destructiveStorageAcknowledgements)
+	if err != nil {
+		return err
+	}
+	opts.destructiveStorageAcknowledgements = acknowledgements
 	inv, err := kubeadmConfigInventory(opts)
 	if err != nil {
 		return err
@@ -473,6 +480,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			ApiVersion: operation.APIVersion, Kind: "ValidateConfigRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
 			Actor: "katlctl cluster apply", ExpectedMachineId: status.MachineId, ApplyMode: generation.ApplyModeAuto,
 			CandidateGenerationId: generationID, NodeName: node.Name, ConfigYaml: string(input.configYAML),
+			DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...),
 		})
 		if err != nil {
 			_ = conn.Close()
@@ -599,7 +607,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
 			OperationKind: operationKind, Actor: "katlctl cluster apply", ExpectedMachineId: input.machineID, ExpectedCurrentGenerationId: input.currentGeneration,
-			ConfigApply: &agentapi.ConfigApplyOperationRequest{CandidateGenerationId: generationID, ApplyMode: generation.ApplyModeAuto, NodeName: node.Name, ConfigYaml: string(input.configYAML)},
+			ConfigApply: &agentapi.ConfigApplyOperationRequest{CandidateGenerationId: generationID, ApplyMode: generation.ApplyModeAuto, NodeName: node.Name, ConfigYaml: string(input.configYAML), DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...)},
 		})
 		if err != nil {
 			_ = conn.Close()

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -619,14 +620,14 @@ func TestActivateClusterConfigUsesOneLiveWholeNodeGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1"}, inv.Nodes)
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1", destructiveStorageAcknowledgements: []string{"cp-1/data"}}, inv.Nodes)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if activated.generations["cp-1"] != "cluster-config-42" {
 		t.Fatalf("generations = %#v", activated.generations)
 	}
-	if client.validateRequest == nil || client.validateRequest.ApplyMode != "auto" || client.validateRequest.CandidateGenerationId != "cluster-config-42" {
+	if client.validateRequest == nil || client.validateRequest.ApplyMode != "auto" || client.validateRequest.CandidateGenerationId != "cluster-config-42" || !slices.Equal(client.validateRequest.DestructiveStorageAcknowledgements, []string{"cp-1/data"}) {
 		t.Fatalf("validate request = %#v", client.validateRequest)
 	}
 	for _, required := range []string{"identity:", "controlPlaneEndpoint:", "kubeadmConfigs:"} {
@@ -639,6 +640,9 @@ func TestActivateClusterConfigUsesOneLiveWholeNodeGeneration(t *testing.T) {
 	}
 	if client.submitRequest == nil || client.submitRequest.OperationKind != "generation-apply" || client.submitRequest.ConfigApply == nil {
 		t.Fatalf("submit request = %#v", client.submitRequest)
+	}
+	if !slices.Equal(client.submitRequest.ConfigApply.DestructiveStorageAcknowledgements, []string{"cp-1/data"}) {
+		t.Fatalf("submit acknowledgements = %v", client.submitRequest.ConfigApply.DestructiveStorageAcknowledgements)
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -23,6 +24,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/readiness"
 	"github.com/katl-dev/katl/internal/installer/configapply"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/katlosimage"
 	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
@@ -2024,18 +2026,19 @@ func configApplySystemExtensionPayloads(payloads []configbundle.SystemExtensionP
 }
 
 type configApplyOptions struct {
-	endpoint            string
-	workstationConfig   string
-	contextName         string
-	nodeConfig          nodeConfigInputOptions
-	mode                string
-	candidateGeneration string
-	clientRequestID     string
-	actor               string
-	plan                bool
-	noWait              bool
-	waitTimeout         time.Duration
-	output              string
+	endpoint                           string
+	workstationConfig                  string
+	contextName                        string
+	nodeConfig                         nodeConfigInputOptions
+	mode                               string
+	candidateGeneration                string
+	clientRequestID                    string
+	actor                              string
+	plan                               bool
+	noWait                             bool
+	waitTimeout                        time.Duration
+	output                             string
+	destructiveStorageAcknowledgements []string
 }
 
 var configApplyNow = func() time.Time { return time.Now().UTC() }
@@ -2105,6 +2108,7 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	cmd.Flags().BoolVar(&opts.noWait, "no-wait", false, "return after the node accepts the operation")
 	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
+	cmd.Flags().StringArrayVar(&opts.destructiveStorageAcknowledgements, "acknowledge-storage-wipe", nil, "authorize overwriting one non-blank node volume as NODE/VOLUME (repeatable)")
 }
 
 func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr io.Writer) error {
@@ -2113,6 +2117,10 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	}
 	if opts.waitTimeout <= 0 {
 		return fmt.Errorf("--timeout must be positive")
+	}
+	acknowledgements, err := normalizeDestructiveStorageAcknowledgements(opts.destructiveStorageAcknowledgements)
+	if err != nil {
+		return err
 	}
 	requestID, err := clientRequestID(opts.clientRequestID)
 	if err != nil {
@@ -2154,14 +2162,15 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	defer conn.Close()
 	if opts.plan {
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
-			ApiVersion:            operation.APIVersion,
-			Kind:                  "ValidateConfigRequest",
-			ClientRequestId:       requestID,
-			Actor:                 opts.actor,
-			ApplyMode:             opts.mode,
-			CandidateGenerationId: opts.candidateGeneration,
-			NodeName:              opts.nodeConfig.nodeName,
-			ConfigYaml:            string(configYAML),
+			ApiVersion:                         operation.APIVersion,
+			Kind:                               "ValidateConfigRequest",
+			ClientRequestId:                    requestID,
+			Actor:                              opts.actor,
+			ApplyMode:                          opts.mode,
+			CandidateGenerationId:              opts.candidateGeneration,
+			NodeName:                           opts.nodeConfig.nodeName,
+			ConfigYaml:                         string(configYAML),
+			DestructiveStorageAcknowledgements: acknowledgements,
 		})
 		if err != nil {
 			return err
@@ -2191,13 +2200,14 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 	}
 	requestedMode := strings.TrimSpace(opts.mode)
 	req := &agentapi.GenerationApplyRequest{
-		ApiVersion:            operation.APIVersion,
-		Kind:                  "GenerationApplyRequest",
-		ClientRequestId:       requestID,
-		Actor:                 opts.actor,
-		CandidateGenerationId: opts.candidateGeneration,
-		NodeName:              opts.nodeConfig.nodeName,
-		ConfigYaml:            string(configYAML),
+		ApiVersion:                         operation.APIVersion,
+		Kind:                               "GenerationApplyRequest",
+		ClientRequestId:                    requestID,
+		Actor:                              opts.actor,
+		CandidateGenerationId:              opts.candidateGeneration,
+		NodeName:                           opts.nodeConfig.nodeName,
+		ConfigYaml:                         string(configYAML),
+		DestructiveStorageAcknowledgements: acknowledgements,
 	}
 	var accepted *agentapi.OperationAccepted
 	switch requestedMode {
@@ -2207,14 +2217,15 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		accepted, err = conn.Client.StageGeneration(ctx, req)
 	case generation.ApplyModeAuto:
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
-			ApiVersion:            operation.APIVersion,
-			Kind:                  "ValidateConfigRequest",
-			ClientRequestId:       requestID,
-			Actor:                 opts.actor,
-			ApplyMode:             requestedMode,
-			CandidateGenerationId: opts.candidateGeneration,
-			NodeName:              opts.nodeConfig.nodeName,
-			ConfigYaml:            string(configYAML),
+			ApiVersion:                         operation.APIVersion,
+			Kind:                               "ValidateConfigRequest",
+			ClientRequestId:                    requestID,
+			Actor:                              opts.actor,
+			ApplyMode:                          requestedMode,
+			CandidateGenerationId:              opts.candidateGeneration,
+			NodeName:                           opts.nodeConfig.nodeName,
+			ConfigYaml:                         string(configYAML),
+			DestructiveStorageAcknowledgements: acknowledgements,
 		})
 		if err != nil {
 			return err
@@ -2253,10 +2264,11 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			OperationKind:   operationKind,
 			Actor:           opts.actor,
 			ConfigApply: &agentapi.ConfigApplyOperationRequest{
-				CandidateGenerationId: opts.candidateGeneration,
-				ApplyMode:             requestedMode,
-				NodeName:              opts.nodeConfig.nodeName,
-				ConfigYaml:            string(configYAML),
+				CandidateGenerationId:              opts.candidateGeneration,
+				ApplyMode:                          requestedMode,
+				NodeName:                           opts.nodeConfig.nodeName,
+				ConfigYaml:                         string(configYAML),
+				DestructiveStorageAcknowledgements: acknowledgements,
 			},
 		})
 	default:
@@ -2280,6 +2292,18 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		return err
 	}
 	return operationResultError(terminal)
+}
+
+func normalizeDestructiveStorageAcknowledgements(values []string) ([]string, error) {
+	normalized := make([]string, len(values))
+	for i, value := range values {
+		normalized[i] = strings.TrimSpace(value)
+	}
+	sort.Strings(normalized)
+	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(normalized); err != nil {
+		return nil, fmt.Errorf("--acknowledge-storage-wipe: %w", err)
+	}
+	return normalized, nil
 }
 
 func isRenderedNodeConfig(path string) bool {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2339,21 +2340,37 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 		"--config", configPath,
 		"--candidate-generation", "generation-auto",
 		"--client-request-id", "req-auto",
+		"--acknowledge-storage-wipe", "node-a/data",
 		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
-	if fake.validateRequest == nil || fake.validateRequest.ApplyMode != generation.ApplyModeAuto || fake.validateRequest.CandidateGenerationId != "generation-auto" || fake.validateRequest.Actor != "katlctl node apply" {
+	if fake.validateRequest == nil || fake.validateRequest.ApplyMode != generation.ApplyModeAuto || fake.validateRequest.CandidateGenerationId != "generation-auto" || fake.validateRequest.Actor != "katlctl node apply" || !slices.Equal(fake.validateRequest.DestructiveStorageAcknowledgements, []string{"node-a/data"}) {
 		t.Fatalf("validate request = %+v", fake.validateRequest)
 	}
-	if fake.submitRequest == nil || fake.submitRequest.OperationKind != "generation-apply" || fake.submitRequest.Actor != "katlctl node apply" || fake.submitRequest.GetConfigApply().GetApplyMode() != generation.ApplyModeAuto {
+	if fake.submitRequest == nil || fake.submitRequest.OperationKind != "generation-apply" || fake.submitRequest.Actor != "katlctl node apply" || fake.submitRequest.GetConfigApply().GetApplyMode() != generation.ApplyModeAuto || !slices.Equal(fake.submitRequest.GetConfigApply().GetDestructiveStorageAcknowledgements(), []string{"node-a/data"}) {
 		t.Fatalf("submit request = %+v", fake.submitRequest)
 	}
 	if fake.stageRequest != nil || fake.applyRequest != nil {
 		t.Fatalf("direct mutation request was sent: stage=%+v apply=%+v", fake.stageRequest, fake.applyRequest)
 	}
 	assertSuccessfulMutationOutput(t, stdout.Bytes())
+}
+
+func TestNormalizeDestructiveStorageAcknowledgements(t *testing.T) {
+	got, err := normalizeDestructiveStorageAcknowledgements([]string{"worker-1/cache", " cp-1/data "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, []string{"cp-1/data", "worker-1/cache"}) {
+		t.Fatalf("normalized acknowledgements = %v", got)
+	}
+	for _, values := range [][]string{{"cp-1"}, {"CP-1/data"}, {"cp-1/data", "cp-1/data"}} {
+		if _, err := normalizeDestructiveStorageAcknowledgements(values); err == nil || !strings.Contains(err.Error(), "--acknowledge-storage-wipe") {
+			t.Fatalf("normalize invalid %v error = %v", values, err)
+		}
+	}
 }
 
 func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {

--- a/cmd/katlos-install/main.go
+++ b/cmd/katlos-install/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 }
 
-func runManifest(ctx context.Context, manifestPath, stateDir, inputMode, inputSource string, stdout io.Writer) error {
+func runManifest(ctx context.Context, manifestPath, stateDir, inputMode, inputSource string, stdout io.Writer, destructiveStorageAcknowledgements ...string) error {
 	if manifestPath == "" {
 		return fmt.Errorf("--manifest is required unless --list-states, --version, --apply-input, or --boot is set")
 	}
@@ -56,7 +56,7 @@ func runManifest(ctx context.Context, manifestPath, stateDir, inputMode, inputSo
 		inputSource = manifestPath
 	}
 
-	install, err := manifestRunnerContext(manifestPath, stateDir, inputMode, inputSource)
+	install, err := manifestRunnerContext(manifestPath, stateDir, inputMode, inputSource, destructiveStorageAcknowledgements...)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func runManifest(ctx context.Context, manifestPath, stateDir, inputMode, inputSo
 	return nil
 }
 
-func manifestRunnerContext(manifestPath, stateDir, inputMode, inputSource string) (*installer.Context, error) {
+func manifestRunnerContext(manifestPath, stateDir, inputMode, inputSource string, destructiveStorageAcknowledgements ...string) (*installer.Context, error) {
 	mediaRoot, err := manifestMediaRoot(manifestPath)
 	if err != nil {
 		return nil, err
@@ -102,18 +102,19 @@ func manifestRunnerContext(manifestPath, stateDir, inputMode, inputSource string
 			WorkDir:   filepath.Join(stateDir, "katlos-image"),
 			Commands:  commands,
 		},
-		DefaultKatlosImage: media.Image,
-		Discovery:          discovery.NewCommandDiscoverySource(commands),
-		RootSlotOpener:     disk.FileRootSlotDeviceOpener{},
-		IdentityRandom:     rand.Reader,
-		Chown:              os.Lchown,
-		KubeadmConfigs:     kubeadmConfigs,
-		InputMode:          inputMode,
-		InputSource:        inputSource,
+		DefaultKatlosImage:                 media.Image,
+		Discovery:                          discovery.NewCommandDiscoverySource(commands),
+		RootSlotOpener:                     disk.FileRootSlotDeviceOpener{},
+		IdentityRandom:                     rand.Reader,
+		Chown:                              os.Lchown,
+		KubeadmConfigs:                     kubeadmConfigs,
+		InputMode:                          inputMode,
+		InputSource:                        inputSource,
+		DestructiveStorageAcknowledgements: append([]string(nil), destructiveStorageAcknowledgements...),
 	}, nil
 }
 
-func runBundle(ctx context.Context, bundlePath, selectedNode, expectedDigest, stateDir, inputMode, inputSource string, stdout io.Writer) error {
+func runBundle(ctx context.Context, bundlePath, selectedNode, expectedDigest, stateDir, inputMode, inputSource string, stdout io.Writer, destructiveStorageAcknowledgements ...string) error {
 	if strings.TrimSpace(bundlePath) == "" {
 		return fmt.Errorf("--bundle is required")
 	}
@@ -139,7 +140,7 @@ func runBundle(ctx context.Context, bundlePath, selectedNode, expectedDigest, st
 	if err != nil {
 		return err
 	}
-	install, err := bundleRunnerContext(bundlePath, manifestPath, stateDir, inputMode, inputSource, selected)
+	install, err := bundleRunnerContext(bundlePath, manifestPath, stateDir, inputMode, inputSource, selected, destructiveStorageAcknowledgements)
 	if err != nil {
 		return err
 	}
@@ -154,7 +155,7 @@ func runBundle(ctx context.Context, bundlePath, selectedNode, expectedDigest, st
 	return nil
 }
 
-func bundleRunnerContext(bundlePath, manifestPath, stateDir, inputMode, inputSource string, selected configbundle.SelectedNodeMaterial) (*installer.Context, error) {
+func bundleRunnerContext(bundlePath, manifestPath, stateDir, inputMode, inputSource string, selected configbundle.SelectedNodeMaterial, destructiveStorageAcknowledgements []string) (*installer.Context, error) {
 	mediaRoot, err := manifestMediaRoot(bundlePath)
 	if err != nil {
 		return nil, err
@@ -180,20 +181,21 @@ func bundleRunnerContext(bundlePath, manifestPath, stateDir, inputMode, inputSou
 			WorkDir:   filepath.Join(stateDir, "katlos-image"),
 			Commands:  commands,
 		},
-		DefaultKatlosImage:      media.Image,
-		KatlosImageFromMedia:    selected.KatlosImageFromMedia,
-		Discovery:               discovery.NewCommandDiscoverySource(commands),
-		RootSlotOpener:          disk.FileRootSlotDeviceOpener{},
-		IdentityRandom:          rand.Reader,
-		Chown:                   os.Lchown,
-		KubeadmConfigs:          selected.KubeadmConfigs,
-		SystemExtensionPayloads: installSystemExtensionPayloads(selected.SystemExtensionPayloads),
-		InputMode:               inputMode,
-		InputSource:             inputSource,
-		BundleDigest:            selected.BundleDigest,
-		SourceDigest:            selected.SourceDigest,
-		NodeMaterialDigest:      selected.NodeMaterialDigest,
-		InstallMaterialDigest:   selected.InstallMaterialDigest,
+		DefaultKatlosImage:                 media.Image,
+		KatlosImageFromMedia:               selected.KatlosImageFromMedia,
+		Discovery:                          discovery.NewCommandDiscoverySource(commands),
+		RootSlotOpener:                     disk.FileRootSlotDeviceOpener{},
+		IdentityRandom:                     rand.Reader,
+		Chown:                              os.Lchown,
+		KubeadmConfigs:                     selected.KubeadmConfigs,
+		SystemExtensionPayloads:            installSystemExtensionPayloads(selected.SystemExtensionPayloads),
+		InputMode:                          inputMode,
+		InputSource:                        inputSource,
+		BundleDigest:                       selected.BundleDigest,
+		SourceDigest:                       selected.SourceDigest,
+		NodeMaterialDigest:                 selected.NodeMaterialDigest,
+		InstallMaterialDigest:              selected.InstallMaterialDigest,
+		DestructiveStorageAcknowledgements: append([]string(nil), destructiveStorageAcknowledgements...),
 	}, nil
 }
 
@@ -628,7 +630,7 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 				return fmt.Errorf("write handoff config bundle: %w", err)
 			}
 			fmt.Fprintf(stdout, "katlos-install handoff accepted bundle=%s node=%s\n", bundlePath, bundle.NodeName)
-			err := runBundle(ctx, bundlePath, bundle.NodeName, "", filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, bundlePath, stdout)
+			err := runBundle(ctx, bundlePath, bundle.NodeName, "", filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, bundlePath, stdout, bundle.DestructiveStorageAcknowledgements...)
 			if prepareHandoffRetry(server, runDir, err, stdout) {
 				continue
 			}
@@ -648,7 +650,7 @@ func runHandoff(ctx context.Context, runDir, addr string, stdout io.Writer) erro
 				return err
 			}
 			fmt.Fprintf(stdout, "katlos-install handoff accepted manifest=%s\n", manifestPath)
-			err := runManifest(ctx, manifestPath, filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, manifestPath, stdout)
+			err := runManifest(ctx, manifestPath, filepath.Join(runDir, "state"), installstatus.InputModeLocalHandoff, manifestPath, stdout, server.DestructiveStorageAcknowledgements()...)
 			if prepareHandoffRetry(server, runDir, err, stdout) {
 				continue
 			}

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -230,9 +230,9 @@ filesystem, and `wipe: false`. Stable disk or partition identity and
 `spec.defaults` so one inherited value cannot select or erase storage across
 the cluster.
 
-A disk-backed entry with `wipe: true` authorizes Katl to reinitialize the
-selected disk. Katl uses `systemd-repart` to create and format its
-convention-labelled partition:
+A disk-backed entry with `wipe: true` requests reinitialization of the selected
+disk. It is desired state, not permission to overwrite existing contents. Katl
+uses `systemd-repart` to create and format its convention-labelled partition:
 
 ```yaml
 install:
@@ -267,6 +267,25 @@ filesystem and Katl preserves it. With `wipe: true`, Katl formats the selected
 target; a partition selector never repartitions its parent disk. Live apply
 refuses mounted or otherwise active destructive targets rather than disrupting
 workloads.
+
+Katl provisions a discovered blank target automatically. If the selected disk
+or partition already has a partition-table, partition, or filesystem
+signature, planning stops before mutation and reports the exact `NODE/VOLUME`
+acknowledgement required. Inspect the selected hardware, then repeat the
+operation with the reported flag, for example:
+
+```console
+katlctl install apply --config ./cluster.yaml --node worker-1 \
+  --acknowledge-storage-wipe worker-1/data
+
+katlctl cluster apply --config ./cluster.yaml \
+  --acknowledge-storage-wipe worker-1/data
+```
+
+Repeat the flag for multiple affected volumes. The acknowledgement belongs to
+that operation and is never written into ClusterConfig or a node generation;
+changing a selector or encountering existing contents in a later operation
+requires acknowledgement again.
 
 For a routed endpoint advertised by Katl, add the VIP and fabric peers. Katl
 then installs and runs the endpoint advertiser only on control-plane nodes;

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -57,6 +57,13 @@ selector (including the convention-derived empty selector), `partUUID`,
 `filesystemUUID`, and `wipe: true`. Those choices must appear on the concrete
 node volume that they affect.
 
+Node-specific `wipe: true` expresses the desired formatting result but is not
+destructive authority. Installer and online-apply planning discover the target;
+blank targets may proceed automatically, while non-blank targets require a
+separate operation acknowledgement naming the concrete node and volume. That
+acknowledgement is never persisted in ClusterConfig or inherited by later
+operations.
+
 ## Supported Shape
 
 ```yaml

--- a/docs/internal/writable-state-layout.md
+++ b/docs/internal/writable-state-layout.md
@@ -28,9 +28,14 @@ Kubernetes, or generation state.
 Each volume selects exactly one whole disk or one partition. `wipe: false` is
 the preservation path: the selected target must already contain the requested
 filesystem. A disk selector resolves its convention-labelled partition.
-`wipe: true` formats the selected target; for a disk selector Katl reinitializes
-the disk with a single convention-labelled partition through
-`systemd-repart`, while a partition selector never repartitions its parent.
+`wipe: true` requests formatting of the selected target; for a disk selector
+Katl reinitializes the disk with a single convention-labelled partition through
+`systemd-repart`, while a partition selector never repartitions its parent. It
+does not itself grant destructive authority. A blank target is provisioned
+automatically. A target with any discovered partition-table, partition, or
+filesystem signature requires an operation-level `NODE/VOLUME`
+acknowledgement, checked again immediately before destructive preparation. The
+acknowledgement is carried in the operation record and never in desired state.
 The supported filesystems are `ext4`, `xfs`, and `btrfs`.
 
 ## Etcd Data Placement

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -57,6 +57,16 @@ node, proves Kubernetes and stacked-etcd removal where required, reports what
 disk state is preserved, and stops before installer formatting. See
 [Wipe and reinstall KatlOS](wipe-reinstall.md#plan-one-node-replacement).
 
+## Destructive Storage Changes
+
+`wipe: true` on a node volume requests formatting but does not authorize an
+operation to overwrite existing contents. `cluster apply` validates every node
+before mutation. When discovery finds data or disk metadata on a destructive
+target, it refuses the whole apply and reports one or more exact
+`--acknowledge-storage-wipe NODE/VOLUME` flags. Inspect those targets and repeat
+the command with only the acknowledgements you intend. Blank targets need no
+flag, and acknowledgements are not retained for later applies.
+
 ## Configure Kernel Arguments
 
 Set `kernel.commandLine` under defaults or a concrete node:

--- a/internal/installer/disk/authority.go
+++ b/internal/installer/disk/authority.go
@@ -1,0 +1,98 @@
+package disk
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DestructiveVolumeAuthorityError reports the concrete node volumes whose
+// existing contents would be overwritten without operation-level authority.
+type DestructiveVolumeAuthorityError struct {
+	Required []string
+}
+
+func (e *DestructiveVolumeAuthorityError) Error() string {
+	flags := make([]string, 0, len(e.Required))
+	for _, target := range e.Required {
+		flags = append(flags, "--acknowledge-storage-wipe "+target)
+	}
+	return fmt.Sprintf(
+		"destructive storage acknowledgement required for non-blank node volumes: %s; inspect the selected devices, then retry with %s",
+		strings.Join(e.Required, ", "), strings.Join(flags, " "),
+	)
+}
+
+// RequiredDestructiveVolumeAcknowledgements returns stable NODE/VOLUME keys
+// for destructive plans whose discovered target already contains signatures.
+// A destructive plan against a blank target needs no acknowledgement.
+func RequiredDestructiveVolumeAcknowledgements(node string, plans []VolumePlan) []string {
+	node = strings.TrimSpace(node)
+	seen := make(map[string]struct{})
+	for _, plan := range plans {
+		if (!plan.Wipe && !plan.Repartition) || len(plan.Signatures) == 0 {
+			continue
+		}
+		key := node + "/" + strings.TrimSpace(plan.Name)
+		if node == "" || strings.TrimSpace(plan.Name) == "" {
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	required := make([]string, 0, len(seen))
+	for key := range seen {
+		required = append(required, key)
+	}
+	sort.Strings(required)
+	return required
+}
+
+// ValidateDestructiveVolumeAcknowledgements enforces operation-level
+// authority for every non-blank destructive volume plan.
+func ValidateDestructiveVolumeAcknowledgements(node string, plans []VolumePlan, acknowledged []string) error {
+	provided := make(map[string]struct{}, len(acknowledged))
+	for _, value := range acknowledged {
+		provided[strings.TrimSpace(value)] = struct{}{}
+	}
+	var missing []string
+	for _, required := range RequiredDestructiveVolumeAcknowledgements(node, plans) {
+		if _, ok := provided[required]; !ok {
+			missing = append(missing, required)
+		}
+	}
+	if len(missing) > 0 {
+		return &DestructiveVolumeAuthorityError{Required: missing}
+	}
+	return nil
+}
+
+// ValidateDestructiveVolumeAcknowledgementKeys validates the public
+// NODE/VOLUME acknowledgement shape independently of a particular plan.
+func ValidateDestructiveVolumeAcknowledgementKeys(values []string) error {
+	seen := make(map[string]struct{}, len(values))
+	for i, raw := range values {
+		value := strings.TrimSpace(raw)
+		parts := strings.Split(value, "/")
+		if len(parts) != 2 || !validAuthoritySegment(parts[0]) || !validAuthoritySegment(parts[1]) {
+			return fmt.Errorf("destructive storage acknowledgement %d must be NODE/VOLUME using lowercase DNS-label names", i+1)
+		}
+		if _, exists := seen[value]; exists {
+			return fmt.Errorf("destructive storage acknowledgement %q is duplicated", value)
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+
+func validAuthoritySegment(value string) bool {
+	if value == "" || value[0] == '-' || value[len(value)-1] == '-' {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/installer/disk/authority_test.go
+++ b/internal/installer/disk/authority_test.go
@@ -1,0 +1,44 @@
+package disk
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDestructiveVolumeAcknowledgementsOnlyCoverNonBlankTargets(t *testing.T) {
+	plans := []VolumePlan{
+		{Name: "blank-disk", Wipe: true, Repartition: true},
+		{Name: "existing-partition", Wipe: true, Signatures: []SignatureReport{{Kind: "filesystem", Value: "ext4"}}},
+		{Name: "existing-disk", Wipe: true, Repartition: true, Signatures: []SignatureReport{{Kind: "partition-table", Value: "gpt"}}},
+		{Name: "preserved", Signatures: []SignatureReport{{Kind: "filesystem", Value: "xfs"}}},
+	}
+	want := []string{"cp-1/existing-disk", "cp-1/existing-partition"}
+	if got := RequiredDestructiveVolumeAcknowledgements("cp-1", plans); !reflect.DeepEqual(got, want) {
+		t.Fatalf("RequiredDestructiveVolumeAcknowledgements() = %v, want %v", got, want)
+	}
+
+	err := ValidateDestructiveVolumeAcknowledgements("cp-1", plans, []string{"cp-1/existing-disk"})
+	var authority *DestructiveVolumeAuthorityError
+	if !errors.As(err, &authority) || !reflect.DeepEqual(authority.Required, []string{"cp-1/existing-partition"}) {
+		t.Fatalf("ValidateDestructiveVolumeAcknowledgements() error = %#v", err)
+	}
+	if !strings.Contains(err.Error(), "--acknowledge-storage-wipe cp-1/existing-partition") {
+		t.Fatalf("authority error lacks retry command: %v", err)
+	}
+	if err := ValidateDestructiveVolumeAcknowledgements("cp-1", plans, want); err != nil {
+		t.Fatalf("acknowledged validation error = %v", err)
+	}
+}
+
+func TestValidateDestructiveVolumeAcknowledgementKeys(t *testing.T) {
+	if err := ValidateDestructiveVolumeAcknowledgementKeys([]string{"cp-1/data", "worker-1/cache"}); err != nil {
+		t.Fatalf("valid acknowledgement keys rejected: %v", err)
+	}
+	for _, values := range [][]string{{"cp-1"}, {"CP-1/data"}, {"cp-1/data/extra"}, {"cp-1/data", "cp-1/data"}} {
+		if err := ValidateDestructiveVolumeAcknowledgementKeys(values); err == nil {
+			t.Fatalf("invalid acknowledgement keys accepted: %v", values)
+		}
+	}
+}

--- a/internal/installer/handoff/handoff.go
+++ b/internal/installer/handoff/handoff.go
@@ -3,6 +3,8 @@ package handoff
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/discovery"
+	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	installstatus "github.com/katl-dev/katl/internal/installer/status"
 )
@@ -28,13 +31,15 @@ type HandoffServer struct {
 	defaultKatlosImage manifest.KatlosImage
 	statusReader       func() (installstatus.Record, error)
 
-	mu       sync.Mutex
-	state    HandoffState
-	manifest []byte
-	bundle   []byte
-	nodeName string
-	status   installstatus.Record
-	disks    []HandoffDisk
+	mu                                 sync.Mutex
+	state                              HandoffState
+	manifest                           []byte
+	bundle                             []byte
+	nodeName                           string
+	destructiveStorageAcknowledgements []string
+	status                             installstatus.Record
+	disks                              []HandoffDisk
+	hardwareFacts                      discovery.HardwareFacts
 }
 
 type HandoffStatus struct {
@@ -59,8 +64,9 @@ type HandoffDisk struct {
 }
 
 type BundlePayload struct {
-	Data     []byte
-	NodeName string
+	Data                               []byte
+	NodeName                           string
+	DestructiveStorageAcknowledgements []string
 }
 
 func NewHandoffServer(validate func([]byte) error) *HandoffServer {
@@ -93,13 +99,21 @@ func (s *HandoffServer) Manifest() []byte {
 	return append([]byte(nil), s.manifest...)
 }
 
+func (s *HandoffServer) DestructiveStorageAcknowledgements() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.destructiveStorageAcknowledgements...)
+}
+
 func (s *HandoffServer) Bundle() BundlePayload {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	return BundlePayload{
-		Data:     append([]byte(nil), s.bundle...),
-		NodeName: s.nodeName,
+		Data:                               append([]byte(nil), s.bundle...),
+		NodeName:                           s.nodeName,
+		DestructiveStorageAcknowledgements: append([]string(nil), s.destructiveStorageAcknowledgements...),
 	}
 }
 
@@ -148,6 +162,7 @@ func (s *HandoffServer) PrepareRetry(status installstatus.Record) bool {
 	s.manifest = nil
 	s.bundle = nil
 	s.nodeName = ""
+	s.destructiveStorageAcknowledgements = nil
 	s.status = status
 	return true
 }
@@ -183,6 +198,7 @@ func (s *HandoffServer) SetHardwareFacts(facts discovery.HardwareFacts) {
 	sort.Slice(disks, func(i, j int) bool { return disks[i].Path < disks[j].Path })
 	s.mu.Lock()
 	s.disks = disks
+	s.hardwareFacts = facts
 	s.mu.Unlock()
 }
 
@@ -229,6 +245,15 @@ func (s *HandoffServer) handleInstall(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid manifest: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	acknowledgements, err := destructiveStorageAcknowledgements(r)
+	if err != nil {
+		http.Error(w, "invalid destructive storage acknowledgement: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.validateDestructiveStorageAuthority(decoded, decoded.Node.Identity.Hostname, acknowledgements); err != nil {
+		http.Error(w, err.Error(), destructiveStorageAuthorityStatus(err))
+		return
+	}
 	digest, err := installstatus.DigestManifest(decoded)
 	if err != nil {
 		http.Error(w, "invalid manifest: "+err.Error(), http.StatusBadRequest)
@@ -243,6 +268,7 @@ func (s *HandoffServer) handleInstall(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.manifest = append([]byte(nil), body...)
+	s.destructiveStorageAcknowledgements = acknowledgements
 	s.state = HandoffAccepted
 	status := installstatus.New(installstatus.StateRunning, time.Now().UTC())
 	status.InputMode = installstatus.InputModeLocalHandoff
@@ -279,6 +305,15 @@ func (s *HandoffServer) handleConfigBundle(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "invalid config bundle: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	acknowledgements, err := destructiveStorageAcknowledgements(r)
+	if err != nil {
+		http.Error(w, "invalid destructive storage acknowledgement: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.validateDestructiveStorageAuthority(selected.InstallManifest, selected.Node.Name, acknowledgements); err != nil {
+		http.Error(w, err.Error(), destructiveStorageAuthorityStatus(err))
+		return
+	}
 	digest, err := installstatus.DigestManifest(selected.InstallManifest)
 	if err != nil {
 		http.Error(w, "invalid config bundle: "+err.Error(), http.StatusBadRequest)
@@ -294,6 +329,7 @@ func (s *HandoffServer) handleConfigBundle(w http.ResponseWriter, r *http.Reques
 
 	s.bundle = append([]byte(nil), body...)
 	s.nodeName = selected.Node.Name
+	s.destructiveStorageAcknowledgements = acknowledgements
 	s.state = HandoffAccepted
 	status := installstatus.New(installstatus.StateRunning, time.Now().UTC())
 	status.InputMode = installstatus.InputModeLocalHandoff
@@ -317,6 +353,47 @@ func (s *HandoffServer) handleConfigBundle(w http.ResponseWriter, r *http.Reques
 	s.mu.Unlock()
 
 	writeJSON(w, response)
+}
+
+func destructiveStorageAcknowledgements(r *http.Request) ([]string, error) {
+	acknowledgements := append([]string(nil), r.URL.Query()["acknowledgeStorageWipe"]...)
+	for i := range acknowledgements {
+		acknowledgements[i] = strings.TrimSpace(acknowledgements[i])
+	}
+	sort.Strings(acknowledgements)
+	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(acknowledgements); err != nil {
+		return nil, err
+	}
+	return acknowledgements, nil
+}
+
+func (s *HandoffServer) validateDestructiveStorageAuthority(installManifest manifest.Manifest, nodeName string, acknowledgements []string) error {
+	s.mu.Lock()
+	facts := s.hardwareFacts
+	s.mu.Unlock()
+	if len(facts.BlockDevices) == 0 {
+		return nil
+	}
+	rootDisk, err := discovery.MatchDiskIdentity(facts, discovery.TargetDiskSelector{
+		ByID: installManifest.Install.TargetDisk.ByID, WWN: installManifest.Install.TargetDisk.WWN,
+		Serial: installManifest.Install.TargetDisk.Serial, MinSizeMiB: installManifest.Install.TargetDisk.MinSizeMiB,
+	})
+	if err != nil {
+		return fmt.Errorf("plan storage targets: resolve install root disk: %w", err)
+	}
+	plans, err := disk.PlanVolumes(facts, rootDisk, manifest.BuildVolumeRequests(installManifest.Install.Volumes))
+	if err != nil {
+		return fmt.Errorf("plan storage targets: %w", err)
+	}
+	return disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements)
+}
+
+func destructiveStorageAuthorityStatus(err error) int {
+	var authorityErr *disk.DestructiveVolumeAuthorityError
+	if errors.As(err, &authorityErr) {
+		return http.StatusPreconditionRequired
+	}
+	return http.StatusBadRequest
 }
 
 func ValidateInstallManifestEnvelope(data []byte) error {

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -3,8 +3,10 @@ package handoff
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,6 +227,85 @@ func TestHandoffServerAcceptsConfigBundleWithSelectedNode(t *testing.T) {
 	}
 }
 
+func TestHandoffServerRequiresOperationAuthorityForNonBlankStorage(t *testing.T) {
+	server := newTestHandoffServer(t)
+	server.SetHardwareFacts(discovery.HardwareFacts{BlockDevices: []discovery.BlockDevice{
+		{Path: "/dev/vda", Type: discovery.DeviceDisk, ByID: []string{"/dev/disk/by-id/ata-root"}, SizeBytes: 64 << 30},
+		{Path: "/dev/vdb", Type: discovery.DeviceDisk, ByID: []string{"/dev/disk/by-id/ata-data"}, SizeBytes: 64 << 30, PartitionSignature: "gpt"},
+	}})
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+	source := strings.Replace(validBundleSourceConfig(), "      install:\n        systemDisk:\n          byID: /dev/disk/by-id/ata-root\n", `      install:
+        systemDisk:
+          byID: /dev/disk/by-id/ata-root
+      storage:
+        disks:
+          - name: data
+            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-data
+            filesystem: xfs
+            wipe: true
+`, 1)
+	bundle, result := configBundleFromSource(t, source)
+
+	resp := postBundle(t, ts.URL, "cp-1", result.Digest, bundle)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusPreconditionRequired || !strings.Contains(string(body), "--acknowledge-storage-wipe cp-1/data") {
+		t.Fatalf("unacknowledged POST status=%d body=%s", resp.StatusCode, body)
+	}
+	if server.Status().State != HandoffWaiting {
+		t.Fatalf("refused handoff state = %s", server.Status().State)
+	}
+
+	resp = postBundle(t, ts.URL, "cp-1", result.Digest, bundle, "cp-1/data")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("acknowledged POST status = %d", resp.StatusCode)
+	}
+	if got := server.Bundle().DestructiveStorageAcknowledgements; len(got) != 1 || got[0] != "cp-1/data" {
+		t.Fatalf("stored acknowledgements = %v", got)
+	}
+}
+
+func TestHandoffServerRequiresOperationAuthorityForRawManifestStorage(t *testing.T) {
+	server := newTestHandoffServer(t)
+	server.SetHardwareFacts(discovery.HardwareFacts{BlockDevices: []discovery.BlockDevice{
+		{Path: "/dev/vda", Type: discovery.DeviceDisk, ByID: []string{"/dev/disk/by-id/ata-root"}, SizeBytes: 64 << 30},
+		{Path: "/dev/vdb", Type: discovery.DeviceDisk, ByID: []string{"/dev/disk/by-id/ata-data"}, SizeBytes: 64 << 30, PartitionSignature: "gpt"},
+	}})
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+	install := []byte(`"targetDisk": {"byID": "/dev/disk/by-id/ata-root"},
+			"volumes": [{
+				"name": "data",
+				"selector": {"disk": {"byID": "/dev/disk/by-id/ata-data"}},
+				"filesystem": "xfs",
+				"wipe": true
+			}]`)
+	input := bytes.Replace(validManifestJSON(), []byte(`"targetDisk": {"byID": "/dev/disk/by-id/ata-root"}`), install, 1)
+
+	resp := postManifest(t, ts.URL, input)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusPreconditionRequired || !strings.Contains(string(body), "--acknowledge-storage-wipe lab-node-01/data") {
+		t.Fatalf("unacknowledged POST status=%d body=%s", resp.StatusCode, body)
+	}
+	if server.Status().State != HandoffWaiting || len(server.Manifest()) != 0 {
+		t.Fatalf("refused handoff state = %#v", server.Status())
+	}
+
+	resp = postManifest(t, ts.URL, input, "lab-node-01/data")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("acknowledged POST status = %d", resp.StatusCode)
+	}
+	if got := server.DestructiveStorageAcknowledgements(); len(got) != 1 || got[0] != "lab-node-01/data" {
+		t.Fatalf("stored acknowledgements = %v", got)
+	}
+}
+
 func TestHandoffServerRejectsConfigBundleWithoutSelectedNode(t *testing.T) {
 	server := newTestHandoffServer(t)
 	ts := httptest.NewServer(server.Handler())
@@ -321,9 +402,17 @@ func newTestHandoffServer(t *testing.T) *HandoffServer {
 	})
 }
 
-func postManifest(t *testing.T, baseURL string, manifest []byte) *http.Response {
+func postManifest(t *testing.T, baseURL string, manifest []byte, acknowledgements ...string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/install", bytes.NewReader(manifest))
+	query := url.Values{}
+	for _, acknowledgement := range acknowledgements {
+		query.Add("acknowledgeStorageWipe", acknowledgement)
+	}
+	endpoint := baseURL + "/v1/install"
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(manifest))
 	if err != nil {
 		t.Fatalf("NewRequest() error = %v", err)
 	}
@@ -334,9 +423,13 @@ func postManifest(t *testing.T, baseURL string, manifest []byte) *http.Response 
 	return resp
 }
 
-func postBundle(t *testing.T, baseURL, node, digest string, bundle []byte) *http.Response {
+func postBundle(t *testing.T, baseURL, node, digest string, bundle []byte, acknowledgements ...string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/config-bundle?node="+node+"&digest="+digest, bytes.NewReader(bundle))
+	query := url.Values{"node": []string{node}, "digest": []string{digest}}
+	for _, acknowledgement := range acknowledgements {
+		query.Add("acknowledgeStorageWipe", acknowledgement)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/config-bundle?"+query.Encode(), bytes.NewReader(bundle))
 	if err != nil {
 		t.Fatalf("NewRequest() error = %v", err)
 	}
@@ -348,10 +441,14 @@ func postBundle(t *testing.T, baseURL, node, digest string, bundle []byte) *http
 }
 
 func validConfigBundle(t *testing.T) ([]byte, configbundle.Result) {
+	return configBundleFromSource(t, validBundleSourceConfig())
+}
+
+func configBundleFromSource(t *testing.T, source string) ([]byte, configbundle.Result) {
 	t.Helper()
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "cluster.yaml")
-	if err := os.WriteFile(sourcePath, []byte(validBundleSourceConfig()), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{SourcePath: sourcePath})

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/persistedrecord"
 )
 
@@ -158,12 +159,13 @@ type BootstrapRequest struct {
 }
 
 type ConfigApplyRequest struct {
-	ApplyMode             string `json:"applyMode"`
-	NodeName              string `json:"nodeName,omitempty"`
-	CandidateGenerationID string `json:"candidateGenerationID,omitempty"`
-	ConfigYAML            string `json:"configYAML,omitempty"`
-	ConfigYAMLPath        string `json:"configYAMLPath,omitempty"`
-	ConfigYAMLSHA256      string `json:"configYAMLSHA256,omitempty"`
+	ApplyMode                          string   `json:"applyMode"`
+	NodeName                           string   `json:"nodeName,omitempty"`
+	CandidateGenerationID              string   `json:"candidateGenerationID,omitempty"`
+	ConfigYAML                         string   `json:"configYAML,omitempty"`
+	ConfigYAMLPath                     string   `json:"configYAMLPath,omitempty"`
+	ConfigYAMLSHA256                   string   `json:"configYAMLSHA256,omitempty"`
+	DestructiveStorageAcknowledgements []string `json:"destructiveStorageAcknowledgements,omitempty"`
 }
 
 type KubeadmControlPlaneConfig struct {
@@ -1165,6 +1167,7 @@ func cloneRecord(record OperationRecord) OperationRecord {
 	}
 	if record.ConfigApplyRequest != nil {
 		request := *record.ConfigApplyRequest
+		request.DestructiveStorageAcknowledgements = cloneStrings(request.DestructiveStorageAcknowledgements)
 		record.ConfigApplyRequest = &request
 	}
 	if record.KubernetesSysextUpdate != nil {
@@ -1796,6 +1799,9 @@ func validateConfigApplyRequest(request ConfigApplyRequest) error {
 		if err := validateSHA256Hex("configApplyRequest configYAMLSHA256", request.ConfigYAMLSHA256); err != nil {
 			return err
 		}
+	}
+	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(request.DestructiveStorageAcknowledgements); err != nil {
+		return fmt.Errorf("configApplyRequest: %w", err)
 	}
 	return nil
 }

--- a/internal/installer/operation/store_test.go
+++ b/internal/installer/operation/store_test.go
@@ -897,6 +897,19 @@ func TestValidateConfigApplyRequestRejectsPersistedPathTraversal(t *testing.T) {
 	}
 }
 
+func TestValidateConfigApplyRequestAcceptsScopedStorageAcknowledgements(t *testing.T) {
+	request := ConfigApplyRequest{
+		ApplyMode: "live", ConfigYAML: "config", DestructiveStorageAcknowledgements: []string{"cp-1/data"},
+	}
+	if err := validateConfigApplyRequest(request); err != nil {
+		t.Fatalf("validateConfigApplyRequest() error = %v", err)
+	}
+	request.DestructiveStorageAcknowledgements = []string{"cp-1"}
+	if err := validateConfigApplyRequest(request); err == nil || !strings.Contains(err.Error(), "NODE/VOLUME") {
+		t.Fatalf("invalid acknowledgement error = %v", err)
+	}
+}
+
 func TestStoreRejectsKubernetesSysextUpdateBodyMismatch(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -50,44 +50,45 @@ const (
 )
 
 type Context struct {
-	ManifestPath            string
-	StateDir                string
-	TargetRoot              string
-	BootRoot                string
-	Commands                CommandRunner
-	Store                   StateStore
-	Manifest                manifest.Manifest
-	LoaderRecord            *generation.Record
-	KatlosImage             *katlosimage.Payload
-	KatlosResolver          KatlosImageResolver
-	MediaKatlosResolver     KatlosImageResolver
-	DefaultKatlosImage      manifest.KatlosImage
-	KatlosImageFromMedia    bool
-	Discovery               discovery.DiscoverySource
-	HardwareFacts           discovery.HardwareFacts
-	RootProfile             manifest.RootDiskProfile
-	DiskLayout              *disk.DiskLayoutPlan
-	RootSlotPlan            *disk.RootSlotWritePlan
-	RootSlotTarget          disk.RootSlotDevice
-	RootSlotOpener          disk.RootSlotDeviceOpener
-	RootSlotInstaller       disk.RootSlotInstaller
-	CurrentRootSlot         disk.RootSlot
-	RootPartitionUUID       string
-	GenerationID            string
-	KubeadmConfigs          map[string]kubeadmconfig.Plan
-	SystemExtensionPayloads []configapply.SystemExtensionPayload
-	IdentityRandom          io.Reader
-	Completed               []StepID
-	Chown                   func(path string, uid int, gid int) error
-	InputMode               string
-	InputSource             string
-	RequestDigest           string
-	BundleDigest            string
-	SourceDigest            string
-	NodeMaterialDigest      string
-	InstallMaterialDigest   string
-	PreviousStatus          *installstatus.Record
-	ReportStep              func(StepID)
+	ManifestPath                       string
+	StateDir                           string
+	TargetRoot                         string
+	BootRoot                           string
+	Commands                           CommandRunner
+	Store                              StateStore
+	Manifest                           manifest.Manifest
+	LoaderRecord                       *generation.Record
+	KatlosImage                        *katlosimage.Payload
+	KatlosResolver                     KatlosImageResolver
+	MediaKatlosResolver                KatlosImageResolver
+	DefaultKatlosImage                 manifest.KatlosImage
+	KatlosImageFromMedia               bool
+	Discovery                          discovery.DiscoverySource
+	HardwareFacts                      discovery.HardwareFacts
+	RootProfile                        manifest.RootDiskProfile
+	DiskLayout                         *disk.DiskLayoutPlan
+	RootSlotPlan                       *disk.RootSlotWritePlan
+	RootSlotTarget                     disk.RootSlotDevice
+	RootSlotOpener                     disk.RootSlotDeviceOpener
+	RootSlotInstaller                  disk.RootSlotInstaller
+	CurrentRootSlot                    disk.RootSlot
+	RootPartitionUUID                  string
+	GenerationID                       string
+	KubeadmConfigs                     map[string]kubeadmconfig.Plan
+	SystemExtensionPayloads            []configapply.SystemExtensionPayload
+	IdentityRandom                     io.Reader
+	Completed                          []StepID
+	Chown                              func(path string, uid int, gid int) error
+	InputMode                          string
+	InputSource                        string
+	RequestDigest                      string
+	BundleDigest                       string
+	SourceDigest                       string
+	NodeMaterialDigest                 string
+	InstallMaterialDigest              string
+	DestructiveStorageAcknowledgements []string
+	PreviousStatus                     *installstatus.Record
+	ReportStep                         func(StepID)
 }
 
 type Step interface {
@@ -309,6 +310,9 @@ func planInstall(install *Context) error {
 	}
 	layout, err := disk.PlanDiskLayout(install.HardwareFacts, layoutRequest)
 	if err != nil {
+		return err
+	}
+	if err := disk.ValidateDestructiveVolumeAcknowledgements(inventoryNodeName(install.Manifest), layout.VolumeMounts, install.DestructiveStorageAcknowledgements); err != nil {
 		return err
 	}
 	rootPlan, err := disk.PlanRootSlotWrite(layout, disk.RootSlotWriteRequest{

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -633,6 +633,43 @@ func TestRunnerPlansInstallFromKatlosImagePayload(t *testing.T) {
 	}
 }
 
+func TestPlanInstallRequiresAuthorityForNonBlankStorageVolume(t *testing.T) {
+	file, err := os.Open(writeManifest(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	installManifest, err := manifest.Decode(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installManifest.Install.Volumes = []manifest.Volume{{
+		Name: "data", Selector: manifest.VolumeSelector{Disk: &manifest.DiskSelector{Serial: "data"}}, Filesystem: "xfs", Wipe: true,
+	}}
+	payload := planningPayload()
+	install := &Context{
+		Manifest:    installManifest,
+		KatlosImage: &payload,
+		HardwareFacts: discovery.HardwareFacts{BlockDevices: []discovery.BlockDevice{
+			{Path: "/dev/vda", Type: discovery.DeviceDisk, ByID: []string{"/dev/disk/by-id/ata-root"}, SizeBytes: 64 << 30},
+			{Path: "/dev/vdb", Type: discovery.DeviceDisk, Serial: "data", SizeBytes: 64 << 30, PartitionSignature: "gpt"},
+		}},
+	}
+	err = planInstall(install)
+	var authority *disk.DestructiveVolumeAuthorityError
+	if !errors.As(err, &authority) || !reflect.DeepEqual(authority.Required, []string{"lab-node-01/data"}) {
+		t.Fatalf("planInstall() error = %#v", err)
+	}
+	if install.DiskLayout != nil {
+		t.Fatal("refused install retained a disk layout")
+	}
+
+	install.DestructiveStorageAcknowledgements = []string{"lab-node-01/data"}
+	if err := planInstall(install); err != nil {
+		t.Fatalf("acknowledged planInstall() error = %v", err)
+	}
+}
+
 func TestRunnerCapturesRootUUIDAfterMountTarget(t *testing.T) {
 	store := &MemoryStateStore{}
 	payload := planningPayload()

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -17,6 +17,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/configapply"
+	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/kernelcmdline"
 	"github.com/katl-dev/katl/internal/installer/kubeadmconfig"
@@ -78,17 +79,18 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		provisionalOperationKind = OperationKindGenerationApply
 	}
 	submitBase := &agentapi.GenerationApplyRequest{
-		ApiVersion:                  APIVersion,
-		Kind:                        "GenerationApplyRequest",
-		ClientRequestId:             req.ClientRequestId,
-		Actor:                       req.Actor,
-		ExpectedMachineId:           req.ExpectedMachineId,
-		ExpectedCurrentGenerationId: req.ExpectedCurrentGenerationId,
-		RequestDigest:               "",
-		OperationTimeout:            req.OperationTimeout,
-		CandidateGenerationId:       candidateID,
-		NodeName:                    req.NodeName,
-		ConfigYaml:                  req.ConfigYaml,
+		ApiVersion:                         APIVersion,
+		Kind:                               "GenerationApplyRequest",
+		ClientRequestId:                    req.ClientRequestId,
+		Actor:                              req.Actor,
+		ExpectedMachineId:                  req.ExpectedMachineId,
+		ExpectedCurrentGenerationId:        req.ExpectedCurrentGenerationId,
+		RequestDigest:                      "",
+		OperationTimeout:                   req.OperationTimeout,
+		CandidateGenerationId:              candidateID,
+		NodeName:                           req.NodeName,
+		ConfigYaml:                         req.ConfigYaml,
+		DestructiveStorageAcknowledgements: append([]string(nil), req.DestructiveStorageAcknowledgements...),
 	}
 	submit := generationSubmitRequest(submitBase, provisionalOperationKind, applyMode)
 	requestDigest, err := RequestDigest(submit)
@@ -182,6 +184,12 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		}
 		return rejected(err, configApplyDiagnostics(plan.Plan.Decision)), nil
 	}
+	requiredStorage, err := s.validateDestructiveStorageAuthority(ctx, req.NodeName, base.CurrentManifest, plan.Manifest, req.DestructiveStorageAcknowledgements)
+	if err != nil {
+		result := rejected(err, []string{inventory.Redact(err.Error())})
+		result.RequiredDestructiveStorageAcknowledgements = requiredStorage
+		return result, nil
+	}
 	operationKind, err := configApplyOperationKind(plan.Plan.Decision.AcceptedMode)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -203,6 +211,7 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		AcceptedApplyMode:     plan.Plan.Decision.AcceptedMode,
 		CandidateGenerationId: candidateID,
 		ChangedDomains:        append([]string(nil), plan.Plan.Decision.ChangedDomains...),
+		RequiredDestructiveStorageAcknowledgements: requiredStorage,
 	}, nil
 }
 
@@ -258,10 +267,11 @@ func generationSubmitRequest(req *agentapi.GenerationApplyRequest, operationKind
 		RequestDigest:               req.RequestDigest,
 		OperationTimeout:            req.OperationTimeout,
 		ConfigApply: &agentapi.ConfigApplyOperationRequest{
-			CandidateGenerationId: req.CandidateGenerationId,
-			ApplyMode:             applyMode,
-			NodeName:              req.NodeName,
-			ConfigYaml:            req.ConfigYaml,
+			CandidateGenerationId:              req.CandidateGenerationId,
+			ApplyMode:                          applyMode,
+			NodeName:                           req.NodeName,
+			ConfigYaml:                         req.ConfigYaml,
+			DestructiveStorageAcknowledgements: append([]string(nil), req.DestructiveStorageAcknowledgements...),
 		},
 	}
 }
@@ -413,7 +423,7 @@ func configApplyDomainActionsToProto(actions []generation.ConfigApplyDomainActio
 	return out
 }
 
-func (s *Server) acceptConfigApplyOperation(req *agentapi.SubmitOperationRequest, digest string, id string, locks []string, now time.Time) (operation.OperationRecord, *agentapi.OperationAccepted, error) {
+func (s *Server) acceptConfigApplyOperation(ctx context.Context, req *agentapi.SubmitOperationRequest, digest string, id string, locks []string, now time.Time) (operation.OperationRecord, *agentapi.OperationAccepted, error) {
 	configReq := configApplyRequestFromProto(req.GetConfigApply())
 	if strings.TrimSpace(configReq.CandidateGenerationID) == "" {
 		configReq.CandidateGenerationID = id + "-candidate"
@@ -425,6 +435,7 @@ func (s *Server) acceptConfigApplyOperation(req *agentapi.SubmitOperationRequest
 	if err != nil {
 		return operation.OperationRecord{}, nil, status.Errorf(codes.FailedPrecondition, "config apply base state: %v", err)
 	}
+	configReq.NodeName = storageAuthorityNodeName(configReq.NodeName, base.CurrentManifest)
 	if diagnostics := validateConfigApplyDocument(configReq.ConfigYAML, base.KubeadmConfigs); !diagnostics.Accepted() {
 		return operation.OperationRecord{}, nil, status.Error(codes.InvalidArgument, configValidationError(diagnostics.Strings()).Error())
 	}
@@ -436,6 +447,9 @@ func (s *Server) acceptConfigApplyOperation(req *agentapi.SubmitOperationRequest
 	decoded.GenerationID = configReq.CandidateGenerationID
 	plan, err := configapply.PlanTrustedBundle(decoded)
 	if err == nil {
+		if _, authorityErr := s.validateDestructiveStorageAuthority(ctx, configReq.NodeName, base.CurrentManifest, plan.Manifest, configReq.DestructiveStorageAcknowledgements); authorityErr != nil {
+			return operation.OperationRecord{}, nil, status.Error(codes.FailedPrecondition, authorityErr.Error())
+		}
 		operationKind, err := configApplyOperationKind(plan.Plan.Decision.AcceptedMode)
 		if err != nil {
 			return operation.OperationRecord{}, nil, status.Error(codes.Internal, err.Error())
@@ -541,11 +555,13 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 			activator = generationActivator{root: e.Root}
 		}
 		decoded.Executor = &configapply.Executor{
-			Root:         e.Root,
-			Runner:       runner,
-			Activator:    activator,
-			ApplyVolumes: e.applyVolumes,
-			Now:          e.clock,
+			Root:      e.Root,
+			Runner:    runner,
+			Activator: activator,
+			ApplyVolumes: func(ctx context.Context, current, desired manifest.Manifest) error {
+				return e.applyVolumes(ctx, current, desired, record.ConfigApplyRequest.NodeName, record.ConfigApplyRequest.DestructiveStorageAcknowledgements)
+			},
+			Now: e.clock,
 		}
 	}
 	result, err := configapply.ApplyTrustedBundle(ctx, decoded)
@@ -783,10 +799,11 @@ func configApplyRequestFromProto(req *agentapi.ConfigApplyOperationRequest) oper
 		return operation.ConfigApplyRequest{}
 	}
 	return operation.ConfigApplyRequest{
-		ApplyMode:             strings.TrimSpace(req.ApplyMode),
-		NodeName:              strings.TrimSpace(req.NodeName),
-		CandidateGenerationID: strings.TrimSpace(req.CandidateGenerationId),
-		ConfigYAML:            strings.TrimSpace(req.ConfigYaml),
+		ApplyMode:                          strings.TrimSpace(req.ApplyMode),
+		NodeName:                           strings.TrimSpace(req.NodeName),
+		CandidateGenerationID:              strings.TrimSpace(req.CandidateGenerationId),
+		ConfigYAML:                         strings.TrimSpace(req.ConfigYaml),
+		DestructiveStorageAcknowledgements: append([]string(nil), req.DestructiveStorageAcknowledgements...),
 	}
 }
 
@@ -831,6 +848,9 @@ func validateConfigApplyRequest(operationKind string, req *agentapi.ConfigApplyO
 	}
 	if strings.TrimSpace(req.ConfigYaml) == "" {
 		return fmt.Errorf("configYAML is required")
+	}
+	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(req.DestructiveStorageAcknowledgements); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	RunEndpointLifecycle     ToolRunner
 	RunKubernetesStatus      ToolRunner
 	RunSystemExtensionStatus ToolRunner
+	RunVolumeDiscovery       ToolRunner
 	RunEtcd                  ToolRunner
 	RunReboot                ToolRunner
 	RunShutdown              ToolRunner
@@ -97,6 +98,7 @@ func NewServer(root string, store operation.Store) *Server {
 		RunEndpointLifecycle:     runChildProcess,
 		RunKubernetesStatus:      runChildProcess,
 		RunSystemExtensionStatus: runChildProcess,
+		RunVolumeDiscovery:       runChildProcess,
 		RunEtcd:                  runChildProcess,
 		RunReboot:                runChildProcess,
 		RunShutdown:              runChildProcess,
@@ -270,7 +272,7 @@ func (s *Server) SubmitOperation(ctx context.Context, req *agentapi.SubmitOperat
 	if !req.DryRun && s.Dispatcher == nil {
 		return nil, status.Error(codes.FailedPrecondition, "agent executor is not configured")
 	}
-	created, dryRun, err := s.acceptOperation(req, digest)
+	created, dryRun, err := s.acceptOperation(ctx, req, digest)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +424,7 @@ func (s *Server) joinDiscoveryKubeconfig(material cluster.JoinMaterial) ([]byte,
 	return cluster.RenderJoinDiscoveryKubeconfig(material, material.Argv[2], config.Clusters[0].Cluster.CertificateAuthorityData)
 }
 
-func (s *Server) acceptOperation(req *agentapi.SubmitOperationRequest, digest string) (operation.OperationRecord, *agentapi.OperationAccepted, error) {
+func (s *Server) acceptOperation(ctx context.Context, req *agentapi.SubmitOperationRequest, digest string) (operation.OperationRecord, *agentapi.OperationAccepted, error) {
 	s.submitMu.Lock()
 	defer s.submitMu.Unlock()
 	if existing, ok, err := s.findClientRequest(req.ClientRequestId); err != nil {
@@ -484,7 +486,7 @@ func (s *Server) acceptOperation(req *agentapi.SubmitOperationRequest, digest st
 		return operation.OperationRecord{}, nil, status.Errorf(codes.Internal, "generate operation id: %v", err)
 	}
 	if req.GetConfigApply() != nil {
-		return s.acceptConfigApplyOperation(req, digest, id, locks, now)
+		return s.acceptConfigApplyOperation(ctx, req, digest, id, locks, now)
 	}
 	if req.GetKubeadmControlPlaneConfig() != nil {
 		return s.acceptKubeadmControlPlaneConfigOperation(req, digest, id, locks, now)

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -1169,6 +1169,51 @@ func TestValidateConfigReturnsDeterministicPlanDiagnostics(t *testing.T) {
 	}
 }
 
+func TestValidateConfigRequiresOperationAuthorityForNonBlankStorage(t *testing.T) {
+	server := newTestServer(t)
+	writeConfigApplyBaseState(t, server.Root)
+	server.RunVolumeDiscovery = volumeAuthorityRunner("gpt", nil)
+	request := &agentapi.ValidateConfigRequest{
+		ApiVersion: APIVersion, Kind: "ValidateConfigRequest", ClientRequestId: "req-storage-authority",
+		Actor: "test-actor", ApplyMode: generation.ApplyModeAuto, CandidateGenerationId: "generation-storage-authority", NodeName: "node-a",
+		ConfigYaml: strings.Join([]string{
+			"apiVersion: katl.dev/v1alpha1",
+			"kind: NodeConfigurationChange",
+			"metadata:",
+			"  sourceID: operator",
+			"  desiredVersion: \"4\"",
+			"apply:",
+			"  mode: auto",
+			"spec:",
+			"  clusterDefaults:",
+			"    volumes:",
+			"      - name: data",
+			"        selector:",
+			"          disk:",
+			"            serial: data",
+			"        filesystem: xfs",
+			"        wipe: true",
+			"",
+		}, "\n"),
+	}
+
+	result, err := server.ValidateConfig(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Accepted || !reflect.DeepEqual(result.RequiredDestructiveStorageAcknowledgements, []string{"node-a/data"}) || !strings.Contains(result.FailureReason, "--acknowledge-storage-wipe node-a/data") {
+		t.Fatalf("unacknowledged validation result = %+v", result)
+	}
+	request.DestructiveStorageAcknowledgements = []string{"node-a/data"}
+	result, err = server.ValidateConfig(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Accepted || !reflect.DeepEqual(result.RequiredDestructiveStorageAcknowledgements, []string{"node-a/data"}) || result.AcceptedApplyMode != generation.ApplyModeLive {
+		t.Fatalf("acknowledged validation result = %+v", result)
+	}
+}
+
 func TestValidateConfigAcceptsDesiredStateThatAlreadyMatches(t *testing.T) {
 	server := newTestServer(t)
 	writeConfigApplyBaseState(t, server.Root)
@@ -3348,7 +3393,7 @@ const configApplyInstallManifestJSON = `{
   },
   "install": {
     "wipeTarget": true,
-    "targetDisk": {"byID": "disk/by-id/test"}
+    "targetDisk": {"serial": "root"}
   },
   "katlosImage": {
     "localRef": "images/katlos.raw",

--- a/internal/katlc/agent/volume_apply.go
+++ b/internal/katlc/agent/volume_apply.go
@@ -15,12 +15,56 @@ import (
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
-func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.Manifest) error {
+func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.Manifest, nodeName string, acknowledgements []string) error {
 	run := e.RunTool
 	if run == nil {
 		run = runChildProcess
 	}
+	stopNames, changed := changedVolumes(current, desired)
+	if len(changed) == 0 {
+		return nil
+	}
 
+	plans, err := preflightLiveVolumes(ctx, run, desired, stopNames, changed)
+	if err != nil {
+		return err
+	}
+	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
+		return err
+	}
+
+	for _, name := range stopNames {
+		unit, err := generation.MountUnitName("/var/mnt/" + name)
+		if err != nil {
+			return err
+		}
+		result := run(ctx, []string{"systemctl", "stop", unit}, nil)
+		if result.Err != nil || result.ExitStatus != 0 && result.ExitStatus != 5 {
+			err := fmt.Errorf("stop volume %s: %s", name, toolFailure(result))
+			return fmt.Errorf("%w; stop workloads using /var/mnt/%s and retry", err, name)
+		}
+	}
+
+	facts, err := discoverVolumeFacts(ctx, run)
+	if err != nil {
+		return err
+	}
+	plans, err = planLiveVolumes(facts, desired, changed)
+	if err != nil {
+		return err
+	}
+	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
+		return err
+	}
+	for _, plan := range plans {
+		if err := prepareLiveVolume(ctx, run, e.Root, plan); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func changedVolumes(current, desired manifest.Manifest) ([]string, []manifest.Volume) {
 	currentByName := volumesByName(current.Install.Volumes)
 	desiredByName := volumesByName(desired.Install.Volumes)
 	var stopNames []string
@@ -41,48 +85,51 @@ func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.M
 		changed = append(changed, after)
 	}
 	sort.Slice(changed, func(i, j int) bool { return changed[i].Name < changed[j].Name })
+	return stopNames, changed
+}
 
-	if len(changed) > 0 {
-		facts, err := discoverVolumeFacts(ctx, run)
-		if err != nil {
-			return err
-		}
-		preflight := factsWithoutManagedVolumeMounts(facts, stopNames)
-		if _, err := planLiveVolumes(preflight, desired, changed); err != nil {
-			return err
-		}
-	}
-
-	for _, name := range stopNames {
-		unit, err := generation.MountUnitName("/var/mnt/" + name)
-		if err != nil {
-			return err
-		}
-		result := run(ctx, []string{"systemctl", "stop", unit}, nil)
-		if result.Err != nil || result.ExitStatus != 0 && result.ExitStatus != 5 {
-			err := fmt.Errorf("stop volume %s: %s", name, toolFailure(result))
-			return fmt.Errorf("%w; stop workloads using /var/mnt/%s and retry", err, name)
-		}
-	}
-
-	if len(changed) == 0 {
-		return nil
-	}
-
+func preflightLiveVolumes(ctx context.Context, run ToolRunner, desired manifest.Manifest, stopNames []string, changed []manifest.Volume) ([]disk.VolumePlan, error) {
 	facts, err := discoverVolumeFacts(ctx, run)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	plans, err := planLiveVolumes(facts, desired, changed)
+	return planLiveVolumes(factsWithoutManagedVolumeMounts(facts, stopNames), desired, changed)
+}
+
+func (s *Server) validateDestructiveStorageAuthority(ctx context.Context, nodeName string, current, desired manifest.Manifest, acknowledgements []string) ([]string, error) {
+	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(acknowledgements); err != nil {
+		return nil, err
+	}
+	stopNames, changed := changedVolumes(current, desired)
+	if len(changed) == 0 {
+		return nil, nil
+	}
+	run := s.RunVolumeDiscovery
+	if run == nil {
+		run = runChildProcess
+	}
+	plans, err := preflightLiveVolumes(ctx, run, desired, stopNames, changed)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for _, plan := range plans {
-		if err := prepareLiveVolume(ctx, run, e.Root, plan); err != nil {
-			return err
+	nodeName = storageAuthorityNodeName(nodeName, current)
+	required := disk.RequiredDestructiveVolumeAcknowledgements(nodeName, plans)
+	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
+		return required, err
+	}
+	return required, nil
+}
+
+func storageAuthorityNodeName(requested string, current manifest.Manifest) string {
+	if requested = strings.TrimSpace(requested); requested != "" {
+		return requested
+	}
+	if current.Node.Bootstrap != nil {
+		if name := strings.TrimSpace(current.Node.Bootstrap.InventoryNodeName); name != "" {
+			return name
 		}
 	}
-	return nil
+	return strings.TrimSpace(current.Node.Identity.Hostname)
 }
 
 func discoverVolumeFacts(ctx context.Context, run ToolRunner) (discovery.HardwareFacts, error) {

--- a/internal/katlc/agent/volume_apply_test.go
+++ b/internal/katlc/agent/volume_apply_test.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -108,12 +111,106 @@ func TestApplyVolumesPreflightsBeforeStoppingExistingMount(t *testing.T) {
 			return ToolResult{Err: fmt.Errorf("unexpected command %q", argv[0]), ExitStatus: 1}
 		}
 	}
-	err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired)
+	err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, "node-a", nil)
 	if err == nil || !strings.Contains(err.Error(), "partition selector matched no partitions") {
 		t.Fatalf("applyVolumes() error = %v, want missing partition", err)
 	}
 	if systemctlCalled {
 		t.Fatal("applyVolumes() stopped the existing mount before preflight completed")
+	}
+}
+
+func TestDestructiveStorageAuthorityUsesDiscoveredTargetState(t *testing.T) {
+	current := manifest.Manifest{Install: manifest.InstallConfig{TargetDisk: manifest.DiskSelector{Serial: "root"}}}
+	desired := current
+	desired.Install.Volumes = []manifest.Volume{{
+		Name: "data", Selector: manifest.VolumeSelector{Disk: &manifest.DiskSelector{Serial: "data"}}, Filesystem: "xfs", Wipe: true,
+	}}
+
+	for _, test := range []struct {
+		name             string
+		partitionTable   string
+		acknowledgements []string
+		wantRequired     []string
+		wantError        bool
+	}{
+		{name: "blank target is automatic"},
+		{name: "non-blank target is refused", partitionTable: "gpt", wantRequired: []string{"cp-1/data"}, wantError: true},
+		{name: "named non-blank target is authorized", partitionTable: "gpt", acknowledgements: []string{"cp-1/data"}, wantRequired: []string{"cp-1/data"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runner := volumeAuthorityRunner(test.partitionTable, nil)
+			server := newTestServer(t)
+			server.RunVolumeDiscovery = runner
+			required, err := server.validateDestructiveStorageAuthority(context.Background(), "cp-1", current, desired, test.acknowledgements)
+			if !slices.Equal(required, test.wantRequired) {
+				t.Fatalf("required acknowledgements = %v, want %v", required, test.wantRequired)
+			}
+			var authority *disk.DestructiveVolumeAuthorityError
+			if errors.As(err, &authority) != test.wantError {
+				t.Fatalf("authority error = %v, want error %t", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestApplyVolumesRefusesNonBlankTargetBeforeMutation(t *testing.T) {
+	current := manifest.Manifest{Install: manifest.InstallConfig{TargetDisk: manifest.DiskSelector{Serial: "root"}}}
+	desired := current
+	desired.Install.Volumes = []manifest.Volume{{
+		Name: "data", Selector: manifest.VolumeSelector{Disk: &manifest.DiskSelector{Serial: "data"}}, Filesystem: "xfs", Wipe: true,
+	}}
+	var mutations [][]string
+	runner := volumeAuthorityRunner("gpt", &mutations)
+	err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, "cp-1", nil)
+	var authority *disk.DestructiveVolumeAuthorityError
+	if !errors.As(err, &authority) || !reflect.DeepEqual(authority.Required, []string{"cp-1/data"}) {
+		t.Fatalf("applyVolumes() error = %#v", err)
+	}
+	if len(mutations) != 0 {
+		t.Fatalf("destructive storage refusal ran mutating tools: %v", mutations)
+	}
+}
+
+func TestApplyVolumesMutatesNonBlankTargetOnlyWithNamedAuthority(t *testing.T) {
+	current := manifest.Manifest{Install: manifest.InstallConfig{TargetDisk: manifest.DiskSelector{Serial: "root"}}}
+	desired := current
+	desired.Install.Volumes = []manifest.Volume{{
+		Name: "data", Selector: manifest.VolumeSelector{Disk: &manifest.DiskSelector{Serial: "data"}}, Filesystem: "xfs", Wipe: true,
+	}}
+	var mutations [][]string
+	runner := volumeAuthorityRunner("gpt", &mutations)
+	err := (&Executor{Root: t.TempDir(), RunTool: runner}).applyVolumes(context.Background(), current, desired, "cp-1", []string{"cp-1/data"})
+	if err != nil {
+		t.Fatalf("applyVolumes() error = %v", err)
+	}
+	if len(mutations) != 2 || mutations[0][0] != "systemd-repart" || mutations[1][0] != "udevadm" {
+		t.Fatalf("acknowledged volume mutations = %v", mutations)
+	}
+}
+
+func volumeAuthorityRunner(partitionTable string, mutations *[][]string) ToolRunner {
+	return func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		switch argv[0] {
+		case "lsblk":
+			pttype := ""
+			if partitionTable != "" {
+				pttype = `,"pttype":"` + partitionTable + `"`
+			}
+			return ToolResult{Stdout: []byte(`{"blockdevices":[` +
+				`{"name":"vda","path":"/dev/vda","type":"disk","serial":"root","size":68719476736,"ro":false,"mountpoints":[]},` +
+				`{"name":"vdb","path":"/dev/vdb","type":"disk","serial":"data","size":68719476736,"ro":false,"mountpoints":[]` + pttype + `}` +
+				`]}`)}
+		case "findmnt":
+			return ToolResult{Stdout: []byte(`{"filesystems":[]}`)}
+		case "ip":
+			return ToolResult{Stdout: []byte(`[]`)}
+		default:
+			if mutations != nil {
+				*mutations = append(*mutations, append([]string(nil), argv...))
+			}
+			return ToolResult{}
+		}
 	}
 }
 

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -1814,20 +1814,21 @@ func (x *EtcdMemberRemoveOperationRequest) GetExpectedMemberCount() uint32 {
 }
 
 type ValidateConfigRequest struct {
-	state                       protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind                        string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	Actor                       string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
-	ExpectedMachineId           string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
-	ExpectedCurrentGenerationId string                 `protobuf:"bytes,5,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
-	ApplyMode                   string                 `protobuf:"bytes,6,opt,name=apply_mode,json=applyMode,proto3" json:"apply_mode,omitempty"`
-	CandidateGenerationId       string                 `protobuf:"bytes,7,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
-	NodeName                    string                 `protobuf:"bytes,8,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
-	ConfigYaml                  string                 `protobuf:"bytes,9,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
-	ClientRequestId             string                 `protobuf:"bytes,10,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
-	OperationTimeout            string                 `protobuf:"bytes,11,opt,name=operation_timeout,json=operationTimeout,proto3" json:"operation_timeout,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	state                              protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                         string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                               string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor                              string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId                  string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	ExpectedCurrentGenerationId        string                 `protobuf:"bytes,5,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
+	ApplyMode                          string                 `protobuf:"bytes,6,opt,name=apply_mode,json=applyMode,proto3" json:"apply_mode,omitempty"`
+	CandidateGenerationId              string                 `protobuf:"bytes,7,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
+	NodeName                           string                 `protobuf:"bytes,8,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	ConfigYaml                         string                 `protobuf:"bytes,9,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
+	ClientRequestId                    string                 `protobuf:"bytes,10,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
+	OperationTimeout                   string                 `protobuf:"bytes,11,opt,name=operation_timeout,json=operationTimeout,proto3" json:"operation_timeout,omitempty"`
+	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
 }
 
 func (x *ValidateConfigRequest) Reset() {
@@ -1937,21 +1938,29 @@ func (x *ValidateConfigRequest) GetOperationTimeout() string {
 	return ""
 }
 
+func (x *ValidateConfigRequest) GetDestructiveStorageAcknowledgements() []string {
+	if x != nil {
+		return x.DestructiveStorageAcknowledgements
+	}
+	return nil
+}
+
 type ConfigValidationResult struct {
-	state                 protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion            string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind                  string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	Accepted              bool                   `protobuf:"varint,3,opt,name=accepted,proto3" json:"accepted,omitempty"`
-	RequestDigest         string                 `protobuf:"bytes,4,opt,name=request_digest,json=requestDigest,proto3" json:"request_digest,omitempty"`
-	RequestedApplyMode    string                 `protobuf:"bytes,5,opt,name=requested_apply_mode,json=requestedApplyMode,proto3" json:"requested_apply_mode,omitempty"`
-	AcceptedApplyMode     string                 `protobuf:"bytes,6,opt,name=accepted_apply_mode,json=acceptedApplyMode,proto3" json:"accepted_apply_mode,omitempty"`
-	CandidateGenerationId string                 `protobuf:"bytes,7,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
-	ChangedDomains        []string               `protobuf:"bytes,8,rep,name=changed_domains,json=changedDomains,proto3" json:"changed_domains,omitempty"`
-	Diagnostics           []string               `protobuf:"bytes,9,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
-	FailureReason         string                 `protobuf:"bytes,10,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
-	NoChanges             bool                   `protobuf:"varint,11,opt,name=no_changes,json=noChanges,proto3" json:"no_changes,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                                      protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                                 string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                                       string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Accepted                                   bool                   `protobuf:"varint,3,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	RequestDigest                              string                 `protobuf:"bytes,4,opt,name=request_digest,json=requestDigest,proto3" json:"request_digest,omitempty"`
+	RequestedApplyMode                         string                 `protobuf:"bytes,5,opt,name=requested_apply_mode,json=requestedApplyMode,proto3" json:"requested_apply_mode,omitempty"`
+	AcceptedApplyMode                          string                 `protobuf:"bytes,6,opt,name=accepted_apply_mode,json=acceptedApplyMode,proto3" json:"accepted_apply_mode,omitempty"`
+	CandidateGenerationId                      string                 `protobuf:"bytes,7,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
+	ChangedDomains                             []string               `protobuf:"bytes,8,rep,name=changed_domains,json=changedDomains,proto3" json:"changed_domains,omitempty"`
+	Diagnostics                                []string               `protobuf:"bytes,9,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	FailureReason                              string                 `protobuf:"bytes,10,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	NoChanges                                  bool                   `protobuf:"varint,11,opt,name=no_changes,json=noChanges,proto3" json:"no_changes,omitempty"`
+	RequiredDestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=required_destructive_storage_acknowledgements,json=requiredDestructiveStorageAcknowledgements,proto3" json:"required_destructive_storage_acknowledgements,omitempty"`
+	unknownFields                              protoimpl.UnknownFields
+	sizeCache                                  protoimpl.SizeCache
 }
 
 func (x *ConfigValidationResult) Reset() {
@@ -2061,21 +2070,29 @@ func (x *ConfigValidationResult) GetNoChanges() bool {
 	return false
 }
 
+func (x *ConfigValidationResult) GetRequiredDestructiveStorageAcknowledgements() []string {
+	if x != nil {
+		return x.RequiredDestructiveStorageAcknowledgements
+	}
+	return nil
+}
+
 type GenerationApplyRequest struct {
-	state                       protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind                        string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	ClientRequestId             string                 `protobuf:"bytes,3,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
-	Actor                       string                 `protobuf:"bytes,4,opt,name=actor,proto3" json:"actor,omitempty"`
-	ExpectedMachineId           string                 `protobuf:"bytes,5,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
-	ExpectedCurrentGenerationId string                 `protobuf:"bytes,6,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
-	RequestDigest               string                 `protobuf:"bytes,7,opt,name=request_digest,json=requestDigest,proto3" json:"request_digest,omitempty"`
-	OperationTimeout            string                 `protobuf:"bytes,8,opt,name=operation_timeout,json=operationTimeout,proto3" json:"operation_timeout,omitempty"`
-	CandidateGenerationId       string                 `protobuf:"bytes,9,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
-	NodeName                    string                 `protobuf:"bytes,10,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
-	ConfigYaml                  string                 `protobuf:"bytes,11,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	state                              protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                         string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                               string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	ClientRequestId                    string                 `protobuf:"bytes,3,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
+	Actor                              string                 `protobuf:"bytes,4,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId                  string                 `protobuf:"bytes,5,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	ExpectedCurrentGenerationId        string                 `protobuf:"bytes,6,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
+	RequestDigest                      string                 `protobuf:"bytes,7,opt,name=request_digest,json=requestDigest,proto3" json:"request_digest,omitempty"`
+	OperationTimeout                   string                 `protobuf:"bytes,8,opt,name=operation_timeout,json=operationTimeout,proto3" json:"operation_timeout,omitempty"`
+	CandidateGenerationId              string                 `protobuf:"bytes,9,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
+	NodeName                           string                 `protobuf:"bytes,10,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	ConfigYaml                         string                 `protobuf:"bytes,11,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
+	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
 }
 
 func (x *GenerationApplyRequest) Reset() {
@@ -2185,14 +2202,22 @@ func (x *GenerationApplyRequest) GetConfigYaml() string {
 	return ""
 }
 
+func (x *GenerationApplyRequest) GetDestructiveStorageAcknowledgements() []string {
+	if x != nil {
+		return x.DestructiveStorageAcknowledgements
+	}
+	return nil
+}
+
 type ConfigApplyOperationRequest struct {
-	state                 protoimpl.MessageState `protogen:"open.v1"`
-	CandidateGenerationId string                 `protobuf:"bytes,1,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
-	ApplyMode             string                 `protobuf:"bytes,2,opt,name=apply_mode,json=applyMode,proto3" json:"apply_mode,omitempty"`
-	NodeName              string                 `protobuf:"bytes,3,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
-	ConfigYaml            string                 `protobuf:"bytes,4,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                              protoimpl.MessageState `protogen:"open.v1"`
+	CandidateGenerationId              string                 `protobuf:"bytes,1,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
+	ApplyMode                          string                 `protobuf:"bytes,2,opt,name=apply_mode,json=applyMode,proto3" json:"apply_mode,omitempty"`
+	NodeName                           string                 `protobuf:"bytes,3,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	ConfigYaml                         string                 `protobuf:"bytes,4,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
+	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,5,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
 }
 
 func (x *ConfigApplyOperationRequest) Reset() {
@@ -2251,6 +2276,13 @@ func (x *ConfigApplyOperationRequest) GetConfigYaml() string {
 		return x.ConfigYaml
 	}
 	return ""
+}
+
+func (x *ConfigApplyOperationRequest) GetDestructiveStorageAcknowledgements() []string {
+	if x != nil {
+		return x.DestructiveStorageAcknowledgements
+	}
+	return nil
 }
 
 type KubeadmControlPlaneConfigOperationRequest struct {
@@ -5133,7 +5165,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x10target_member_id\x18\x02 \x01(\tR\x0etargetMemberId\x12&\n" +
 	"\x0ftarget_peer_url\x18\x03 \x01(\tR\rtargetPeerUrl\x12.\n" +
 	"\x13expected_cluster_id\x18\x04 \x01(\tR\x11expectedClusterId\x122\n" +
-	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\xc5\x03\n" +
+	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\x97\x04\n" +
 	"\x15ValidateConfigRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5149,7 +5181,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"configYaml\x12*\n" +
 	"\x11client_request_id\x18\n" +
 	" \x01(\tR\x0fclientRequestId\x12+\n" +
-	"\x11operation_timeout\x18\v \x01(\tR\x10operationTimeout\"\xbb\x03\n" +
+	"\x11operation_timeout\x18\v \x01(\tR\x10operationTimeout\x12P\n" +
+	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\"\x9e\x04\n" +
 	"\x16ConfigValidationResult\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5164,7 +5197,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0efailure_reason\x18\n" +
 	" \x01(\tR\rfailureReason\x12\x1d\n" +
 	"\n" +
-	"no_changes\x18\v \x01(\bR\tnoChanges\"\xce\x03\n" +
+	"no_changes\x18\v \x01(\bR\tnoChanges\x12a\n" +
+	"-required_destructive_storage_acknowledgements\x18\f \x03(\tR*requiredDestructiveStorageAcknowledgements\"\xa0\x04\n" +
 	"\x16GenerationApplyRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5179,14 +5213,16 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\tnode_name\x18\n" +
 	" \x01(\tR\bnodeName\x12\x1f\n" +
 	"\vconfig_yaml\x18\v \x01(\tR\n" +
-	"configYaml\"\xb2\x01\n" +
+	"configYaml\x12P\n" +
+	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\"\x84\x02\n" +
 	"\x1bConfigApplyOperationRequest\x126\n" +
 	"\x17candidate_generation_id\x18\x01 \x01(\tR\x15candidateGenerationId\x12\x1d\n" +
 	"\n" +
 	"apply_mode\x18\x02 \x01(\tR\tapplyMode\x12\x1b\n" +
 	"\tnode_name\x18\x03 \x01(\tR\bnodeName\x12\x1f\n" +
 	"\vconfig_yaml\x18\x04 \x01(\tR\n" +
-	"configYaml\"\x8d\b\n" +
+	"configYaml\x12P\n" +
+	"$destructive_storage_acknowledgements\x18\x05 \x03(\tR\"destructiveStorageAcknowledgements\"\x8d\b\n" +
 	")KubeadmControlPlaneConfigOperationRequest\x12\x1d\n" +
 	"\n" +
 	"rollout_id\x18\x01 \x01(\tR\trolloutId\x12#\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -229,6 +229,7 @@ message ValidateConfigRequest {
   string config_yaml = 9;
   string client_request_id = 10;
   string operation_timeout = 11;
+  repeated string destructive_storage_acknowledgements = 12;
 }
 
 message ConfigValidationResult {
@@ -243,6 +244,7 @@ message ConfigValidationResult {
   repeated string diagnostics = 9;
   string failure_reason = 10;
   bool no_changes = 11;
+  repeated string required_destructive_storage_acknowledgements = 12;
 }
 
 message GenerationApplyRequest {
@@ -257,6 +259,7 @@ message GenerationApplyRequest {
   string candidate_generation_id = 9;
   string node_name = 10;
   string config_yaml = 11;
+  repeated string destructive_storage_acknowledgements = 12;
 }
 
 message ConfigApplyOperationRequest {
@@ -264,6 +267,7 @@ message ConfigApplyOperationRequest {
   string apply_mode = 2;
   string node_name = 3;
   string config_yaml = 4;
+  repeated string destructive_storage_acknowledgements = 5;
 }
 
 message KubeadmControlPlaneConfigOperationRequest {

--- a/internal/vmtest/scenarios/installer_iso_vmtest_test.go
+++ b/internal/vmtest/scenarios/installer_iso_vmtest_test.go
@@ -1,10 +1,16 @@
 package scenarios
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,7 +119,7 @@ func TestInstallerPXEBootSmoke(t *testing.T) {
 	}
 }
 
-func TestInstallerISOFirstInstallSmoke(t *testing.T) {
+func TestInstallerISOFirstInstallStorageAuthority(t *testing.T) {
 	options := vmtest.DefaultOptions()
 	if !options.Enabled {
 		t.Skip("set -katl.vmtest.run or KATL_VMTEST_RUN=1 to run installer ISO first-install smoke")
@@ -155,8 +161,10 @@ install:
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
+	var dataDisk string
+	diskRunner := nonBlankDataDiskRunner{dataPath: &dataDisk}
 	result, err := vmtest.RunFirstInstall(ctx, vmtest.NewRunner(options), vmtest.Scenario{
-		Name: "installer-iso-first-install",
+		Name: "installer-iso-first-install-storage-authority",
 		Disks: []vmtest.DiskFixture{
 			vmtest.TargetDisk("root", string(vmtest.DiskRaw), "32G"),
 			vmtest.ExtraDisk("data", string(vmtest.DiskRaw), "4G"),
@@ -168,9 +176,34 @@ install:
 			VM:     vm,
 		},
 		Manifest:            manifest,
-		PreseedManifest:     true,
+		GuestHandoff:        true,
 		RebootIntoInstalled: true,
 		TargetDisk:          vmtest.TargetDisk("root", string(vmtest.DiskRaw), "32G"),
+		DiskRunner:          diskRunner,
+		HandoffPoster: func(ctx context.Context, endpoint string, payload []byte) (int, string, error) {
+			status, body, err := postInstallerManifest(ctx, endpoint, payload)
+			if err != nil {
+				return 0, "", err
+			}
+			if status != http.StatusPreconditionRequired || !strings.Contains(body, "--acknowledge-storage-wipe iso-node/data") {
+				return 0, "", fmt.Errorf("unacknowledged handoff status=%d body=%s", status, body)
+			}
+			if dataDisk == "" {
+				return 0, "", fmt.Errorf("non-blank data disk path was not recorded")
+			}
+			filesystem, err := exec.CommandContext(ctx, "blkid", "-p", "-s", "TYPE", "-o", "value", dataDisk).CombinedOutput()
+			if err != nil || strings.TrimSpace(string(filesystem)) != "ext4" {
+				return 0, "", fmt.Errorf("refused handoff changed existing data disk signature: type=%q err=%v", filesystem, err)
+			}
+			acknowledged, err := url.Parse(endpoint)
+			if err != nil {
+				return 0, "", err
+			}
+			query := acknowledged.Query()
+			query.Add("acknowledgeStorageWipe", "iso-node/data")
+			acknowledged.RawQuery = query.Encode()
+			return postInstallerManifest(ctx, acknowledged.String(), payload)
+		},
 	})
 	if err != nil {
 		_ = worldScenario.WriteSetupFailure(err)
@@ -185,4 +218,41 @@ install:
 	if err := worldScenario.WriteResult(vmtest.WorldStatusPassed, ""); err != nil {
 		t.Fatalf("write passed world result: %v", err)
 	}
+}
+
+type nonBlankDataDiskRunner struct {
+	dataPath *string
+}
+
+func (r nonBlankDataDiskRunner) Run(ctx context.Context, name string, args ...string) error {
+	if err := (vmtest.ExecDiskRunner{}).Run(ctx, name, args...); err != nil {
+		return err
+	}
+	if name != "qemu-img" || len(args) < 2 {
+		return nil
+	}
+	path := args[len(args)-2]
+	if !strings.Contains(filepath.Base(path), "-data.") {
+		return nil
+	}
+	if err := exec.CommandContext(ctx, "mkfs.ext4", "-F", path).Run(); err != nil {
+		return fmt.Errorf("create existing ext4 data signature: %w", err)
+	}
+	*r.dataPath = path
+	return nil
+}
+
+func postInstallerManifest(ctx context.Context, endpoint string, payload []byte) (int, string, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return 0, "", err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := (&http.Client{Timeout: 10 * time.Second}).Do(request)
+	if err != nil {
+		return 0, "", err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	return response.StatusCode, string(body), err
 }


### PR DESCRIPTION
## What changed

- require an operation-scoped `NODE/VOLUME` acknowledgement before installer or live-agent storage planning can overwrite discovered contents
- keep blank-device provisioning automatic and revalidate discovered state immediately before destructive tools run
- carry acknowledgements through public install, node, and cluster operations without persisting them as desired-state permission
- document the refusal and exact retry workflow

## Why

`wipe: true` expressed the desired storage result but also acted as durable authority. A later selector or hardware change could therefore expose an existing filesystem to overwrite without a fresh operator decision. This separates intent from destructive permission and scopes that permission to the affected node and volume for one operation.

The current-artifact VM journey and persistent `katldev` public journey both proved refusal preserves the existing signature, the named acknowledgement permits the transition, the resulting XFS volume is active, and a repeat apply is unchanged without retaining authority.
