### PR TITLE
config: expose effective node inspection

### DIFF
--- a/cmd/katlctl/config_inspect.go
+++ b/cmd/katlctl/config_inspect.go
@@ -78,7 +78,7 @@ func newConfigDiffCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func resolveNodeConfig(sourcePath, nodeName string) (configbundle.NodeResolution, error) {
-	archive, _, err := configbundle.BuildArchive(configbundle.BuildRequest{
+	archive, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
 		SourcePath:     sourcePath,
 		KatlctlVersion: version,
 		KatlctlCommit:  commit,
@@ -87,8 +87,12 @@ func resolveNodeConfig(sourcePath, nodeName string) (configbundle.NodeResolution
 	if err != nil {
 		return configbundle.NodeResolution{}, err
 	}
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" && len(result.Manifest.Nodes) == 1 {
+		nodeName = result.Manifest.Nodes[0].Name
+	}
 	selected, err := configbundle.ReadSelectedNode(bytes.NewReader(archive), configbundle.ReadOptions{
-		NodeName:                strings.TrimSpace(nodeName),
+		NodeName:                nodeName,
 		AllowMissingKatlosImage: true,
 	})
 	if err != nil {

--- a/cmd/katlctl/config_inspect.go
+++ b/cmd/katlctl/config_inspect.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type configResolveOptions struct {
+	node   string
+	output string
+}
+
+func newConfigResolveCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := configResolveOptions{output: "yaml"}
+	cmd := &cobra.Command{
+		Use:   "resolve SOURCE --node NODE",
+		Short: "Show the effective configuration for one node",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			_ = stderr
+			if opts.output != "yaml" && opts.output != "json" {
+				return fmt.Errorf("--output = %q, want yaml or json", opts.output)
+			}
+			report, err := resolveNodeConfig(args[0], opts.node)
+			if err != nil {
+				return err
+			}
+			return writeConfigInspection(stdout, opts.output, report)
+		},
+	}
+	cmd.Flags().StringVar(&opts.node, "node", "", "node name to resolve (required for multi-node configs)")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: yaml or json")
+	return cmd
+}
+
+type configDiffOptions struct {
+	node   string
+	output string
+}
+
+func newConfigDiffCommand(stdout, stderr io.Writer) *cobra.Command {
+	opts := configDiffOptions{output: "text"}
+	cmd := &cobra.Command{
+		Use:   "diff BEFORE AFTER --node NODE",
+		Short: "Compare effective node configuration",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			_ = stderr
+			if opts.output != "text" && opts.output != "yaml" && opts.output != "json" {
+				return fmt.Errorf("--output = %q, want text, yaml, or json", opts.output)
+			}
+			before, err := resolveNodeConfig(args[0], opts.node)
+			if err != nil {
+				return fmt.Errorf("resolve before config: %w", err)
+			}
+			after, err := resolveNodeConfig(args[1], opts.node)
+			if err != nil {
+				return fmt.Errorf("resolve after config: %w", err)
+			}
+			report := configbundle.DiffNodeResolutions(before, after)
+			if opts.output == "text" {
+				return writeConfigDiffText(stdout, report)
+			}
+			return writeConfigInspection(stdout, opts.output, report)
+		},
+	}
+	cmd.Flags().StringVar(&opts.node, "node", "", "node name to compare (required for multi-node configs)")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "output format: text, yaml, or json")
+	return cmd
+}
+
+func resolveNodeConfig(sourcePath, nodeName string) (configbundle.NodeResolution, error) {
+	archive, _, err := configbundle.BuildArchive(configbundle.BuildRequest{
+		SourcePath:     sourcePath,
+		KatlctlVersion: version,
+		KatlctlCommit:  commit,
+		CreatedBy:      "katlctl config resolve",
+	})
+	if err != nil {
+		return configbundle.NodeResolution{}, err
+	}
+	selected, err := configbundle.ReadSelectedNode(bytes.NewReader(archive), configbundle.ReadOptions{
+		NodeName:                strings.TrimSpace(nodeName),
+		AllowMissingKatlosImage: true,
+	})
+	if err != nil {
+		return configbundle.NodeResolution{}, err
+	}
+	return configbundle.InspectSelectedNode(selected)
+}
+
+func writeConfigInspection(stdout io.Writer, output string, report any) error {
+	switch output {
+	case "json":
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal config inspection: %w", err)
+		}
+		_, err = stdout.Write(append(data, '\n'))
+		return err
+	case "yaml":
+		data, err := yaml.Marshal(report)
+		if err != nil {
+			return fmt.Errorf("marshal config inspection: %w", err)
+		}
+		_, err = stdout.Write(data)
+		return err
+	default:
+		return fmt.Errorf("--output = %q, want yaml or json", output)
+	}
+}
+
+func writeConfigDiffText(stdout io.Writer, report configbundle.ConfigDiff) error {
+	if len(report.Changes) == 0 {
+		_, err := fmt.Fprintf(stdout, "%s has no effective changes for node %s\n", report.AfterCluster, report.Node)
+		return err
+	}
+	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintf(w, "PATH\tCLASSIFICATION\tREQUIRED OPERATION\n"); err != nil {
+		return err
+	}
+	for _, change := range report.Changes {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", change.Path, change.Classification, change.RequiredOperation); err != nil {
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(stdout, "Overall: %s\n", report.Classification.Overall)
+	return err
+}

--- a/cmd/katlctl/config_inspect_test.go
+++ b/cmd/katlctl/config_inspect_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/installer/configbundle"
+)
+
+func TestConfigResolveShowsPublicEffectiveNode(t *testing.T) {
+	source := configInspectionSource()
+	path := filepath.Join(t.TempDir(), "cluster.yaml")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "resolve", path, "--node", "cp-1", "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var report struct {
+		Kind    string `json:"kind"`
+		Node    string `json:"node"`
+		Derived struct {
+			StorageVolumes []configbundle.DerivedVolume `json:"storageVolumes"`
+		} `json:"derived"`
+		Provenance []configbundle.FieldProvenance   `json:"provenance"`
+		OwnedFiles []configbundle.OwnedFile         `json:"ownedFiles"`
+		Warnings   []configbundle.ResolutionWarning `json:"warnings"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if report.Kind != configbundle.NodeResolutionKind || report.Node != "cp-1" {
+		t.Fatalf("report identity = %#v", report)
+	}
+	if len(report.Derived.StorageVolumes) != 1 || report.Derived.StorageVolumes[0].MountPath != "/var/mnt/data" || report.Derived.StorageVolumes[0].PartitionLabel != "u-data" {
+		t.Fatalf("derived volumes = %#v", report.Derived.StorageVolumes)
+	}
+	if len(report.Provenance) == 0 || len(report.OwnedFiles) == 0 || len(report.Warnings) == 0 {
+		t.Fatalf("inspection detail missing: provenance=%d files=%d warnings=%d", len(report.Provenance), len(report.OwnedFiles), len(report.Warnings))
+	}
+	for _, internal := range []string{`"targetDisk"`, `"volumes"`, `"sets"`, `"notify"`, `"name":"kernel.`} {
+		if strings.Contains(stdout.String(), internal) {
+			t.Fatalf("resolve output exposes internal field %q:\n%s", internal, stdout.String())
+		}
+	}
+	for _, public := range []string{`"systemDisk"`, `"storage"`, `"disks"`, `"classification"`} {
+		if !strings.Contains(stdout.String(), public) {
+			t.Fatalf("resolve output missing %q:\n%s", public, stdout.String())
+		}
+	}
+	foundDefaultFilesystem := false
+	foundDefaultSize := false
+	foundNodeIdentity := false
+	for _, entry := range report.Provenance {
+		if entry.Source == `spec.defaults.storage.disks[name="data"].filesystem` {
+			foundDefaultFilesystem = true
+		}
+		if entry.Source == `spec.defaults.storage.disks[name="data"].selector.disk.minSizeMiB` {
+			foundDefaultSize = true
+		}
+		if entry.Source == `spec.nodes["cp-1"].storage.disks[name="data"].selector.disk.byID` {
+			foundNodeIdentity = true
+		}
+	}
+	if !foundDefaultFilesystem || !foundDefaultSize || !foundNodeIdentity {
+		t.Fatalf("provenance does not attribute layered storage fields: %#v", report.Provenance)
+	}
+}
+
+func TestConfigDiffClassifiesLifecycleAndTargetChanges(t *testing.T) {
+	dir := t.TempDir()
+	beforePath := filepath.Join(dir, "before.yaml")
+	afterPath := filepath.Join(dir, "after.yaml")
+	before := configInspectionSource()
+	after := strings.Replace(before, "/dev/disk/by-id/ata-cp-root", "/dev/disk/by-id/ata-new-root", 1)
+	after = strings.Replace(after, "address: 10.0.0.11", "address: 10.0.0.12", 1)
+	if err := os.WriteFile(beforePath, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(afterPath, []byte(after), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "diff", beforePath, afterPath, "--node", "cp-1", "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var report configbundle.ConfigDiff
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if report.Classification.Overall != "operation-only" || len(report.Changes) != 2 {
+		t.Fatalf("diff = %#v", report)
+	}
+	if report.Changes[0].RequiredOperation != "wipe-reinstall" || report.Changes[1].Classification != "target-only" {
+		t.Fatalf("changes = %#v", report.Changes)
+	}
+}
+
+func configInspectionSource() string {
+	source := strings.Replace(configBundleSource(), "  nodes:\n", `    storage:
+      disks:
+        - name: data
+          selector:
+            disk:
+              minSizeMiB: 1024
+          filesystem: xfs
+  nodes:
+`, 1)
+	return strings.Replace(source, "      install:\n", `      storage:
+        disks:
+          - name: data
+            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
+      install:
+`, 1)
+}

--- a/cmd/katlctl/config_inspect_test.go
+++ b/cmd/katlctl/config_inspect_test.go
@@ -19,7 +19,7 @@ func TestConfigResolveShowsPublicEffectiveNode(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"config", "resolve", path, "--node", "cp-1", "--output", "json"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"config", "resolve", path, "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 	}
 	var report struct {
@@ -99,6 +99,18 @@ func TestConfigDiffClassifiesLifecycleAndTargetChanges(t *testing.T) {
 	}
 	if report.Changes[0].RequiredOperation != "wipe-reinstall" || report.Changes[1].Classification != "target-only" {
 		t.Fatalf("changes = %#v", report.Changes)
+	}
+}
+
+func TestConfigResolveRequiresSelectionForMultipleNodes(t *testing.T) {
+	path := writeMultiControlPlaneClusterConfig(t)
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"config", "resolve", path}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "selected node is required") {
+		t.Fatalf("run() error = %v, want explicit multi-node selection", err)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("stdout=%q stderr=%q, want empty", stdout.String(), stderr.String())
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -128,6 +128,8 @@ Start with "katlctl install discover" for a waiting installer or
 	configCmd.AddCommand(newConfigValidateCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigSchemaCommand(stdout, stderr))
 	configCmd.AddCommand(newConfigBundleCommand(stdout, stderr))
+	configCmd.AddCommand(newConfigResolveCommand(stdout, stderr))
+	configCmd.AddCommand(newConfigDiffCommand(stdout, stderr))
 	renderNodeCmd := newConfigRenderNodeCommand(stdout, stderr)
 	renderNodeCmd.Hidden = true
 	configCmd.AddCommand(renderNodeCmd)
@@ -215,6 +217,8 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 		"katlctl config validate":           "katlctl config validate cluster.yaml",
 		"katlctl config schema":             "katlctl config schema",
 		"katlctl config bundle":             "katlctl config bundle cluster.yaml --output cluster.katlcfg",
+		"katlctl config resolve":            "katlctl config resolve cluster.yaml --node cp-1",
+		"katlctl config diff":               "katlctl config diff before.yaml after.yaml --node cp-1",
 		"katlctl config render-node":        "katlctl config render-node --config cluster.yaml --node cp-1 --desired-version 1",
 		"katlctl context":                   "katlctl context show",
 		"katlctl context path":              "katlctl context path",

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -26,7 +26,14 @@ Use the compiler and its schema directly:
 ```console
 katlctl config validate ./cluster.yaml
 katlctl config schema > cluster-config-v1alpha1.schema.json
+katlctl config resolve ./cluster.yaml --node cp-1
+katlctl config diff ./cluster-before.yaml ./cluster-after.yaml --node cp-1
 ```
+
+`config resolve` is the supported effective-value view. It preserves public
+ClusterConfig names while showing field provenance, derived storage paths and
+labels, owned files, warnings, and apply/lifecycle boundaries. `config diff`
+compares that model rather than compiled install-manifest internals.
 
 ## Authoring Model
 

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -21,6 +21,33 @@ and kubeadm phases internally. System-disk installation selection and
 Kubernetes version changes use the dedicated install and Kubernetes upgrade
 workflows; data disks remain desired node storage.
 
+## Inspect Effective Configuration
+
+Resolve one node before applying a config:
+
+```console
+katlctl config resolve ./cluster.yaml --node cp-1
+```
+
+The YAML output uses ClusterConfig field names and shows the final values after
+defaults, named-entry overlays, removals, and explicit empty collections. It
+also reports where each effective value came from, derived hostnames, storage
+mount paths and GPT labels, Katl-owned `/etc` paths, warnings, and the boundary
+between normal apply and lifecycle operations. Use `--output json` for tooling.
+
+Compare two revisions through the same effective per-node model:
+
+```console
+katlctl config diff ./cluster-before.yaml ./cluster-after.yaml --node cp-1
+```
+
+The default table classifies every changed public path. `operation-only`
+changes name the required workflow; `staged-only` changes activate through a
+node generation; storage changes call out live discovery and destructive
+authorization; `target-only` means workstation targeting changes without a
+node generation. Use `--output yaml` or `--output json` to retain before and
+after values in review or automation.
+
 If `spec.kubernetes.kubeadm` changes, cluster apply validates every node before
 mutation and then reconciles every affected Kubernetes component online. A
 Kubernetes configuration change never falls back to next-boot application or

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -1223,6 +1223,9 @@ func TestReadSelectedNodeVerifiesBundleAndSelectsNodeMaterial(t *testing.T) {
 	if selected.Node.Name != "cp-1" || selected.InstallManifest.Node.Identity.Hostname != "cp-1" {
 		t.Fatalf("selected node/install material = %#v / %#v", selected.Node, selected.InstallManifest.Node.Identity)
 	}
+	if selected.Source.Kind != Kind || selected.Source.Metadata.Name != "lab" || len(selected.Source.Spec.Nodes) != 2 {
+		t.Fatalf("selected normalized source = %#v", selected.Source)
+	}
 	if _, ok := selected.KubeadmConfigs["control-plane"]; !ok {
 		t.Fatalf("KubeadmConfigs = %#v, want control-plane", selected.KubeadmConfigs)
 	}

--- a/internal/installer/configbundle/consume.go
+++ b/internal/installer/configbundle/consume.go
@@ -26,6 +26,7 @@ type ReadOptions struct {
 
 type SelectedNodeMaterial struct {
 	BundleManifest          BundleManifest
+	Source                  SourceConfig
 	Node                    NodeRecord
 	NodeMaterial            clusterplan.NodeMaterial
 	InstallManifest         manifest.Manifest
@@ -107,6 +108,14 @@ func ReadSelectedNode(reader io.Reader, options ReadOptions) (SelectedNodeMateri
 	if err := validateBundleManifest(bundle); err != nil {
 		return SelectedNodeMaterial{}, err
 	}
+	normalizedSourceData, err := archive.descriptorData(bundle.Source.NormalizedConfig)
+	if err != nil {
+		return SelectedNodeMaterial{}, fmt.Errorf("read normalized source config: %w", err)
+	}
+	source, err := DecodeSource(bytes.NewReader(normalizedSourceData))
+	if err != nil {
+		return SelectedNodeMaterial{}, fmt.Errorf("decode normalized source config: %w", err)
+	}
 	node, err := selectNode(bundle.Nodes, options.NodeName)
 	if err != nil {
 		return SelectedNodeMaterial{}, err
@@ -148,6 +157,7 @@ func ReadSelectedNode(reader io.Reader, options ReadOptions) (SelectedNodeMateri
 
 	return SelectedNodeMaterial{
 		BundleManifest:          bundle,
+		Source:                  source,
 		Node:                    node,
 		NodeMaterial:            nodeMaterial,
 		InstallManifest:         installManifest,

--- a/internal/installer/configbundle/inspect.go
+++ b/internal/installer/configbundle/inspect.go
@@ -1,0 +1,577 @@
+package configbundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"github.com/katl-dev/katl/internal/installer/confext"
+	"github.com/katl-dev/katl/internal/installer/controlplaneendpoint"
+)
+
+const (
+	NodeResolutionKind = "ClusterConfigNodeResolution"
+	ConfigDiffKind     = "ClusterConfigDiff"
+)
+
+type NodeResolution struct {
+	APIVersion     string                   `json:"apiVersion" yaml:"apiVersion"`
+	Kind           string                   `json:"kind" yaml:"kind"`
+	ClusterName    string                   `json:"clusterName" yaml:"clusterName"`
+	Node           string                   `json:"node" yaml:"node"`
+	Effective      SourceNode               `json:"effective" yaml:"effective"`
+	Cluster        ResolvedCluster          `json:"cluster" yaml:"cluster"`
+	Derived        ResolvedDerived          `json:"derived" yaml:"derived"`
+	Provenance     []FieldProvenance        `json:"provenance" yaml:"provenance"`
+	OwnedFiles     []OwnedFile              `json:"ownedFiles" yaml:"ownedFiles"`
+	Warnings       []ResolutionWarning      `json:"warnings" yaml:"warnings"`
+	Classification ResolutionClassification `json:"classification" yaml:"classification"`
+}
+
+type ResolvedCluster struct {
+	ControlPlaneEndpoint *controlplaneendpoint.Config `json:"controlPlaneEndpoint,omitempty" yaml:"controlPlaneEndpoint,omitempty"`
+	KubernetesVersion    string                       `json:"kubernetesVersion" yaml:"kubernetesVersion"`
+}
+
+type ResolvedDerived struct {
+	Hostname       string          `json:"hostname" yaml:"hostname"`
+	SystemRole     string          `json:"systemRole" yaml:"systemRole"`
+	KubeadmConfig  string          `json:"kubeadmConfig,omitempty" yaml:"kubeadmConfig,omitempty"`
+	StorageVolumes []DerivedVolume `json:"storageVolumes,omitempty" yaml:"storageVolumes,omitempty"`
+}
+
+type DerivedVolume struct {
+	Name           string `json:"name" yaml:"name"`
+	MountPath      string `json:"mountPath" yaml:"mountPath"`
+	MountSource    string `json:"mountSource" yaml:"mountSource"`
+	PartitionLabel string `json:"partitionLabel,omitempty" yaml:"partitionLabel,omitempty"`
+}
+
+type FieldProvenance struct {
+	Path   string `json:"path" yaml:"path"`
+	Source string `json:"source" yaml:"source"`
+	Kind   string `json:"kind" yaml:"kind"`
+}
+
+type OwnedFile struct {
+	Path  string `json:"path" yaml:"path"`
+	Type  string `json:"type" yaml:"type"`
+	Mode  string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Owner string `json:"owner" yaml:"owner"`
+}
+
+type ResolutionWarning struct {
+	Path    string `json:"path" yaml:"path"`
+	Message string `json:"message" yaml:"message"`
+}
+
+type ResolutionClassification struct {
+	Install   string `json:"install" yaml:"install"`
+	Apply     string `json:"apply" yaml:"apply"`
+	Lifecycle string `json:"lifecycle" yaml:"lifecycle"`
+}
+
+func InspectSelectedNode(selected SelectedNodeMaterial) (NodeResolution, error) {
+	var node SourceNode
+	nodeIndex := -1
+	for i, candidate := range selected.Source.Spec.Nodes {
+		if candidate.Name == selected.Node.Name {
+			node = candidate
+			nodeIndex = i
+			break
+		}
+	}
+	if nodeIndex < 0 {
+		return NodeResolution{}, fmt.Errorf("normalized source does not contain selected node %q", selected.Node.Name)
+	}
+	resolved, err := mergeSourceNodeLayer(selected.Source.Spec.Defaults, sourceNodeLayer(node))
+	if err != nil {
+		return NodeResolution{}, fmt.Errorf("resolve node %q: %w", node.Name, err)
+	}
+	effective := SourceNode{
+		Name:              node.Name,
+		ControlPlane:      node.ControlPlane,
+		Access:            resolved.Access,
+		Kernel:            resolved.Kernel,
+		HostConfiguration: resolved.HostConfiguration,
+		SystemExtensions:  resolved.SystemExtensions,
+		Install:           resolved.Install,
+		Storage:           resolved.Storage,
+		Kubernetes:        resolved.Kubernetes,
+		Management:        node.Management,
+	}
+	base := sourceNodePath(node, nodeIndex)
+	report := NodeResolution{
+		APIVersion:  APIVersion,
+		Kind:        NodeResolutionKind,
+		ClusterName: selected.Source.Metadata.Name,
+		Node:        node.Name,
+		Effective:   effective,
+		Cluster: ResolvedCluster{
+			ControlPlaneEndpoint: selected.Source.Spec.ControlPlaneEndpoint,
+			KubernetesVersion:    selected.NodeMaterial.KubernetesVersion,
+		},
+		Derived: ResolvedDerived{
+			Hostname:      selected.InstallManifest.Node.Identity.Hostname,
+			SystemRole:    selected.InstallManifest.Node.SystemRole,
+			KubeadmConfig: selected.NodeMaterial.KubeadmConfig.Ref,
+		},
+		Classification: ResolutionClassification{
+			Install:   "supported for unenrolled or explicitly reinstalled nodes",
+			Apply:     "use config diff against the current desired config before applying",
+			Lifecycle: "node role and system-disk changes require dedicated lifecycle operations",
+		},
+	}
+	report.Provenance = nodeProvenance(node, resolved, base)
+	report.Provenance = append(report.Provenance, FieldProvenance{
+		Path: "spec.kubernetes.version", Source: "spec.kubernetes.version", Kind: "cluster",
+	})
+	if selected.Source.Spec.ControlPlaneEndpoint != nil {
+		report.Provenance = append(report.Provenance, FieldProvenance{
+			Path: "spec.controlPlaneEndpoint", Source: "spec.controlPlaneEndpoint", Kind: "cluster",
+		})
+	}
+	report.Derived.StorageVolumes, report.Warnings = derivedVolumesAndWarnings(resolved.Storage, base)
+	if node.Management.Address != "" {
+		report.Warnings = append(report.Warnings, ResolutionWarning{
+			Path:    base + ".management.address",
+			Message: "management.address selects the workstation target and does not change generated node state",
+		})
+	}
+	report.OwnedFiles = ownedFiles(selected.NodeMaterial.NativeEtcFiles)
+	sort.Slice(report.Provenance, func(i, j int) bool { return report.Provenance[i].Path < report.Provenance[j].Path })
+	sort.Slice(report.Warnings, func(i, j int) bool { return report.Warnings[i].Path < report.Warnings[j].Path })
+	return report, nil
+}
+
+func nodeProvenance(node SourceNode, resolved SourceNodeLayer, base string) []FieldProvenance {
+	entries := []FieldProvenance{
+		{Path: base + ".name", Source: base + ".name", Kind: "node"},
+		{Path: base + ".controlPlane", Source: base + ".controlPlane", Kind: "node"},
+	}
+	choose := func(path string, nodeSet bool) {
+		source := "spec.defaults." + path
+		kind := "default"
+		if nodeSet {
+			source = base + "." + path
+			kind = "node"
+		}
+		entries = append(entries, FieldProvenance{Path: base + "." + path, Source: source, Kind: kind})
+	}
+	_, keysSet := node.Access.SSH.AuthorizedKeys.Get()
+	if _, set := resolved.Access.SSH.AuthorizedKeys.Get(); set {
+		choose("access.ssh.authorizedKeys", keysSet)
+	}
+	if resolved.Kernel != nil {
+		choose("kernel", node.Kernel != nil)
+	}
+	_, sysfsSet := node.HostConfiguration.Sysfs.Get()
+	if _, set := resolved.HostConfiguration.Sysfs.Get(); set {
+		choose("hostConfiguration.sysfs", sysfsSet)
+	}
+	resolvedSets, _ := resolved.HostConfiguration.FileSets.Get()
+	nodeSets, nodeSetsSet := node.HostConfiguration.FileSets.Get()
+	for _, name := range sortedMapKeys(resolvedSets) {
+		_, fromNode := nodeSets[name]
+		choose(fmt.Sprintf("hostConfiguration.fileSets[%q]", name), nodeSetsSet && fromNode)
+	}
+	resolvedExtensions, _ := resolved.SystemExtensions.Get()
+	nodeExtensions, nodeExtensionsSet := node.SystemExtensions.Get()
+	for _, extension := range resolvedExtensions {
+		choose(fmt.Sprintf("systemExtensions[name=%q]", extension.Name), nodeExtensionsSet && hasExtension(nodeExtensions, extension.Name))
+	}
+	resolvedSystemDisk := resolved.Install.SystemDisk
+	diskFields := []struct {
+		name string
+		used bool
+		set  bool
+	}{
+		{"byID", optionalStringSet(resolvedSystemDisk, func(v *SourceDiskSelector) Optional[string] { return v.ByID }), optionalStringSet(node.Install.SystemDisk, func(v *SourceDiskSelector) Optional[string] { return v.ByID })},
+		{"wwn", optionalStringSet(resolvedSystemDisk, func(v *SourceDiskSelector) Optional[string] { return v.WWN }), optionalStringSet(node.Install.SystemDisk, func(v *SourceDiskSelector) Optional[string] { return v.WWN })},
+		{"serial", optionalStringSet(resolvedSystemDisk, func(v *SourceDiskSelector) Optional[string] { return v.Serial }), optionalStringSet(node.Install.SystemDisk, func(v *SourceDiskSelector) Optional[string] { return v.Serial })},
+		{"minSizeMiB", optionalUintSet(resolvedSystemDisk), optionalUintSet(node.Install.SystemDisk)},
+	}
+	for _, field := range diskFields {
+		if field.used {
+			choose("install.systemDisk."+field.name, field.set)
+		}
+	}
+	resolvedDisks, _ := resolved.Storage.Disks.Get()
+	nodeDisks, nodeDisksSet := node.Storage.Disks.Get()
+	for _, disk := range resolvedDisks {
+		nodeDisk, found := storageDisk(nodeDisks, disk.Name)
+		prefix := fmt.Sprintf("storage.disks[name=%q]", disk.Name)
+		var nodeSelector *SourceVolumeSelector
+		if nodeDisksSet && found {
+			nodeSelector = nodeDisk.Selector
+		}
+		if disk.Selector != nil && disk.Selector.Disk != nil {
+			var nodeDiskSelector *SourceDiskSelector
+			if nodeSelector != nil {
+				nodeDiskSelector = nodeSelector.Disk
+			}
+			selectorFields := []struct {
+				name string
+				used bool
+				set  bool
+			}{
+				{"byID", optionalStringSet(disk.Selector.Disk, func(v *SourceDiskSelector) Optional[string] { return v.ByID }), optionalStringSet(nodeDiskSelector, func(v *SourceDiskSelector) Optional[string] { return v.ByID })},
+				{"wwn", optionalStringSet(disk.Selector.Disk, func(v *SourceDiskSelector) Optional[string] { return v.WWN }), optionalStringSet(nodeDiskSelector, func(v *SourceDiskSelector) Optional[string] { return v.WWN })},
+				{"serial", optionalStringSet(disk.Selector.Disk, func(v *SourceDiskSelector) Optional[string] { return v.Serial }), optionalStringSet(nodeDiskSelector, func(v *SourceDiskSelector) Optional[string] { return v.Serial })},
+				{"minSizeMiB", optionalUintSet(disk.Selector.Disk), optionalUintSet(nodeDiskSelector)},
+			}
+			for _, field := range selectorFields {
+				if field.used {
+					choose(prefix+".selector.disk."+field.name, field.set)
+				}
+			}
+		}
+		if disk.Selector != nil && disk.Selector.Partition != nil {
+			var nodePartition *SourcePartitionSelector
+			if nodeSelector != nil {
+				nodePartition = nodeSelector.Partition
+			}
+			partitionFields := []struct {
+				name string
+				used bool
+				set  bool
+			}{
+				{"byID", optionalPartitionStringSet(disk.Selector.Partition, func(v *SourcePartitionSelector) Optional[string] { return v.ByID }), optionalPartitionStringSet(nodePartition, func(v *SourcePartitionSelector) Optional[string] { return v.ByID })},
+				{"partUUID", optionalPartitionStringSet(disk.Selector.Partition, func(v *SourcePartitionSelector) Optional[string] { return v.PartUUID }), optionalPartitionStringSet(nodePartition, func(v *SourcePartitionSelector) Optional[string] { return v.PartUUID })},
+				{"filesystemUUID", optionalPartitionStringSet(disk.Selector.Partition, func(v *SourcePartitionSelector) Optional[string] { return v.FilesystemUUID }), optionalPartitionStringSet(nodePartition, func(v *SourcePartitionSelector) Optional[string] { return v.FilesystemUUID })},
+			}
+			selected := false
+			for _, field := range partitionFields {
+				if field.used {
+					selected = true
+					choose(prefix+".selector.partition."+field.name, field.set)
+				}
+			}
+			if !selected {
+				choose(prefix+".selector.partition", nodePartition != nil)
+			}
+		}
+		_, filesystemSet := nodeDisk.Filesystem.Get()
+		if _, set := disk.Filesystem.Get(); set {
+			choose(prefix+".filesystem", nodeDisksSet && found && filesystemSet)
+		}
+		_, wipeSet := nodeDisk.Wipe.Get()
+		if _, set := disk.Wipe.Get(); set {
+			choose(prefix+".wipe", nodeDisksSet && found && wipeSet)
+		}
+	}
+	resolvedLabels, _ := resolved.Kubernetes.Labels.Get()
+	nodeLabels, nodeLabelsSet := node.Kubernetes.Labels.Get()
+	for _, key := range sortedMapKeys(resolvedLabels) {
+		_, found := nodeLabels[key]
+		choose(fmt.Sprintf("kubernetes.labels[%q]", key), nodeLabelsSet && found)
+	}
+	if strings.TrimSpace(resolved.Kubernetes.Address) != "" {
+		choose("kubernetes.address", strings.TrimSpace(node.Kubernetes.Address) != "")
+	}
+	_, taintsSet := node.Kubernetes.Taints.Get()
+	if _, set := resolved.Kubernetes.Taints.Get(); set {
+		choose("kubernetes.taints", taintsSet)
+	}
+	if node.Management.Address != "" {
+		entries = append(entries, FieldProvenance{Path: base + ".management.address", Source: base + ".management.address", Kind: "node"})
+	}
+	return entries
+}
+
+func derivedVolumesAndWarnings(storage SourceStorageLayer, base string) ([]DerivedVolume, []ResolutionWarning) {
+	disks, _ := storage.Disks.Get()
+	volumes := make([]DerivedVolume, 0, len(disks))
+	var warnings []ResolutionWarning
+	for _, disk := range disks {
+		derived := DerivedVolume{Name: disk.Name, MountPath: "/var/mnt/" + disk.Name}
+		path := fmt.Sprintf("%s.storage.disks[name=%q]", base, disk.Name)
+		switch {
+		case disk.Selector != nil && disk.Selector.Disk != nil:
+			derived.PartitionLabel = "u-" + disk.Name
+			derived.MountSource = "/dev/disk/by-partlabel/" + derived.PartitionLabel
+		case disk.Selector != nil && disk.Selector.Partition != nil:
+			selector := disk.Selector.Partition
+			switch {
+			case selector.ByID.Value() != "":
+				derived.MountSource = selector.ByID.Value()
+			case selector.PartUUID.Value() != "":
+				derived.MountSource = "PARTUUID=" + selector.PartUUID.Value()
+			case selector.FilesystemUUID.Value() != "":
+				derived.MountSource = "UUID=" + selector.FilesystemUUID.Value()
+			default:
+				derived.PartitionLabel = "u-" + disk.Name
+				derived.MountSource = "/dev/disk/by-partlabel/" + derived.PartitionLabel
+				warnings = append(warnings, ResolutionWarning{Path: path + ".selector.partition", Message: "empty partition selector uses the convention-derived GPT label " + derived.PartitionLabel})
+			}
+		}
+		if wipe, set := disk.Wipe.Get(); set && wipe {
+			warnings = append(warnings, ResolutionWarning{Path: path + ".wipe", Message: "overwriting existing data requires operation-level acknowledgement naming this node and volume"})
+		}
+		volumes = append(volumes, derived)
+	}
+	sort.Slice(volumes, func(i, j int) bool { return volumes[i].Name < volumes[j].Name })
+	return volumes, warnings
+}
+
+func ownedFiles(files []confext.NativeEtcFile) []OwnedFile {
+	out := make([]OwnedFile, 0, len(files))
+	for _, file := range files {
+		kind := string(file.Type)
+		if kind == "" {
+			kind = string(confext.NativeEtcRegularFile)
+		}
+		mode := file.Mode
+		if mode == 0 && file.Type != confext.NativeEtcSymlink {
+			mode = 0o644
+		}
+		entry := OwnedFile{Path: file.Path, Type: kind, Owner: fmt.Sprintf("%d:%d", file.UID, file.GID)}
+		if file.Type != confext.NativeEtcSymlink {
+			entry.Mode = formatMode(mode)
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func formatMode(mode fs.FileMode) string { return fmt.Sprintf("%04o", mode.Perm()) }
+
+func hasExtension(values []SourceSystemExtension, name string) bool {
+	for _, value := range values {
+		if value.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func storageDisk(values []SourceStorageDisk, name string) (SourceStorageDisk, bool) {
+	for _, value := range values {
+		if value.Name == name {
+			return value, true
+		}
+	}
+	return SourceStorageDisk{}, false
+}
+
+func optionalStringSet(selector *SourceDiskSelector, get func(*SourceDiskSelector) Optional[string]) bool {
+	if selector == nil {
+		return false
+	}
+	_, ok := get(selector).Get()
+	return ok
+}
+
+func optionalUintSet(selector *SourceDiskSelector) bool {
+	if selector == nil {
+		return false
+	}
+	_, ok := selector.MinSizeMiB.Get()
+	return ok
+}
+
+func optionalPartitionStringSet(selector *SourcePartitionSelector, get func(*SourcePartitionSelector) Optional[string]) bool {
+	if selector == nil {
+		return false
+	}
+	_, ok := get(selector).Get()
+	return ok
+}
+
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+type ConfigDiff struct {
+	APIVersion     string              `json:"apiVersion" yaml:"apiVersion"`
+	Kind           string              `json:"kind" yaml:"kind"`
+	Node           string              `json:"node" yaml:"node"`
+	BeforeCluster  string              `json:"beforeCluster" yaml:"beforeCluster"`
+	AfterCluster   string              `json:"afterCluster" yaml:"afterCluster"`
+	Changes        []ConfigFieldChange `json:"changes" yaml:"changes"`
+	Classification DiffClassification  `json:"classification" yaml:"classification"`
+}
+
+type ConfigFieldChange struct {
+	Path              string `json:"path" yaml:"path"`
+	Before            any    `json:"before,omitempty" yaml:"before,omitempty"`
+	After             any    `json:"after,omitempty" yaml:"after,omitempty"`
+	Classification    string `json:"classification" yaml:"classification"`
+	RequiredOperation string `json:"requiredOperation,omitempty" yaml:"requiredOperation,omitempty"`
+	Message           string `json:"message" yaml:"message"`
+}
+
+type DiffClassification struct {
+	Overall            string   `json:"overall" yaml:"overall"`
+	RequiredOperations []string `json:"requiredOperations,omitempty" yaml:"requiredOperations,omitempty"`
+}
+
+func DiffNodeResolutions(before, after NodeResolution) ConfigDiff {
+	base := fmt.Sprintf("spec.nodes[%q]", after.Node)
+	if after.Node == "" {
+		base = fmt.Sprintf("spec.nodes[%q]", before.Node)
+	}
+	diff := ConfigDiff{
+		APIVersion:    APIVersion,
+		Kind:          ConfigDiffKind,
+		Node:          after.Node,
+		BeforeCluster: before.ClusterName,
+		AfterCluster:  after.ClusterName,
+	}
+	if diff.Node == "" {
+		diff.Node = before.Node
+	}
+	add := func(path string, left, right any) {
+		if publicEqual(left, right) {
+			return
+		}
+		classification, operation, message := classifyDiffPath(path)
+		diff.Changes = append(diff.Changes, ConfigFieldChange{
+			Path: path, Before: left, After: right, Classification: classification,
+			RequiredOperation: operation, Message: message,
+		})
+	}
+	add("spec.controlPlaneEndpoint", before.Cluster.ControlPlaneEndpoint, after.Cluster.ControlPlaneEndpoint)
+	add("spec.kubernetes.version", before.Cluster.KubernetesVersion, after.Cluster.KubernetesVersion)
+	add(base+".controlPlane", before.Effective.ControlPlane, after.Effective.ControlPlane)
+	add(base+".access.ssh.authorizedKeys", before.Effective.Access.SSH.AuthorizedKeys.Value(), after.Effective.Access.SSH.AuthorizedKeys.Value())
+	add(base+".kernel", before.Effective.Kernel, after.Effective.Kernel)
+	add(base+".hostConfiguration.sysfs", before.Effective.HostConfiguration.Sysfs.Value(), after.Effective.HostConfiguration.Sysfs.Value())
+	diffNamedMaps(&diff, base+".hostConfiguration.fileSets", before.Effective.HostConfiguration.FileSets.Value(), after.Effective.HostConfiguration.FileSets.Value())
+	diffNamedExtensions(&diff, base+".systemExtensions", before.Effective.SystemExtensions.Value(), after.Effective.SystemExtensions.Value())
+	add(base+".install.systemDisk", before.Effective.Install.SystemDisk, after.Effective.Install.SystemDisk)
+	diffNamedDisks(&diff, base+".storage.disks", before.Effective.Storage.Disks.Value(), after.Effective.Storage.Disks.Value())
+	add(base+".kubernetes.address", before.Effective.Kubernetes.Address, after.Effective.Kubernetes.Address)
+	diffStringMaps(&diff, base+".kubernetes.labels", before.Effective.Kubernetes.Labels.Value(), after.Effective.Kubernetes.Labels.Value())
+	add(base+".kubernetes.taints", before.Effective.Kubernetes.Taints.Value(), after.Effective.Kubernetes.Taints.Value())
+	add(base+".management.address", before.Effective.Management.Address, after.Effective.Management.Address)
+	sort.Slice(diff.Changes, func(i, j int) bool { return diff.Changes[i].Path < diff.Changes[j].Path })
+	diff.Classification = summarizeDiff(diff.Changes)
+	return diff
+}
+
+func appendNamedChange(diff *ConfigDiff, path string, before, after any) {
+	if publicEqual(before, after) {
+		return
+	}
+	classification, operation, message := classifyDiffPath(path)
+	diff.Changes = append(diff.Changes, ConfigFieldChange{Path: path, Before: before, After: after, Classification: classification, RequiredOperation: operation, Message: message})
+}
+
+func diffNamedMaps[V any](diff *ConfigDiff, prefix string, before, after map[string]V) {
+	for _, name := range sortedUnionKeys(before, after) {
+		left, leftOK := before[name]
+		right, rightOK := after[name]
+		appendNamedChange(diff, fmt.Sprintf("%s[%q]", prefix, name), optionalAny(left, leftOK), optionalAny(right, rightOK))
+	}
+}
+
+func diffNamedExtensions(diff *ConfigDiff, prefix string, before, after []SourceSystemExtension) {
+	left := make(map[string]SourceSystemExtension, len(before))
+	right := make(map[string]SourceSystemExtension, len(after))
+	for _, value := range before {
+		left[value.Name] = value
+	}
+	for _, value := range after {
+		right[value.Name] = value
+	}
+	diffNamedMaps(diff, prefix, left, right)
+}
+
+func diffNamedDisks(diff *ConfigDiff, prefix string, before, after []SourceStorageDisk) {
+	left := make(map[string]SourceStorageDisk, len(before))
+	right := make(map[string]SourceStorageDisk, len(after))
+	for _, value := range before {
+		left[value.Name] = value
+	}
+	for _, value := range after {
+		right[value.Name] = value
+	}
+	diffNamedMaps(diff, prefix, left, right)
+}
+
+func diffStringMaps(diff *ConfigDiff, prefix string, before, after map[string]string) {
+	for _, name := range sortedUnionKeys(before, after) {
+		left, leftOK := before[name]
+		right, rightOK := after[name]
+		appendNamedChange(diff, fmt.Sprintf("%s[%q]", prefix, name), optionalAny(left, leftOK), optionalAny(right, rightOK))
+	}
+}
+
+func classifyDiffPath(path string) (string, string, string) {
+	switch {
+	case path == "spec.kubernetes.version":
+		return "operation-only", "kubernetes-upgrade", "Kubernetes payload changes use the Kubernetes upgrade operation"
+	case path == "spec.controlPlaneEndpoint":
+		return "operation-only", "control-plane-endpoint-migration", "an initialized control-plane endpoint needs a dedicated migration; this operation is not yet supported"
+	case strings.HasSuffix(path, ".controlPlane"):
+		return "operation-only", "wipe-reinstall", "changing a node role requires an explicit lifecycle operation"
+	case strings.Contains(path, ".install.systemDisk"):
+		return "operation-only", "wipe-reinstall", "changing the system disk requires an explicit reinstall and never wipes implicitly"
+	case strings.Contains(path, ".kubernetes.address"):
+		return "operation-only", "kubeadm-aware operation", "changing kubelet node identity requires a kubeadm-aware operation"
+	case strings.Contains(path, ".kubernetes.labels"), strings.Contains(path, ".kubernetes.taints"):
+		return "operation-only", "kubeadm-aware operation", "Kubernetes node metadata changes require Kubernetes-aware reconciliation"
+	case strings.Contains(path, ".management.address"):
+		return "target-only", "", "changes only the workstation management target; no node generation or mutation is planned"
+	case strings.Contains(path, ".storage.disks"):
+		return "online-applicable", "", "volume changes require live target discovery; existing data is preserved unless explicitly authorized"
+	case strings.Contains(path, ".hostConfiguration"):
+		return "online-or-next-boot", "", "the concrete file or sysfs change determines whether live preflight succeeds"
+	case strings.Contains(path, ".kernel"), strings.Contains(path, ".systemExtensions"), strings.Contains(path, ".authorizedKeys"):
+		return "staged-only", "", "change activates through a staged node generation"
+	default:
+		return "online-or-next-boot", "", "change is handled by normal configuration apply"
+	}
+}
+
+func summarizeDiff(changes []ConfigFieldChange) DiffClassification {
+	if len(changes) == 0 {
+		return DiffClassification{Overall: "no-change"}
+	}
+	rank := map[string]int{"target-only": 1, "online-applicable": 2, "online-or-next-boot": 3, "staged-only": 4, "operation-only": 5}
+	overall := "target-only"
+	operations := map[string]struct{}{}
+	for _, change := range changes {
+		if rank[change.Classification] > rank[overall] {
+			overall = change.Classification
+		}
+		if change.RequiredOperation != "" {
+			operations[change.RequiredOperation] = struct{}{}
+		}
+	}
+	return DiffClassification{Overall: overall, RequiredOperations: sortedMapKeys(operations)}
+}
+
+func publicEqual(left, right any) bool {
+	leftData, leftErr := json.Marshal(left)
+	rightData, rightErr := json.Marshal(right)
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftData, rightData)
+}
+
+func optionalAny[V any](value V, ok bool) any {
+	if !ok {
+		return nil
+	}
+	return value
+}
+
+func sortedUnionKeys[V any](left, right map[string]V) []string {
+	keys := make(map[string]struct{}, len(left)+len(right))
+	for key := range left {
+		keys[key] = struct{}{}
+	}
+	for key := range right {
+		keys[key] = struct{}{}
+	}
+	return sortedMapKeys(keys)
+}


### PR DESCRIPTION
## What changed

- add `katlctl config resolve SOURCE --node NODE` with effective public values, provenance, derived storage conventions, owned files, warnings, and lifecycle guidance
- add `katlctl config diff BEFORE AFTER --node NODE` with per-path before/after values and apply or operation classifications
- document both inspection workflows for operators and in the ClusterConfig contract

## Why

The compiler already resolved defaults, overlays, clearing, and derived state, but discarded the operator-facing explanation. Operators had to infer the final node result from authored layers or inspect internal install material, which exposed the wrong vocabulary and did not explain lifecycle boundaries.
