### PR TITLE
config: clarify Kubernetes networking ownership

### DIFF
--- a/cmd/katlctl/config_inspect_test.go
+++ b/cmd/katlctl/config_inspect_test.go
@@ -102,6 +102,35 @@ func TestConfigDiffClassifiesLifecycleAndTargetChanges(t *testing.T) {
 	}
 }
 
+func TestConfigDiffClassifiesManagementAddressOnlyAsTargetOnly(t *testing.T) {
+	dir := t.TempDir()
+	beforePath := filepath.Join(dir, "before.yaml")
+	afterPath := filepath.Join(dir, "after.yaml")
+	before := configInspectionSource()
+	after := strings.Replace(before, "address: 10.0.0.11", "address: 10.0.0.12", 1)
+	if err := os.WriteFile(beforePath, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(afterPath, []byte(after), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"config", "diff", beforePath, afterPath, "--node", "cp-1", "--output", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var report configbundle.ConfigDiff
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if report.Classification.Overall != "target-only" || len(report.Changes) != 1 {
+		t.Fatalf("diff = %#v", report)
+	}
+	change := report.Changes[0]
+	if change.Path != `spec.nodes["cp-1"].management.address` || change.Classification != "target-only" || change.RequiredOperation != "" || !strings.Contains(change.Message, "no node generation or mutation") {
+		t.Fatalf("management address change = %#v", change)
+	}
+}
+
 func TestConfigResolveRequiresSelectionForMultipleNodes(t *testing.T) {
 	path := writeMultiControlPlaneClusterConfig(t)
 	var stdout, stderr bytes.Buffer

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/configapply"
+	"github.com/katl-dev/katl/internal/installer/configbundle"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -221,6 +222,74 @@ func TestRunClusterApplySkipsKubernetesComponentsBeforeBootstrap(t *testing.T) {
 	}
 	if len(client.submitRequests) != 0 {
 		t.Fatalf("pre-bootstrap no-op submitted mutations: %#v", client.submitRequests)
+	}
+}
+
+func TestRunClusterApplyManagementAddressOnlyTargetsWithoutMutation(t *testing.T) {
+	beforePath := writeClusterConfig(t)
+	afterPath := filepath.Join(t.TempDir(), "cluster.yaml")
+	afterSource := strings.Replace(configBundleSource(), "address: 10.0.0.11", "address: 10.0.0.12", 1)
+	if err := os.WriteFile(afterPath, []byte(afterSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	render := func(path string) []byte {
+		t.Helper()
+		loaded, err := loadKatlConfig(path, configBundleCreator, configbundle.PlanningInputs{}, nil)
+		if err != nil {
+			t.Fatalf("load %s: %v", path, err)
+		}
+		selected, err := configbundle.ReadSelectedNode(bytes.NewReader(loaded.Archive), configbundle.ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+		if err != nil {
+			t.Fatalf("select cp-1 from %s: %v", path, err)
+		}
+		data, err := configapply.RenderNodeConfigurationChange(configapply.RenderNodeRequest{
+			NodeName:       "cp-1",
+			Manifest:       selected.InstallManifest,
+			KubeadmConfigs: selected.KubeadmConfigs,
+			SourceID:       selected.BundleManifest.ClusterName,
+			DesiredVersion: "1",
+			ApplyMode:      generation.ApplyModeAuto,
+		})
+		if err != nil {
+			t.Fatalf("render %s: %v", path, err)
+		}
+		return data
+	}
+	beforeRendered := render(beforePath)
+	afterRendered := render(afterPath)
+	if !bytes.Equal(beforeRendered, afterRendered) {
+		t.Fatalf("management address changed rendered node state:\nbefore:\n%s\nafter:\n%s", beforeRendered, afterRendered)
+	}
+
+	client := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-1",
+			CurrentGenerationId: "generation-current",
+			Kubernetes:          &agentapi.KubernetesStatus{State: "ready"},
+		},
+		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: generation.ApplyModeLive, NoChanges: true},
+	}
+	previousDial := dialKatlcAgent
+	defer func() { dialKatlcAgent = previousDial }()
+	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != "10.0.0.12:9443" {
+			t.Fatalf("management target = %q, want updated address", endpoint)
+		}
+		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := runClusterApply(context.Background(), kubeadmControlPlaneConfigOptions{configPath: afterPath}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.submitRequests) != 0 || client.generationRequest != nil {
+		t.Fatalf("management-only apply mutated node state: submits=%#v generation=%#v", client.submitRequests, client.generationRequest)
+	}
+	if !strings.Contains(stderr.String(), "phase=node-config node=cp-1 status=unchanged") {
+		t.Fatalf("apply progress = %q, want unchanged node", stderr.String())
+	}
+	if client.validateRequest == nil || strings.Contains(client.validateRequest.ConfigYaml, "10.0.0.12") {
+		t.Fatalf("validated node config contains workstation management target: %#v", client.validateRequest)
 	}
 }
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -400,6 +400,28 @@ and injects bootstrap tokens and certificate material only when the explicit
 bootstrap operation runs. Omit the entire `kubeadm` block for Katl's complete
 defaults.
 
+This bounded native file is the stable interface for cluster-wide Kubernetes
+networking choices. Set Pod and Service CIDRs in
+`ClusterConfiguration.networking`, and use `InitConfiguration.skipPhases` when
+the chosen CNI replaces kube-proxy:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+skipPhases:
+  - addon/kube-proxy
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+networking:
+  podSubnet: 172.20.0.0/16
+  serviceSubnet: 172.21.0.0/16
+```
+
+Include a native `KubeProxyConfiguration` document when kube-proxy remains in
+use but needs non-default policy. Katl does not duplicate these upstream
+cluster-wide fields under a second typed ClusterConfig networking surface.
+
 For node-specific kubelet policy, reference one native
 `kubelet.config.k8s.io/v1beta1` `KubeletConfiguration` from that node:
 

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -277,6 +277,15 @@ cluster match it requires the dedicated kubeadm-aware operation. Native input
 acceptance does not imply that every kubeadm change has a supported live
 transition.
 
+Cluster-wide Pod CIDRs, Service CIDRs, kube-proxy configuration, and
+kube-proxy omission deliberately remain native kubeadm choices. Operators set
+the CIDRs in `ClusterConfiguration.networking`, include a
+`KubeProxyConfiguration` document when needed, and use
+`InitConfiguration.skipPhases` with `addon/kube-proxy` when their CNI replaces
+it. These upstream fields do not gain duplicate typed ClusterConfig options.
+Node-specific Kubernetes identity and kubelet policy remain the bounded typed
+exceptions described above.
+
 Changing `nodes[].kubernetes.address` on an already installed node is a
 node-identity migration. Normal config apply keeps the requested field visible
 but refuses the change with a kubeadm-aware operation requirement; set the

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -969,6 +969,10 @@ kind: ClusterConfiguration
 networking:
   podSubnet: 172.20.0.0/16
   serviceSubnet: 172.21.0.0/16
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+mode: nftables
 `)
 	source := strings.Replace(validSourceConfig(), "    version: v1.36.1", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml", 1)
 	sourcePath := filepath.Join(dir, "cluster.yaml")
@@ -981,11 +985,26 @@ networking:
 	if err != nil {
 		t.Fatalf("ReadSelectedNode() error = %v", err)
 	}
-	config := string(selected.KubeadmConfigs["control-plane"].Config.Content)
-	for _, want := range []string{"addon/kube-proxy", "podSubnet: 172.20.0.0/16", "serviceSubnet: 172.21.0.0/16"} {
-		if !strings.Contains(config, want) {
-			t.Fatalf("control-plane kubeadm input is missing %q:\n%s", want, config)
-		}
+	config := selected.KubeadmConfigs["control-plane"].Config.Content
+	documents, err := decodeKubeadmDocuments(config)
+	if err != nil {
+		t.Fatalf("decode control-plane kubeadm input: %v", err)
+	}
+	init := kubeadmDocument(documents, "InitConfiguration")
+	skipPhases, _ := init["skipPhases"].([]any)
+	if len(skipPhases) != 1 || skipPhases[0] != "addon/kube-proxy" {
+		t.Fatalf("InitConfiguration.skipPhases = %#v", skipPhases)
+	}
+	cluster := kubeadmDocument(documents, "ClusterConfiguration")
+	if got := nestedString(cluster, "networking", "podSubnet"); got != "172.20.0.0/16" {
+		t.Fatalf("ClusterConfiguration.networking.podSubnet = %q", got)
+	}
+	if got := nestedString(cluster, "networking", "serviceSubnet"); got != "172.21.0.0/16" {
+		t.Fatalf("ClusterConfiguration.networking.serviceSubnet = %q", got)
+	}
+	proxy := kubeadmDocument(documents, "KubeProxyConfiguration")
+	if got, _ := proxy["mode"].(string); got != "nftables" {
+		t.Fatalf("KubeProxyConfiguration.mode = %q", got)
 	}
 }
 

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -957,6 +957,38 @@ clusterName: operator-cluster
 	}
 }
 
+func TestBuildArchiveAcceptsCommonNetworkingThroughNativeKubeadm(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "kubeadm.yaml"), `apiVersion: kubeadm.k8s.io/v1beta4
+kind: InitConfiguration
+skipPhases:
+  - addon/kube-proxy
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+networking:
+  podSubnet: 172.20.0.0/16
+  serviceSubnet: 172.21.0.0/16
+`)
+	source := strings.Replace(validSourceConfig(), "    version: v1.36.1", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml", 1)
+	sourcePath := filepath.Join(dir, "cluster.yaml")
+	writeFile(t, sourcePath, source)
+	archive, _, err := BuildArchive(BuildRequest{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("BuildArchive() error = %v", err)
+	}
+	selected, err := ReadSelectedNode(bytes.NewReader(archive), ReadOptions{NodeName: "cp-1", AllowMissingKatlosImage: true})
+	if err != nil {
+		t.Fatalf("ReadSelectedNode() error = %v", err)
+	}
+	config := string(selected.KubeadmConfigs["control-plane"].Config.Content)
+	for _, want := range []string{"addon/kube-proxy", "podSubnet: 172.20.0.0/16", "serviceSubnet: 172.21.0.0/16"} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("control-plane kubeadm input is missing %q:\n%s", want, config)
+		}
+	}
+}
+
 func TestBuildArchiveRequiresControlPlaneNode(t *testing.T) {
 	source := strings.Replace(validSourceConfig(), "      controlPlane: true\n", "", 1)
 	_, _, err := BuildArchive(BuildRequest{SourcePath: writeSource(t, source)})


### PR DESCRIPTION
## What changed

- document bounded native kubeadm as the stable interface for Pod CIDRs, Service CIDRs, and kube-proxy policy
- prove those settings survive ClusterConfig compilation
- prove a `management.address`-only diff is target-only and plans no node mutation

## Why

These cluster-wide networking settings already belong to kubeadm's native API; duplicating them would create two sources of truth. Management addresses are workstation routing information, so their lifecycle classification should be explicit and independently tested.
