### PR TITLE
config: support per-node kubelet policy

### DIFF
--- a/cmd/katlctl/config_inspect_test.go
+++ b/cmd/katlctl/config_inspect_test.go
@@ -136,6 +136,41 @@ func TestConfigDiffRefusesDifferentInferredNodes(t *testing.T) {
 	}
 }
 
+func TestConfigInspectionReportsPerNodeKubeletConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"kubelet-a.yaml", "kubelet-b.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nsystemReserved:\n  cpu: 500m\ntopologyManagerPolicy: restricted\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := strings.Replace(configInspectionSource(), "      management:\n", "      kubernetes:\n        kubelet:\n          configFile: ./kubelet-a.yaml\n      management:\n", 1)
+	after := strings.Replace(before, "./kubelet-a.yaml", "./kubelet-b.yaml", 1)
+	beforePath := filepath.Join(dir, "before.yaml")
+	afterPath := filepath.Join(dir, "after.yaml")
+	if err := os.WriteFile(beforePath, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(afterPath, []byte(after), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "resolve", beforePath, "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("resolve error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{`"kubelet"`, `"configFile": "./kubelet-a.yaml"`, `/etc/katl/kubeadm/node-cp-1/patches/kubeletconfiguration999+merge.yaml`} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("resolve output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	stdout.Reset()
+	if err := run(context.Background(), []string{"config", "diff", beforePath, afterPath, "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("diff error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `.kubernetes.kubelet`) || !strings.Contains(stdout.String(), `"requiredOperation": "kubeadm-aware operation"`) {
+		t.Fatalf("diff output does not classify kubelet change:\n%s", stdout.String())
+	}
+}
+
 func configInspectionSource() string {
 	source := strings.Replace(configBundleSource(), "  nodes:\n", `    storage:
       disks:

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -372,7 +372,8 @@ func kubeadmControlPlaneConfigBody(opts kubeadmControlPlaneConfigOptions, node i
 	} else if opts.component == "kubelet" {
 		component = kubeadmConfigComponentKubelet
 	}
-	return &agentapi.KubeadmControlPlaneConfigOperationRequest{RolloutId: opts.rolloutID, NodePosition: position, NodeCount: count, NodeName: node.Name, CoordinatorNode: opts.coordinator, CoordinatorUpload: node.Name == opts.coordinator, DesiredGenerationId: generationID, ConfigName: node.KubeadmConfig.Ref, SupportedFieldDelta: []string{component}}
+	localKubelet := component == kubeadmConfigComponentKubelet && node.KubeadmConfig.NodeLocalKubelet
+	return &agentapi.KubeadmControlPlaneConfigOperationRequest{RolloutId: opts.rolloutID, NodePosition: position, NodeCount: count, NodeName: node.Name, CoordinatorNode: opts.coordinator, CoordinatorUpload: node.Name == opts.coordinator && !localKubelet, NodeLocalKubelet: localKubelet, DesiredGenerationId: generationID, ConfigName: node.KubeadmConfig.Ref, SupportedFieldDelta: []string{component}}
 }
 
 const (

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -31,6 +31,14 @@ func TestOrderControlPlanesChangesCoordinatorLast(t *testing.T) {
 	}
 }
 
+func TestKubeadmControlPlaneConfigBodyKeepsNodeLocalKubeletOffCluster(t *testing.T) {
+	node := inventory.Node{Name: "cp-1", KubeadmConfig: inventory.KubeadmConfig{Ref: "node-cp-1", NodeLocalKubelet: true}}
+	body := kubeadmControlPlaneConfigBody(kubeadmControlPlaneConfigOptions{rolloutID: "rollout", coordinator: "cp-1", component: "kubelet"}, node, "generation-1", 1, 1)
+	if !body.NodeLocalKubelet || body.CoordinatorUpload {
+		t.Fatalf("body = %#v", body)
+	}
+}
+
 func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) {
 	root := t.TempDir()
 	inventoryPath := filepath.Join(root, "inventory.yaml")

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -376,6 +376,35 @@ and injects bootstrap tokens and certificate material only when the explicit
 bootstrap operation runs. Omit the entire `kubeadm` block for Katl's complete
 defaults.
 
+For node-specific kubelet policy, reference one native
+`kubelet.config.k8s.io/v1beta1` `KubeletConfiguration` from that node:
+
+```yaml
+spec:
+  nodes:
+    - name: worker-1
+      kubernetes:
+        kubelet:
+          configFile: ./worker-1-kubelet.yaml
+```
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+systemReserved:
+  cpu: 500m
+  memory: 1Gi
+topologyManagerPolicy: restricted
+```
+
+The file is a bounded native overlay, not a Katl-owned host path. Katl applies
+it as a node-local kubeadm kubelet patch during bootstrap and online changes,
+then verifies the local kubelet configuration and node health. It is never
+uploaded to the cluster-wide `kubelet-config` ConfigMap and does not change
+other nodes. This input is node-only: defaults cannot set it. Katl rejects
+multiple documents, other API kinds or versions, and fields that replace
+Katl-owned runtime paths.
+
 The ISO flow consumes this source directly: `katlctl install apply` and
 `katlctl cluster bootstrap` compile the internal bundle automatically. Produce
 an explicit bundle only for PXE or offline provisioning, as shown in the next

--- a/docs/internal/supported-node-config-domains.md
+++ b/docs/internal/supported-node-config-domains.md
@@ -216,6 +216,16 @@ Bootstrap profile input
   golden tests cover init, join, kubelet configuration, patches, and selected
   sysext mismatch
 
+per-node kubelet input
+  accept one native kubelet.config.k8s.io/v1beta1 KubeletConfiguration from a
+  node-specific source path; defaults cannot set it
+  compile it to a node-local kubeadm patch and a node-specific desired
+  KubeletConfiguration without exposing the generated profile as public input
+  apply online with kubeadm upgrade node phase kubelet-config --patches and
+  never upload the node overlay to the shared kubelet-config ConfigMap
+  verify the resulting local config, restart, and node health; removing the
+  input refreshes that node from shared kubeadm configuration
+
 SSH and operator access
   validate SSH public key syntax
   render only Katl-owned authorized_keys and bounded sshd policy

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -14,6 +14,7 @@ renderer carries:
 - native host configuration file sets, including systemd-networkd files and
   drop-ins;
 - desired data disks under `storage.disks`;
+- per-node native kubelet configuration under `nodes[].kubernetes.kubelet`;
 - operation-only system role and role-dependent Kubernetes bootstrap state.
 
 Runtime-safe fields apply normally. Katl coordinates affected node generations
@@ -52,6 +53,15 @@ If `spec.kubernetes.kubeadm` changes, cluster apply validates every node before
 mutation and then reconciles every affected Kubernetes component online. A
 Kubernetes configuration change never falls back to next-boot application or
 requires a host reboot.
+
+Per-node `kubernetes.kubelet.configFile` changes use kubeadm's node-local patch
+path. Katl validates and stages the native KubeletConfiguration, refreshes only
+that node's `/var/lib/kubelet/config.yaml`, restarts its kubelet, and checks node
+health. It does not upload the overlay to the shared kubelet ConfigMap. Removing
+the per-node input refreshes that node from the shared kubeadm configuration.
+Use `config resolve` to see the selected native input and owned patch path, and
+`config diff` to review its `kubeadm-aware operation` classification before
+applying.
 
 ## Node Lifecycle Matrix
 

--- a/internal/bootstrap/inventory/inventory.go
+++ b/internal/bootstrap/inventory/inventory.go
@@ -80,9 +80,10 @@ type Access struct {
 }
 
 type KubeadmConfig struct {
-	Ref    string        `json:"ref"`
-	Path   string        `json:"path"`
-	Intent KubeadmIntent `json:"intent"`
+	Ref              string        `json:"ref"`
+	Path             string        `json:"path"`
+	Intent           KubeadmIntent `json:"intent"`
+	NodeLocalKubelet bool          `json:"nodeLocalKubelet,omitempty"`
 }
 
 type PlanRequest struct {

--- a/internal/installer/clusterplan/compile.go
+++ b/internal/installer/clusterplan/compile.go
@@ -281,9 +281,10 @@ func compileNode(config Config, name string, role inventory.SystemRole, layer No
 		}
 		kubeadmPlan = &configPlan
 		kubeadmConfig = inventory.KubeadmConfig{
-			Ref:    kubeadmRef,
-			Path:   configPlan.Config.RenderPath,
-			Intent: inventory.KubeadmIntent(role),
+			Ref:              kubeadmRef,
+			Path:             configPlan.Config.RenderPath,
+			Intent:           inventory.KubeadmIntent(role),
+			NodeLocalKubelet: configPlan.NodeLocalKubelet,
 		}
 	}
 	nativeEtcFiles, err := configdomain.NativeEtcFiles(configdomain.RenderRequest{

--- a/internal/installer/configapply/render.go
+++ b/internal/installer/configapply/render.go
@@ -148,6 +148,6 @@ func renderKubeadmConfigs(ref string, configs map[string]kubeadmconfig.Plan) (ma
 		patches = nil
 	}
 	return map[string]inlineKubeadmConfig{
-		ref: {Config: string(plan.Config.Content), Patches: patches},
+		ref: {Config: string(plan.Config.Content), Patches: patches, NodeLocalKubelet: plan.NodeLocalKubelet},
 	}, nil
 }

--- a/internal/installer/configapply/render_test.go
+++ b/internal/installer/configapply/render_test.go
@@ -126,6 +126,7 @@ func TestRenderNodeConfigurationChangeCarriesSelectedKubeadmInput(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	plan.NodeLocalKubelet = true
 	data, err := RenderNodeConfigurationChange(RenderNodeRequest{
 		NodeName: "cp-1",
 		Manifest: manifest.Manifest{Node: manifest.NodeConfig{
@@ -145,7 +146,7 @@ func TestRenderNodeConfigurationChangeCarriesSelectedKubeadmInput(t *testing.T) 
 		t.Fatalf("DecodeNodeConfigurationChange() error = %v\n%s", err, data)
 	}
 	resolved := request.KubeadmConfigs["control-plane"]
-	if !strings.Contains(string(resolved.Config.Content), "kubernetesVersion: v1.36.1") || len(resolved.Patches) != 1 {
+	if !strings.Contains(string(resolved.Config.Content), "kubernetesVersion: v1.36.1") || !resolved.NodeLocalKubelet || len(resolved.Patches) != 1 {
 		t.Fatalf("resolved kubeadm input = %#v", resolved)
 	}
 	if !request.NodeOverrides["cp-1"].KubeadmChanged {

--- a/internal/installer/configapply/runtime_request.go
+++ b/internal/installer/configapply/runtime_request.go
@@ -42,8 +42,9 @@ type SystemExtensionPayload struct {
 }
 
 type inlineKubeadmConfig struct {
-	Config  string            `json:"config" yaml:"config"`
-	Patches map[string]string `json:"patches,omitempty" yaml:"patches,omitempty"`
+	Config           string            `json:"config" yaml:"config"`
+	Patches          map[string]string `json:"patches,omitempty" yaml:"patches,omitempty"`
+	NodeLocalKubelet bool              `json:"nodeLocalKubelet,omitempty" yaml:"nodeLocalKubelet,omitempty"`
 }
 
 type nodeConfigurationOverlay struct {
@@ -209,6 +210,7 @@ func mergeInlineKubeadmConfigs(installed map[string]kubeadmconfig.Plan, inline m
 		if err != nil {
 			return nil, nil, fmt.Errorf("spec.kubeadmConfigs.%s: %w", name, err)
 		}
+		plan.NodeLocalKubelet = input.NodeLocalKubelet
 		previous, exists := installed[name]
 		if !exists || !equivalentKubeadmPlans(previous, plan) {
 			changed[name] = struct{}{}

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -194,6 +195,11 @@ type SourceKubernetesLayer struct {
 	Address string                         `yaml:"address,omitempty" json:"address,omitempty"`
 	Labels  Optional[map[string]string]    `yaml:"labels,omitempty" json:"labels,omitzero"`
 	Taints  Optional[[]manifest.NodeTaint] `yaml:"taints,omitempty" json:"taints,omitzero"`
+	Kubelet *SourceKubeletConfig           `yaml:"kubelet,omitempty" json:"kubelet,omitempty"`
+}
+
+type SourceKubeletConfig struct {
+	ConfigFile string `yaml:"configFile" json:"configFile"`
 }
 
 type BundleManifest struct {
@@ -337,6 +343,11 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 	if err != nil {
 		return nil, Result{}, err
 	}
+	kubeadmConfigs, nodeKubeletInputs, err := resolveNodeKubeletConfigs(filepath.Dir(sourcePath), source, kubeadmConfigs)
+	if err != nil {
+		return nil, Result{}, err
+	}
+	kubeadmSourceInputs = append(kubeadmSourceInputs, nodeKubeletInputs...)
 	sourceDigest := digestSourceInputs(normalized, kubeadmSourceInputs)
 	planning := request.Planning
 	if strings.TrimSpace(planning.KubernetesBundle) == "" {
@@ -477,6 +488,9 @@ func LowerSource(source SourceConfig, planning PlanningInputs) (clusterplan.Conf
 			layer.Bootstrap.Access = access
 		}
 		layer.Kubernetes.KubeadmConfigRef = defaultKubeadmConfigRef(role)
+		if node.Kubernetes.Kubelet != nil {
+			layer.Kubernetes.KubeadmConfigRef = nodeKubeadmConfigRef(node.Name)
+		}
 		nodes = append(nodes, clusterplan.Node{
 			Name:       node.Name,
 			SystemRole: role,
@@ -622,6 +636,9 @@ func normalizeSource(source SourceConfig) (SourceConfig, error) {
 	if strings.TrimSpace(source.Spec.Defaults.Kubernetes.Address) != "" {
 		return SourceConfig{}, fmt.Errorf("spec.defaults.kubernetes.address is not allowed; Kubernetes address must be set per node")
 	}
+	if source.Spec.Defaults.Kubernetes.Kubelet != nil {
+		return SourceConfig{}, fmt.Errorf("spec.defaults.kubernetes.kubelet is not allowed; kubelet configuration must be set per node")
+	}
 	if source.Spec.Defaults.Kernel != nil {
 		if err := manifest.ValidateKernelConfig(*lowerKernelConfig(source.Spec.Defaults.Kernel)); err != nil {
 			return SourceConfig{}, fmt.Errorf("spec.defaults.kernel: %w", err)
@@ -634,6 +651,9 @@ func normalizeSource(source SourceConfig) (SourceConfig, error) {
 			return SourceConfig{}, fmt.Errorf("%s.kubernetes.address: %w", path, err)
 		}
 		source.Spec.Nodes[i].Kubernetes.Address = address
+		if kubelet := source.Spec.Nodes[i].Kubernetes.Kubelet; kubelet != nil && strings.TrimSpace(kubelet.ConfigFile) == "" {
+			return SourceConfig{}, fmt.Errorf("%s.kubernetes.kubelet.configFile is required", path)
+		}
 		if source.Spec.Nodes[i].Kernel != nil {
 			if err := manifest.ValidateKernelConfig(*lowerKernelConfig(source.Spec.Nodes[i].Kernel)); err != nil {
 				return SourceConfig{}, fmt.Errorf("%s.kernel: %w", path, err)
@@ -1043,9 +1063,10 @@ func addNodeKubeadmInputs(members *[]member, descriptors *[]Descriptor, node clu
 	for _, file := range files {
 		rel := strings.TrimPrefix(strings.TrimPrefix(filepath.ToSlash(file.RenderPath), "/etc/katl/kubeadm/"+ref+"/"), "/")
 		desc := addBytes(members, descriptors, "kubeadm-input", node.Name, "application/vnd.katl.kubeadm.input.v1+yaml", "nodes/"+node.Name+"/kubernetes/kubeadm/"+rel, file.Content, map[string]string{
-			"dev.katl.kubeadm.resolved-id":  ref,
-			"dev.katl.kubeadm.intent":       string(node.KubeadmConfig.Intent),
-			"dev.katl.kubeadm.api-versions": strings.Join(kubeadmAPIVersions(map[string]kubeadmconfig.Plan{ref: plan}), ","),
+			"dev.katl.kubeadm.resolved-id":        ref,
+			"dev.katl.kubeadm.intent":             string(node.KubeadmConfig.Intent),
+			"dev.katl.kubeadm.api-versions":       strings.Join(kubeadmAPIVersions(map[string]kubeadmconfig.Plan{ref: plan}), ","),
+			"dev.katl.kubeadm.node-local-kubelet": strconv.FormatBool(plan.NodeLocalKubelet),
 		})
 		out = append(out, desc)
 	}

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -520,6 +520,94 @@ shutdownGracePeriod: 45s
 	}
 }
 
+func TestBuildArchiveAddsPerNodeKubeletConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	kubeletPath := filepath.Join(dir, "worker-kubelet.yaml")
+	writeFile(t, kubeletPath, `apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+systemReserved:
+  cpu: 500m
+  memory: 1Gi
+topologyManagerPolicy: restricted
+`)
+	source := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/pool: workers", "      kubernetes:\n        kubelet:\n          configFile: ./worker-kubelet.yaml\n        labels:\n          katl.dev/pool: workers", 1)
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	writeFile(t, sourcePath, source)
+	archive, result, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	selected, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "worker-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode() error = %v", err)
+	}
+	if selected.NodeMaterial.KubeadmConfig.Ref != "node-worker-1" || !selected.NodeMaterial.KubeadmConfig.NodeLocalKubelet || selected.InstallManifest.Node.Kubernetes.Kubeadm.ConfigRef != "node-worker-1" {
+		t.Fatalf("selected kubeadm ref = %#v / %#v", selected.NodeMaterial.KubeadmConfig, selected.InstallManifest.Node.Kubernetes.Kubeadm)
+	}
+	plan, ok := selected.KubeadmConfigs["node-worker-1"]
+	if !ok || !plan.NodeLocalKubelet || len(plan.Patches) != 1 {
+		t.Fatalf("per-node kubeadm plan = %#v", selected.KubeadmConfigs)
+	}
+	if !strings.Contains(string(plan.Config.Content), "directory: /etc/katl/kubeadm/node-worker-1/patches") || !strings.Contains(string(plan.Config.Content), "topologyManagerPolicy: restricted") || !strings.Contains(string(plan.Patches[0].Content), "topologyManagerPolicy: restricted") || strings.Contains(string(plan.Patches[0].Content), "kind: KubeletConfiguration") {
+		t.Fatalf("per-node kubelet material = config %s patch %s", plan.Config.Content, plan.Patches[0].Content)
+	}
+	report, err := InspectSelectedNode(selected)
+	if err != nil {
+		t.Fatalf("InspectSelectedNode() error = %v", err)
+	}
+	if report.Effective.Kubernetes.Kubelet == nil || report.Effective.Kubernetes.Kubelet.ConfigFile != "./worker-kubelet.yaml" || report.Derived.KubeadmConfig != "node-worker-1" {
+		t.Fatalf("resolved kubelet config = %#v", report)
+	}
+	data, err := os.ReadFile(kubeletPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, kubeletPath, strings.Replace(string(data), "500m", "750m", 1))
+	_, changed, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("changed BuildArchive() error = %v", err)
+	}
+	if changed.Manifest.Source.SourceDigest == result.Manifest.Source.SourceDigest {
+		t.Fatalf("source digest did not include per-node kubelet input: %s", changed.Manifest.Source.SourceDigest)
+	}
+}
+
+func TestBuildArchiveRejectsInvalidPerNodeKubeletConfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "wrong kind", content: "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: NotKubelet\ncpuManagerPolicy: static\n", want: "kind must be KubeletConfiguration"},
+		{name: "multiple documents", content: "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\ncpuManagerPolicy: static\n---\nfoo: bar\n", want: "multiple YAML documents"},
+		{name: "Katl-owned path", content: "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nvolumePluginDir: /var/lib/kubelet/plugins/custom\n", want: "host path /var/lib/kubelet/plugins/custom is denied"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "worker-kubelet.yaml"), test.content)
+			source := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/pool: workers", "      kubernetes:\n        kubelet:\n          configFile: ./worker-kubelet.yaml\n        labels:\n          katl.dev/pool: workers", 1)
+			sourcePath := filepath.Join(dir, "cluster.yaml")
+			writeFile(t, sourcePath, source)
+			_, _, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+			if err == nil || !strings.Contains(err.Error(), `spec.nodes["worker-1"].kubernetes.kubelet.configFile`) || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("BuildArchive() error = %v, want public path and %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestBuildArchiveRequiresConcretePerNodeKubeletConfiguration(t *testing.T) {
+	defaultSource := strings.Replace(validSourceConfig(), "    access:\n", "    kubernetes:\n      kubelet:\n        configFile: ./kubelet.yaml\n    access:\n", 1)
+	if _, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, defaultSource)}); err == nil || !strings.Contains(err.Error(), "spec.defaults.kubernetes.kubelet is not allowed") {
+		t.Fatalf("default BuildArchive() error = %v", err)
+	}
+	emptySource := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/pool: workers", "      kubernetes:\n        kubelet:\n          configFile: \"\"\n        labels:\n          katl.dev/pool: workers", 1)
+	if _, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, emptySource)}); err == nil || !strings.Contains(err.Error(), `spec.nodes["worker-1"].kubernetes.kubelet.configFile is required`) {
+		t.Fatalf("empty BuildArchive() error = %v", err)
+	}
+}
+
 func TestBuildArchiveRendersExactKubernetesAddressPerNode(t *testing.T) {
 	source := strings.Replace(validSourceConfig(), "      kubernetes:\n        labels:\n          katl.dev/zone: rack-a", "      kubernetes:\n        address: 10.254.1.1\n        labels:\n          katl.dev/zone: rack-a", 1)
 	source = strings.Replace(source, "      kubernetes:\n        labels:\n          katl.dev/pool: workers", "      kubernetes:\n        address: 10.254.1.3\n        labels:\n          katl.dev/pool: workers", 1)
@@ -1162,10 +1250,13 @@ func TestSourceSchemaExposesAuthoringContract(t *testing.T) {
 		[]string{"bundle", "configuration", "name", "state", "units"},
 		[]string{"architecture", "artifactVersion", "bundleManifestDigest", "ociManifestDigest", "payloadVersion", "payloads", "supportedRuntimeInterfaces"})
 	assertSchemaFields(t, document.Defs, "controlplaneendpoint.BGP", []string{"routeExchanges"}, []string{"routeExchange"})
+	assertSchemaFields(t, document.Defs, "configbundle.SourceKubernetesLayer", []string{"address", "kubelet", "labels", "taints"}, nil)
+	assertSchemaFields(t, document.Defs, "configbundle.SourceKubeletConfig", []string{"configFile"}, nil)
 	assertSchemaFields(t, document.Defs, "controlplaneendpoint.PrefixEnvelope", []string{"exactPrefixLength"}, []string{"prefixLength"})
 	assertSchemaRequired(t, document.Defs, "configbundle.SourceSpec", "nodes")
 	assertSchemaRequired(t, document.Defs, "configbundle.SourceNode", "name")
 	assertSchemaRequired(t, document.Defs, "configbundle.SourceHostConfigurationSysfsSetting", "path", "value")
+	assertSchemaRequired(t, document.Defs, "configbundle.SourceKubeletConfig", "configFile")
 	if selector := document.Defs["configbundle.SourceVolumeSelector"]; len(selector.OneOf) != 2 {
 		t.Fatalf("volume selector oneOf branches = %d, want 2", len(selector.OneOf))
 	}

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -77,6 +77,31 @@ func TestBuildArchiveWritesDeterministicBundle(t *testing.T) {
 	}
 }
 
+func TestSelectedKubeadmConfigsDefaultsMissingNodeLocalAnnotation(t *testing.T) {
+	data := []byte(defaultKubeadmJoinConfig())
+	digest := digestBytes(data)
+	node := NodeRecord{
+		Name: "worker-1",
+		KubeadmInputs: []Descriptor{{
+			Role:      "kubeadm-input",
+			Node:      "worker-1",
+			Digest:    digest,
+			SizeBytes: len(data),
+			FileName:  "nodes/worker-1/kubernetes/kubeadm/config.yaml",
+			Annotations: map[string]string{
+				"dev.katl.kubeadm.resolved-id": "worker",
+			},
+		}},
+	}
+	configs, err := selectedKubeadmConfigs(ociArchive{blobs: map[string][]byte{digest: data}}, node)
+	if err != nil {
+		t.Fatalf("selectedKubeadmConfigs() error = %v", err)
+	}
+	if configs["worker"].NodeLocalKubelet {
+		t.Fatal("missing node-local annotation selected node-local mode")
+	}
+}
+
 func TestDecodeSourceAcceptsKernelCommandLineDefaultsAndNodeClear(t *testing.T) {
 	source := strings.Replace(validSourceConfig(), "  defaults:\n", `  defaults:
     kernel:

--- a/internal/installer/configbundle/consume.go
+++ b/internal/installer/configbundle/consume.go
@@ -407,9 +407,13 @@ func selectedKubeadmConfigs(archive ociArchive, node NodeRecord) (map[string]kub
 		if ref == "" {
 			return nil, fmt.Errorf("node %s kubeadm input %s missing resolved id", node.Name, desc.FileName)
 		}
-		nodeLocal, err := strconv.ParseBool(desc.Annotations["dev.katl.kubeadm.node-local-kubelet"])
-		if err != nil {
-			return nil, fmt.Errorf("node %s kubeadm input %s has invalid node-local kubelet annotation", node.Name, desc.FileName)
+		nodeLocal := false
+		if value, ok := desc.Annotations["dev.katl.kubeadm.node-local-kubelet"]; ok {
+			var err error
+			nodeLocal, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("node %s kubeadm input %s has invalid node-local kubelet annotation", node.Name, desc.FileName)
+			}
 		}
 		if previous, exists := nodeLocalByRef[ref]; exists && previous != nodeLocal {
 			return nil, fmt.Errorf("node %s kubeadm config %q has inconsistent node-local kubelet annotations", node.Name, ref)

--- a/internal/installer/configbundle/consume.go
+++ b/internal/installer/configbundle/consume.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/clusterplan"
@@ -393,6 +394,7 @@ func selectedKubeadmConfigs(archive ociArchive, node NodeRecord) (map[string]kub
 		return nil, nil
 	}
 	filesByRef := map[string][]kubeadmconfig.File{}
+	nodeLocalByRef := map[string]bool{}
 	prefix := "nodes/" + node.Name + "/kubernetes/kubeadm/"
 	for _, desc := range node.KubeadmInputs {
 		if desc.Role != "kubeadm-input" {
@@ -405,6 +407,14 @@ func selectedKubeadmConfigs(archive ociArchive, node NodeRecord) (map[string]kub
 		if ref == "" {
 			return nil, fmt.Errorf("node %s kubeadm input %s missing resolved id", node.Name, desc.FileName)
 		}
+		nodeLocal, err := strconv.ParseBool(desc.Annotations["dev.katl.kubeadm.node-local-kubelet"])
+		if err != nil {
+			return nil, fmt.Errorf("node %s kubeadm input %s has invalid node-local kubelet annotation", node.Name, desc.FileName)
+		}
+		if previous, exists := nodeLocalByRef[ref]; exists && previous != nodeLocal {
+			return nil, fmt.Errorf("node %s kubeadm config %q has inconsistent node-local kubelet annotations", node.Name, ref)
+		}
+		nodeLocalByRef[ref] = nodeLocal
 		if !strings.HasPrefix(desc.FileName, prefix) {
 			return nil, fmt.Errorf("node %s kubeadm input %s is outside expected prefix", node.Name, desc.FileName)
 		}
@@ -433,6 +443,7 @@ func selectedKubeadmConfigs(archive ociArchive, node NodeRecord) (map[string]kub
 		if err != nil {
 			return nil, fmt.Errorf("node %s kubeadm config %q: %w", node.Name, ref, err)
 		}
+		plan.NodeLocalKubelet = nodeLocalByRef[ref]
 		configs[ref] = plan
 	}
 	return configs, nil

--- a/internal/installer/configbundle/inspect.go
+++ b/internal/installer/configbundle/inspect.go
@@ -141,7 +141,11 @@ func InspectSelectedNode(selected SelectedNodeMaterial) (NodeResolution, error) 
 			Message: "management.address selects the workstation target and does not change generated node state",
 		})
 	}
-	report.OwnedFiles = ownedFiles(selected.NodeMaterial.NativeEtcFiles)
+	owned := append([]confext.NativeEtcFile(nil), selected.NodeMaterial.NativeEtcFiles...)
+	if plan, ok := selected.KubeadmConfigs[selected.NodeMaterial.KubeadmConfig.Ref]; ok {
+		owned = append(owned, plan.NativeEtcFiles()...)
+	}
+	report.OwnedFiles = ownedFiles(owned)
 	sort.Slice(report.Provenance, func(i, j int) bool { return report.Provenance[i].Path < report.Provenance[j].Path })
 	sort.Slice(report.Warnings, func(i, j int) bool { return report.Warnings[i].Path < report.Warnings[j].Path })
 	return report, nil
@@ -271,6 +275,9 @@ func nodeProvenance(node SourceNode, resolved SourceNodeLayer, base string) []Fi
 	}
 	if strings.TrimSpace(resolved.Kubernetes.Address) != "" {
 		choose("kubernetes.address", strings.TrimSpace(node.Kubernetes.Address) != "")
+	}
+	if resolved.Kubernetes.Kubelet != nil {
+		choose("kubernetes.kubelet.configFile", node.Kubernetes.Kubelet != nil)
 	}
 	_, taintsSet := node.Kubernetes.Taints.Get()
 	if _, set := resolved.Kubernetes.Taints.Get(); set {
@@ -454,6 +461,7 @@ func DiffNodeResolutions(before, after NodeResolution) (ConfigDiff, error) {
 	add(base+".install.systemDisk", before.Effective.Install.SystemDisk, after.Effective.Install.SystemDisk)
 	diffNamedDisks(&diff, base+".storage.disks", before.Effective.Storage.Disks.Value(), after.Effective.Storage.Disks.Value())
 	add(base+".kubernetes.address", before.Effective.Kubernetes.Address, after.Effective.Kubernetes.Address)
+	add(base+".kubernetes.kubelet", before.Effective.Kubernetes.Kubelet, after.Effective.Kubernetes.Kubelet)
 	diffStringMaps(&diff, base+".kubernetes.labels", before.Effective.Kubernetes.Labels.Value(), after.Effective.Kubernetes.Labels.Value())
 	add(base+".kubernetes.taints", before.Effective.Kubernetes.Taints.Value(), after.Effective.Kubernetes.Taints.Value())
 	add(base+".management.address", before.Effective.Management.Address, after.Effective.Management.Address)
@@ -522,6 +530,8 @@ func classifyDiffPath(path string) (string, string, string) {
 		return "operation-only", "wipe-reinstall", "changing the system disk requires an explicit reinstall and never wipes implicitly"
 	case strings.Contains(path, ".kubernetes.address"):
 		return "operation-only", "kubeadm-aware operation", "changing kubelet node identity requires a kubeadm-aware operation"
+	case strings.Contains(path, ".kubernetes.kubelet"):
+		return "operation-only", "kubeadm-aware operation", "per-node kubelet configuration changes require kubeadm-aware reconciliation on this node"
 	case strings.Contains(path, ".kubernetes.labels"), strings.Contains(path, ".kubernetes.taints"):
 		return "operation-only", "kubeadm-aware operation", "Kubernetes node metadata changes require Kubernetes-aware reconciliation"
 	case strings.Contains(path, ".management.address"):

--- a/internal/installer/configbundle/kubeadm.go
+++ b/internal/installer/configbundle/kubeadm.go
@@ -62,6 +62,153 @@ func resolveKubeadmConfigs(sourceRoot string, input *SourceKubeadmInput, kuberne
 	return plans, inputs, nil
 }
 
+func resolveNodeKubeletConfigs(sourceRoot string, source SourceConfig, base map[string]kubeadmconfig.Plan) (map[string]kubeadmconfig.Plan, []kubeadmSourceInput, error) {
+	configs := make(map[string]kubeadmconfig.Plan, len(base)+len(source.Spec.Nodes))
+	for name, plan := range base {
+		configs[name] = plan
+	}
+	var inputs []kubeadmSourceInput
+	for i, node := range source.Spec.Nodes {
+		if node.Kubernetes.Kubelet == nil {
+			continue
+		}
+		field := sourceNodePath(node, i) + ".kubernetes.kubelet.configFile"
+		configFile := strings.TrimSpace(node.Kubernetes.Kubelet.ConfigFile)
+		data, err := readHostConfigurationSource(sourceRoot, configFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", field, err)
+		}
+		patch, err := kubeletConfigurationPatch(data)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", field, err)
+		}
+		roleRef := defaultKubeadmConfigRef(sourceNodeRole(node))
+		rolePlan, ok := base[roleRef]
+		if !ok {
+			return nil, nil, fmt.Errorf("%s: base %s kubeadm input is unavailable", field, roleRef)
+		}
+		ref := nodeKubeadmConfigRef(node.Name)
+		plan, err := kubeadmPlanWithNodeKubeletConfig(rolePlan, ref, configFile, patch)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: %w", field, err)
+		}
+		configs[ref] = plan
+		inputs = append(inputs, kubeadmSourceInput{Name: "nodes/" + node.Name + "/kubelet/" + configFile, Content: data})
+	}
+	return configs, inputs, nil
+}
+
+func kubeletConfigurationPatch(data []byte) ([]byte, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var document map[string]any
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("decode KubeletConfiguration: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("decode KubeletConfiguration: multiple YAML documents")
+	}
+	if version, _ := document["apiVersion"].(string); strings.TrimSpace(version) != "kubelet.config.k8s.io/v1beta1" {
+		return nil, fmt.Errorf("apiVersion must be kubelet.config.k8s.io/v1beta1")
+	}
+	if kind, _ := document["kind"].(string); strings.TrimSpace(kind) != "KubeletConfiguration" {
+		return nil, fmt.Errorf("kind must be KubeletConfiguration")
+	}
+	delete(document, "apiVersion")
+	delete(document, "kind")
+	if len(document) == 0 {
+		return nil, fmt.Errorf("KubeletConfiguration must set at least one kubelet field")
+	}
+	patch, err := yaml.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("encode kubelet patch: %w", err)
+	}
+	return patch, nil
+}
+
+func kubeadmPlanWithNodeKubeletConfig(base kubeadmconfig.Plan, name, sourcePath string, patch []byte) (kubeadmconfig.Plan, error) {
+	documents, err := decodeKubeadmDocuments(base.Config.Content)
+	if err != nil {
+		return kubeadmconfig.Plan{}, fmt.Errorf("decode base kubeadm input: %w", err)
+	}
+	var patchFields map[string]any
+	if err := yaml.Unmarshal(patch, &patchFields); err != nil {
+		return kubeadmconfig.Plan{}, fmt.Errorf("decode kubelet patch: %w", err)
+	}
+	foundKubelet := false
+	for _, document := range documents {
+		if document["kind"] != "KubeletConfiguration" {
+			continue
+		}
+		mergeKubeletFields(document, patchFields)
+		foundKubelet = true
+		break
+	}
+	if !foundKubelet {
+		return kubeadmconfig.Plan{}, fmt.Errorf("base kubeadm input has no KubeletConfiguration")
+	}
+	content, err := encodeKubeadmDocuments(documents, name, true)
+	if err != nil {
+		return kubeadmconfig.Plan{}, err
+	}
+	files := []kubeadmconfig.File{{
+		SourcePath: base.Config.SourcePath,
+		RenderPath: "/etc/katl/kubeadm/" + name + "/config.yaml",
+		Content:    content,
+		Mode:       0o644,
+	}}
+	basePrefix := "/etc/katl/kubeadm/" + base.Name + "/patches/"
+	for _, existing := range base.Patches {
+		rel := strings.TrimPrefix(filepath.ToSlash(existing.RenderPath), basePrefix)
+		copy := existing
+		copy.RenderPath = "/etc/katl/kubeadm/" + name + "/patches/" + rel
+		files = append(files, copy)
+	}
+	const patchName = "kubeletconfiguration999+merge.yaml"
+	for _, existing := range files[1:] {
+		if filepath.Base(existing.RenderPath) == patchName {
+			return kubeadmconfig.Plan{}, fmt.Errorf("cluster kubeadm patches already contain reserved per-node patch name %q", patchName)
+		}
+	}
+	files = append(files, kubeadmconfig.File{
+		SourcePath: sourcePath,
+		RenderPath: "/etc/katl/kubeadm/" + name + "/patches/" + patchName,
+		Content:    patch,
+		Mode:       0o644,
+	})
+	plan, err := kubeadmconfig.PlanFromRenderedFiles(name, files)
+	if err != nil {
+		return kubeadmconfig.Plan{}, fmt.Errorf("compile per-node kubelet input: %w", err)
+	}
+	plan.NodeLocalKubelet = true
+	return plan, nil
+}
+
+func mergeKubeletFields(target, patch map[string]any) {
+	for key, value := range patch {
+		if value == nil {
+			delete(target, key)
+			continue
+		}
+		patchMap, patchIsMap := value.(map[string]any)
+		targetMap, targetIsMap := target[key].(map[string]any)
+		if patchIsMap && targetIsMap {
+			mergeKubeletFields(targetMap, patchMap)
+			continue
+		}
+		target[key] = value
+	}
+}
+
+func nodeKubeadmConfigRef(nodeName string) string {
+	name := "node-" + strings.TrimSpace(nodeName)
+	if len(name) <= 63 {
+		return name
+	}
+	digest := strings.TrimPrefix(digestBytes([]byte(nodeName)), "sha256:")[:10]
+	return name[:52] + "-" + digest
+}
+
 func splitKubeadmPlans(input kubeadmconfig.Plan, kubernetesVersion string) (map[string]kubeadmconfig.Plan, error) {
 	documents, err := decodeKubeadmDocuments(input.Config.Content)
 	if err != nil {

--- a/internal/installer/configbundle/schema_rules.go
+++ b/internal/installer/configbundle/schema_rules.go
@@ -166,6 +166,10 @@ func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
 		return mapRule("Kubernetes labels merged by key; an empty node map clears inherited labels.", kubernetesLabelKeyPattern)
 	case "configbundle.SourceKubernetesLayer.taints":
 		return description("Complete Kubernetes taint list; an empty node list clears inherited taints.")
+	case "configbundle.SourceKubernetesLayer.kubelet":
+		return description("Per-node native KubeletConfiguration applied through kubeadm's bounded kubelet patch path.")
+	case "configbundle.SourceKubeletConfig.configFile":
+		return schemaFieldRule{Required: true, Description: "Relative path to one kubelet.config.k8s.io/v1beta1 KubeletConfiguration document.", MinLength: intPointer(1)}
 	case "controlplaneendpoint.Config.host":
 		return stringRule("Stable Kubernetes API DNS name or IP address.", "", 1, 253)
 	case "controlplaneendpoint.Config.port":

--- a/internal/installer/configbundle/source_layering.go
+++ b/internal/installer/configbundle/source_layering.go
@@ -36,6 +36,9 @@ func mergeSourceNodeLayer(base, next SourceNodeLayer) (SourceNodeLayer, error) {
 	if taints, ok := next.Kubernetes.Taints.Get(); ok {
 		out.Kubernetes.Taints = supplied(slices.Clone(taints))
 	}
+	if next.Kubernetes.Kubelet != nil {
+		out.Kubernetes.Kubelet = cloneSourceKubeletConfig(next.Kubernetes.Kubelet)
+	}
 	return out, nil
 }
 
@@ -49,7 +52,16 @@ func cloneSourceNodeLayer(layer SourceNodeLayer) SourceNodeLayer {
 	out.Storage.Disks = cloneOptionalStorageDisks(layer.Storage.Disks)
 	out.Kubernetes.Labels = cloneOptionalMap(layer.Kubernetes.Labels)
 	out.Kubernetes.Taints = cloneOptionalSlice(layer.Kubernetes.Taints)
+	out.Kubernetes.Kubelet = cloneSourceKubeletConfig(layer.Kubernetes.Kubelet)
 	return out
+}
+
+func cloneSourceKubeletConfig(config *SourceKubeletConfig) *SourceKubeletConfig {
+	if config == nil {
+		return nil
+	}
+	copy := *config
+	return &copy
 }
 
 func mergeSourceHostConfiguration(base, next SourceHostConfiguration) SourceHostConfiguration {

--- a/internal/installer/configdomain/configdomain.go
+++ b/internal/installer/configdomain/configdomain.go
@@ -293,9 +293,10 @@ type nodeMetadataIdentity struct {
 }
 
 type nodeMetadataKubeadm struct {
-	ConfigRef  string `json:"configRef,omitempty"`
-	ConfigPath string `json:"configPath,omitempty"`
-	Intent     string `json:"intent,omitempty"`
+	ConfigRef        string `json:"configRef,omitempty"`
+	ConfigPath       string `json:"configPath,omitempty"`
+	Intent           string `json:"intent,omitempty"`
+	NodeLocalKubelet bool   `json:"nodeLocalKubelet,omitempty"`
 }
 
 type nodeMetadataKubernetes struct {
@@ -324,9 +325,10 @@ func nodeMetadataFile(installManifest manifest.Manifest, config *kubeadmconfig.P
 			return confext.NativeEtcFile{}, err
 		}
 		metadata.Kubeadm = &nodeMetadataKubeadm{
-			ConfigRef:  config.Name,
-			ConfigPath: config.Config.RenderPath,
-			Intent:     intent,
+			ConfigRef:        config.Name,
+			ConfigPath:       config.Config.RenderPath,
+			Intent:           intent,
+			NodeLocalKubelet: config.NodeLocalKubelet,
 		}
 	}
 	data, err := json.MarshalIndent(metadata, "", "  ")

--- a/internal/installer/configdomain/configdomain_test.go
+++ b/internal/installer/configdomain/configdomain_test.go
@@ -109,12 +109,14 @@ func TestNativeEtcFilesRendersWorkerNodeMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode() error = %v", err)
 	}
+	plan := workerPlan()
+	plan.NodeLocalKubelet = true
 	files, err := NativeEtcFiles(RenderRequest{
 		Manifest:                 installManifest,
 		KubernetesVersion:        "v1.36.1",
 		KubernetesActivationPath: "/run/extensions/katl-kubernetes.raw",
 		KubeadmConfigs: map[string]kubeadmconfig.Plan{
-			"worker": workerPlan(),
+			"worker": plan,
 		},
 	})
 	if err != nil {
@@ -132,7 +134,7 @@ func TestNativeEtcFilesRendersWorkerNodeMetadata(t *testing.T) {
 		t.Fatalf("metadata = %#v", metadata)
 	}
 	kubeadm := metadata["kubeadm"].(map[string]any)
-	if kubeadm["intent"] != "worker" || kubeadm["configRef"] != "worker" {
+	if kubeadm["intent"] != "worker" || kubeadm["configRef"] != "worker" || kubeadm["nodeLocalKubelet"] != true {
 		t.Fatalf("metadata kubeadm = %#v", kubeadm)
 	}
 }

--- a/internal/installer/kubeadmconfig/kubeadmconfig.go
+++ b/internal/installer/kubeadmconfig/kubeadmconfig.go
@@ -45,10 +45,11 @@ type ResolveRequest struct {
 }
 
 type Plan struct {
-	Name      string
-	Config    File
-	Patches   []File
-	Documents []Document
+	Name             string
+	Config           File
+	Patches          []File
+	Documents        []Document
+	NodeLocalKubelet bool
 }
 
 type File struct {

--- a/internal/installer/kubeadmconfig/kubeadmconfig_test.go
+++ b/internal/installer/kubeadmconfig/kubeadmconfig_test.go
@@ -415,6 +415,24 @@ func assertFile(t *testing.T, path string, want string) {
 	}
 }
 
+func TestWithNodeAddressPreservesNodeLocalKubeletMode(t *testing.T) {
+	plan, err := PlanFromRenderedFiles("control-plane", []File{{
+		RenderPath: "/etc/katl/kubeadm/control-plane/config.yaml",
+		Content:    []byte(initConfig()),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan.NodeLocalKubelet = true
+	got, err := WithNodeAddress(plan, "192.0.2.10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.NodeLocalKubelet {
+		t.Fatal("WithNodeAddress() dropped node-local kubelet mode")
+	}
+}
+
 func initConfig() string {
 	return `apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration

--- a/internal/installer/kubeadmconfig/node_address.go
+++ b/internal/installer/kubeadmconfig/node_address.go
@@ -67,6 +67,7 @@ func WithNodeAddress(plan Plan, address string) (Plan, error) {
 	if err != nil {
 		return Plan{}, fmt.Errorf("validate KubeadmConfig %q with node address: %w", plan.Name, err)
 	}
+	rendered.NodeLocalKubelet = plan.NodeLocalKubelet
 	return rendered, nil
 }
 

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -176,6 +176,7 @@ type KubeadmControlPlaneConfig struct {
 	CoordinatorNode           string            `json:"coordinatorNode"`
 	NodeName                  string            `json:"nodeName"`
 	CoordinatorUpload         bool              `json:"coordinatorUpload"`
+	NodeLocalKubelet          bool              `json:"nodeLocalKubelet,omitempty"`
 	DesiredGenerationID       string            `json:"desiredGenerationID"`
 	ConfigName                string            `json:"configName"`
 	ConfigPath                string            `json:"configPath"`

--- a/internal/katlc/agent/kubeadm_control_plane_config.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config.go
@@ -83,6 +83,12 @@ func validateKubeadmControlPlaneConfigRequest(kind string, req *agentapi.Kubeadm
 	if (component == kubeadmConfigComponentKubelet || component == kubeadmConfigComponentKubeProxy) && len(seen) != 1 {
 		return fmt.Errorf("%s configuration does not accept control-plane field deltas", strings.TrimPrefix(component, "component/"))
 	}
+	if req.GetNodeLocalKubelet() && component != kubeadmConfigComponentKubelet {
+		return fmt.Errorf("nodeLocalKubelet requires the kubelet component")
+	}
+	if req.GetNodeLocalKubelet() && req.GetCoordinatorUpload() {
+		return fmt.Errorf("node-local kubelet configuration must not be uploaded cluster-wide")
+	}
 	return nil
 }
 
@@ -107,7 +113,7 @@ func controlPlaneConfigFromProto(req *agentapi.KubeadmControlPlaneConfigOperatio
 		}
 	}
 	return operation.KubeadmControlPlaneConfig{
-		Component: component, RolloutID: req.GetRolloutId(), NodePosition: req.GetNodePosition(), NodeCount: req.GetNodeCount(), CoordinatorNode: req.GetCoordinatorNode(), NodeName: req.GetNodeName(), CoordinatorUpload: req.GetCoordinatorUpload(), DesiredGenerationID: req.GetDesiredGenerationId(), ConfigName: req.GetConfigName(), ConfigPath: "/etc/katl/kubeadm/" + req.GetConfigName() + "/config.yaml", DesiredConfigSHA256: req.GetDesiredConfigSha256(), ExpectedLiveConfigSHA256: req.GetExpectedLiveConfigSha256(), KubernetesPayloadVersion: req.GetKubernetesPayloadVersion(), KubernetesPayloadSHA256: req.GetKubernetesPayloadSha256(), SupportedFieldDelta: fields, SnapshotRef: req.GetSnapshotRef(), SnapshotDigest: req.GetSnapshotDigest(), SnapshotRevision: req.GetSnapshotRevision(), CapturedMemberListDigest: req.GetCapturedMemberListDigest(), SourceEtcdVersion: req.GetSourceEtcdVersion(), SnapshotCreatedAt: req.GetSnapshotCreatedAt(), SnapshotStorageLocation: req.GetSnapshotStorageLocation(), SnapshotOperatorIdentity: req.GetSnapshotOperatorIdentity(),
+		Component: component, RolloutID: req.GetRolloutId(), NodePosition: req.GetNodePosition(), NodeCount: req.GetNodeCount(), CoordinatorNode: req.GetCoordinatorNode(), NodeName: req.GetNodeName(), CoordinatorUpload: req.GetCoordinatorUpload(), NodeLocalKubelet: req.GetNodeLocalKubelet(), DesiredGenerationID: req.GetDesiredGenerationId(), ConfigName: req.GetConfigName(), ConfigPath: "/etc/katl/kubeadm/" + req.GetConfigName() + "/config.yaml", DesiredConfigSHA256: req.GetDesiredConfigSha256(), ExpectedLiveConfigSHA256: req.GetExpectedLiveConfigSha256(), KubernetesPayloadVersion: req.GetKubernetesPayloadVersion(), KubernetesPayloadSHA256: req.GetKubernetesPayloadSha256(), SupportedFieldDelta: fields, SnapshotRef: req.GetSnapshotRef(), SnapshotDigest: req.GetSnapshotDigest(), SnapshotRevision: req.GetSnapshotRevision(), CapturedMemberListDigest: req.GetCapturedMemberListDigest(), SourceEtcdVersion: req.GetSourceEtcdVersion(), SnapshotCreatedAt: req.GetSnapshotCreatedAt(), SnapshotStorageLocation: req.GetSnapshotStorageLocation(), SnapshotOperatorIdentity: req.GetSnapshotOperatorIdentity(),
 	}
 }
 
@@ -176,7 +182,8 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 	}
 	var node struct {
 		Kubeadm struct {
-			ConfigRef string `json:"configRef"`
+			ConfigRef        string `json:"configRef"`
+			NodeLocalKubelet bool   `json:"nodeLocalKubelet"`
 		} `json:"kubeadm"`
 	}
 	if err := json.Unmarshal(metadata, &node); err != nil {
@@ -184,6 +191,9 @@ func (s *Server) validateKubeadmControlPlaneConfigState(req *agentapi.SubmitOper
 	}
 	if strings.TrimSpace(node.Kubeadm.ConfigRef) != body.ConfigName {
 		return body, fmt.Errorf("active generation does not select kubeadm config %q", body.ConfigName)
+	}
+	if node.Kubeadm.NodeLocalKubelet != body.NodeLocalKubelet {
+		return body, fmt.Errorf("active generation node-local kubelet mode does not match the request")
 	}
 	applyStatusPath, err := generation.ConfigApplyStatusPath(s.Root, body.DesiredGenerationID)
 	if err != nil {
@@ -566,7 +576,12 @@ func (e *Executor) executeKubeletConfig(ctx context.Context, record operation.Op
 		}
 	}
 	if !localMatches {
-		if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kubelet-config-dry-run", []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config", "--dry-run"}, false); err != nil {
+		argv := []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config"}
+		if request.NodeLocalKubelet {
+			argv = append(argv, "--patches", filepath.Dir(request.ConfigPath)+"/patches")
+		}
+		argv = append(argv, "--dry-run")
+		if err := e.runControlPlaneConfigCommand(ctx, record, "preflight-kubelet-config-dry-run", argv, false); err != nil {
 			return err
 		}
 	}
@@ -607,7 +622,11 @@ func (e *Executor) executeKubeletConfig(ctx context.Context, record operation.Op
 	}
 	afterData := localBefore
 	if !localMatches {
-		if err := e.runControlPlaneConfigCommand(ctx, record, "kubelet-config-running", []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config"}, true); err != nil {
+		argv := []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config"}
+		if request.NodeLocalKubelet {
+			argv = append(argv, "--patches", filepath.Dir(request.ConfigPath)+"/patches")
+		}
+		if err := e.runControlPlaneConfigCommand(ctx, record, "kubelet-config-running", argv, true); err != nil {
 			return err
 		}
 		afterData, err = os.ReadFile(rootedRuntimePath(e.Root, "/var/lib/kubelet/config.yaml"))

--- a/internal/katlc/agent/kubeadm_control_plane_config_test.go
+++ b/internal/katlc/agent/kubeadm_control_plane_config_test.go
@@ -36,6 +36,11 @@ func TestValidateKubeadmKubeletConfigRequestAllowsAnyRolloutSize(t *testing.T) {
 	if err := validateKubeadmControlPlaneConfigRequest(OperationKindKubeadmControlPlaneConfig, req); err != nil {
 		t.Fatalf("validate request: %v", err)
 	}
+	req.NodeLocalKubelet = true
+	req.CoordinatorUpload = true
+	if err := validateKubeadmControlPlaneConfigRequest(OperationKindKubeadmControlPlaneConfig, req); err == nil || !strings.Contains(err.Error(), "must not be uploaded") {
+		t.Fatalf("node-local upload error = %v", err)
+	}
 }
 
 func TestAcceptKubeadmControlPlaneConfigBindsActiveGeneration(t *testing.T) {
@@ -384,6 +389,71 @@ func TestExecuteKubeletConfigNoChangeDoesNotRestart(t *testing.T) {
 	}
 	completed, err := store.Read(record.OperationID)
 	if err != nil || !completed.Terminal || completed.Result != operation.ResultSucceeded || completed.MutatingToolRan {
+		t.Fatalf("completed = %#v, err = %v", completed, err)
+	}
+}
+
+func TestExecuteNodeLocalKubeletConfigUsesPatchesWithoutUpload(t *testing.T) {
+	root := t.TempDir()
+	store, err := operation.NewStore(filepath.Join(root, "var/lib/katl/operations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	desiredConfig := "apiVersion: kubeadm.k8s.io/v1beta4\nkind: JoinConfiguration\n---\napiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 120\ntopologyManagerPolicy: restricted\n"
+	desiredPath := filepath.Join(root, "etc/katl/kubeadm/node-worker-1/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(desiredPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(desiredPath, []byte(desiredConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	livePath := filepath.Join(root, "var/lib/kubelet/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(livePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(livePath, []byte("apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 110\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := controlPlaneConfigFromProto(validControlPlaneConfigRequest())
+	body.Component = "kubelet"
+	body.ConfigName = "node-worker-1"
+	body.ConfigPath = "/etc/katl/kubeadm/node-worker-1/config.yaml"
+	body.CoordinatorUpload = false
+	body.NodeLocalKubelet = true
+	body.KubernetesPayloadVersion = "v1.36.1"
+	body.KubernetesPayloadSHA256 = strings.Repeat("c", 64)
+	body.DesiredConfigSHA256, _ = kubeadmplan.CanonicalKubeletConfigurationSHA256([]byte(desiredConfig))
+	record, err := store.Create(operation.OperationRecord{OperationID: "node-local-kubelet", OperationKind: OperationKindKubeadmControlPlaneConfig, Scope: "kubeadm-state", RequestDigest: strings.Repeat("f", 64), Phase: "accepted", KubeadmControlPlaneConfig: &body}, "accepted", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var commands [][]string
+	executor := NewExecutor(root, store, "agent-start")
+	executor.Async = false
+	executor.RunTool = func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		commands = append(commands, append([]string(nil), argv...))
+		if reflect.DeepEqual(argv, []string{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config", "--patches", "/etc/katl/kubeadm/node-worker-1/patches"}) {
+			updated := "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nmaxPods: 120\ntopologyManagerPolicy: restricted\ncgroupDriver: systemd\n"
+			if err := os.WriteFile(livePath, []byte(updated), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return ToolResult{}
+	}
+	executor.RunPostHealth = func(context.Context, []string, func(int)) ToolResult { return ToolResult{} }
+	if err := executor.Execute(context.Background(), record); err != nil {
+		t.Fatal(err)
+	}
+	want := [][]string{
+		{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config", "--patches", "/etc/katl/kubeadm/node-worker-1/patches", "--dry-run"},
+		{"/usr/bin/kubeadm", "upgrade", "node", "phase", "kubelet-config", "--patches", "/etc/katl/kubeadm/node-worker-1/patches"},
+		{"/usr/bin/systemctl", "restart", "kubelet.service"},
+	}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %#v, want %#v", commands, want)
+	}
+	completed, err := store.Read(record.OperationID)
+	if err != nil || !completed.Terminal || completed.Result != operation.ResultSucceeded || completed.KubeadmControlPlaneConfig.ConfigUploadRan {
 		t.Fatalf("completed = %#v, err = %v", completed, err)
 	}
 }

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -2308,6 +2308,7 @@ type KubeadmControlPlaneConfigOperationRequest struct {
 	SnapshotStorageLocation  string                 `protobuf:"bytes,19,opt,name=snapshot_storage_location,json=snapshotStorageLocation,proto3" json:"snapshot_storage_location,omitempty"`
 	SnapshotOperatorIdentity string                 `protobuf:"bytes,20,opt,name=snapshot_operator_identity,json=snapshotOperatorIdentity,proto3" json:"snapshot_operator_identity,omitempty"`
 	NodeName                 string                 `protobuf:"bytes,21,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	NodeLocalKubelet         bool                   `protobuf:"varint,22,opt,name=node_local_kubelet,json=nodeLocalKubelet,proto3" json:"node_local_kubelet,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -2487,6 +2488,13 @@ func (x *KubeadmControlPlaneConfigOperationRequest) GetNodeName() string {
 		return x.NodeName
 	}
 	return ""
+}
+
+func (x *KubeadmControlPlaneConfigOperationRequest) GetNodeLocalKubelet() bool {
+	if x != nil {
+		return x.NodeLocalKubelet
+	}
+	return false
 }
 
 type KubernetesSysextUpdateOperationRequest struct {
@@ -5222,7 +5230,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\tnode_name\x18\x03 \x01(\tR\bnodeName\x12\x1f\n" +
 	"\vconfig_yaml\x18\x04 \x01(\tR\n" +
 	"configYaml\x12P\n" +
-	"$destructive_storage_acknowledgements\x18\x05 \x03(\tR\"destructiveStorageAcknowledgements\"\x8d\b\n" +
+	"$destructive_storage_acknowledgements\x18\x05 \x03(\tR\"destructiveStorageAcknowledgements\"\xbb\b\n" +
 	")KubeadmControlPlaneConfigOperationRequest\x12\x1d\n" +
 	"\n" +
 	"rollout_id\x18\x01 \x01(\tR\trolloutId\x12#\n" +
@@ -5248,7 +5256,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x13snapshot_created_at\x18\x12 \x01(\tR\x11snapshotCreatedAt\x12:\n" +
 	"\x19snapshot_storage_location\x18\x13 \x01(\tR\x17snapshotStorageLocation\x12<\n" +
 	"\x1asnapshot_operator_identity\x18\x14 \x01(\tR\x18snapshotOperatorIdentity\x12\x1b\n" +
-	"\tnode_name\x18\x15 \x01(\tR\bnodeName\"\x89\b\n" +
+	"\tnode_name\x18\x15 \x01(\tR\bnodeName\x12,\n" +
+	"\x12node_local_kubelet\x18\x16 \x01(\bR\x10nodeLocalKubelet\"\x89\b\n" +
 	"&KubernetesSysextUpdateOperationRequest\x124\n" +
 	"\x16target_payload_version\x18\x01 \x01(\tR\x14targetPayloadVersion\x12,\n" +
 	"\x12target_sysext_path\x18\x02 \x01(\tR\x10targetSysextPath\x120\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -292,6 +292,7 @@ message KubeadmControlPlaneConfigOperationRequest {
   string snapshot_storage_location = 19;
   string snapshot_operator_identity = 20;
   string node_name = 21;
+  bool node_local_kubelet = 22;
 }
 
 message KubernetesSysextUpdateOperationRequest {


### PR DESCRIPTION
## Summary

- add a bounded node-specific native KubeletConfiguration input
- apply it through kubeadm's node-local patch path without updating the shared kubelet ConfigMap
- expose effective values, provenance, generated paths, schema help, and kubeadm-aware diff classification

## Why

Specialized kubelet policy previously required cluster-wide native kubeadm configuration or writing Katl-owned runtime paths. This gives each node a supported upstream-native surface while preserving Katl's ownership and rollout safety boundaries.