### PR TITLE
config: refuse cross-node diffs

### DIFF
--- a/cmd/katlctl/config_inspect.go
+++ b/cmd/katlctl/config_inspect.go
@@ -65,7 +65,10 @@ func newConfigDiffCommand(stdout, stderr io.Writer) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("resolve after config: %w", err)
 			}
-			report := configbundle.DiffNodeResolutions(before, after)
+			report, err := configbundle.DiffNodeResolutions(before, after)
+			if err != nil {
+				return err
+			}
 			if opts.output == "text" {
 				return writeConfigDiffText(stdout, report)
 			}

--- a/cmd/katlctl/config_inspect_test.go
+++ b/cmd/katlctl/config_inspect_test.go
@@ -114,6 +114,28 @@ func TestConfigResolveRequiresSelectionForMultipleNodes(t *testing.T) {
 	}
 }
 
+func TestConfigDiffRefusesDifferentInferredNodes(t *testing.T) {
+	dir := t.TempDir()
+	beforePath := filepath.Join(dir, "before.yaml")
+	afterPath := filepath.Join(dir, "after.yaml")
+	before := configInspectionSource()
+	after := strings.Replace(before, "name: cp-1", "name: cp-2", 1)
+	if err := os.WriteFile(beforePath, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(afterPath, []byte(after), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"config", "diff", beforePath, afterPath}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), `config diff resolved different nodes "cp-1" and "cp-2"`) || !strings.Contains(err.Error(), "node renames require an explicit lifecycle operation") {
+		t.Fatalf("run() error = %v, want cross-node lifecycle refusal", err)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("stdout=%q stderr=%q, want empty", stdout.String(), stderr.String())
+	}
+}
+
 func configInspectionSource() string {
 	source := strings.Replace(configBundleSource(), "  nodes:\n", `    storage:
       disks:

--- a/internal/installer/configbundle/inspect.go
+++ b/internal/installer/configbundle/inspect.go
@@ -415,7 +415,10 @@ type DiffClassification struct {
 	RequiredOperations []string `json:"requiredOperations,omitempty" yaml:"requiredOperations,omitempty"`
 }
 
-func DiffNodeResolutions(before, after NodeResolution) ConfigDiff {
+func DiffNodeResolutions(before, after NodeResolution) (ConfigDiff, error) {
+	if before.Node != after.Node {
+		return ConfigDiff{}, fmt.Errorf("config diff resolved different nodes %q and %q; use --node to compare one stable node identity; node renames require an explicit lifecycle operation", before.Node, after.Node)
+	}
 	base := fmt.Sprintf("spec.nodes[%q]", after.Node)
 	if after.Node == "" {
 		base = fmt.Sprintf("spec.nodes[%q]", before.Node)
@@ -456,7 +459,7 @@ func DiffNodeResolutions(before, after NodeResolution) ConfigDiff {
 	add(base+".management.address", before.Effective.Management.Address, after.Effective.Management.Address)
 	sort.Slice(diff.Changes, func(i, j int) bool { return diff.Changes[i].Path < diff.Changes[j].Path })
 	diff.Classification = summarizeDiff(diff.Changes)
-	return diff
+	return diff, nil
 }
 
 func appendNamedChange(diff *ConfigDiff, path string, before, after any) {

--- a/internal/installer/configbundle/inspect_test.go
+++ b/internal/installer/configbundle/inspect_test.go
@@ -1,0 +1,16 @@
+package configbundle
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiffNodeResolutionsRefusesDifferentNodeNames(t *testing.T) {
+	_, err := DiffNodeResolutions(
+		NodeResolution{Node: "cp-1"},
+		NodeResolution{Node: "cp-2"},
+	)
+	if err == nil || !strings.Contains(err.Error(), `different nodes "cp-1" and "cp-2"`) || !strings.Contains(err.Error(), "node renames require an explicit lifecycle operation") {
+		t.Fatalf("DiffNodeResolutions() error = %v, want lifecycle refusal", err)
+	}
+}


### PR DESCRIPTION
## What changed

- reject effective config diffs when the resolved node identities differ
- direct rename cases to explicit lifecycle handling before any report is attributed
- cover the reusable diff model and public CLI refusal paths

## Why

Single-node inference could select a different sole node from each input and then label the comparison as the after-node. That produced misleading apply guidance for what is actually a node rename or replacement boundary.
