### PR TITLE
config: aggregate validation diagnostics

### DIFF
--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -1809,6 +1809,9 @@ func runConfigValidate(sourcePath, output string, stdout, stderr io.Writer) erro
 	if output != "text" && output != "json" {
 		return fmt.Errorf("--output = %q, want text or json", output)
 	}
+	if err := configbundle.ValidateSourceFile(sourcePath); err != nil {
+		return err
+	}
 	_, result, err := configbundle.BuildArchive(configbundle.BuildRequest{
 		SourcePath:     sourcePath,
 		KatlctlVersion: version,

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -785,6 +785,128 @@ func TestConfigValidateReportsNestedFieldPath(t *testing.T) {
 	}
 }
 
+func TestConfigValidateAggregatesPublicErrorsInStablePathOrder(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
+	source := `apiVersion: config.katl.dev/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: invalid
+spec:
+  kubernetes: {}
+  defaults:
+    kubernetes:
+      address: 10.0.0.10
+      kubelet: {}
+    storage:
+      disks: []
+  nodes:
+    - name: node-b
+      kubernetes:
+        address: 10.0.0.0/24
+        kubelet: {}
+      install:
+        systemDisk:
+          byID: /dev/disk/by-id/node-b-root
+          serial: duplicate
+      unsupported: true
+    - name: node-a
+      controlPlane: true
+      access:
+        ssh:
+          authorizedKeys:
+            - not-an-ssh-key
+      install: {}
+      kubernetes:
+        taints:
+          - key: dedicated
+            effect: Sometimes
+`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	validate := func() string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr)
+		if err == nil {
+			t.Fatal("config validate error = nil")
+		}
+		if stdout.Len() != 0 || stderr.Len() != 0 {
+			t.Fatalf("stdout=%q stderr=%q, want empty", stdout.String(), stderr.String())
+		}
+		return err.Error()
+	}
+	first := validate()
+	if second := validate(); second != first {
+		t.Fatalf("validation order changed between runs:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	wants := []string{
+		"spec.defaults.kubernetes.address is not allowed; Kubernetes address must be set per node (line 9)",
+		"spec.defaults.kubernetes.kubelet is not allowed; kubelet configuration must be set per node (line 10)",
+		"spec.defaults.storage.disks: field is not supported (line 12)",
+		"spec.kubernetes.version is required; set an exact version such as v1.36.1 (line 6)",
+		`spec.nodes["node-a"].access.ssh.authorizedKeys[0] must be an SSH public key (line 28)`,
+		`spec.nodes["node-a"].install.systemDisk is required (line 29)`,
+		`spec.nodes["node-a"].kubernetes.taints[0].effect "Sometimes" is unsupported (line 33)`,
+		`spec.nodes["node-b"].access.ssh.authorizedKeys must not be empty (line 14)`,
+		`spec.nodes["node-b"].install.systemDisk must set exactly one of byID, wwn, or serial (line 20)`,
+		`spec.nodes["node-b"].kubernetes.address: "10.0.0.0/24" must be a literal unicast IP address (line 16)`,
+		`spec.nodes["node-b"].kubernetes.kubelet.configFile is required (line 17)`,
+		`spec.nodes["node-b"].unsupported: field is not supported (line 22)`,
+	}
+	previous := -1
+	for _, want := range wants {
+		index := strings.Index(first, want)
+		if index < 0 {
+			t.Fatalf("validation output is missing %q:\n%s", want, first)
+		}
+		if index <= previous {
+			t.Fatalf("validation output is not in public path order at %q:\n%s", want, first)
+		}
+		previous = index
+	}
+	for _, internal := range []string{"targetDisk", "install.volumes", "sets", "notify", "configbundle."} {
+		if strings.Contains(first, internal) {
+			t.Fatalf("validation output exposes internal name %q:\n%s", internal, first)
+		}
+	}
+}
+
+func TestConfigValidateAggregatesPublicSourceTypeErrors(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
+	source := `apiVersion: config.katl.dev/v1alpha1
+kind: ClusterConfig
+spec:
+  kubernetes:
+    version: []
+  defaults:
+    kernel: []
+    unknown: true
+  nodes: {}
+`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"config", "validate", sourcePath}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("config validate error = nil")
+	}
+	for _, want := range []string{
+		"spec.defaults.kernel must be an object (line 7)",
+		"spec.defaults.unknown: field is not supported (line 8)",
+		"spec.kubernetes.version must be a string (line 5)",
+		"spec.nodes must be a list (line 9)",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validation output is missing %q:\n%s", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "configbundle.") {
+		t.Fatalf("validation output exposes a Go type:\n%s", err)
+	}
+}
+
 func TestConfigValidateReportsOnlyPublicNodePaths(t *testing.T) {
 	base := configBundleSource()
 	tests := []struct {

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -142,6 +142,11 @@ internally.
 image embedded in the release ISO. Replace the SSH key, node addresses, and
 stable disk IDs:
 
+Run `katlctl config validate ./cluster.yaml` while authoring. One run reports
+all independent source-policy and effective per-node errors in stable public
+field-path order, names the affected node, and includes YAML line numbers when
+the source location is available.
+
 ```yaml
 apiVersion: config.katl.dev/v1alpha1
 kind: ClusterConfig

--- a/docs/internal/cluster-manifest-contract.md
+++ b/docs/internal/cluster-manifest-contract.md
@@ -30,6 +30,11 @@ katlctl config resolve ./cluster.yaml --node cp-1
 katlctl config diff ./cluster-before.yaml ./cluster-after.yaml --node cp-1
 ```
 
+`config validate` collects independent structural and semantic failures before
+returning. Diagnostics are sorted by public ClusterConfig path, use named node
+paths, and include the nearest YAML line where available; compiler and manifest
+implementation names are never part of the operator-facing error contract.
+
 `config resolve` is the supported effective-value view. It preserves public
 ClusterConfig names while showing field provenance, derived storage paths and
 labels, owned files, warnings, and apply/lifecycle boundaries. `config diff`

--- a/internal/installer/configbundle/bundle.go
+++ b/internal/installer/configbundle/bundle.go
@@ -552,16 +552,20 @@ func LowerSource(source SourceConfig, planning PlanningInputs) (clusterplan.Conf
 }
 
 func validateResolvedSourceNodes(source SourceConfig) error {
+	return newValidationErrors(validationIssuesFromErrors(validateResolvedSourceNodeIssues(source), nil))
+}
+
+func validateResolvedSourceNodeIssues(source SourceConfig) []error {
+	var errs []error
 	for i, node := range source.Spec.Nodes {
 		resolved, err := mergeSourceNodeLayer(source.Spec.Defaults, sourceNodeLayer(node))
 		if err != nil {
-			return fmt.Errorf("%s: %w", sourceNodePath(node, i), err)
+			errs = append(errs, fmt.Errorf("%s: %w", sourceNodePath(node, i), err))
+			continue
 		}
-		if err := validateResolvedSourceNode(sourceNodePath(node, i), resolved); err != nil {
-			return err
-		}
+		errs = append(errs, validateResolvedSourceNodeLayerIssues(sourceNodePath(node, i), resolved)...)
 	}
-	return nil
+	return errs
 }
 
 func lowerKubernetesSelection(source SourceConfig, bundle string) (clusterplan.KubernetesSelection, error) {
@@ -643,8 +647,20 @@ func selectedKubernetesVersion(source SourceConfig) string {
 }
 
 func normalizeSource(source SourceConfig) (SourceConfig, error) {
+	source, errs := normalizeSourceIssues(source)
+	if err := newValidationErrors(validationIssuesFromErrors(errs, nil)); err != nil {
+		return SourceConfig{}, err
+	}
+	return source, nil
+}
+
+func normalizeSourceIssues(source SourceConfig) (SourceConfig, []error) {
+	var errs []error
+	if strings.TrimSpace(source.Metadata.Name) == "" {
+		errs = append(errs, fmt.Errorf("metadata.name is required"))
+	}
 	if strings.TrimSpace(source.Spec.Kubernetes.Version) == "" {
-		return SourceConfig{}, fmt.Errorf("spec.kubernetes.version is required; set an exact version such as %s", DefaultKubernetesVersion)
+		errs = append(errs, fmt.Errorf("spec.kubernetes.version is required; set an exact version such as %s", DefaultKubernetesVersion))
 	}
 	source.Spec.Nodes = slices.Clone(source.Spec.Nodes)
 	seenNodes := make(map[string]struct{}, len(source.Spec.Nodes))
@@ -652,82 +668,99 @@ func normalizeSource(source SourceConfig) (SourceConfig, error) {
 		name := strings.TrimSpace(node.Name)
 		path := sourceNodePath(node, i)
 		if name == "" {
-			return SourceConfig{}, fmt.Errorf("%s.name is required", path)
+			errs = append(errs, fmt.Errorf("%s.name is required", path))
+			continue
 		}
 		if !manifest.ValidHostname(name) {
-			return SourceConfig{}, fmt.Errorf("%s.name %q must be a single DNS-style label", path, node.Name)
+			errs = append(errs, fmt.Errorf("%s.name %q must be a single DNS-style label", path, node.Name))
 		}
 		if _, exists := seenNodes[name]; exists {
-			return SourceConfig{}, fmt.Errorf("%s.name %q duplicates another node", path, name)
+			errs = append(errs, fmt.Errorf("%s.name %q duplicates another node", path, name))
 		}
 		seenNodes[name] = struct{}{}
 	}
+	if len(source.Spec.Nodes) == 0 {
+		errs = append(errs, fmt.Errorf("spec.nodes must not be empty"))
+	} else {
+		hasControlPlane := false
+		for _, node := range source.Spec.Nodes {
+			if node.ControlPlane {
+				hasControlPlane = true
+				break
+			}
+		}
+		if !hasControlPlane {
+			errs = append(errs, fmt.Errorf("spec.nodes must include at least one node with controlPlane: true"))
+		}
+	}
 	if strings.TrimSpace(source.Spec.Defaults.Kubernetes.Address) != "" {
-		return SourceConfig{}, fmt.Errorf("spec.defaults.kubernetes.address is not allowed; Kubernetes address must be set per node")
+		errs = append(errs, fmt.Errorf("spec.defaults.kubernetes.address is not allowed; Kubernetes address must be set per node"))
 	}
 	if source.Spec.Defaults.Kubernetes.Kubelet != nil {
-		return SourceConfig{}, fmt.Errorf("spec.defaults.kubernetes.kubelet is not allowed; kubelet configuration must be set per node")
+		errs = append(errs, fmt.Errorf("spec.defaults.kubernetes.kubelet is not allowed; kubelet configuration must be set per node"))
 	}
 	if source.Spec.Defaults.Kernel != nil {
 		if err := manifest.ValidateKernelConfig(*lowerKernelConfig(source.Spec.Defaults.Kernel)); err != nil {
-			return SourceConfig{}, fmt.Errorf("spec.defaults.kernel: %w", err)
+			errs = append(errs, fmt.Errorf("spec.defaults.kernel: %w", err))
 		}
 	}
 	for i := range source.Spec.Nodes {
 		path := sourceNodePath(source.Spec.Nodes[i], i)
 		address, err := manifest.NormalizeKubernetesAddress(source.Spec.Nodes[i].Kubernetes.Address)
 		if err != nil {
-			return SourceConfig{}, fmt.Errorf("%s.kubernetes.address: %w", path, err)
+			errs = append(errs, fmt.Errorf("%s.kubernetes.address: %w", path, err))
+		} else {
+			source.Spec.Nodes[i].Kubernetes.Address = address
 		}
-		source.Spec.Nodes[i].Kubernetes.Address = address
 		if kubelet := source.Spec.Nodes[i].Kubernetes.Kubelet; kubelet != nil && strings.TrimSpace(kubelet.ConfigFile) == "" {
-			return SourceConfig{}, fmt.Errorf("%s.kubernetes.kubelet.configFile is required", path)
+			errs = append(errs, fmt.Errorf("%s.kubernetes.kubelet.configFile is required", path))
 		}
 		if source.Spec.Nodes[i].Kernel != nil {
 			if err := manifest.ValidateKernelConfig(*lowerKernelConfig(source.Spec.Nodes[i].Kernel)); err != nil {
-				return SourceConfig{}, fmt.Errorf("%s.kernel: %w", path, err)
+				errs = append(errs, fmt.Errorf("%s.kernel: %w", path, err))
 			}
 		}
 	}
 	if err := validateSourceHostConfiguration("spec.defaults.hostConfiguration", source.Spec.Defaults.HostConfiguration); err != nil {
-		return SourceConfig{}, err
+		errs = append(errs, err)
 	}
 	for i := range source.Spec.Nodes {
 		if err := validateSourceHostConfiguration(sourceNodePath(source.Spec.Nodes[i], i)+".hostConfiguration", source.Spec.Nodes[i].HostConfiguration); err != nil {
-			return SourceConfig{}, err
+			errs = append(errs, err)
 		}
 	}
 	if err := validateSourceSystemExtensions("spec.defaults.systemExtensions", source.Spec.Defaults.SystemExtensions); err != nil {
-		return SourceConfig{}, err
+		errs = append(errs, err)
 	}
 	for i := range source.Spec.Nodes {
 		if err := validateSourceSystemExtensions(sourceNodePath(source.Spec.Nodes[i], i)+".systemExtensions", source.Spec.Nodes[i].SystemExtensions); err != nil {
-			return SourceConfig{}, err
+			errs = append(errs, err)
 		}
 	}
 	if err := validateDefaultSystemDisk(source.Spec.Defaults.Install.SystemDisk); err != nil {
-		return SourceConfig{}, fmt.Errorf("spec.defaults.install.systemDisk: %w", err)
+		errs = append(errs, fmt.Errorf("spec.defaults.install.systemDisk: %w", err))
 	}
 	if err := validateDefaultStorageVolumes(source.Spec.Defaults.Storage.Volumes); err != nil {
-		return SourceConfig{}, err
+		errs = append(errs, err)
 	}
 	if err := validateSourceStorageVolumes("spec.defaults.storage.volumes", source.Spec.Defaults.Storage.Volumes, false); err != nil {
-		return SourceConfig{}, err
+		errs = append(errs, err)
 	}
 	for i := range source.Spec.Nodes {
 		if err := validateSourceStorageVolumes(sourceNodePath(source.Spec.Nodes[i], i)+".storage.volumes", source.Spec.Nodes[i].Storage.Volumes, false); err != nil {
-			return SourceConfig{}, err
+			errs = append(errs, err)
 		}
 	}
 	if source.Spec.ControlPlaneEndpoint == nil {
-		return source, nil
+		return source, errs
 	}
 	plan, err := controlplaneendpoint.Normalize(*source.Spec.ControlPlaneEndpoint)
 	if err != nil {
-		return SourceConfig{}, err
+		errs = append(errs, fmt.Errorf("spec.controlPlaneEndpoint: %w", err))
+	} else {
+		source.Spec.ControlPlaneEndpoint = &plan.Config
 	}
-	source.Spec.ControlPlaneEndpoint = &plan.Config
-	return source, nil
+	return source, errs
 }
 
 func resolveHostConfigurationSources(sourceRoot string, source SourceConfig) (SourceConfig, error) {

--- a/internal/installer/configbundle/schema.go
+++ b/internal/installer/configbundle/schema.go
@@ -171,23 +171,34 @@ func yamlField(field reflect.StructField) (name string, omitEmpty, visible bool)
 }
 
 func validateSourceFields(node *yaml.Node) error {
+	return newValidationErrors(validateSourceFieldIssues(node))
+}
+
+func validateSourceFieldIssues(node *yaml.Node) []validationIssue {
 	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
 		node = node.Content[0]
 	}
-	return validateYAMLFields(node, reflect.TypeOf(SourceConfig{}), "")
+	var issues []validationIssue
+	validateYAMLFields(node, reflect.TypeOf(SourceConfig{}), "", &issues)
+	return issues
 }
 
-func validateYAMLFields(node *yaml.Node, t reflect.Type, path string) error {
+func validateYAMLFields(node *yaml.Node, t reflect.Type, path string, issues *[]validationIssue) {
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if valueType, ok := optionalValueType(t); ok {
-		return validateYAMLFields(node, valueType, path)
+		validateYAMLFields(node, valueType, path, issues)
+		return
+	}
+	if node.Tag == "!!null" {
+		return
 	}
 	switch t.Kind() {
 	case reflect.Struct:
 		if node.Kind != yaml.MappingNode {
-			return nil
+			addYAMLShapeIssue(issues, path, "an object", node.Line)
+			return
 		}
 		fields := map[string]reflect.Type{}
 		for i := 0; i < t.NumField(); i++ {
@@ -202,33 +213,53 @@ func validateYAMLFields(node *yaml.Node, t reflect.Type, path string) error {
 			fieldType, ok := fields[key.Value]
 			fieldPath := joinFieldPath(path, key.Value)
 			if !ok {
-				return fmt.Errorf("%s: field is not supported (line %d)", fieldPath, key.Line)
+				*issues = append(*issues, validationIssue{Path: fieldPath, Message: fmt.Sprintf("%s: field is not supported", fieldPath), Line: key.Line})
+				continue
 			}
-			if err := validateYAMLFields(value, fieldType, fieldPath); err != nil {
-				return err
-			}
+			validateYAMLFields(value, fieldType, fieldPath, issues)
 		}
 	case reflect.Map:
 		if node.Kind != yaml.MappingNode {
-			return nil
+			addYAMLShapeIssue(issues, path, "a map", node.Line)
+			return
 		}
 		for i := 0; i+1 < len(node.Content); i += 2 {
-			if err := validateYAMLFields(node.Content[i+1], t.Elem(), joinFieldPath(path, node.Content[i].Value)); err != nil {
-				return err
-			}
+			validateYAMLFields(node.Content[i+1], t.Elem(), joinFieldPath(path, node.Content[i].Value), issues)
 		}
 	case reflect.Slice, reflect.Array:
 		if node.Kind != yaml.SequenceNode {
-			return nil
+			addYAMLShapeIssue(issues, path, "a list", node.Line)
+			return
 		}
 		for i, item := range node.Content {
 			itemPath := sequenceItemPath(path, item, i)
-			if err := validateYAMLFields(item, t.Elem(), itemPath); err != nil {
-				return err
-			}
+			validateYAMLFields(item, t.Elem(), itemPath, issues)
+		}
+	case reflect.String:
+		validateYAMLScalar(node, path, "a string", "!!str", issues)
+	case reflect.Bool:
+		validateYAMLScalar(node, path, "a boolean", "!!bool", issues)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		validateYAMLScalar(node, path, "an integer", "!!int", issues)
+	case reflect.Float32, reflect.Float64:
+		if node.Kind != yaml.ScalarNode || node.Tag != "!!float" && node.Tag != "!!int" {
+			addYAMLShapeIssue(issues, path, "a number", node.Line)
 		}
 	}
-	return nil
+}
+
+func validateYAMLScalar(node *yaml.Node, path, expected, tag string, issues *[]validationIssue) {
+	if node.Kind != yaml.ScalarNode || node.Tag != tag {
+		addYAMLShapeIssue(issues, path, expected, node.Line)
+	}
+}
+
+func addYAMLShapeIssue(issues *[]validationIssue, path, expected string, line int) {
+	if path == "" {
+		path = "document"
+	}
+	*issues = append(*issues, validationIssue{Path: path, Message: fmt.Sprintf("%s must be %s", path, expected), Line: line})
 }
 
 func sequenceItemPath(path string, item *yaml.Node, index int) string {

--- a/internal/installer/configbundle/source_layering.go
+++ b/internal/installer/configbundle/source_layering.go
@@ -402,16 +402,17 @@ func validateDefaultStorageVolumes(disks Optional[[]SourceStorageVolume]) error 
 	if !ok {
 		return nil
 	}
+	var errs []error
 	for i, volume := range values {
 		field := fmt.Sprintf("spec.defaults.storage.volumes[%d]", i)
 		if wipe, supplied := volume.Wipe.Get(); supplied && wipe {
-			return fmt.Errorf("%s.wipe must not be true in defaults; set destructive authority on a concrete node volume", field)
+			errs = append(errs, fmt.Errorf("%s.wipe must not be true in defaults; set destructive authority on a concrete node volume", field))
 		}
 		if volume.Selector == nil {
 			continue
 		}
 		if volume.Selector.Partition != nil {
-			return fmt.Errorf("%s.selector.partition identifies a target and must be set on a concrete node volume", field)
+			errs = append(errs, fmt.Errorf("%s.selector.partition identifies a target and must be set on a concrete node volume", field))
 		}
 		if volume.Selector.Disk == nil {
 			continue
@@ -425,11 +426,11 @@ func validateDefaultStorageVolumes(disks Optional[[]SourceStorageVolume]) error 
 			{name: "serial", value: volume.Selector.Disk.Serial},
 		} {
 			if configured, supplied := identity.value.Get(); supplied && strings.TrimSpace(configured) != "" {
-				return fmt.Errorf("%s.selector.disk.%s identifies a target and must be set on a concrete node volume", field, identity.name)
+				errs = append(errs, fmt.Errorf("%s.selector.disk.%s identifies a target and must be set on a concrete node volume", field, identity.name))
 			}
 		}
 	}
-	return nil
+	return newValidationErrors(validationIssuesFromErrors(errs, nil))
 }
 
 func validateSourceStorageVolumes(field string, disks Optional[[]SourceStorageVolume], requireComplete bool) error {
@@ -437,26 +438,27 @@ func validateSourceStorageVolumes(field string, disks Optional[[]SourceStorageVo
 	if !ok {
 		return nil
 	}
+	var errs []error
 	seen := map[string]struct{}{}
 	for i, disk := range values {
 		name := strings.TrimSpace(disk.Name)
 		if name == "" {
-			return fmt.Errorf("%s[%d].name is required", field, i)
+			errs = append(errs, fmt.Errorf("%s[%d].name is required", field, i))
+		} else if _, exists := seen[name]; exists {
+			errs = append(errs, fmt.Errorf("%s[%d].name %q duplicates another volume", field, i, name))
+		} else {
+			seen[name] = struct{}{}
 		}
-		if _, exists := seen[name]; exists {
-			return fmt.Errorf("%s contains duplicate name %q", field, name)
-		}
-		seen[name] = struct{}{}
 		switch state := strings.TrimSpace(disk.State); state {
 		case "", manifest.SystemExtensionPresent, manifest.SystemExtensionAbsent:
 		default:
-			return fmt.Errorf("%s[%d].state must be %q or %q", field, i, manifest.SystemExtensionPresent, manifest.SystemExtensionAbsent)
+			errs = append(errs, fmt.Errorf("%s[%d].state must be %q or %q", field, i, manifest.SystemExtensionPresent, manifest.SystemExtensionAbsent))
 		}
 		if strings.TrimSpace(disk.State) == manifest.SystemExtensionAbsent {
 			continue
 		}
 		if disk.Selector != nil && disk.Selector.Disk != nil && disk.Selector.Partition != nil {
-			return fmt.Errorf("%s[%d].selector must set exactly one of disk or partition", field, i)
+			errs = append(errs, fmt.Errorf("%s[%d].selector must set exactly one of disk or partition", field, i))
 		}
 		if disk.Selector != nil && disk.Selector.Partition != nil {
 			selected := 0
@@ -473,7 +475,7 @@ func validateSourceStorageVolumes(field string, disks Optional[[]SourceStorageVo
 				selected++
 			}
 			if selected > 1 || requireComplete && selected != 1 {
-				return fmt.Errorf("%s[%d].selector.partition must set exactly one of byID, partUUID, filesystemUUID, or byVolumeName: true", field, i)
+				errs = append(errs, fmt.Errorf("%s[%d].selector.partition must set exactly one of byID, partUUID, filesystemUUID, or byVolumeName: true", field, i))
 			}
 		}
 		if !requireComplete {
@@ -482,51 +484,93 @@ func validateSourceStorageVolumes(field string, disks Optional[[]SourceStorageVo
 		volume := lowerStorageVolumes(supplied([]SourceStorageVolume{disk}))
 		if err := manifest.ValidateVolumes(volume); err != nil {
 			message := strings.Replace(err.Error(), "install.volumes[0]", fmt.Sprintf("%s[%d]", field, i), 1)
-			return fmt.Errorf("%s", message)
+			errs = append(errs, fmt.Errorf("%s", message))
 		}
 	}
-	return nil
+	return newValidationErrors(validationIssuesFromErrors(errs, nil))
 }
 
 func validateResolvedSourceNode(path string, layer SourceNodeLayer) error {
+	return newValidationErrors(validationIssuesFromErrors(validateResolvedSourceNodeLayerIssues(path, layer), nil))
+}
+
+func validateResolvedSourceNodeLayerIssues(path string, layer SourceNodeLayer) []error {
+	var errs []error
 	if keys, ok := layer.Access.SSH.AuthorizedKeys.Get(); !ok || len(keys) == 0 {
-		return fmt.Errorf("%s.access.ssh.authorizedKeys must not be empty", path)
+		errs = append(errs, fmt.Errorf("%s.access.ssh.authorizedKeys must not be empty", path))
 	} else {
 		for i, key := range keys {
 			if !manifest.ValidAuthorizedKey(key) {
-				return fmt.Errorf("%s.access.ssh.authorizedKeys[%d] must be an SSH public key", path, i)
+				errs = append(errs, fmt.Errorf("%s.access.ssh.authorizedKeys[%d] must be an SSH public key", path, i))
 			}
 		}
 	}
 	if layer.Install.SystemDisk == nil {
-		return fmt.Errorf("%s.install.systemDisk is required", path)
-	}
-	selected := 0
-	for _, value := range []Optional[string]{layer.Install.SystemDisk.ByID, layer.Install.SystemDisk.WWN, layer.Install.SystemDisk.Serial} {
-		if configured, ok := value.Get(); ok && strings.TrimSpace(configured) != "" {
-			selected++
+		errs = append(errs, fmt.Errorf("%s.install.systemDisk is required", path))
+	} else {
+		selected := 0
+		for _, value := range []Optional[string]{layer.Install.SystemDisk.ByID, layer.Install.SystemDisk.WWN, layer.Install.SystemDisk.Serial} {
+			if configured, ok := value.Get(); ok && strings.TrimSpace(configured) != "" {
+				selected++
+			}
+		}
+		if selected != 1 {
+			errs = append(errs, fmt.Errorf("%s.install.systemDisk must set exactly one of byID, wwn, or serial", path))
 		}
 	}
-	if selected != 1 {
-		return fmt.Errorf("%s.install.systemDisk must set exactly one of byID, wwn, or serial", path)
-	}
 	if err := validateSourceStorageVolumes(path+".storage.volumes", layer.Storage.Volumes, true); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 	if err := validateSourceHostConfiguration(path+".hostConfiguration", layer.HostConfiguration); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 	if err := validateSourceSystemExtensions(path+".systemExtensions", layer.SystemExtensions); err != nil {
-		return err
+		errs = append(errs, err)
 	}
-	return nil
+	labels, _ := layer.Kubernetes.Labels.Get()
+	labelKeys := make([]string, 0, len(labels))
+	for key := range labels {
+		labelKeys = append(labelKeys, key)
+	}
+	sort.Strings(labelKeys)
+	for _, key := range labelKeys {
+		if err := manifest.ValidateKubernetesMetadata(map[string]string{key: labels[key]}, nil); err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s", path, publicManifestMessage(err.Error())))
+		}
+	}
+	taints, _ := layer.Kubernetes.Taints.Get()
+	for i, taint := range taints {
+		if err := manifest.ValidateKubernetesMetadata(nil, []manifest.NodeTaint{taint}); err != nil {
+			message := strings.Replace(publicManifestMessage(err.Error()), "kubernetes.taints[0]", fmt.Sprintf("kubernetes.taints[%d]", i), 1)
+			errs = append(errs, fmt.Errorf("%s.%s", path, message))
+		}
+	}
+	return errs
 }
 
 func validateSourceHostConfiguration(field string, config SourceHostConfiguration) error {
-	if err := manifest.ValidateHostConfiguration(lowerHostConfiguration(config), true); err != nil {
-		return fmt.Errorf("%s.%s", field, publicHostConfigurationMessage(err.Error()))
+	lowered := lowerHostConfiguration(config)
+	var errs []error
+	for i, setting := range lowered.Sysfs {
+		if err := manifest.ValidateHostConfiguration(manifest.HostConfiguration{Sysfs: []manifest.HostConfigurationSysfsSetting{setting}}, true); err != nil {
+			message := strings.Replace(publicHostConfigurationMessage(err.Error()), "sysfs[0]", fmt.Sprintf("sysfs[%d]", i), 1)
+			errs = append(errs, fmt.Errorf("%s.%s", field, message))
+		}
 	}
-	return nil
+	setNames := make([]string, 0, len(lowered.Sets))
+	for name := range lowered.Sets {
+		setNames = append(setNames, name)
+	}
+	sort.Strings(setNames)
+	for _, name := range setNames {
+		if err := manifest.ValidateHostConfiguration(manifest.HostConfiguration{Sets: map[string]manifest.HostConfigurationSet{name: lowered.Sets[name]}}, true); err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s", field, publicHostConfigurationMessage(err.Error())))
+		}
+	}
+	if err := manifest.ValidateHostConfiguration(lowered, true); err != nil {
+		errs = append(errs, fmt.Errorf("%s.%s", field, publicHostConfigurationMessage(err.Error())))
+	}
+	return newValidationErrors(validationIssuesFromErrors(errs, nil))
 }
 
 func publicHostConfigurationMessage(message string) string {
@@ -542,10 +586,18 @@ func publicHostConfigurationMessage(message string) string {
 }
 
 func validateSourceSystemExtensions(field string, extensions Optional[[]SourceSystemExtension]) error {
-	if err := manifest.ValidateSystemExtensions(lowerSystemExtensions(extensions), true); err != nil {
-		return fmt.Errorf("%s%s", field, publicSystemExtensionsMessage(err.Error()))
+	lowered := lowerSystemExtensions(extensions)
+	var errs []error
+	for i, extension := range lowered {
+		if err := manifest.ValidateSystemExtensions([]manifest.SystemExtension{extension}, true); err != nil {
+			message := strings.Replace(publicSystemExtensionsMessage(err.Error()), "[0]", fmt.Sprintf("[%d]", i), 1)
+			errs = append(errs, fmt.Errorf("%s%s", field, message))
+		}
 	}
-	return nil
+	if err := manifest.ValidateSystemExtensions(lowered, true); err != nil {
+		errs = append(errs, fmt.Errorf("%s%s", field, publicSystemExtensionsMessage(err.Error())))
+	}
+	return newValidationErrors(validationIssuesFromErrors(errs, nil))
 }
 
 func publicSystemExtensionsMessage(message string) string {

--- a/internal/installer/configbundle/validation.go
+++ b/internal/installer/configbundle/validation.go
@@ -1,0 +1,343 @@
+package configbundle
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type validationIssue struct {
+	Path    string
+	Message string
+	Line    int
+}
+
+type validationErrors struct {
+	issues []validationIssue
+}
+
+func (e *validationErrors) Error() string {
+	if e == nil || len(e.issues) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	noun := "errors"
+	if len(e.issues) == 1 {
+		noun = "error"
+	}
+	fmt.Fprintf(&out, "cluster config has %d validation %s:", len(e.issues), noun)
+	for _, issue := range e.issues {
+		out.WriteString("\n- ")
+		out.WriteString(issue.Message)
+		if issue.Line > 0 && !strings.Contains(issue.Message, "(line ") {
+			fmt.Fprintf(&out, " (line %d)", issue.Line)
+		}
+	}
+	return out.String()
+}
+
+func newValidationErrors(issues []validationIssue) error {
+	if len(issues) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	filtered := make([]validationIssue, 0, len(issues))
+	for _, issue := range issues {
+		issue.Path = strings.TrimSpace(issue.Path)
+		issue.Message = strings.TrimSpace(issue.Message)
+		if issue.Message == "" {
+			continue
+		}
+		key := issue.Path + "\x00" + issue.Message
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		filtered = append(filtered, issue)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].Path != filtered[j].Path {
+			return filtered[i].Path < filtered[j].Path
+		}
+		if filtered[i].Line != filtered[j].Line {
+			return filtered[i].Line < filtered[j].Line
+		}
+		return filtered[i].Message < filtered[j].Message
+	})
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &validationErrors{issues: filtered}
+}
+
+func validationIssuesFromErrors(errs []error, lines map[string]int) []validationIssue {
+	var issues []validationIssue
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		var aggregate *validationErrors
+		if errors.As(err, &aggregate) {
+			for _, issue := range aggregate.issues {
+				if issue.Line == 0 {
+					issue.Line = nearestValidationLine(issue.Path, lines)
+				}
+				issues = append(issues, issue)
+			}
+			continue
+		}
+		message := strings.TrimSpace(err.Error())
+		path := nearestValidationPath(message, lines)
+		issues = append(issues, validationIssue{Path: path, Message: message, Line: nearestValidationLine(path, lines)})
+	}
+	return issues
+}
+
+func nearestValidationPath(message string, lines map[string]int) string {
+	if token := validationPathToken(message); token != "" {
+		return token
+	}
+	best := ""
+	for path := range lines {
+		if len(path) <= len(best) || !strings.HasPrefix(message, path) {
+			continue
+		}
+		if len(message) > len(path) {
+			switch message[len(path)] {
+			case '.', '[', ':', ' ':
+			default:
+				continue
+			}
+		}
+		best = path
+	}
+	if best != "" {
+		return best
+	}
+	for _, prefix := range []string{"apiVersion", "kind", "metadata", "spec"} {
+		if strings.HasPrefix(message, prefix) {
+			return prefix
+		}
+	}
+	return "document"
+}
+
+func validationPathToken(message string) string {
+	end := len(message)
+	for i, char := range message {
+		if char == ':' || char == ' ' {
+			end = i
+			break
+		}
+	}
+	token := strings.TrimRight(message[:end], ".,;")
+	for _, prefix := range []string{"apiVersion", "kind", "metadata", "spec"} {
+		if token == prefix || strings.HasPrefix(token, prefix+".") || strings.HasPrefix(token, prefix+"[") {
+			return token
+		}
+	}
+	return ""
+}
+
+func nearestValidationLine(path string, lines map[string]int) int {
+	for candidate := path; candidate != ""; candidate = parentValidationPath(candidate) {
+		if line := lines[candidate]; line > 0 {
+			return line
+		}
+	}
+	return 0
+}
+
+func parentValidationPath(path string) string {
+	if index := strings.LastIndex(path, "."); index >= 0 {
+		return path[:index]
+	}
+	if index := strings.LastIndex(path, "["); index >= 0 {
+		return path[:index]
+	}
+	return ""
+}
+
+// ValidateSourceFile reports every independent source and semantic error that
+// can be determined without resolving external artifacts.
+func ValidateSourceFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read source config: %w", err)
+	}
+	return validateSourceData(data)
+}
+
+func validateSourceData(data []byte) error {
+	var document yaml.Node
+	nodeDecoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := nodeDecoder.Decode(&document); err != nil {
+		return fmt.Errorf("decode cluster config: %w", err)
+	}
+	var trailing yaml.Node
+	if err := nodeDecoder.Decode(&trailing); err != io.EOF {
+		return fmt.Errorf("decode cluster config: multiple YAML documents")
+	}
+
+	lines := sourceLineIndex(&document)
+	issues := validateSourceFieldIssues(&document)
+	structuralPaths := map[string]struct{}{}
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, " must be ") {
+			structuralPaths[issue.Path] = struct{}{}
+		}
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var source SourceConfig
+	decodeErr := decoder.Decode(&source)
+	if decodeErr != nil {
+		for _, issue := range yamlDecodeIssues(decodeErr, lines) {
+			if _, covered := structuralPaths[issue.Path]; !covered {
+				issues = append(issues, issue)
+			}
+		}
+	}
+	if source.APIVersion != APIVersion && !validationPathCovered("apiVersion", structuralPaths) {
+		issues = append(issues, validationIssue{Path: "apiVersion", Message: fmt.Sprintf("apiVersion must be %s", APIVersion), Line: lines["apiVersion"]})
+	}
+	if source.Kind != Kind && !validationPathCovered("kind", structuralPaths) {
+		issues = append(issues, validationIssue{Path: "kind", Message: fmt.Sprintf("kind must be %s", Kind), Line: lines["kind"]})
+	}
+
+	normalized, semanticErrs := normalizeSourceIssues(source)
+	for _, issue := range validationIssuesFromErrors(semanticErrs, lines) {
+		if !validationPathCovered(issue.Path, structuralPaths) {
+			issues = append(issues, issue)
+		}
+	}
+	for _, issue := range validationIssuesFromErrors(validateResolvedSourceNodeIssues(normalized), lines) {
+		if !validationPathCovered(issue.Path, structuralPaths) {
+			issues = append(issues, issue)
+		}
+	}
+	return newValidationErrors(issues)
+}
+
+func validationPathCovered(path string, invalid map[string]struct{}) bool {
+	for candidate := range invalid {
+		if path == candidate || strings.HasPrefix(path, candidate+".") || strings.HasPrefix(path, candidate+"[") ||
+			strings.HasPrefix(candidate, path+".") || strings.HasPrefix(candidate, path+"[") {
+			return true
+		}
+	}
+	return false
+}
+
+var yamlLineError = regexp.MustCompile(`^line ([0-9]+): (.*)$`)
+
+func yamlDecodeIssues(err error, lines map[string]int) []validationIssue {
+	messages := []string{err.Error()}
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) {
+		messages = typeErr.Errors
+	}
+	var issues []validationIssue
+	for _, message := range messages {
+		line := 0
+		detail := strings.TrimSpace(message)
+		if match := yamlLineError.FindStringSubmatch(detail); len(match) == 3 {
+			line, _ = strconv.Atoi(match[1])
+			detail = match[2]
+		}
+		path := pathAtLine(line, lines)
+		if path == "" {
+			path = "document"
+		}
+		if strings.Contains(detail, "cannot unmarshal") {
+			detail = "value has the wrong type"
+		}
+		issues = append(issues, validationIssue{Path: path, Message: path + ": " + detail, Line: line})
+	}
+	return issues
+}
+
+func pathAtLine(line int, lines map[string]int) string {
+	best := ""
+	for path, candidateLine := range lines {
+		if candidateLine == line && len(path) > len(best) {
+			best = path
+		}
+	}
+	return best
+}
+
+func sourceLineIndex(document *yaml.Node) map[string]int {
+	lines := map[string]int{}
+	if document.Kind == yaml.DocumentNode && len(document.Content) == 1 {
+		document = document.Content[0]
+	}
+	indexYAMLLines(document, reflect.TypeOf(SourceConfig{}), "", lines)
+	return lines
+}
+
+func indexYAMLLines(node *yaml.Node, t reflect.Type, path string, lines map[string]int) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if valueType, ok := optionalValueType(t); ok {
+		t = valueType
+		for t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+	}
+	if path != "" && node.Line > 0 {
+		lines[path] = node.Line
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		if node.Kind != yaml.MappingNode {
+			return
+		}
+		fields := map[string]reflect.Type{}
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			name, _, visible := yamlField(field)
+			if visible {
+				fields[name] = field.Type
+			}
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			fieldPath := joinFieldPath(path, key.Value)
+			lines[fieldPath] = key.Line
+			if fieldType, ok := fields[key.Value]; ok {
+				indexYAMLLines(value, fieldType, fieldPath, lines)
+			}
+		}
+	case reflect.Map:
+		if node.Kind != yaml.MappingNode {
+			return
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+			fieldPath := joinFieldPath(path, key.Value)
+			quotedPath := fmt.Sprintf("%s[%q]", path, key.Value)
+			lines[fieldPath] = key.Line
+			lines[quotedPath] = key.Line
+			indexYAMLLines(value, t.Elem(), fieldPath, lines)
+		}
+	case reflect.Slice, reflect.Array:
+		if node.Kind != yaml.SequenceNode {
+			return
+		}
+		for i, item := range node.Content {
+			itemPath := sequenceItemPath(path, item, i)
+			lines[itemPath] = item.Line
+			indexYAMLLines(item, t.Elem(), itemPath, lines)
+		}
+	}
+}

--- a/internal/installer/manifest/manifest.go
+++ b/internal/installer/manifest/manifest.go
@@ -520,7 +520,13 @@ func validateBootstrapIntent(intent BootstrapIntent) error {
 	if err := validateBootstrapAccess(intent.Access); err != nil {
 		return err
 	}
-	for key, value := range intent.Labels {
+	labelKeys := make([]string, 0, len(intent.Labels))
+	for key := range intent.Labels {
+		labelKeys = append(labelKeys, key)
+	}
+	sort.Strings(labelKeys)
+	for _, key := range labelKeys {
+		value := intent.Labels[key]
 		if strings.TrimSpace(key) == "" {
 			return fmt.Errorf("node.bootstrap.labels contains an empty key")
 		}
@@ -561,6 +567,12 @@ func validateBootstrapIntent(intent BootstrapIntent) error {
 		}
 	}
 	return nil
+}
+
+// ValidateKubernetesMetadata validates operator-authored node labels and
+// taints without requiring the rest of a compiled bootstrap intent.
+func ValidateKubernetesMetadata(labels map[string]string, taints []NodeTaint) error {
+	return validateBootstrapIntent(BootstrapIntent{Labels: labels, Taints: taints})
 }
 
 func validateBootstrapAccess(access BootstrapAccess) error {


### PR DESCRIPTION
Collect independent structural and semantic ClusterConfig failures in one validation pass. Diagnostics are deterministically ordered, use public named-node paths, include YAML source lines where available, suppress cascades from malformed values, and avoid exposing internal compiler names.