### PR TITLE
config: pin system-extension selection

### DIFF
--- a/cmd/katlctl/config_input.go
+++ b/cmd/katlctl/config_input.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -10,9 +11,10 @@ import (
 )
 
 type katlConfigInput struct {
-	Archive []byte
-	Bundle  configbundle.Bundle
-	Source  bool
+	Archive  []byte
+	Bundle   configbundle.Bundle
+	Source   bool
+	Warnings []configbundle.CompilationWarning
 }
 
 func loadKatlConfig(path, createdBy string, planning configbundle.PlanningInputs) (katlConfigInput, error) {
@@ -41,7 +43,7 @@ func loadKatlConfig(path, createdBy string, planning configbundle.PlanningInputs
 		if err != nil {
 			return katlConfigInput{}, fmt.Errorf("read compiled --config %s: %w", path, err)
 		}
-		return katlConfigInput{Archive: archive, Bundle: bundle, Source: true}, nil
+		return katlConfigInput{Archive: archive, Bundle: bundle, Source: true, Warnings: result.Warnings}, nil
 	}
 
 	bundle, bundleErr := configbundle.ReadBundle(bytes.NewReader(data), "")
@@ -49,4 +51,21 @@ func loadKatlConfig(path, createdBy string, planning configbundle.PlanningInputs
 		return katlConfigInput{}, fmt.Errorf("read --config %s as ClusterConfig YAML or Katl config bundle: YAML: %v; bundle: %w", path, sourceErr, bundleErr)
 	}
 	return katlConfigInput{Archive: data, Bundle: bundle}, nil
+}
+
+func writeCompilationWarnings(stderr io.Writer, warnings []configbundle.CompilationWarning) error {
+	if stderr == nil {
+		return nil
+	}
+	for _, warning := range warnings {
+		if _, err := fmt.Fprintf(stderr, "warning: %s (node %s): %s\n", warning.Path, warning.Node, warning.Message); err != nil {
+			return err
+		}
+		if warning.SuggestedValue != "" {
+			if _, err := fmt.Fprintf(stderr, "  suggested value: %s\n", warning.SuggestedValue); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/katlctl/enroll.go
+++ b/cmd/katlctl/enroll.go
@@ -176,12 +176,14 @@ func newContextUseCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func runContextSave(ctx context.Context, opts contextSaveOptions, stdout, stderr io.Writer) error {
-	_ = stderr
 	if opts.output != "text" && opts.output != "json" {
 		return fmt.Errorf("--output = %q, want text or json", opts.output)
 	}
 	config, err := loadKatlConfig(opts.configInput, "katlctl context save", configbundle.PlanningInputs{})
 	if err != nil {
+		return err
+	}
+	if err := writeCompilationWarnings(stderr, config.Warnings); err != nil {
 		return err
 	}
 	bundle := config.Bundle

--- a/cmd/katlctl/install.go
+++ b/cmd/katlctl/install.go
@@ -109,6 +109,9 @@ func runInstallApply(ctx context.Context, opts installApplyOptions, stdout, stde
 	if err != nil {
 		return err
 	}
+	if err := writeCompilationWarnings(stderr, config.Warnings); err != nil {
+		return err
+	}
 	archive := config.Archive
 	if len(archive) > maxInstallBundleSize {
 		return fmt.Errorf("compiled config bundle size %d exceeds %d bytes", len(archive), maxInstallBundleSize)

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -408,6 +408,9 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 	if err != nil {
 		return activatedClusterConfig{}, err
 	}
+	if err := writeCompilationWarnings(opts.progress, loaded.Warnings); err != nil {
+		return activatedClusterConfig{}, err
+	}
 	now := kubeadmConfigNow()
 	generationID := strings.TrimSpace(opts.generationID)
 	if generationID == "" {

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1783,11 +1783,12 @@ type configValidationNode struct {
 }
 
 type configValidationReport struct {
-	APIVersion  string                 `json:"apiVersion"`
-	Kind        string                 `json:"kind"`
-	Source      string                 `json:"source"`
-	ClusterName string                 `json:"clusterName"`
-	Nodes       []configValidationNode `json:"nodes"`
+	APIVersion  string                            `json:"apiVersion"`
+	Kind        string                            `json:"kind"`
+	Source      string                            `json:"source"`
+	ClusterName string                            `json:"clusterName"`
+	Nodes       []configValidationNode            `json:"nodes"`
+	Warnings    []configbundle.CompilationWarning `json:"warnings,omitempty"`
 }
 
 func newConfigValidateCommand(stdout, stderr io.Writer) *cobra.Command {
@@ -1805,7 +1806,6 @@ func newConfigValidateCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func runConfigValidate(sourcePath, output string, stdout, stderr io.Writer) error {
-	_ = stderr
 	if output != "text" && output != "json" {
 		return fmt.Errorf("--output = %q, want text or json", output)
 	}
@@ -1828,10 +1828,13 @@ func runConfigValidate(sourcePath, output string, stdout, stderr io.Writer) erro
 		Source:      sourcePath,
 		ClusterName: result.Manifest.ClusterName,
 		Nodes:       nodes,
+		Warnings:    result.Warnings,
 	}
 	if output == "text" {
-		_, err := fmt.Fprintf(stdout, "%s is valid for cluster %s (%d node(s))\n", sourcePath, report.ClusterName, len(report.Nodes))
-		return err
+		if _, err := fmt.Fprintf(stdout, "%s is valid for cluster %s (%d node(s))\n", sourcePath, report.ClusterName, len(report.Nodes)); err != nil {
+			return err
+		}
+		return writeCompilationWarnings(stderr, result.Warnings)
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
@@ -1859,10 +1862,11 @@ func newConfigSchemaCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 type configBundleReport struct {
-	APIVersion  string `json:"apiVersion"`
-	Kind        string `json:"kind"`
-	Output      string `json:"output"`
-	ArchiveSize int64  `json:"archiveSizeBytes"`
+	APIVersion  string                            `json:"apiVersion"`
+	Kind        string                            `json:"kind"`
+	Output      string                            `json:"output"`
+	ArchiveSize int64                             `json:"archiveSizeBytes"`
+	Warnings    []configbundle.CompilationWarning `json:"warnings,omitempty"`
 }
 
 func newConfigBundleCommand(stdout, stderr io.Writer) *cobra.Command {
@@ -1888,7 +1892,6 @@ func newConfigBundleCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func runConfigBundle(opts configBundleOptions, stdout, stderr io.Writer) error {
-	_ = stderr
 	if strings.TrimSpace(opts.outputPath) == "" {
 		return fmt.Errorf("--output is required")
 	}
@@ -1911,13 +1914,16 @@ func runConfigBundle(opts configBundleOptions, stdout, stderr io.Writer) error {
 		Kind:        "ConfigBundleReport",
 		Output:      opts.outputPath,
 		ArchiveSize: result.ArchiveSize,
+		Warnings:    result.Warnings,
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal config bundle report: %w", err)
 	}
-	_, err = stdout.Write(append(data, '\n'))
-	return err
+	if _, err = stdout.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return writeCompilationWarnings(stderr, result.Warnings)
 }
 
 func loadKatlosImagePlanningInput(imageURL, metadataPath string) (manifest.KatlosImage, error) {
@@ -2633,8 +2639,7 @@ func newClusterBootstrapCommand(ctx context.Context, stdout, stderr io.Writer) *
 }
 
 func runClusterBootstrap(ctx context.Context, opts clusterBootstrapOptions, stdout, stderr io.Writer) error {
-	_ = stderr
-	inv, err := bootstrapInventory(opts)
+	inv, err := bootstrapInventory(opts, stderr)
 	if err != nil {
 		return err
 	}
@@ -2712,7 +2717,7 @@ func fallbackText(value, fallback string) string {
 	return value
 }
 
-func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, error) {
+func bootstrapInventory(opts clusterBootstrapOptions, stderr io.Writer) (inventory.Inventory, error) {
 	configPath := strings.TrimSpace(opts.configPath)
 	inventoryPath := strings.TrimSpace(opts.inventoryPath)
 	inputs := 0
@@ -2732,6 +2737,9 @@ func bootstrapInventory(opts clusterBootstrapOptions) (inventory.Inventory, erro
 	}
 	config, err := loadKatlConfig(configPath, clusterBootstrapCreator, configbundle.PlanningInputs{KubernetesBundle: opts.kubernetesBundle})
 	if err != nil {
+		return inventory.Inventory{}, err
+	}
+	if err := writeCompilationWarnings(stderr, config.Warnings); err != nil {
 		return inventory.Inventory{}, err
 	}
 	if !config.Source && strings.TrimSpace(opts.kubernetesBundle) != "" {

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -751,6 +751,24 @@ func TestConfigValidateResolvesWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestWriteCompilationWarningsShowsPublicPathNodeAndPinnedValue(t *testing.T) {
+	var stderr bytes.Buffer
+	warning := configbundle.CompilationWarning{
+		Path:           `spec.nodes["worker-1"].systemExtensions[name="bird"].bundle`,
+		Node:           "worker-1",
+		Message:        "mutable system-extension reference resolved to sha256:abc",
+		SuggestedValue: "registry.example/extensions/bird:v1@sha256:abc",
+	}
+	if err := writeCompilationWarnings(&stderr, []configbundle.CompilationWarning{warning}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{warning.Path, "node worker-1", warning.Message, warning.SuggestedValue} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("warning output %q does not contain %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestConfigValidateReportsNestedFieldPath(t *testing.T) {
 	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
 	source := strings.Replace(configBundleSource(), "systemDisk:\n          byID:", "systemDisk:\n          unsupportedSelector: true\n          byID:", 1)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -359,6 +359,18 @@ apply. Registry credentials, when needed during workstation compilation, come
 from the normal Docker credential store and are never embedded in config or
 node state.
 
+A tag-only `bundle` reference keeps the routine home-lab path convenient, but
+the tag may select different bytes in a later compilation. Katl resolves it
+once, verifies the content, and prints a warning for every affected node with
+the exact digest-pinned replacement:
+
+```text
+registry.example/katl/extensions/bird:v3.3.1-katl.4@sha256:<OCI-manifest-digest>
+```
+
+Commit that value in `cluster.yaml` when repeatable selection matters. A
+digest-pinned reference compiles without the mutable-reference warning.
+
 Advanced users can keep native kubeadm settings without waiting for Katl to add
 a typed field for each upstream option:
 

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -27,6 +27,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/kubernetesbundle"
 	"github.com/katl-dev/katl/internal/installer/kubernetescompat"
 	"github.com/katl-dev/katl/internal/installer/manifest"
+	"github.com/katl-dev/katl/internal/installer/payloadbundle"
 	"github.com/katl-dev/katl/internal/installer/systemextensionbundle"
 	"gopkg.in/yaml.v3"
 )
@@ -63,6 +64,15 @@ type Result struct {
 	Digest      string
 	Manifest    BundleManifest
 	ArchiveSize int64
+	Warnings    []CompilationWarning
+}
+
+type CompilationWarning struct {
+	Code           string `json:"code" yaml:"code"`
+	Path           string `json:"path" yaml:"path"`
+	Node           string `json:"node" yaml:"node"`
+	Message        string `json:"message" yaml:"message"`
+	SuggestedValue string `json:"suggestedValue,omitempty" yaml:"suggestedValue,omitempty"`
 }
 
 type SourceConfig struct {
@@ -368,6 +378,7 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 	if err != nil {
 		return nil, Result{}, err
 	}
+	warnings := systemExtensionReferenceWarnings(config)
 	plan, err := clusterplan.Compile(clusterplan.CompileRequest{
 		Config:         config,
 		KubeadmConfigs: kubeadmConfigs,
@@ -404,7 +415,32 @@ func BuildArchive(request BuildRequest) ([]byte, Result, error) {
 	if err != nil {
 		return nil, Result{}, err
 	}
-	return archive, Result{Digest: manifestDigest, Manifest: manifest, ArchiveSize: int64(len(archive))}, nil
+	return archive, Result{Digest: manifestDigest, Manifest: manifest, ArchiveSize: int64(len(archive)), Warnings: warnings}, nil
+}
+
+func systemExtensionReferenceWarnings(config clusterplan.Config) []CompilationWarning {
+	var warnings []CompilationWarning
+	for _, node := range config.Spec.Nodes {
+		for _, extension := range node.Overrides.SystemExtensions {
+			if extension.State == manifest.SystemExtensionAbsent || strings.TrimSpace(extension.Bundle) == "" {
+				continue
+			}
+			parsed, err := payloadbundle.ParseReference(extension.Bundle)
+			if err != nil || parsed.ManifestDigest != "" || strings.TrimSpace(extension.OCIManifestDigest) == "" {
+				continue
+			}
+			pinned := parsed.Repository + ":" + parsed.Tag + "@" + extension.OCIManifestDigest
+			warnings = append(warnings, CompilationWarning{
+				Code:           "mutable-system-extension-reference",
+				Path:           fmt.Sprintf("spec.nodes[%q].systemExtensions[name=%q].bundle", node.Name, extension.Name),
+				Node:           node.Name,
+				Message:        fmt.Sprintf("mutable system-extension reference %q resolved to %s; use the suggested digest-pinned value to make later compilations select the same payload", extension.Bundle, extension.OCIManifestDigest),
+				SuggestedValue: pinned,
+			})
+		}
+	}
+	sort.Slice(warnings, func(i, j int) bool { return warnings[i].Path < warnings[j].Path })
+	return warnings
 }
 
 func WriteArchive(path string, request BuildRequest) (Result, error) {

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -387,39 +387,46 @@ func TestBuildArchiveResolvesAndVendorsSystemExtensionOnce(t *testing.T) {
 	customManifest := []byte(`{"apiVersion":"payload.katl.dev/v1alpha1","kind":"SystemExtensionBundle"}`)
 	customDigest := digestBytes(customManifest)
 	resolveCalls := 0
-	archive, result, err := BuildArchive(BuildRequest{
-		SourcePath: writeSource(t, source),
-		Planning:   PlanningInputs{KatlosImage: testKatlosImage()},
-		ResolveSystemExtension: func(_ context.Context, request systemextensionbundle.ResolveRequest) (systemextensionbundle.Resolved, error) {
-			resolveCalls++
-			if request.Reference != "registry.example/katl-dev/bird:v3.1.2-katl.1" ||
-				request.Architecture != "x86_64" || request.RuntimeInterface != "katl-runtime-1" {
-				t.Fatalf("resolve request = %#v", request)
-			}
-			return systemextensionbundle.Resolved{
-				Reference:            request.Reference,
-				OCIManifestDigest:    "sha256:" + strings.Repeat("a", 64),
-				BundleManifestDigest: customDigest,
-				BundleManifest:       customManifest,
-				Bundle: systemextensionbundle.Bundle{
-					ArtifactVersion: "v3.1.2-katl.1", PayloadVersion: "v3.1.2",
-					Architecture: "x86_64", SupportedRuntimeInterfaces: []string{"katl-runtime-1"},
+	resolver := func(_ context.Context, request systemextensionbundle.ResolveRequest) (systemextensionbundle.Resolved, error) {
+		resolveCalls++
+		if !strings.HasPrefix(request.Reference, "registry.example/katl-dev/bird:v3.1.2-katl.1") ||
+			request.Architecture != "x86_64" || request.RuntimeInterface != "katl-runtime-1" {
+			t.Fatalf("resolve request = %#v", request)
+		}
+		return systemextensionbundle.Resolved{
+			Reference:            request.Reference,
+			OCIManifestDigest:    "sha256:" + strings.Repeat("a", 64),
+			BundleManifestDigest: customDigest,
+			BundleManifest:       customManifest,
+			Bundle: systemextensionbundle.Bundle{
+				ArtifactVersion: "v3.1.2-katl.1", PayloadVersion: "v3.1.2",
+				Architecture: "x86_64", SupportedRuntimeInterfaces: []string{"katl-runtime-1"},
+			},
+			Payloads: []systemextensionbundle.Payload{{
+				Descriptor: systemextensionbundle.Descriptor{
+					Role: systemextensionbundle.SysextRole, MediaType: systemextensionbundle.SysextMediaType,
+					Digest: payloadDigest, SizeBytes: int64(len(payloadData)), FileName: "katl-bird.raw",
 				},
-				Payloads: []systemextensionbundle.Payload{{
-					Descriptor: systemextensionbundle.Descriptor{
-						Role: systemextensionbundle.SysextRole, MediaType: systemextensionbundle.SysextMediaType,
-						Digest: payloadDigest, SizeBytes: int64(len(payloadData)), FileName: "katl-bird.raw",
-					},
-					Data: payloadData,
-				}},
-			}, nil
-		},
+				Data: payloadData,
+			}},
+		}, nil
+	}
+	archive, result, err := BuildArchive(BuildRequest{
+		SourcePath:             writeSource(t, source),
+		Planning:               PlanningInputs{KatlosImage: testKatlosImage()},
+		ResolveSystemExtension: resolver,
 	})
 	if err != nil {
 		t.Fatalf("BuildArchive() error = %v", err)
 	}
 	if resolveCalls != 1 {
 		t.Fatalf("resolver calls = %d, want one for shared defaults", resolveCalls)
+	}
+	wantPinned := "registry.example/katl-dev/bird:v3.1.2-katl.1@sha256:" + strings.Repeat("a", 64)
+	if len(result.Warnings) != 2 || result.Warnings[0].Node != "cp-1" || result.Warnings[1].Node != "worker-1" ||
+		result.Warnings[0].Path != `spec.nodes["cp-1"].systemExtensions[name="bird"].bundle` ||
+		result.Warnings[0].SuggestedValue != wantPinned || result.Warnings[1].SuggestedValue != wantPinned {
+		t.Fatalf("compilation warnings = %#v", result.Warnings)
 	}
 	files := readTarFiles(t, archive)
 	normalized := files["blobs/sha256/"+strings.TrimPrefix(result.Manifest.Source.NormalizedConfig.Digest, "sha256:")]
@@ -440,6 +447,32 @@ func TestBuildArchiveResolvesAndVendorsSystemExtensionOnce(t *testing.T) {
 		len(selected.SystemExtensionPayloads) != 1 ||
 		!bytes.Equal(selected.SystemExtensionPayloads[0].Data, payloadData) {
 		t.Fatalf("selected system extension material = %#v / %#v", selected.InstallManifest.Node.SystemExtensions, selected.SystemExtensionPayloads)
+	}
+	inspection, err := InspectSelectedNode(selected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundMutableWarning := false
+	for _, warning := range inspection.Warnings {
+		if warning.Path == `spec.nodes["cp-1"].systemExtensions[name="bird"].bundle` && strings.Contains(warning.Message, wantPinned) {
+			foundMutableWarning = true
+		}
+	}
+	if !foundMutableWarning {
+		t.Fatalf("inspection warnings = %#v", inspection.Warnings)
+	}
+
+	pinnedSource := strings.Replace(source, "registry.example/katl-dev/bird:v3.1.2-katl.1", wantPinned, 1)
+	_, pinnedResult, err := BuildArchive(BuildRequest{
+		SourcePath:             writeSource(t, pinnedSource),
+		Planning:               PlanningInputs{KatlosImage: testKatlosImage()},
+		ResolveSystemExtension: resolver,
+	})
+	if err != nil {
+		t.Fatalf("BuildArchive(pinned) error = %v", err)
+	}
+	if len(pinnedResult.Warnings) != 0 {
+		t.Fatalf("pinned compilation warnings = %#v", pinnedResult.Warnings)
 	}
 }
 

--- a/internal/installer/configbundle/inspect.go
+++ b/internal/installer/configbundle/inspect.go
@@ -135,6 +135,23 @@ func InspectSelectedNode(selected SelectedNodeMaterial) (NodeResolution, error) 
 		})
 	}
 	report.Derived.StorageVolumes, report.Warnings = derivedVolumesAndWarnings(resolved.Storage, base)
+	if extensions, ok := resolved.SystemExtensions.Get(); ok {
+		installedByName := make(map[string]string, len(selected.InstallManifest.Node.SystemExtensions))
+		for _, extension := range selected.InstallManifest.Node.SystemExtensions {
+			installedByName[extension.Name] = extension.OCIManifestDigest
+		}
+		for _, extension := range extensions {
+			digest := installedByName[extension.Name]
+			if digest == "" || strings.Contains(extension.Bundle, "@") {
+				continue
+			}
+			pinned := strings.SplitN(extension.Bundle, "@", 2)[0] + "@" + digest
+			report.Warnings = append(report.Warnings, ResolutionWarning{
+				Path:    fmt.Sprintf("%s.systemExtensions[name=%q].bundle", base, extension.Name),
+				Message: fmt.Sprintf("mutable reference %q resolved to %s; pin it as %s for reproducible compilation", extension.Bundle, digest, pinned),
+			})
+		}
+	}
 	if node.Management.Address != "" {
 		report.Warnings = append(report.Warnings, ResolutionWarning{
 			Path:    base + ".management.address",

--- a/internal/installer/configbundle/schema_rules.go
+++ b/internal/installer/configbundle/schema_rules.go
@@ -115,7 +115,7 @@ func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
 	case "configbundle.SourceSystemExtension.state":
 		return enumRule("Whether the extension is present or removed.", "present", "", "present", "absent")
 	case "configbundle.SourceSystemExtension.bundle":
-		return stringRule("OCI bundle reference including registry, repository, and tag.", "", 1, 0)
+		return stringRule("OCI bundle reference including registry, repository, and tag. Add @sha256:<OCI-manifest-digest> to pin an immutable payload; Katl warns when compiling a tag-only reference.", "", 1, 0)
 	case "configbundle.SourceSystemExtension.configuration":
 		return description("Files consumed by the selected extension.")
 	case "configbundle.SourceSystemExtension.units":


### PR DESCRIPTION
## Summary

- report tag-only system-extension references at each affected public node path
- provide the exact resolved digest-pinned value operators can commit
- carry warnings through validation, compilation, lifecycle entry points, schema help, and resolved configuration

## Why

Mutable OCI tags could select different extension payloads when the same ClusterConfig was compiled later. Katl still keeps tag-only references convenient, while making the reproducibility tradeoff and recovery action explicit.