### PR TITLE
config: require explicit Kubernetes version

### DIFF
--- a/cmd/katlctl/config_init.go
+++ b/cmd/katlctl/config_init.go
@@ -107,6 +107,10 @@ func addConfigInitFlags(cmd *cobra.Command, opts *configInitOptions) {
 }
 
 func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr io.Writer) error {
+	kubernetesVersion := strings.TrimSpace(opts.kubernetesVersion)
+	if kubernetesVersion == "" {
+		return fmt.Errorf("--kubernetes-version is required and must be an exact version such as %s", configbundle.DefaultKubernetesVersion)
+	}
 	if len(opts.nodes) > 0 && len(opts.installers.values) > 0 {
 		return fmt.Errorf("--node and --installer cannot be used together")
 	}
@@ -150,7 +154,7 @@ func runConfigInit(ctx context.Context, opts configInitOptions, stdout, stderr i
 		Spec: configbundle.SourceSpec{
 			ControlPlaneEndpoint: controlPlaneEndpoint,
 			Kubernetes: configbundle.SourceKubernetesCluster{
-				Version: strings.TrimSpace(opts.kubernetesVersion),
+				Version: kubernetesVersion,
 			},
 			Defaults: configbundle.SourceNodeLayer{
 				Access: configbundle.SourceAccess{SSH: configbundle.SourceSSHAccess{

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -92,6 +92,18 @@ func TestConfigInitRendersExplicitIntent(t *testing.T) {
 	}
 }
 
+func TestConfigInitRejectsEmptyKubernetesVersion(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"config", "init",
+		"--kubernetes-version", "",
+		"--node", "cp-1=control-plane,192.0.2.11,/dev/disk/by-id/ata-cp-root",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "--kubernetes-version is required") {
+		t.Fatalf("run() error = %v, want required concrete Kubernetes version", err)
+	}
+}
+
 func TestConfigInitUsesSSHAgentKeys(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -196,7 +196,10 @@ Pod CIDRs from `10.244.0.0/16` and Service IPs from `10.96.0.0/12`. Supply
 including different or intentionally absent Pod and Service subnets.
 
 The release ISO supplies the KatlOS image, and Katl resolves the selected
-Kubernetes version itself. ClusterConfig does not expose KatlOS or Kubernetes
+Kubernetes payload from the exact required `spec.kubernetes.version`. Keeping
+that version in source makes compilation reproducible across `katlctl`
+versions; `katlctl config init` always writes a concrete compatible version.
+ClusterConfig does not expose KatlOS or Kubernetes
 image URLs, credentials, named kubeadm profiles, node classes, or other
 compiler mechanisms. An advanced `systemExtensions` entry may select an
 operator-owned native software bundle by OCI reference as described below.

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -605,19 +605,11 @@ func selectedKubernetesVersion(source SourceConfig) string {
 	return strings.TrimSpace(source.Spec.Kubernetes.Version)
 }
 
-func defaultSource(source SourceConfig) SourceConfig {
-	spec := source.Spec
-	spec.Nodes = slices.Clone(spec.Nodes)
-	version := strings.TrimSpace(spec.Kubernetes.Version)
-	if version == "" {
-		spec.Kubernetes.Version = DefaultKubernetesVersion
-	}
-	source.Spec = spec
-	return source
-}
-
 func normalizeSource(source SourceConfig) (SourceConfig, error) {
-	source = defaultSource(source)
+	if strings.TrimSpace(source.Spec.Kubernetes.Version) == "" {
+		return SourceConfig{}, fmt.Errorf("spec.kubernetes.version is required; set an exact version such as %s", DefaultKubernetesVersion)
+	}
+	source.Spec.Nodes = slices.Clone(source.Spec.Nodes)
 	seenNodes := make(map[string]struct{}, len(source.Spec.Nodes))
 	for i, node := range source.Spec.Nodes {
 		name := strings.TrimSpace(node.Name)

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -788,6 +788,18 @@ func TestBuildArchiveRejectsInvalidKubernetesAddress(t *testing.T) {
 	}
 }
 
+func TestBuildArchiveRequiresExplicitKubernetesVersion(t *testing.T) {
+	for _, source := range []string{
+		strings.Replace(validSourceConfig(), "  kubernetes:\n    version: v1.36.1\n", "", 1),
+		strings.Replace(validSourceConfig(), "    version: v1.36.1", `    version: ""`, 1),
+	} {
+		_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+		if err == nil || !strings.Contains(err.Error(), "spec.kubernetes.version is required") {
+			t.Fatalf("BuildArchive() error = %v, want required public version path", err)
+		}
+	}
+}
+
 func TestBuildArchiveRequiresKubernetesAddressPerNode(t *testing.T) {
 	source := strings.Replace(validSourceConfig(), "  defaults:\n", "  defaults:\n    kubernetes:\n      address: 10.254.1.1\n", 1)
 	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})

--- a/internal/installer/configbundle/schema_rules.go
+++ b/internal/installer/configbundle/schema_rules.go
@@ -63,7 +63,7 @@ func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
 	case "configbundle.SourceSpec.controlPlaneEndpoint":
 		return description("Stable Kubernetes API endpoint and optional Katl-managed advertisement.")
 	case "configbundle.SourceSpec.kubernetes":
-		return description("Cluster-wide Kubernetes version and optional native kubeadm input.")
+		return schemaFieldRule{Required: true, Description: "Cluster-wide Kubernetes version and optional native kubeadm input."}
 	case "configbundle.SourceSpec.defaults":
 		return description("Non-identifying values inherited by every node unless overridden.")
 	case "configbundle.SourceSpec.nodes":
@@ -153,7 +153,7 @@ func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
 	case "configbundle.SourcePartitionSelector.filesystemUUID":
 		return description("Existing filesystem UUID; an empty value clears an inherited identity.")
 	case "configbundle.SourceKubernetesCluster.version":
-		return schemaFieldRule{Description: "Exact Kubernetes patch version compiled into the cluster.", Default: DefaultKubernetesVersion, Pattern: `^(?:|v[0-9]+\.[0-9]+\.[0-9]+)$`}
+		return schemaFieldRule{Required: true, Description: "Exact Kubernetes patch version compiled into the cluster.", Pattern: `^v[0-9]+\.[0-9]+\.[0-9]+$`, MinLength: intPointer(1)}
 	case "configbundle.SourceKubernetesCluster.kubeadm":
 		return description("Optional native kubeadm configuration and patches.")
 	case "configbundle.SourceKubeadmInput.configFile":

--- a/internal/installer/configbundle/schema_test.go
+++ b/internal/installer/configbundle/schema_test.go
@@ -13,8 +13,6 @@ func TestSourceSchemaAcceptsConfigsAcceptedByKatl(t *testing.T) {
               partition: {}
 `, 1)
 	zeroDefaults := strings.Replace(validSourceConfig(), "    port: 6443\n", "    port: 0\n", 1)
-	zeroDefaults = strings.Replace(zeroDefaults, "    version: v1.36.1\n", `    version: ""
-`, 1)
 	zeroDefaults = strings.Replace(zeroDefaults, "          files:\n", `          state: ""
           files:
 `, 1)
@@ -52,6 +50,18 @@ func TestSourceSchemaRejectsSemanticErrors(t *testing.T) {
 		name   string
 		source string
 	}{
+		{
+			name:   "missing Kubernetes block",
+			source: strings.Replace(validSourceConfig(), "  kubernetes:\n    version: v1.36.1\n", "", 1),
+		},
+		{
+			name:   "missing Kubernetes version",
+			source: strings.Replace(validSourceConfig(), "    version: v1.36.1\n", "", 1),
+		},
+		{
+			name:   "empty Kubernetes version",
+			source: strings.Replace(validSourceConfig(), "    version: v1.36.1", `    version: ""`, 1),
+		},
 		{
 			name: "disk and partition",
 			source: strings.Replace(validSourceConfig(), `            selector:


### PR DESCRIPTION
## Summary

- reject ClusterConfig sources without an exact Kubernetes patch version
- require the Kubernetes block and version in JSON Schema
- keep config init reproducible by emitting a concrete compatible version

## Why

Implicit version selection made the same source resolve differently with different katlctl releases. Persisting the requested version makes cluster intent stable and reviewable.