### PR TITLE
config: name storage volumes explicitly

### DIFF
--- a/cmd/katlctl/config_inspect_test.go
+++ b/cmd/katlctl/config_inspect_test.go
@@ -44,12 +44,12 @@ func TestConfigResolveShowsPublicEffectiveNode(t *testing.T) {
 	if len(report.Provenance) == 0 || len(report.OwnedFiles) == 0 || len(report.Warnings) == 0 {
 		t.Fatalf("inspection detail missing: provenance=%d files=%d warnings=%d", len(report.Provenance), len(report.OwnedFiles), len(report.Warnings))
 	}
-	for _, internal := range []string{`"targetDisk"`, `"volumes"`, `"sets"`, `"notify"`, `"name":"kernel.`} {
+	for _, internal := range []string{`"targetDisk"`, `"sets"`, `"notify"`, `"name":"kernel.`} {
 		if strings.Contains(stdout.String(), internal) {
 			t.Fatalf("resolve output exposes internal field %q:\n%s", internal, stdout.String())
 		}
 	}
-	for _, public := range []string{`"systemDisk"`, `"storage"`, `"disks"`, `"classification"`} {
+	for _, public := range []string{`"systemDisk"`, `"storage"`, `"volumes"`, `"classification"`} {
 		if !strings.Contains(stdout.String(), public) {
 			t.Fatalf("resolve output missing %q:\n%s", public, stdout.String())
 		}
@@ -58,13 +58,13 @@ func TestConfigResolveShowsPublicEffectiveNode(t *testing.T) {
 	foundDefaultSize := false
 	foundNodeIdentity := false
 	for _, entry := range report.Provenance {
-		if entry.Source == `spec.defaults.storage.disks[name="data"].filesystem` {
+		if entry.Source == `spec.defaults.storage.volumes[name="data"].filesystem` {
 			foundDefaultFilesystem = true
 		}
-		if entry.Source == `spec.defaults.storage.disks[name="data"].selector.disk.minSizeMiB` {
+		if entry.Source == `spec.defaults.storage.volumes[name="data"].selector.disk.minSizeMiB` {
 			foundDefaultSize = true
 		}
-		if entry.Source == `spec.nodes["cp-1"].storage.disks[name="data"].selector.disk.byID` {
+		if entry.Source == `spec.nodes["cp-1"].storage.volumes[name="data"].selector.disk.byID` {
 			foundNodeIdentity = true
 		}
 	}
@@ -173,7 +173,7 @@ func TestConfigInspectionReportsPerNodeKubeletConfiguration(t *testing.T) {
 
 func configInspectionSource() string {
 	source := strings.Replace(configBundleSource(), "  nodes:\n", `    storage:
-      disks:
+      volumes:
         - name: data
           selector:
             disk:
@@ -182,7 +182,7 @@ func configInspectionSource() string {
   nodes:
 `, 1)
 	return strings.Replace(source, "      install:\n", `      storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -802,7 +802,7 @@ func TestConfigValidateReportsOnlyPublicNodePaths(t *testing.T) {
 		{
 			name: "storage selector",
 			source: strings.Replace(base, "      install:\n", `      storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:
@@ -812,7 +812,7 @@ func TestConfigValidateReportsOnlyPublicNodePaths(t *testing.T) {
             filesystem: xfs
       install:
 `, 1),
-			want: `spec.nodes["cp-1"].storage.disks[0].selector must set exactly one of disk or partition`,
+			want: `spec.nodes["cp-1"].storage.volumes[0].selector must set exactly one of disk or partition`,
 		},
 		{
 			name: "sysfs path",

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -220,7 +220,7 @@ would override its root, immutable-runtime, generation identity, or recovery
 policy. Image-required and Katl-owned arguments remain internal and are always
 carried alongside the configured additions.
 
-Persistent data disks are configured under a node's `storage.disks` during
+Persistent data disks are configured under a node's `storage.volumes` during
 installation or through normal node configuration. The supported and
 journey-verified filesystems are `ext4`, `xfs`, and `btrfs`. Each entry selects
 exactly one whole disk or one existing partition, and Katl derives both the GPT
@@ -235,7 +235,7 @@ the cluster.
 
 Removing a volume is non-destructive. Set an inherited entry to
 `state: absent`, omit a node-specific entry from the desired collection, or
-use `storage.disks: []` to clear all inherited volumes for that node. Online
+use `storage.volumes: []` to clear all inherited volumes for that node. Online
 apply first unmounts `/var/mnt/<name>`, then removes Katl's generated mount
 unit and stops managing the target. It does not format, repartition, run
 `wipefs`, or erase the partition, filesystem, mount-point directory, or data.
@@ -250,7 +250,7 @@ install:
   systemDisk:
     byID: /dev/disk/by-id/ata-KATL_WORKER_1_ROOT
 storage:
-  disks:
+  volumes:
     - name: data
       selector:
         disk:
@@ -260,16 +260,17 @@ storage:
 ```
 
 To preserve an existing Talos UserVolumeConfig partition, select
-`partition: {}`. Katl derives `u-<name>` and requires it to identify exactly
-one unmounted partition. A stable partition by-id path, PARTUUID, or filesystem
-UUID may be supplied inside `partition` instead:
+`partition.byVolumeName: true`. Katl derives `u-<name>` and requires it to
+identify exactly one unmounted partition. A stable partition by-id path,
+PARTUUID, or filesystem UUID may be supplied inside `partition` instead:
 
 ```yaml
 storage:
-  disks:
+  volumes:
     - name: local-hostpath
       selector:
-        partition: {}
+        partition:
+          byVolumeName: true
       filesystem: xfs
 ```
 
@@ -715,7 +716,7 @@ role-dependent Kubernetes intent. Networkd files are supplied through
 operation-owned differences: cluster apply invokes the required internal
 kubeadm-aware phases and verifies the live result. System-disk install
 selection and Kubernetes version changes keep their dedicated install and
-upgrade workflows; `storage.disks` remains desired node state.
+upgrade workflows; `storage.volumes` remains desired node state.
 The node-agent request envelope remains an internal API documented separately
 from the operator installation flow.
 

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -48,19 +48,31 @@ Katl selects its control-plane and worker kubeadm profiles internally from
 model may supply one bounded cluster-wide kubeadm file and optional patch
 directory. They never name or select the generated profiles.
 
-Layering follows one source-level rule: omitted node fields inherit from
-`spec.defaults`, while explicitly supplied node values replace the
-corresponding default values. Empty maps and lists therefore clear inherited
-values. Lists without a stable identity replace wholesale. Named collections
-compose by name: a node entry replaces the default entry with the same name,
-and `state: absent` removes it. Structured disk selectors compose by supplied
-field so a common size constraint can be combined with a node-specific durable
-identifier.
+Layering is defined by collection shape:
+
+- Scalars and structured selectors inherit omitted fields. Supplied values
+  replace the corresponding field; an empty identity string or `false` clears
+  that inherited field.
+- Anonymous lists, including kernel command-line entries, SSH keys, sysfs
+  settings, and Kubernetes taints, replace wholesale. An explicit `[]` clears
+  the inherited list.
+- Maps such as Kubernetes labels merge by key. An explicit `{}` clears the
+  inherited map.
+- Named file sets and system extensions compose by name. A node entry replaces
+  the complete default entry with that name, `state: absent` removes it, and an
+  explicit empty collection clears all inherited entries.
+- Storage volumes deliberately differ from other named collections. They
+  compose by name, but a same-name node entry inherits individual omitted
+  fields, including selector constraints, filesystem, and `wipe`. This lets a
+  default minimum-size or filesystem policy combine with a node-specific
+  identity. Switching between `disk` and `partition` replaces the selector
+  kind. `state: absent` removes a named volume and `volumes: []` clears the
+  collection without erasing its storage.
 
 Storage defaults are policy, never target identity or destructive authority.
 They may carry fields such as `minSizeMiB`, `filesystem`, and explicit
 `wipe: false`. Katl rejects default `byID`, `wwn`, `serial`, every partition
-selector (including the convention-derived empty selector), `partUUID`,
+selector (including `byVolumeName: true`), `partUUID`,
 `filesystemUUID`, and `wipe: true`. Those choices must appear on the concrete
 node volume that they affect.
 
@@ -72,7 +84,7 @@ acknowledgement is never persisted in ClusterConfig or inherited by later
 operations.
 
 Storage removal is a management transition, not a data transition. An empty
-node `storage.disks` collection clears inherited volumes, and an entry with
+node `storage.volumes` collection clears inherited volumes, and an entry with
 `state: absent` removes the inherited entry of the same name. Live apply stops
 the Katl-managed `/var/mnt/<name>` mount before removing its generated unit.
 The underlying partition table, partition, filesystem, and data are preserved;
@@ -139,7 +151,7 @@ spec:
       systemDisk:
         minSizeMiB: 32768
     storage:
-      disks:
+      volumes:
         - name: data
           selector:
             disk:
@@ -161,7 +173,7 @@ spec:
         systemDisk:
           byID: /dev/disk/by-id/ata-KATL_CP_1_ROOT
       storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:
@@ -217,7 +229,7 @@ destructive selectors.
 `defaults.install.systemDisk` may contain only non-identifying constraints such
 as minimum size. It cannot select a disk for several nodes. A node's
 `install.systemDisk` supplies the durable identity and may override common
-constraints. `storage.disks` describes persistent desired data-disk state
+constraints. `storage.volumes` describes persistent desired data-disk state
 rather than a one-time installation input.
 
 The decision to execute a destructive install belongs to the install operation,
@@ -270,7 +282,7 @@ node-identity migration. Normal config apply keeps the requested field visible
 but refuses the change with a kubeadm-aware operation requirement; set the
 address in the ClusterConfig used for installation.
 
-`install.systemDisk` is consumed by installation. `storage.disks` remains
+`install.systemDisk` is consumed by installation. `storage.volumes` remains
 persistent node intent and is reconciled by supported configuration workflows.
 Kubernetes version changes are handled by the Kubernetes upgrade workflow
 rather than ordinary node configuration apply.

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -13,7 +13,7 @@ renderer carries:
 - operator-owned kernel command-line additions;
 - native host configuration file sets, including systemd-networkd files and
   drop-ins;
-- desired data disks under `storage.disks`;
+- desired data disks under `storage.volumes`;
 - per-node native kubelet configuration under `nodes[].kubernetes.kubelet`;
 - operation-only system role and role-dependent Kubernetes bootstrap state.
 

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -162,10 +162,10 @@ type SourceInstallLayer struct {
 }
 
 type SourceStorageLayer struct {
-	Disks Optional[[]SourceStorageDisk] `yaml:"disks,omitempty" json:"disks,omitzero"`
+	Volumes Optional[[]SourceStorageVolume] `yaml:"volumes,omitempty" json:"volumes,omitzero"`
 }
 
-type SourceStorageDisk struct {
+type SourceStorageVolume struct {
 	Name       string                `yaml:"name" json:"name"`
 	State      string                `yaml:"state,omitempty" json:"state,omitempty"`
 	Selector   *SourceVolumeSelector `yaml:"selector,omitempty" json:"selector,omitempty"`
@@ -189,6 +189,7 @@ type SourcePartitionSelector struct {
 	ByID           Optional[string] `yaml:"byID,omitempty" json:"byID,omitzero"`
 	PartUUID       Optional[string] `yaml:"partUUID,omitempty" json:"partUUID,omitzero"`
 	FilesystemUUID Optional[string] `yaml:"filesystemUUID,omitempty" json:"filesystemUUID,omitzero"`
+	ByVolumeName   Optional[bool]   `yaml:"byVolumeName,omitempty" json:"byVolumeName,omitzero"`
 }
 
 type SourceKubernetesCluster struct {
@@ -589,7 +590,7 @@ func lowerNodeLayer(layer SourceNodeLayer) clusterplan.NodeLayer {
 		SystemExtensions:  lowerSystemExtensions(layer.SystemExtensions),
 		Install: clusterplan.InstallLayer{
 			TargetDisk: lowerDiskSelector(layer.Install.SystemDisk),
-			Volumes:    lowerStorageDisks(layer.Storage.Disks),
+			Volumes:    lowerStorageVolumes(layer.Storage.Volumes),
 		},
 		Kubernetes: clusterplan.KubernetesLayer{
 			Address:    strings.TrimSpace(layer.Kubernetes.Address),
@@ -707,14 +708,14 @@ func normalizeSource(source SourceConfig) (SourceConfig, error) {
 	if err := validateDefaultSystemDisk(source.Spec.Defaults.Install.SystemDisk); err != nil {
 		return SourceConfig{}, fmt.Errorf("spec.defaults.install.systemDisk: %w", err)
 	}
-	if err := validateDefaultStorageDisks(source.Spec.Defaults.Storage.Disks); err != nil {
+	if err := validateDefaultStorageVolumes(source.Spec.Defaults.Storage.Volumes); err != nil {
 		return SourceConfig{}, err
 	}
-	if err := validateSourceStorageDisks("spec.defaults.storage.disks", source.Spec.Defaults.Storage.Disks, false); err != nil {
+	if err := validateSourceStorageVolumes("spec.defaults.storage.volumes", source.Spec.Defaults.Storage.Volumes, false); err != nil {
 		return SourceConfig{}, err
 	}
 	for i := range source.Spec.Nodes {
-		if err := validateSourceStorageDisks(sourceNodePath(source.Spec.Nodes[i], i)+".storage.disks", source.Spec.Nodes[i].Storage.Disks, false); err != nil {
+		if err := validateSourceStorageVolumes(sourceNodePath(source.Spec.Nodes[i], i)+".storage.volumes", source.Spec.Nodes[i].Storage.Volumes, false); err != nil {
 			return SourceConfig{}, err
 		}
 	}

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -133,7 +133,7 @@ func TestDecodeSourceAcceptsKernelCommandLineDefaultsAndNodeClear(t *testing.T) 
 	}
 }
 
-func TestLowerSourceAppliesPredictableNodeLayering(t *testing.T) {
+func TestLowerSourceAppliesDocumentedLayeringContract(t *testing.T) {
 	config, err := DecodeSource(strings.NewReader(`apiVersion: config.katl.dev/v1alpha1
 kind: ClusterConfig
 metadata:
@@ -167,7 +167,7 @@ spec:
       systemDisk:
         minSizeMiB: 65536
     storage:
-      disks:
+      volumes:
         - name: data
           selector:
             disk:
@@ -206,7 +206,7 @@ spec:
         systemDisk:
           byID: /dev/disk/by-id/cleared-root
       storage:
-        disks: []
+        volumes: []
       kubernetes:
         labels: {}
         taints: []
@@ -228,7 +228,7 @@ spec:
         systemDisk:
           byID: /dev/disk/by-id/overridden-root
       storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:
@@ -282,19 +282,32 @@ spec:
 		t.Fatalf("named system extensions did not replace or remove by name: %#v", overridden.SystemExtensions)
 	}
 	if len(overridden.Install.Volumes) != 1 {
-		t.Fatalf("named storage disks did not replace or remove by name: %#v", overridden.Install.Volumes)
+		t.Fatalf("named storage volumes did not compose or remove by name: %#v", overridden.Install.Volumes)
 	}
 	data := overridden.Install.Volumes[0]
 	if data.Name != "data" || data.Selector.Disk == nil ||
 		data.Selector.Disk.ByID != "/dev/disk/by-id/overridden-data" ||
 		data.Selector.Disk.MinSizeMiB != 1024 || data.Filesystem != "btrfs" || !data.Wipe {
-		t.Fatalf("storage disk fields did not inherit and override predictably: %#v", data)
+		t.Fatalf("storage volume fields did not inherit and override predictably: %#v", data)
 	}
 	if got := overridden.Kubernetes.NodeLabels; len(got) != 2 || got["environment"] != "lab" || got["topology.kubernetes.io/zone"] != "rack-b" {
 		t.Fatalf("labels did not replace values by key: %#v", got)
 	}
 	if got := overridden.Kubernetes.NodeTaints; len(got) != 1 || got[0].Key != "dedicated" {
 		t.Fatalf("taints did not replace the inherited list: %#v", got)
+	}
+}
+
+func TestBuildArchiveRequiresExplicitPartitionSelector(t *testing.T) {
+	source := strings.Replace(validSourceConfig(), `            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
+`, `            selector:
+              partition: {}
+`, 1)
+	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})
+	if err == nil || !strings.Contains(err.Error(), "spec.nodes[\"cp-1\"].storage.volumes[0].selector.partition must set exactly one of byID, partUUID, filesystemUUID, or byVolumeName: true") {
+		t.Fatalf("BuildArchive() error = %v, want explicit partition selector", err)
 	}
 }
 
@@ -313,7 +326,7 @@ spec:
       hostConfiguration:
         fileSets: {}
       storage:
-        disks: []
+        volumes: []
       kubernetes:
         labels: {}
         taints: []
@@ -331,11 +344,11 @@ spec:
 	}
 	node := roundTripped.Spec.Nodes[0]
 	for name, present := range map[string]bool{
-		"authorizedKeys": optionalIsSet(node.Access.SSH.AuthorizedKeys),
-		"fileSets":       optionalIsSet(node.HostConfiguration.FileSets),
-		"storage.disks":  optionalIsSet(node.Storage.Disks),
-		"labels":         optionalIsSet(node.Kubernetes.Labels),
-		"taints":         optionalIsSet(node.Kubernetes.Taints),
+		"authorizedKeys":  optionalIsSet(node.Access.SSH.AuthorizedKeys),
+		"fileSets":        optionalIsSet(node.HostConfiguration.FileSets),
+		"storage.volumes": optionalIsSet(node.Storage.Volumes),
+		"labels":          optionalIsSet(node.Kubernetes.Labels),
+		"taints":          optionalIsSet(node.Kubernetes.Taints),
 	} {
 		if !present {
 			t.Fatalf("normalized source lost explicit empty %s:\n%s", name, normalized)
@@ -1058,14 +1071,14 @@ func TestBuildArchiveRejectsUnsafeStorageDefaults(t *testing.T) {
 		replacement string
 		want        string
 	}{
-		{name: "by ID", old: "              minSizeMiB: 1024\n", replacement: "              byID: /dev/disk/by-id/shared-data\n", want: "spec.defaults.storage.disks[0].selector.disk.byID identifies a target"},
-		{name: "WWN", old: "              minSizeMiB: 1024\n", replacement: "              wwn: shared-data\n", want: "spec.defaults.storage.disks[0].selector.disk.wwn identifies a target"},
-		{name: "serial", old: "              minSizeMiB: 1024\n", replacement: "              serial: shared-data\n", want: "spec.defaults.storage.disks[0].selector.disk.serial identifies a target"},
-		{name: "partition by ID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              byID: /dev/disk/by-id/shared-data-part1\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
-		{name: "partition UUID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              partUUID: 01234567-89ab-cdef-0123-456789abcdef\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
-		{name: "filesystem UUID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              filesystemUUID: shared-data\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
-		{name: "convention partition", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition: {}\n", want: "spec.defaults.storage.disks[0].selector.partition identifies a target"},
-		{name: "wipe", old: "          filesystem: xfs\n", replacement: "          filesystem: xfs\n          wipe: true\n", want: "spec.defaults.storage.disks[0].wipe must not be true"},
+		{name: "by ID", old: "              minSizeMiB: 1024\n", replacement: "              byID: /dev/disk/by-id/shared-data\n", want: "spec.defaults.storage.volumes[0].selector.disk.byID identifies a target"},
+		{name: "WWN", old: "              minSizeMiB: 1024\n", replacement: "              wwn: shared-data\n", want: "spec.defaults.storage.volumes[0].selector.disk.wwn identifies a target"},
+		{name: "serial", old: "              minSizeMiB: 1024\n", replacement: "              serial: shared-data\n", want: "spec.defaults.storage.volumes[0].selector.disk.serial identifies a target"},
+		{name: "partition by ID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              byID: /dev/disk/by-id/shared-data-part1\n", want: "spec.defaults.storage.volumes[0].selector.partition identifies a target"},
+		{name: "partition UUID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              partUUID: 01234567-89ab-cdef-0123-456789abcdef\n", want: "spec.defaults.storage.volumes[0].selector.partition identifies a target"},
+		{name: "filesystem UUID", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              filesystemUUID: shared-data\n", want: "spec.defaults.storage.volumes[0].selector.partition identifies a target"},
+		{name: "convention partition", old: "            disk:\n              minSizeMiB: 1024\n", replacement: "            partition:\n              byVolumeName: true\n", want: "spec.defaults.storage.volumes[0].selector.partition identifies a target"},
+		{name: "wipe", old: "          filesystem: xfs\n", replacement: "          filesystem: xfs\n          wipe: true\n", want: "spec.defaults.storage.volumes[0].wipe must not be true"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1142,6 +1155,11 @@ func TestBuildArchiveRejectsRemovedIntentMechanisms(t *testing.T) {
 				"      install:\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root",
 				"      install:\n        volumes: []\n        systemDisk:\n          byID: /dev/disk/by-id/ata-cp-root", 1),
 			want: "spec.nodes[\"cp-1\"].install.volumes: field is not supported",
+		},
+		{
+			name: "storage disks",
+			raw:  strings.Replace(validSourceConfig(), "    storage:\n      volumes:\n", "    storage:\n      disks:\n", 1),
+			want: "spec.defaults.storage.disks: field is not supported",
 		},
 		{
 			name: "host configuration sets",
@@ -1312,7 +1330,7 @@ func TestSourceSchemaExposesAuthoringContract(t *testing.T) {
 		}
 	}
 	assertSchemaFields(t, document.Defs, "configbundle.SourceInstallLayer", []string{"systemDisk"}, []string{"extraDisks", "targetDisk", "targetDiskDefaults", "volumes"})
-	assertSchemaFields(t, document.Defs, "configbundle.SourceStorageLayer", []string{"disks"}, nil)
+	assertSchemaFields(t, document.Defs, "configbundle.SourceStorageLayer", []string{"volumes"}, []string{"disks"})
 	assertSchemaFields(t, document.Defs, "configbundle.SourceHostConfiguration", []string{"fileSets", "sysfs"}, []string{"sets"})
 	assertSchemaFields(t, document.Defs, "configbundle.SourceHostConfigurationSysfsSetting", []string{"path", "value"}, []string{"name"})
 	assertSchemaFields(t, document.Defs, "configbundle.SourceHostConfigurationFileSet", []string{"files", "onChange", "state"}, []string{"notify"})
@@ -1330,7 +1348,7 @@ func TestSourceSchemaExposesAuthoringContract(t *testing.T) {
 	if selector := document.Defs["configbundle.SourceVolumeSelector"]; len(selector.OneOf) != 2 {
 		t.Fatalf("volume selector oneOf branches = %d, want 2", len(selector.OneOf))
 	}
-	filesystem := document.Defs["configbundle.SourceStorageDisk"].Properties["filesystem"]
+	filesystem := document.Defs["configbundle.SourceStorageVolume"].Properties["filesystem"]
 	if !slices.Equal(filesystem.Enum, []any{"xfs", "ext4", "btrfs"}) || filesystem.Description == "" {
 		t.Fatalf("filesystem schema = %#v", filesystem)
 	}
@@ -1588,7 +1606,7 @@ spec:
       systemDisk:
         minSizeMiB: 65536
     storage:
-      disks:
+      volumes:
         - name: data
           selector:
             disk:
@@ -1618,7 +1636,7 @@ spec:
         systemDisk:
           byID: /dev/disk/by-id/ata-cp-root
       storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:
@@ -1636,7 +1654,7 @@ spec:
         systemDisk:
           byID: /dev/disk/by-id/ata-worker-root
       storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:

--- a/internal/installer/configbundle/inspect.go
+++ b/internal/installer/configbundle/inspect.go
@@ -220,11 +220,11 @@ func nodeProvenance(node SourceNode, resolved SourceNodeLayer, base string) []Fi
 			choose("install.systemDisk."+field.name, field.set)
 		}
 	}
-	resolvedDisks, _ := resolved.Storage.Disks.Get()
-	nodeDisks, nodeDisksSet := node.Storage.Disks.Get()
+	resolvedDisks, _ := resolved.Storage.Volumes.Get()
+	nodeDisks, nodeDisksSet := node.Storage.Volumes.Get()
 	for _, disk := range resolvedDisks {
-		nodeDisk, found := storageDisk(nodeDisks, disk.Name)
-		prefix := fmt.Sprintf("storage.disks[name=%q]", disk.Name)
+		nodeDisk, found := storageVolume(nodeDisks, disk.Name)
+		prefix := fmt.Sprintf("storage.volumes[name=%q]", disk.Name)
 		var nodeSelector *SourceVolumeSelector
 		if nodeDisksSet && found {
 			nodeSelector = nodeDisk.Selector
@@ -263,6 +263,7 @@ func nodeProvenance(node SourceNode, resolved SourceNodeLayer, base string) []Fi
 				{"byID", optionalPartitionStringSet(disk.Selector.Partition, func(v *SourcePartitionSelector) Optional[string] { return v.ByID }), optionalPartitionStringSet(nodePartition, func(v *SourcePartitionSelector) Optional[string] { return v.ByID })},
 				{"partUUID", optionalPartitionStringSet(disk.Selector.Partition, func(v *SourcePartitionSelector) Optional[string] { return v.PartUUID }), optionalPartitionStringSet(nodePartition, func(v *SourcePartitionSelector) Optional[string] { return v.PartUUID })},
 				{"filesystemUUID", optionalPartitionStringSet(disk.Selector.Partition, func(v *SourcePartitionSelector) Optional[string] { return v.FilesystemUUID }), optionalPartitionStringSet(nodePartition, func(v *SourcePartitionSelector) Optional[string] { return v.FilesystemUUID })},
+				{"byVolumeName", optionalPartitionBoolSet(disk.Selector.Partition), optionalPartitionBoolSet(nodePartition)},
 			}
 			selected := false
 			for _, field := range partitionFields {
@@ -307,12 +308,12 @@ func nodeProvenance(node SourceNode, resolved SourceNodeLayer, base string) []Fi
 }
 
 func derivedVolumesAndWarnings(storage SourceStorageLayer, base string) ([]DerivedVolume, []ResolutionWarning) {
-	disks, _ := storage.Disks.Get()
+	disks, _ := storage.Volumes.Get()
 	volumes := make([]DerivedVolume, 0, len(disks))
 	var warnings []ResolutionWarning
 	for _, disk := range disks {
 		derived := DerivedVolume{Name: disk.Name, MountPath: "/var/mnt/" + disk.Name}
-		path := fmt.Sprintf("%s.storage.disks[name=%q]", base, disk.Name)
+		path := fmt.Sprintf("%s.storage.volumes[name=%q]", base, disk.Name)
 		switch {
 		case disk.Selector != nil && disk.Selector.Disk != nil:
 			derived.PartitionLabel = "u-" + disk.Name
@@ -326,10 +327,9 @@ func derivedVolumesAndWarnings(storage SourceStorageLayer, base string) ([]Deriv
 				derived.MountSource = "PARTUUID=" + selector.PartUUID.Value()
 			case selector.FilesystemUUID.Value() != "":
 				derived.MountSource = "UUID=" + selector.FilesystemUUID.Value()
-			default:
+			case selector.ByVolumeName.Value():
 				derived.PartitionLabel = "u-" + disk.Name
 				derived.MountSource = "/dev/disk/by-partlabel/" + derived.PartitionLabel
-				warnings = append(warnings, ResolutionWarning{Path: path + ".selector.partition", Message: "empty partition selector uses the convention-derived GPT label " + derived.PartitionLabel})
 			}
 		}
 		if wipe, set := disk.Wipe.Get(); set && wipe {
@@ -373,13 +373,13 @@ func hasExtension(values []SourceSystemExtension, name string) bool {
 	return false
 }
 
-func storageDisk(values []SourceStorageDisk, name string) (SourceStorageDisk, bool) {
+func storageVolume(values []SourceStorageVolume, name string) (SourceStorageVolume, bool) {
 	for _, value := range values {
 		if value.Name == name {
 			return value, true
 		}
 	}
-	return SourceStorageDisk{}, false
+	return SourceStorageVolume{}, false
 }
 
 func optionalStringSet(selector *SourceDiskSelector, get func(*SourceDiskSelector) Optional[string]) bool {
@@ -403,6 +403,14 @@ func optionalPartitionStringSet(selector *SourcePartitionSelector, get func(*Sou
 		return false
 	}
 	_, ok := get(selector).Get()
+	return ok
+}
+
+func optionalPartitionBoolSet(selector *SourcePartitionSelector) bool {
+	if selector == nil {
+		return false
+	}
+	_, ok := selector.ByVolumeName.Get()
 	return ok
 }
 
@@ -476,7 +484,7 @@ func DiffNodeResolutions(before, after NodeResolution) (ConfigDiff, error) {
 	diffNamedMaps(&diff, base+".hostConfiguration.fileSets", before.Effective.HostConfiguration.FileSets.Value(), after.Effective.HostConfiguration.FileSets.Value())
 	diffNamedExtensions(&diff, base+".systemExtensions", before.Effective.SystemExtensions.Value(), after.Effective.SystemExtensions.Value())
 	add(base+".install.systemDisk", before.Effective.Install.SystemDisk, after.Effective.Install.SystemDisk)
-	diffNamedDisks(&diff, base+".storage.disks", before.Effective.Storage.Disks.Value(), after.Effective.Storage.Disks.Value())
+	diffNamedVolumes(&diff, base+".storage.volumes", before.Effective.Storage.Volumes.Value(), after.Effective.Storage.Volumes.Value())
 	add(base+".kubernetes.address", before.Effective.Kubernetes.Address, after.Effective.Kubernetes.Address)
 	add(base+".kubernetes.kubelet", before.Effective.Kubernetes.Kubelet, after.Effective.Kubernetes.Kubelet)
 	diffStringMaps(&diff, base+".kubernetes.labels", before.Effective.Kubernetes.Labels.Value(), after.Effective.Kubernetes.Labels.Value())
@@ -492,7 +500,7 @@ func appendNamedChange(diff *ConfigDiff, path string, before, after any) {
 		return
 	}
 	classification, operation, message := classifyDiffPath(path)
-	if strings.Contains(path, ".storage.disks") && after == nil {
+	if strings.Contains(path, ".storage.volumes") && after == nil {
 		message = "removal unmounts the volume and stops Katl management; the partition, filesystem, and data are preserved"
 	}
 	diff.Changes = append(diff.Changes, ConfigFieldChange{Path: path, Before: before, After: after, Classification: classification, RequiredOperation: operation, Message: message})
@@ -518,9 +526,9 @@ func diffNamedExtensions(diff *ConfigDiff, prefix string, before, after []Source
 	diffNamedMaps(diff, prefix, left, right)
 }
 
-func diffNamedDisks(diff *ConfigDiff, prefix string, before, after []SourceStorageDisk) {
-	left := make(map[string]SourceStorageDisk, len(before))
-	right := make(map[string]SourceStorageDisk, len(after))
+func diffNamedVolumes(diff *ConfigDiff, prefix string, before, after []SourceStorageVolume) {
+	left := make(map[string]SourceStorageVolume, len(before))
+	right := make(map[string]SourceStorageVolume, len(after))
 	for _, value := range before {
 		left[value.Name] = value
 	}
@@ -556,7 +564,7 @@ func classifyDiffPath(path string) (string, string, string) {
 		return "operation-only", "kubeadm-aware operation", "Kubernetes node metadata changes require Kubernetes-aware reconciliation"
 	case strings.Contains(path, ".management.address"):
 		return "target-only", "", "changes only the workstation management target; no node generation or mutation is planned"
-	case strings.Contains(path, ".storage.disks"):
+	case strings.Contains(path, ".storage.volumes"):
 		return "online-applicable", "", "volume changes require live target discovery; existing data is preserved unless explicitly authorized"
 	case strings.Contains(path, ".hostConfiguration"):
 		return "online-or-next-boot", "", "the concrete file or sysfs change determines whether live preflight succeeds"

--- a/internal/installer/configbundle/inspect_test.go
+++ b/internal/installer/configbundle/inspect_test.go
@@ -16,16 +16,32 @@ func TestDiffNodeResolutionsRefusesDifferentNodeNames(t *testing.T) {
 }
 
 func TestDiffNodeResolutionsExplainsNonDestructiveStorageRemoval(t *testing.T) {
-	volume := SourceStorageDisk{Name: "data"}
-	before := NodeResolution{Node: "cp-1", Effective: SourceNode{Storage: SourceStorageLayer{Disks: supplied([]SourceStorageDisk{volume})}}}
-	after := NodeResolution{Node: "cp-1", Effective: SourceNode{Storage: SourceStorageLayer{Disks: supplied([]SourceStorageDisk{})}}}
+	volume := SourceStorageVolume{Name: "data"}
+	before := NodeResolution{Node: "cp-1", Effective: SourceNode{Storage: SourceStorageLayer{Volumes: supplied([]SourceStorageVolume{volume})}}}
+	after := NodeResolution{Node: "cp-1", Effective: SourceNode{Storage: SourceStorageLayer{Volumes: supplied([]SourceStorageVolume{})}}}
 	diff, err := DiffNodeResolutions(before, after)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(diff.Changes) != 1 || diff.Changes[0].Path != `spec.nodes["cp-1"].storage.disks["data"]` ||
+	if len(diff.Changes) != 1 || diff.Changes[0].Path != `spec.nodes["cp-1"].storage.volumes["data"]` ||
 		diff.Changes[0].Classification != "online-applicable" ||
 		!strings.Contains(diff.Changes[0].Message, "partition, filesystem, and data are preserved") {
 		t.Fatalf("storage removal diff = %#v", diff)
+	}
+}
+
+func TestDerivedVolumesExposeVolumeNamePartitionConvention(t *testing.T) {
+	storage := SourceStorageLayer{Volumes: supplied([]SourceStorageVolume{{
+		Name: "local-hostpath",
+		Selector: &SourceVolumeSelector{Partition: &SourcePartitionSelector{
+			ByVolumeName: supplied(true),
+		}},
+	}})}
+	volumes, warnings := derivedVolumesAndWarnings(storage, `spec.nodes["cp-1"]`)
+	if len(volumes) != 1 || volumes[0].PartitionLabel != "u-local-hostpath" || volumes[0].MountSource != "/dev/disk/by-partlabel/u-local-hostpath" {
+		t.Fatalf("derived volumes = %#v", volumes)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want explicit convention without warning", warnings)
 	}
 }

--- a/internal/installer/configbundle/schema_rules.go
+++ b/internal/installer/configbundle/schema_rules.go
@@ -122,22 +122,22 @@ func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
 		return description("Systemd units and drop-ins activated with the extension.")
 	case "configbundle.SourceInstallLayer.systemDisk":
 		return description("System disk selector. Defaults may provide only non-identifying size policy; each effective node requires one stable identity.")
-	case "configbundle.SourceStorageLayer.disks":
+	case "configbundle.SourceStorageLayer.volumes":
 		return description("Named whole-disk or partition-backed volumes.")
-	case "configbundle.SourceStorageDisk.name":
+	case "configbundle.SourceStorageVolume.name":
 		return stringRule("Volume name used to derive its GPT label and /var/mnt path.", dnsLabelPattern, 1, 63)
-	case "configbundle.SourceStorageDisk.state":
+	case "configbundle.SourceStorageVolume.state":
 		return enumRule("Whether Katl manages or stops managing this volume.", "present", "", "present", "absent")
-	case "configbundle.SourceStorageDisk.selector":
+	case "configbundle.SourceStorageVolume.selector":
 		return description("Exactly one whole-disk or partition selector.")
-	case "configbundle.SourceStorageDisk.filesystem":
+	case "configbundle.SourceStorageVolume.filesystem":
 		return enumRule("Filesystem required on the selected target.", nil, "xfs", "ext4", "btrfs")
-	case "configbundle.SourceStorageDisk.wipe":
+	case "configbundle.SourceStorageVolume.wipe":
 		return schemaFieldRule{Description: "Whether provisioning may format the selected target.", Default: false}
 	case "configbundle.SourceVolumeSelector.disk":
 		return description("Select a safe whole disk.")
 	case "configbundle.SourceVolumeSelector.partition":
-		return description("Select an existing partition; an empty object uses the u-{volume-name} GPT label convention.")
+		return description("Select an existing partition using one stable identity or the explicit volume-name convention.")
 	case "configbundle.SourceDiskSelector.byID":
 		return stringRule("Absolute stable /dev/disk/by-id path; an empty value clears an inherited identity.", `^(?:|/dev/disk/by-id/[^/]+)$`, 0, 0)
 	case "configbundle.SourceDiskSelector.wwn":
@@ -152,6 +152,8 @@ func sourceSchemaFieldRule(t reflect.Type, field string) schemaFieldRule {
 		return schemaFieldRule{Description: "GPT partition UUID; an empty value clears an inherited identity.", Pattern: `^(?:|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})$`}
 	case "configbundle.SourcePartitionSelector.filesystemUUID":
 		return description("Existing filesystem UUID; an empty value clears an inherited identity.")
+	case "configbundle.SourcePartitionSelector.byVolumeName":
+		return schemaFieldRule{Description: "Select the convention-derived u-{volume-name} GPT label.", Default: false}
 	case "configbundle.SourceKubernetesCluster.version":
 		return schemaFieldRule{Required: true, Description: "Exact Kubernetes patch version compiled into the cluster.", Pattern: `^v[0-9]+\.[0-9]+\.[0-9]+$`, MinLength: intPointer(1)}
 	case "configbundle.SourceKubernetesCluster.kubeadm":
@@ -250,7 +252,12 @@ func sourceSchemaTypeRule(t reflect.Type) schemaTypeRule {
 	case "configbundle.SourceDiskSelector":
 		return schemaTypeRule{OneOf: atMostOneRequired("byID", "wwn", "serial")}
 	case "configbundle.SourcePartitionSelector":
-		return schemaTypeRule{OneOf: atMostOneRequired("byID", "partUUID", "filesystemUUID")}
+		return schemaTypeRule{OneOf: exactlyOneActive(
+			nonEmptyRequired("byID"),
+			nonEmptyRequired("partUUID"),
+			nonEmptyRequired("filesystemUUID"),
+			trueRequired("byVolumeName"),
+		)}
 	case "manifest.HostConfigurationFile":
 		return schemaTypeRule{OneOf: exactlyOneRequired("content", "source")}
 	case "manifest.SystemExtensionUnitDropIn":
@@ -296,6 +303,33 @@ func nonEmptyRequired(field string) schemaObject {
 			field: {Not: &schemaObject{Const: ""}},
 		},
 	}
+}
+
+func trueRequired(field string) schemaObject {
+	return schemaObject{
+		Required: []string{field},
+		Properties: map[string]schemaObject{
+			field: {Const: true},
+		},
+	}
+}
+
+func exactlyOneActive(active ...schemaObject) []schemaObject {
+	branches := make([]schemaObject, 0, len(active))
+	for i := range active {
+		others := make([]schemaObject, 0, len(active)-1)
+		for j := range active {
+			if i != j {
+				others = append(others, active[j])
+			}
+		}
+		branches = append(branches, schemaObject{
+			Required:   active[i].Required,
+			Properties: active[i].Properties,
+			Not:        &schemaObject{AnyOf: others},
+		})
+	}
+	return branches
 }
 
 const (

--- a/internal/installer/configbundle/schema_test.go
+++ b/internal/installer/configbundle/schema_test.go
@@ -10,7 +10,8 @@ func TestSourceSchemaAcceptsConfigsAcceptedByKatl(t *testing.T) {
               disk:
                 byID: /dev/disk/by-id/ata-cp-data
 `, `            selector:
-              partition: {}
+              partition:
+                byVolumeName: true
 `, 1)
 	zeroDefaults := strings.Replace(validSourceConfig(), "    port: 6443\n", "    port: 0\n", 1)
 	zeroDefaults = strings.Replace(zeroDefaults, "          files:\n", `          state: ""
@@ -70,6 +71,16 @@ func TestSourceSchemaRejectsSemanticErrors(t *testing.T) {
 `, `            selector:
               disk:
                 byID: /dev/disk/by-id/ata-cp-data
+              partition:
+                byVolumeName: true
+`, 1),
+		},
+		{
+			name: "empty partition selector",
+			source: strings.Replace(validSourceConfig(), `            selector:
+              disk:
+                byID: /dev/disk/by-id/ata-cp-data
+`, `            selector:
               partition: {}
 `, 1),
 		},

--- a/internal/installer/configbundle/source_errors.go
+++ b/internal/installer/configbundle/source_errors.go
@@ -40,7 +40,7 @@ func publicManifestMessage(message string) string {
 		{"node.bootstrap.inventoryNodeName", "name"},
 		{"node.bootstrap.clusterName", "metadata.name"},
 		{"install.targetDisk", "install.systemDisk"},
-		{"install.volumes", "storage.disks"},
+		{"install.volumes", "storage.volumes"},
 	}
 	for _, replacement := range replacements {
 		if strings.HasPrefix(message, replacement.internal) {
@@ -76,7 +76,7 @@ func publicCompilerMessage(message string) string {
 		"spec.kubernetes.payloadVersion", "spec.kubernetes.version",
 		"spec.defaults.install.targetDisk", "spec.defaults.install.systemDisk",
 		"install.targetDisk", "install.systemDisk",
-		"install.volumes", "storage.disks",
+		"install.volumes", "storage.volumes",
 	)
 	return replacer.Replace(message)
 }

--- a/internal/installer/configbundle/source_layering.go
+++ b/internal/installer/configbundle/source_layering.go
@@ -25,7 +25,7 @@ func mergeSourceNodeLayer(base, next SourceNodeLayer) (SourceNodeLayer, error) {
 		return SourceNodeLayer{}, err
 	}
 	out.Install.SystemDisk = mergeSourceDiskSelector(out.Install.SystemDisk, next.Install.SystemDisk)
-	out.Storage.Disks, err = mergeSourceStorageDisks(out.Storage.Disks, next.Storage.Disks)
+	out.Storage.Volumes, err = mergeSourceStorageVolumes(out.Storage.Volumes, next.Storage.Volumes)
 	if err != nil {
 		return SourceNodeLayer{}, err
 	}
@@ -49,7 +49,7 @@ func cloneSourceNodeLayer(layer SourceNodeLayer) SourceNodeLayer {
 	out.HostConfiguration = cloneSourceHostConfiguration(layer.HostConfiguration)
 	out.SystemExtensions = cloneOptionalSourceSystemExtensions(layer.SystemExtensions)
 	out.Install.SystemDisk = cloneSourceDiskSelector(layer.Install.SystemDisk)
-	out.Storage.Disks = cloneOptionalStorageDisks(layer.Storage.Disks)
+	out.Storage.Volumes = cloneOptionalStorageVolumes(layer.Storage.Volumes)
 	out.Kubernetes.Labels = cloneOptionalMap(layer.Kubernetes.Labels)
 	out.Kubernetes.Taints = cloneOptionalSlice(layer.Kubernetes.Taints)
 	out.Kubernetes.Kubelet = cloneSourceKubeletConfig(layer.Kubernetes.Kubelet)
@@ -136,19 +136,19 @@ func mergeSourceSystemExtensions(base, next Optional[[]SourceSystemExtension]) (
 	return supplied(values), nil
 }
 
-func mergeSourceStorageDisks(base, next Optional[[]SourceStorageDisk]) (Optional[[]SourceStorageDisk], error) {
+func mergeSourceStorageVolumes(base, next Optional[[]SourceStorageVolume]) (Optional[[]SourceStorageVolume], error) {
 	nextDisks, ok := next.Get()
 	if !ok {
-		return cloneOptionalStorageDisks(base), nil
+		return cloneOptionalStorageVolumes(base), nil
 	}
 	if len(nextDisks) == 0 {
-		return supplied([]SourceStorageDisk{}), nil
+		return supplied([]SourceStorageVolume{}), nil
 	}
-	entries := map[string]SourceStorageDisk{}
+	entries := map[string]SourceStorageVolume{}
 	if baseDisks, present := base.Get(); present {
 		for _, disk := range baseDisks {
 			if strings.TrimSpace(disk.State) != manifest.SystemExtensionAbsent {
-				entries[disk.Name] = cloneSourceStorageDisk(disk)
+				entries[disk.Name] = cloneSourceStorageVolume(disk)
 			}
 		}
 	}
@@ -156,7 +156,7 @@ func mergeSourceStorageDisks(base, next Optional[[]SourceStorageDisk]) (Optional
 	for _, disk := range nextDisks {
 		name := strings.TrimSpace(disk.Name)
 		if _, exists := seen[name]; exists {
-			return Optional[[]SourceStorageDisk]{}, fmt.Errorf("storage.disks contains duplicate name %q", name)
+			return Optional[[]SourceStorageVolume]{}, fmt.Errorf("storage.volumes contains duplicate name %q", name)
 		}
 		seen[name] = struct{}{}
 		if strings.TrimSpace(disk.State) == manifest.SystemExtensionAbsent {
@@ -165,24 +165,24 @@ func mergeSourceStorageDisks(base, next Optional[[]SourceStorageDisk]) (Optional
 		}
 		disk.Name = name
 		if inherited, exists := entries[name]; exists {
-			disk = mergeSourceStorageDisk(inherited, disk)
+			disk = mergeSourceStorageVolume(inherited, disk)
 		}
-		entries[name] = cloneSourceStorageDisk(disk)
+		entries[name] = cloneSourceStorageVolume(disk)
 	}
 	names := make([]string, 0, len(entries))
 	for name := range entries {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	values := make([]SourceStorageDisk, 0, len(names))
+	values := make([]SourceStorageVolume, 0, len(names))
 	for _, name := range names {
 		values = append(values, entries[name])
 	}
 	return supplied(values), nil
 }
 
-func mergeSourceStorageDisk(base, next SourceStorageDisk) SourceStorageDisk {
-	out := cloneSourceStorageDisk(base)
+func mergeSourceStorageVolume(base, next SourceStorageVolume) SourceStorageVolume {
+	out := cloneSourceStorageVolume(base)
 	out.Name = next.Name
 	out.State = next.State
 	out.Selector = mergeSourceVolumeSelector(out.Selector, next.Selector)
@@ -260,6 +260,9 @@ func mergeSourcePartitionSelector(base, next *SourcePartitionSelector) *SourcePa
 	if value, ok := next.FilesystemUUID.Get(); ok {
 		out.FilesystemUUID = supplied(value)
 	}
+	if value, ok := next.ByVolumeName.Get(); ok {
+		out.ByVolumeName = supplied(value)
+	}
 	return out
 }
 
@@ -331,7 +334,7 @@ func lowerDiskSelector(selector *SourceDiskSelector) *manifest.DiskSelector {
 	}
 }
 
-func lowerStorageDisks(disks Optional[[]SourceStorageDisk]) []manifest.Volume {
+func lowerStorageVolumes(disks Optional[[]SourceStorageVolume]) []manifest.Volume {
 	values, ok := disks.Get()
 	if !ok {
 		return nil
@@ -394,13 +397,13 @@ func validateDefaultSystemDisk(selector *SourceDiskSelector) error {
 	return nil
 }
 
-func validateDefaultStorageDisks(disks Optional[[]SourceStorageDisk]) error {
+func validateDefaultStorageVolumes(disks Optional[[]SourceStorageVolume]) error {
 	values, ok := disks.Get()
 	if !ok {
 		return nil
 	}
 	for i, volume := range values {
-		field := fmt.Sprintf("spec.defaults.storage.disks[%d]", i)
+		field := fmt.Sprintf("spec.defaults.storage.volumes[%d]", i)
 		if wipe, supplied := volume.Wipe.Get(); supplied && wipe {
 			return fmt.Errorf("%s.wipe must not be true in defaults; set destructive authority on a concrete node volume", field)
 		}
@@ -429,7 +432,7 @@ func validateDefaultStorageDisks(disks Optional[[]SourceStorageDisk]) error {
 	return nil
 }
 
-func validateSourceStorageDisks(field string, disks Optional[[]SourceStorageDisk], requireComplete bool) error {
+func validateSourceStorageVolumes(field string, disks Optional[[]SourceStorageVolume], requireComplete bool) error {
 	values, ok := disks.Get()
 	if !ok {
 		return nil
@@ -455,10 +458,28 @@ func validateSourceStorageDisks(field string, disks Optional[[]SourceStorageDisk
 		if disk.Selector != nil && disk.Selector.Disk != nil && disk.Selector.Partition != nil {
 			return fmt.Errorf("%s[%d].selector must set exactly one of disk or partition", field, i)
 		}
+		if disk.Selector != nil && disk.Selector.Partition != nil {
+			selected := 0
+			for _, identity := range []Optional[string]{
+				disk.Selector.Partition.ByID,
+				disk.Selector.Partition.PartUUID,
+				disk.Selector.Partition.FilesystemUUID,
+			} {
+				if value, supplied := identity.Get(); supplied && strings.TrimSpace(value) != "" {
+					selected++
+				}
+			}
+			if byVolumeName, supplied := disk.Selector.Partition.ByVolumeName.Get(); supplied && byVolumeName {
+				selected++
+			}
+			if selected > 1 || requireComplete && selected != 1 {
+				return fmt.Errorf("%s[%d].selector.partition must set exactly one of byID, partUUID, filesystemUUID, or byVolumeName: true", field, i)
+			}
+		}
 		if !requireComplete {
 			continue
 		}
-		volume := lowerStorageDisks(supplied([]SourceStorageDisk{disk}))
+		volume := lowerStorageVolumes(supplied([]SourceStorageVolume{disk}))
 		if err := manifest.ValidateVolumes(volume); err != nil {
 			message := strings.Replace(err.Error(), "install.volumes[0]", fmt.Sprintf("%s[%d]", field, i), 1)
 			return fmt.Errorf("%s", message)
@@ -489,7 +510,7 @@ func validateResolvedSourceNode(path string, layer SourceNodeLayer) error {
 	if selected != 1 {
 		return fmt.Errorf("%s.install.systemDisk must set exactly one of byID, wwn, or serial", path)
 	}
-	if err := validateSourceStorageDisks(path+".storage.disks", layer.Storage.Disks, true); err != nil {
+	if err := validateSourceStorageVolumes(path+".storage.volumes", layer.Storage.Volumes, true); err != nil {
 		return err
 	}
 	if err := validateSourceHostConfiguration(path+".hostConfiguration", layer.HostConfiguration); err != nil {
@@ -593,19 +614,19 @@ func cloneSourceHostConfigurationFileSet(set SourceHostConfigurationFileSet) Sou
 	return out
 }
 
-func cloneOptionalStorageDisks(optional Optional[[]SourceStorageDisk]) Optional[[]SourceStorageDisk] {
+func cloneOptionalStorageVolumes(optional Optional[[]SourceStorageVolume]) Optional[[]SourceStorageVolume] {
 	disks, ok := optional.Get()
 	if !ok {
-		return Optional[[]SourceStorageDisk]{}
+		return Optional[[]SourceStorageVolume]{}
 	}
-	values := make([]SourceStorageDisk, 0, len(disks))
+	values := make([]SourceStorageVolume, 0, len(disks))
 	for _, disk := range disks {
-		values = append(values, cloneSourceStorageDisk(disk))
+		values = append(values, cloneSourceStorageVolume(disk))
 	}
 	return supplied(values)
 }
 
-func cloneSourceStorageDisk(disk SourceStorageDisk) SourceStorageDisk {
+func cloneSourceStorageVolume(disk SourceStorageVolume) SourceStorageVolume {
 	out := disk
 	out.Selector = cloneSourceVolumeSelector(disk.Selector)
 	return out

--- a/internal/installer/handoff/handoff_test.go
+++ b/internal/installer/handoff/handoff_test.go
@@ -239,7 +239,7 @@ func TestHandoffServerRequiresOperationAuthorityForNonBlankStorage(t *testing.T)
         systemDisk:
           byID: /dev/disk/by-id/ata-root
       storage:
-        disks:
+        volumes:
           - name: data
             selector:
               disk:


### PR DESCRIPTION
## What changed

- rename the unshipped public `storage.disks` field to `storage.volumes`
- require `partition.byVolumeName: true` for convention-labelled partitions
- expose the explicit selector and derived label/path in schema and resolved output
- document and test storage's deliberate field-level layering behavior

## Why

Storage entries may be whole-disk or partition-backed, and the previous name and empty-object convention hid that distinction. The new source shape reads naturally and makes target selection visible to editors and operators without changing compiled runtime semantics.

The persistent `katldev` journey validated, resolved, applied, and reapplied the new shape against the preserved XFS data volume; the old spelling was refused and the existing filesystem identities and marker remained intact.
