### PR TITLE
storage: preserve data when removing volumes

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -233,6 +233,14 @@ filesystem, and `wipe: false`. Stable disk or partition identity and
 `spec.defaults` so one inherited value cannot select or erase storage across
 the cluster.
 
+Removing a volume is non-destructive. Set an inherited entry to
+`state: absent`, omit a node-specific entry from the desired collection, or
+use `storage.disks: []` to clear all inherited volumes for that node. Online
+apply first unmounts `/var/mnt/<name>`, then removes Katl's generated mount
+unit and stops managing the target. It does not format, repartition, run
+`wipefs`, or erase the partition, filesystem, mount-point directory, or data.
+Re-adding a matching selector mounts the preserved filesystem again.
+
 A disk-backed entry with `wipe: true` requests reinitialization of the selected
 disk. It is desired state, not permission to overwrite existing contents. Katl
 uses `systemd-repart` to create and format its convention-labelled partition:

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -71,6 +71,15 @@ separate operation acknowledgement naming the concrete node and volume. That
 acknowledgement is never persisted in ClusterConfig or inherited by later
 operations.
 
+Storage removal is a management transition, not a data transition. An empty
+node `storage.disks` collection clears inherited volumes, and an entry with
+`state: absent` removes the inherited entry of the same name. Live apply stops
+the Katl-managed `/var/mnt/<name>` mount before removing its generated unit.
+The underlying partition table, partition, filesystem, and data are preserved;
+removal never invokes target discovery, repartitioning, formatting, or wiping.
+The mount-point directory may remain empty. Re-adding a selector for the same
+filesystem resumes management and mounts the preserved data.
+
 ## Supported Shape
 
 ```yaml

--- a/internal/installer/configbundle/inspect.go
+++ b/internal/installer/configbundle/inspect.go
@@ -492,6 +492,9 @@ func appendNamedChange(diff *ConfigDiff, path string, before, after any) {
 		return
 	}
 	classification, operation, message := classifyDiffPath(path)
+	if strings.Contains(path, ".storage.disks") && after == nil {
+		message = "removal unmounts the volume and stops Katl management; the partition, filesystem, and data are preserved"
+	}
 	diff.Changes = append(diff.Changes, ConfigFieldChange{Path: path, Before: before, After: after, Classification: classification, RequiredOperation: operation, Message: message})
 }
 

--- a/internal/installer/configbundle/inspect_test.go
+++ b/internal/installer/configbundle/inspect_test.go
@@ -14,3 +14,18 @@ func TestDiffNodeResolutionsRefusesDifferentNodeNames(t *testing.T) {
 		t.Fatalf("DiffNodeResolutions() error = %v, want lifecycle refusal", err)
 	}
 }
+
+func TestDiffNodeResolutionsExplainsNonDestructiveStorageRemoval(t *testing.T) {
+	volume := SourceStorageDisk{Name: "data"}
+	before := NodeResolution{Node: "cp-1", Effective: SourceNode{Storage: SourceStorageLayer{Disks: supplied([]SourceStorageDisk{volume})}}}
+	after := NodeResolution{Node: "cp-1", Effective: SourceNode{Storage: SourceStorageLayer{Disks: supplied([]SourceStorageDisk{})}}}
+	diff, err := DiffNodeResolutions(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diff.Changes) != 1 || diff.Changes[0].Path != `spec.nodes["cp-1"].storage.disks["data"]` ||
+		diff.Changes[0].Classification != "online-applicable" ||
+		!strings.Contains(diff.Changes[0].Message, "partition, filesystem, and data are preserved") {
+		t.Fatalf("storage removal diff = %#v", diff)
+	}
+}

--- a/internal/katlc/agent/volume_apply.go
+++ b/internal/katlc/agent/volume_apply.go
@@ -21,16 +21,18 @@ func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.M
 		run = runChildProcess
 	}
 	stopNames, changed := changedVolumes(current, desired)
-	if len(changed) == 0 {
+	if len(stopNames) == 0 && len(changed) == 0 {
 		return nil
 	}
 
-	plans, err := preflightLiveVolumes(ctx, run, desired, stopNames, changed)
-	if err != nil {
-		return err
-	}
-	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
-		return err
+	if len(changed) > 0 {
+		plans, err := preflightLiveVolumes(ctx, run, desired, stopNames, changed)
+		if err != nil {
+			return err
+		}
+		if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
+			return err
+		}
 	}
 
 	for _, name := range stopNames {
@@ -44,12 +46,15 @@ func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.M
 			return fmt.Errorf("%w; stop workloads using /var/mnt/%s and retry", err, name)
 		}
 	}
+	if len(changed) == 0 {
+		return nil
+	}
 
 	facts, err := discoverVolumeFacts(ctx, run)
 	if err != nil {
 		return err
 	}
-	plans, err = planLiveVolumes(facts, desired, changed)
+	plans, err := planLiveVolumes(facts, desired, changed)
 	if err != nil {
 		return err
 	}

--- a/internal/katlc/agent/volume_apply_test.go
+++ b/internal/katlc/agent/volume_apply_test.go
@@ -120,6 +120,31 @@ func TestApplyVolumesPreflightsBeforeStoppingExistingMount(t *testing.T) {
 	}
 }
 
+func TestApplyVolumesRemovalOnlyUnmountsWithoutTouchingStorage(t *testing.T) {
+	current := manifest.Manifest{Install: manifest.InstallConfig{
+		TargetDisk: manifest.DiskSelector{Serial: "root"},
+		Volumes: []manifest.Volume{{
+			Name: "data", Selector: manifest.VolumeSelector{Partition: &manifest.PartitionSelector{PartUUID: "keep-me"}}, Filesystem: "xfs",
+		}},
+	}}
+	desired := current
+	desired.Install.Volumes = []manifest.Volume{}
+	var calls [][]string
+	runner := func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		calls = append(calls, append([]string(nil), argv...))
+		if len(argv) != 3 || argv[0] != "systemctl" || argv[1] != "stop" || argv[2] != "var-mnt-data.mount" {
+			return ToolResult{Err: fmt.Errorf("unexpected storage-removal command %q", argv), ExitStatus: 1}
+		}
+		return ToolResult{}
+	}
+	if err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, "cp-1", nil); err != nil {
+		t.Fatalf("applyVolumes() removal error = %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("removal commands = %v, want only the managed mount stop", calls)
+	}
+}
+
 func TestDestructiveStorageAuthorityUsesDiscoveredTargetState(t *testing.T) {
 	current := manifest.Manifest{Install: manifest.InstallConfig{TargetDisk: manifest.DiskSelector{Serial: "root"}}}
 	desired := current

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -45,7 +45,10 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 	} else {
 		_ = RequireWorld(t)
 	}
-	scenario := Scenario{Name: "installed-runtime-config-apply-modes"}
+	scenario := Scenario{
+		Name:  "installed-runtime-config-apply-modes",
+		Disks: []DiskFixture{ExtraDisk("data", "raw", "1G")},
+	}
 	result, err := runner.Plan(scenario)
 	if err != nil {
 		t.Fatalf("Plan() error = %v", err)
@@ -58,6 +61,9 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
+	if err := CreateDisks(ctx, diskExec(nil), result.Disks); err != nil {
+		t.Fatalf("create config apply data disk: %v", err)
+	}
 	katlctl := buildKatlctlForConfigApplySmoke(t, ctx)
 	vm := runtime.VM
 	vm.KVM = runner.options().KVM
@@ -319,6 +325,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 		`"previousKnownGoodGenerationID": "`+currentGeneration+`"`,
 		`"pendingHealthValidation": false`,
 	)
+	activeGeneration := runVolumeRemovalSmoke(t, ctx, guest, result, katlctl, endpoint)
 
 	assertGuestNonLoopbackLink(t, ctx, guest)
 	if cmdline := readGuestFile(t, ctx, guest, "/proc/cmdline"); strings.Contains(cmdline, "katl.vmtest.config_apply_kernel=1") {
@@ -335,7 +342,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	}
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/spec.json",
 		`"generationID": "`+stagedGeneration+`"`,
-		`"previousGenerationID": "`+liveGeneration+`"`,
+		`"previousGenerationID": "`+activeGeneration+`"`,
 		`"configuredKernelCommandLine": [`,
 		`"katl.vmtest.config_apply_kernel=1"`,
 	)
@@ -350,7 +357,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	)
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/systemd/network/80-katl-vmtest-dhcp.network.d/50-address.conf", "Address=198.51.100.77/32")
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/containerd/conf.d/80-katl-vmtest.toml", "oom_score = 123")
-	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/boot/selection.json", `"defaultGenerationID": "`+liveGeneration+`"`, `"targetBootGenerationID": "`+stagedGeneration+`"`, `"trialGenerationID": "`+stagedGeneration+`"`, `"pendingTransactionID": "`+stagedAccepted.OperationId+`"`, `"pendingHealthValidation": true`)
+	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/boot/selection.json", `"defaultGenerationID": "`+activeGeneration+`"`, `"targetBootGenerationID": "`+stagedGeneration+`"`, `"trialGenerationID": "`+stagedGeneration+`"`, `"pendingTransactionID": "`+stagedAccepted.OperationId+`"`, `"pendingHealthValidation": true`)
 	assertGuestExists(t, ctx, guest, "/var/lib/katl/generations/"+currentGeneration+"/metadata.json")
 	assertOptionalReadlink(t, ctx, guest, "/run/extensions/katl-kubernetes.raw", beforeSysext)
 	assertGuestFileContains(t, ctx, guest, stagedAccepted.RecordPath, `"operationKind": "generation-stage"`, `"configApplyPhase": "next-boot"`)
@@ -407,6 +414,53 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	assertBootstrappedKubernetesSysextChangeRejected(t, ctx, guest, endpoint)
 	shutdownGuestThroughKatlctl(t, ctx, result, katlctl, endpoint, node, client)
 	return guest, nil
+}
+
+func runVolumeRemovalSmoke(t *testing.T, ctx context.Context, guest *GuestControl, result Result, katlctl, endpoint string) string {
+	t.Helper()
+	addGeneration := "2026.06.06-vmtest-volume-add"
+	removeGeneration := "2026.06.06-vmtest-volume-remove"
+	readdGeneration := "2026.06.06-vmtest-volume-readd"
+
+	added := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, "config-apply-volume-add", "live", addGeneration, configApplyFixture(t, "live-volume-add.yaml"), false)
+	addedStatus := waitKatlcOperationTerminal(t, ctx, endpoint, added.OperationId)
+	if addedStatus.Result != operation.ResultSucceeded || addedStatus.ConfigApplyPhase != "active" {
+		t.Fatalf("volume add operation status = %+v, want active success", addedStatus)
+	}
+	guestCommand(t, ctx, guest, "volume-add-mounted", "findmnt", "--mountpoint", "/var/mnt/data")
+	markerSource := "/var/lib/katl/test-artifacts/config-apply/volume-removal-marker"
+	if _, err := guest.WriteFile(ctx, GuestFileRequest{
+		Name:     "volume-removal-marker-source",
+		Path:     markerSource,
+		Content:  []byte("preserve me\n"),
+		Mode:     0o600,
+		Truncate: true,
+	}); err != nil {
+		t.Fatalf("write volume marker source: %v", err)
+	}
+	guestCommand(t, ctx, guest, "volume-write-marker", "install", "-m", "0600", markerSource, "/var/mnt/data/katl-removal-preserves-data")
+
+	removed := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, "config-apply-volume-remove", "live", removeGeneration, configApplyFixture(t, "live-volume-remove.yaml"), false)
+	removedStatus := waitKatlcOperationTerminal(t, ctx, endpoint, removed.OperationId)
+	if removedStatus.Result != operation.ResultSucceeded || removedStatus.ConfigApplyPhase != "active" {
+		t.Fatalf("volume removal operation status = %+v, want active success", removedStatus)
+	}
+	guestCommand(t, ctx, guest, "volume-removal-unmounted", "test", "!", "-e", "/var/mnt/data/katl-removal-preserves-data")
+	guestCommand(t, ctx, guest, "volume-removal-unit-gone", "test", "!", "-e", "/etc/systemd/system/var-mnt-data.mount")
+	guestCommand(t, ctx, guest, "volume-removal-partition-preserved", "test", "-b", "/dev/disk/by-partlabel/u-data")
+	if filesystem := strings.TrimSpace(guestCommandOutput(t, ctx, guest, "volume-removal-filesystem-preserved", "blkid", "-s", "TYPE", "-o", "value", "/dev/disk/by-partlabel/u-data")); filesystem != "xfs" {
+		t.Fatalf("filesystem after volume removal = %q, want xfs", filesystem)
+	}
+
+	readded := submitKatlctlConfigApply(t, ctx, result, katlctl, endpoint, "config-apply-volume-readd", "live", readdGeneration, configApplyFixture(t, "live-volume-readd.yaml"), false)
+	readdedStatus := waitKatlcOperationTerminal(t, ctx, endpoint, readded.OperationId)
+	if readdedStatus.Result != operation.ResultSucceeded || readdedStatus.ConfigApplyPhase != "active" {
+		t.Fatalf("volume re-add operation status = %+v, want active success", readdedStatus)
+	}
+	guestCommand(t, ctx, guest, "volume-readd-mounted", "findmnt", "--mountpoint", "/var/mnt/data")
+	guestCommand(t, ctx, guest, "volume-readd-marker-preserved", "test", "-f", "/var/mnt/data/katl-removal-preserves-data")
+	assertGuestFileContains(t, ctx, guest, removed.RecordPath, `"operationKind": "generation-apply"`, `"result": "succeeded"`)
+	return readdGeneration
 }
 
 func assertInstalledSSHReady(t *testing.T, ctx context.Context, guest *GuestControl) {

--- a/internal/vmtest/installed_node.go
+++ b/internal/vmtest/installed_node.go
@@ -54,6 +54,7 @@ func StartInstalledRuntimeNode(ctx context.Context, parent Result, config Instal
 		Image:         runtime.Disk,
 		ImageFormat:   diskFormat(runtime.DiskFormat),
 		ImageSnapshot: true,
+		ImageSerial:   "katl-root",
 	}
 	vm.VSock.Enabled = true
 	vm.Agent.RequireHealth = true

--- a/internal/vmtest/libvirt_vm.go
+++ b/internal/vmtest/libvirt_vm.go
@@ -29,6 +29,7 @@ type VMBoot struct {
 	Image         string
 	ImageFormat   DiskFormat
 	ImageSnapshot bool
+	ImageSerial   string
 }
 
 type VMConfig struct {
@@ -1378,6 +1379,7 @@ type domainVSockCID struct {
 
 func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, string, string, string, error) {
 	boot := config.Boot
+	bootImageSerial := first(boot.ImageSerial, "katl-boot")
 	var disks []libvirtDisk
 	efiTree := filepath.Join(result.VMDir, "efi")
 	efiImage := ""
@@ -1428,7 +1430,7 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 	}
 	if boot.Kernel != "" {
 		if boot.Image != "" {
-			add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
+			add(boot.Image, boot.ImageFormat, bootImageSerial, boot.ImageSnapshot)
 		}
 	} else if boot.ISO != "" {
 		isoBootOrder := 1
@@ -1445,7 +1447,7 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 			BootOrder: isoBootOrder,
 		})
 		if boot.Image != "" {
-			add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
+			add(boot.Image, boot.ImageFormat, bootImageSerial, boot.ImageSnapshot)
 		}
 	} else if boot.EFIImage != "" {
 		efiImage = boot.EFIImage
@@ -1453,12 +1455,12 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 		if boot.Image == "" {
 			return nil, "", "", "", "", errors.New("VM boot from EFI image requires disk image")
 		}
-		add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
+		add(boot.Image, boot.ImageFormat, bootImageSerial, boot.ImageSnapshot)
 	} else if boot.UKI != "" {
 		efiImage = filepath.Join(result.VMDir, "efi.img")
 		add(efiImage, DiskRaw, "katl-efi", false)
 		if boot.Image != "" {
-			add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
+			add(boot.Image, boot.ImageFormat, bootImageSerial, boot.ImageSnapshot)
 		}
 	} else if boot.EFITree != "" {
 		efiTree = boot.EFITree
@@ -1467,12 +1469,12 @@ func vmDomainDisks(result Result, config VMConfig) ([]libvirtDisk, string, strin
 		if boot.Image == "" {
 			return nil, "", "", "", "", errors.New("VM boot from EFI tree requires disk image")
 		}
-		add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
+		add(boot.Image, boot.ImageFormat, bootImageSerial, boot.ImageSnapshot)
 	} else {
 		if boot.Image == "" {
 			return nil, "", "", "", "", errors.New("VM boot requires UKI or disk image")
 		}
-		add(boot.Image, boot.ImageFormat, "katl-boot", boot.ImageSnapshot)
+		add(boot.Image, boot.ImageFormat, bootImageSerial, boot.ImageSnapshot)
 	}
 	for _, disk := range result.Disks {
 		add(disk.HostPath, disk.Format, "katl-"+clean(disk.Name), false)

--- a/internal/vmtest/libvirt_vm_test.go
+++ b/internal/vmtest/libvirt_vm_test.go
@@ -87,6 +87,25 @@ func TestVMPlanSupportsIndependentDomainOwnershipAndPersistentSerial(t *testing.
 	}
 }
 
+func TestVMDomainDisksUsesConfiguredBootImageSerial(t *testing.T) {
+	result := Result{
+		VMDir: t.TempDir(),
+	}
+	disks, _, _, _, _, err := vmDomainDisks(result, VMConfig{
+		Boot: VMBoot{
+			Image:       "/tmp/installed.qcow2",
+			ImageFormat: DiskQCOW2,
+			ImageSerial: "katl-root",
+		},
+	})
+	if err != nil {
+		t.Fatalf("vmDomainDisks() error = %v", err)
+	}
+	if len(disks) != 1 || disks[0].Serial != "katl-root" {
+		t.Fatalf("disks = %#v, want boot image serial katl-root", disks)
+	}
+}
+
 func TestVMPlanReservesHotplugPCISlots(t *testing.T) {
 	result, config := vmFixture(t)
 	probe := probe{

--- a/internal/vmtest/testdata/config-apply/live-volume-add.yaml
+++ b/internal/vmtest/testdata/config-apply/live-volume-add.yaml
@@ -1,0 +1,15 @@
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: storage-operator
+  desiredVersion: "1"
+spec:
+  nodeOverrides:
+    cp-1:
+      volumes:
+        - name: data
+          selector:
+            disk:
+              serial: katl-data
+          filesystem: xfs
+          wipe: true

--- a/internal/vmtest/testdata/config-apply/live-volume-readd.yaml
+++ b/internal/vmtest/testdata/config-apply/live-volume-readd.yaml
@@ -1,0 +1,13 @@
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: storage-operator
+  desiredVersion: "3"
+spec:
+  nodeOverrides:
+    cp-1:
+      volumes:
+        - name: data
+          selector:
+            partition: {}
+          filesystem: xfs

--- a/internal/vmtest/testdata/config-apply/live-volume-remove.yaml
+++ b/internal/vmtest/testdata/config-apply/live-volume-remove.yaml
@@ -1,0 +1,9 @@
+apiVersion: katl.dev/v1alpha1
+kind: NodeConfigurationChange
+metadata:
+  sourceID: storage-operator
+  desiredVersion: "2"
+spec:
+  nodeOverrides:
+    cp-1:
+      volumes: []


### PR DESCRIPTION
## What changed
- explicitly stop managed mount units for removal-only storage changes
- return before discovery, repartitioning, formatting, or wiping
- document and expose the non-destructive removal contract in config diff
- cover add, live removal, preserved filesystem, and safe re-add in the installed-runtime journey

## Why
Removal-only changes produced stop targets but returned early when there were no replacement volumes, so a successful online apply could leave the old filesystem mounted until reboot.