### PR TITLE
security: bind mutations to enrolled nodes

### DIFF
--- a/cmd/katlctl/enroll.go
+++ b/cmd/katlctl/enroll.go
@@ -29,6 +29,8 @@ type contextSaveNodeReport struct {
 	Name               string `json:"name"`
 	ManagementEndpoint string `json:"managementEndpoint"`
 	Connected          bool   `json:"connected"`
+	EnrollmentID       string `json:"enrollmentID"`
+	MachineID          string `json:"machineID"`
 }
 
 type contextSaveReport struct {
@@ -198,6 +200,20 @@ func runContextSave(ctx context.Context, opts contextSaveOptions, stdout, stderr
 	}
 	clusterProfile := workstation.Cluster{Name: bundle.Manifest.ClusterName, ControlPlaneEndpoint: inv.ControlPlaneEndpoint}
 	report := contextSaveReport{APIVersion: "katl.dev/v1alpha1", Kind: "ContextSaveReport", Context: contextName, ConfigPath: configPath}
+	cfg := workstation.Config{}
+	if existing, loadErr := workstation.Load(configPath); loadErr == nil {
+		cfg = existing
+	} else if !errors.Is(loadErr, os.ErrNotExist) {
+		return loadErr
+	}
+	known := make(map[string]workstation.Node)
+	for _, cluster := range cfg.Clusters {
+		if cluster.Name == bundle.Manifest.ClusterName {
+			for _, node := range cluster.Nodes {
+				known[node.Name] = node
+			}
+		}
+	}
 
 	for _, node := range inv.Nodes {
 		endpoint := net.JoinHostPort(strings.TrimSpace(node.Address), "9443")
@@ -216,18 +232,22 @@ func runContextSave(ctx context.Context, opts contextSaveOptions, stdout, stderr
 		if strings.TrimSpace(status.GetMachineId()) == "" {
 			return fmt.Errorf("verify node %s management endpoint: agent did not report a machine identity", node.Name)
 		}
+		if strings.TrimSpace(status.GetEnrollmentId()) == "" {
+			return fmt.Errorf("verify node %s management endpoint: agent did not report an enrollment identity", node.Name)
+		}
+		if got := strings.TrimSpace(status.GetInventoryNodeName()); got != node.Name {
+			return fmt.Errorf("verify node %s management endpoint: address answered as enrolled node %q", node.Name, got)
+		}
+		if previous, ok := known[node.Name]; ok && previous.EnrollmentID != "" && (previous.EnrollmentID != status.GetEnrollmentId() || previous.MachineID != status.GetMachineId()) {
+			return fmt.Errorf("verify node %s management endpoint: enrolled identity changed; remove and deliberately recreate the context after reinstalling the node", node.Name)
+		}
 		clusterProfile.Nodes = append(clusterProfile.Nodes, workstation.Node{
 			Name: node.Name, ManagementEndpoint: endpoint, SystemRole: node.SystemRole,
+			EnrollmentID: status.GetEnrollmentId(), MachineID: status.GetMachineId(),
 		})
-		report.Nodes = append(report.Nodes, contextSaveNodeReport{Name: node.Name, ManagementEndpoint: endpoint, Connected: true})
+		report.Nodes = append(report.Nodes, contextSaveNodeReport{Name: node.Name, ManagementEndpoint: endpoint, Connected: true, EnrollmentID: status.GetEnrollmentId(), MachineID: status.GetMachineId()})
 	}
 
-	cfg := workstation.Config{}
-	if existing, loadErr := workstation.Load(configPath); loadErr == nil {
-		cfg = existing
-	} else if !errors.Is(loadErr, os.ErrNotExist) {
-		return loadErr
-	}
 	cfg = cfg.UpsertCluster(contextName, clusterProfile)
 	if err := workstation.Save(configPath, cfg); err != nil {
 		return err
@@ -241,5 +261,89 @@ func runContextSave(ctx context.Context, opts contextSaveOptions, stdout, stderr
 		return fmt.Errorf("encode context save report: %w", err)
 	}
 	_, err = stdout.Write(append(data, '\n'))
+	return err
+}
+
+type contextRebindOptions struct {
+	contextPath string
+	contextName string
+	nodeName    string
+	endpoint    string
+}
+
+func newContextRebindCommand(ctx context.Context, stdout, stderr io.Writer) *cobra.Command {
+	opts := contextRebindOptions{}
+	cmd := &cobra.Command{Use: "rebind", Short: "Verify an enrolled node and save its new management address", Args: cobra.NoArgs, RunE: func(*cobra.Command, []string) error {
+		_ = stderr
+		return runContextRebind(ctx, opts, stdout)
+	}}
+	cmd.Flags().StringVar(&opts.contextPath, "context-file", "", "workstation context file path")
+	cmd.Flags().Lookup("context-file").Hidden = true
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "saved context name")
+	cmd.Flags().StringVar(&opts.nodeName, "node", "", "enrolled inventory node name")
+	cmd.Flags().StringVar(&opts.endpoint, "endpoint", "", "new node address: IP, hostname, host:port, or tcp:// URL")
+	return cmd
+}
+
+func runContextRebind(ctx context.Context, opts contextRebindOptions, stdout io.Writer) error {
+	if strings.TrimSpace(opts.nodeName) == "" || strings.TrimSpace(opts.endpoint) == "" {
+		return fmt.Errorf("--node and --endpoint are required")
+	}
+	cfg, path, err := loadContexts(opts.contextPath)
+	if err != nil {
+		return err
+	}
+	topology, err := cfg.SelectedTopology(opts.contextName)
+	if err != nil {
+		return err
+	}
+	var expected workstation.TopologyNode
+	found := false
+	for _, node := range topology.Nodes {
+		if node.Name == strings.TrimSpace(opts.nodeName) {
+			expected, found = node, true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("node %q was not found in context %q", opts.nodeName, topology.ContextName)
+	}
+	target := managementTarget{nodeName: expected.Name, endpoint: expected.ManagementEndpoint, enrollmentID: expected.EnrollmentID, machineID: expected.MachineID}
+	if err := requireEnrolledTarget(target); err != nil {
+		return err
+	}
+	endpoint, err := normalizeManagementAddress(opts.endpoint)
+	if err != nil {
+		return err
+	}
+	conn, err := dialKatlcAgent(ctx, endpoint)
+	if err != nil {
+		return fmt.Errorf("connect to proposed address %s: %w", endpoint, err)
+	}
+	status, statusErr := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	closeErr := conn.Close()
+	if statusErr != nil {
+		return fmt.Errorf("verify proposed address %s: %w", endpoint, statusErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close proposed address %s: %w", endpoint, closeErr)
+	}
+	if err := verifyEnrolledStatus(target, status); err != nil {
+		return fmt.Errorf("verify proposed address %s: %w", endpoint, err)
+	}
+	for clusterIndex := range cfg.Clusters {
+		if cfg.Clusters[clusterIndex].Name != topology.ClusterName {
+			continue
+		}
+		for nodeIndex := range cfg.Clusters[clusterIndex].Nodes {
+			if cfg.Clusters[clusterIndex].Nodes[nodeIndex].Name == expected.Name {
+				cfg.Clusters[clusterIndex].Nodes[nodeIndex].ManagementEndpoint = endpoint
+			}
+		}
+	}
+	if err := workstation.Save(path, cfg); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(stdout, "Rebound %s from %s to %s after verifying enrollment and machine identity\n", expected.Name, expected.ManagementEndpoint, endpoint)
 	return err
 }

--- a/cmd/katlctl/enrollment_binding_test.go
+++ b/cmd/katlctl/enrollment_binding_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/katl-dev/katl/internal/bootstrap/cluster"
+	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
+)
+
+func TestSwappedManagementAddressRefusesConfigPlanAndMutation(t *testing.T) {
+	contextPath := writeEnrollmentContext(t)
+	changePath := filepath.Join(t.TempDir(), "change.yaml")
+	if err := os.WriteFile(changePath, []byte("apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"node", "apply", "--plan", "--context-file", contextPath, "--node", "cp-1", "--config", changePath},
+		{"node", "apply", "--context-file", contextPath, "--node", "cp-1", "--config", changePath, "--acknowledge-storage-wipe", "cp-1/data"},
+	} {
+		fake := swappedNodeClient()
+		installKatlcDial(t, nil, fake)
+		err := run(context.Background(), args, &bytes.Buffer{}, &bytes.Buffer{})
+		if err == nil || !strings.Contains(err.Error(), `address answered as enrolled node "cp-2"`) {
+			t.Fatalf("run(%v) error = %v, want swapped-address refusal", args, err)
+		}
+		if fake.validateRequest != nil || fake.submitRequest != nil || fake.stageRequest != nil || fake.applyRequest != nil {
+			t.Fatalf("swapped address reached acceptance: validate=%+v submit=%+v stage=%+v apply=%+v", fake.validateRequest, fake.submitRequest, fake.stageRequest, fake.applyRequest)
+		}
+	}
+}
+
+func TestSwappedManagementAddressRefusesShutdownAndWipePlan(t *testing.T) {
+	contextPath := writeEnrollmentContext(t)
+	swapped := swappedNodeClient()
+	installKatlcDial(t, nil, swapped)
+	err := run(context.Background(), []string{"node", "shutdown", "cp-1", "--context-file", contextPath, "--no-wait"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), `address answered as enrolled node "cp-2"`) {
+		t.Fatalf("shutdown error = %v, want swapped-address refusal", err)
+	}
+	if len(swapped.shutdownRequests) != 0 {
+		t.Fatalf("shutdown requests = %d, want none", len(swapped.shutdownRequests))
+	}
+
+	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{"cp-1": swapped})
+	oldConnector := newWipeClusterConnector
+	newWipeClusterConnector = func() cluster.AgentConnector { return connector }
+	t.Cleanup(func() { newWipeClusterConnector = oldConnector })
+	err = run(context.Background(), []string{"node", "wipe", "cp-1", "--context-file", contextPath, "--plan"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "node-local preflight failed") {
+		t.Fatalf("wipe plan error = %v, want identity preflight refusal", err)
+	}
+	if swapped.submitRequest != nil {
+		t.Fatalf("wipe plan submitted mutation: %+v", swapped.submitRequest)
+	}
+}
+
+func TestContextRebindVerifiesIdentityBeforeSavingAddress(t *testing.T) {
+	contextPath := writeEnrollmentContext(t)
+	matching := &fakeKatlcAgentClient{nodeStatus: enrolledStatus("cp-1", "enrollment-cp-1", "machine-cp-1")}
+	installKatlcDial(t, nil, matching)
+	var stdout bytes.Buffer
+	if err := run(context.Background(), []string{"context", "rebind", "--context-file", contextPath, "--node", "cp-1", "--endpoint", "10.0.0.91"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := workstation.Load(contextPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topology, err := cfg.SelectedTopology("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := topology.Nodes[0].ManagementEndpoint; got != "10.0.0.91:9443" {
+		t.Fatalf("rebound endpoint = %q", got)
+	}
+	if !strings.Contains(stdout.String(), "after verifying enrollment and machine identity") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestContextRebindRefusesDifferentEnrollment(t *testing.T) {
+	contextPath := writeEnrollmentContext(t)
+	wrong := &fakeKatlcAgentClient{nodeStatus: enrolledStatus("cp-1", "different-enrollment", "machine-cp-1")}
+	installKatlcDial(t, nil, wrong)
+	err := run(context.Background(), []string{"context", "rebind", "--context-file", contextPath, "--node", "cp-1", "--endpoint", "10.0.0.91"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "enrollment identity does not match") {
+		t.Fatalf("rebind error = %v, want identity mismatch", err)
+	}
+	cfg, loadErr := workstation.Load(contextPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	topology, selectErr := cfg.SelectedTopology("")
+	if selectErr != nil {
+		t.Fatal(selectErr)
+	}
+	if got := topology.Nodes[0].ManagementEndpoint; got != "10.0.0.11:9443" {
+		t.Fatalf("refused rebind changed endpoint to %q", got)
+	}
+}
+
+func swappedNodeClient() *fakeKatlcAgentClient {
+	return &fakeKatlcAgentClient{nodeStatus: enrolledStatus("cp-2", "enrollment-cp-2", "machine-cp-2")}
+}
+
+func enrolledStatus(name, enrollmentID, machineID string) *agentapi.NodeStatus {
+	return &agentapi.NodeStatus{
+		ApiVersion: operation.APIVersion, InventoryNodeName: name, EnrollmentId: enrollmentID,
+		MachineId: machineID, CurrentGenerationId: "generation-0", SupportedOperationKinds: []string{wipeClusterOperationKind},
+		Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"},
+	}
+}
+
+func writeEnrollmentContext(t *testing.T) string {
+	t.Helper()
+	return writeKatlctlConfig(t, `currentContext: lab
+contexts:
+- name: lab
+  cluster: lab
+clusters:
+- name: lab
+  nodes:
+  - name: cp-1
+    managementEndpoint: 10.0.0.11:9443
+    systemRole: control-plane
+    enrollmentID: enrollment-cp-1
+    machineID: machine-cp-1
+  - name: cp-2
+    managementEndpoint: 10.0.0.12:9443
+    systemRole: control-plane
+    enrollmentID: enrollment-cp-2
+    machineID: machine-cp-2
+`)
+}

--- a/cmd/katlctl/etcd.go
+++ b/cmd/katlctl/etcd.go
@@ -231,6 +231,13 @@ func getEtcdStatus(ctx context.Context, coordinator inventory.PlannedNode) (*age
 		return nil, fmt.Errorf("connect etcd coordinator %s: %w", coordinator.Name, err)
 	}
 	defer closeAgentConnection(conn)
+	nodeStatus, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("inspect node identity through %s: %w", coordinator.Name, err)
+	}
+	if err := verifyEnrolledStatus(managementTarget{nodeName: coordinator.Name, endpoint: conn.Endpoint, enrollmentID: coordinator.EnrollmentID, machineID: coordinator.MachineID}, nodeStatus); err != nil {
+		return nil, err
+	}
 	client, ok := conn.Client.(etcdStatusClient)
 	if !ok {
 		return nil, fmt.Errorf("node %s agent does not support etcd maintenance", coordinator.Name)
@@ -256,18 +263,24 @@ func submitEtcdRemoval(ctx context.Context, plan etcdRemovalPlan, timeout time.D
 	if err != nil {
 		return fmt.Errorf("status etcd coordinator %s: %w", plan.Coordinator.Name, err)
 	}
+	if err := verifyEnrolledStatus(managementTarget{nodeName: plan.Coordinator.Name, endpoint: conn.Endpoint, enrollmentID: plan.Coordinator.EnrollmentID, machineID: plan.Coordinator.MachineID}, nodeStatus); err != nil {
+		return err
+	}
 	requestID, err := clientRequestID("")
 	if err != nil {
 		return err
 	}
 	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-		ApiVersion:        operation.APIVersion,
-		Kind:              "SubmitOperationRequest",
-		ClientRequestId:   requestID,
-		OperationKind:     "etcd-member-remove",
-		Actor:             actor,
-		ExpectedMachineId: nodeStatus.GetMachineId(),
-		OperationTimeout:  timeout.String(),
+		ApiVersion:                  operation.APIVersion,
+		Kind:                        "SubmitOperationRequest",
+		ClientRequestId:             requestID,
+		OperationKind:               "etcd-member-remove",
+		Actor:                       actor,
+		ExpectedEnrollmentId:        nodeStatus.GetEnrollmentId(),
+		ExpectedInventoryNodeName:   nodeStatus.GetInventoryNodeName(),
+		ExpectedMachineId:           nodeStatus.GetMachineId(),
+		ExpectedCurrentGenerationId: nodeStatus.GetCurrentGenerationId(),
+		OperationTimeout:            timeout.String(),
 		EtcdMemberRemove: &agentapi.EtcdMemberRemoveOperationRequest{
 			TargetNodeName:      plan.Target.Name,
 			TargetMemberId:      plan.Member.GetId(),

--- a/cmd/katlctl/etcd_test.go
+++ b/cmd/katlctl/etcd_test.go
@@ -150,18 +150,24 @@ nodes:
   access: {method: agent}
   kubeadmConfig: {ref: control-plane, path: /etc/katl/kubeadm/control-plane/config.yaml, intent: control-plane}
   kubernetesVersion: v1.36.1
+  enrollmentID: enrollment-cp-1
+  machineID: machine-cp-1
 - name: cp-2
   address: 10.0.0.12
   systemRole: control-plane
   access: {method: agent}
   kubeadmConfig: {ref: control-plane, path: /etc/katl/kubeadm/control-plane/config.yaml, intent: control-plane}
   kubernetesVersion: v1.36.1
+  enrollmentID: enrollment-cp-2
+  machineID: machine-cp-2
 - name: cp-3
   address: 10.0.0.13
   systemRole: control-plane
   access: {method: agent}
   kubeadmConfig: {ref: control-plane, path: /etc/katl/kubeadm/control-plane/config.yaml, intent: control-plane}
   kubernetesVersion: v1.36.1
+  enrollmentID: enrollment-cp-3
+  machineID: machine-cp-3
 `
 	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
 		t.Fatal(err)

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -247,13 +247,18 @@ func runHostReboot(ctx context.Context, opts hostRebootOptions, stdout, stderr i
 		cancelRequest()
 		return err
 	}
+	if err := verifyEnrolledStatus(target, status); err != nil {
+		_ = conn.Close()
+		cancelRequest()
+		return err
+	}
 	generationID := strings.TrimSpace(status.GetBootTargetGenerationId())
 	if generationID == "" {
 		generationID = strings.TrimSpace(status.GetCurrentGenerationId())
 	}
 	previousAgentStart := status.GetAgentStartId()
 	recoveryRequirement := nodeRecoveryRequirementFor(status)
-	if err := requestNodeReboot(requestCtx, conn.Client, "katlctl node reboot", status.GetMachineId(), generationID); err != nil {
+	if err := requestNodeReboot(requestCtx, conn.Client, "katlctl node reboot", status, generationID); err != nil {
 		_ = conn.Close()
 		cancelRequest()
 		return fmt.Errorf("schedule reboot for %s: %w", node, err)
@@ -302,11 +307,19 @@ func runHostShutdown(ctx context.Context, opts hostShutdownOptions, stdout, stde
 		cancelRequest()
 		return fmt.Errorf("read status from %s: %w", node, err)
 	}
+	if err := verifyEnrolledStatus(target, status); err != nil {
+		_ = conn.Close()
+		cancelRequest()
+		return err
+	}
 	accepted, err := conn.Client.Shutdown(requestCtx, &agentapi.ShutdownRequest{
-		ApiVersion:        generation.APIVersion,
-		Kind:              "ShutdownRequest",
-		Actor:             "katlctl node shutdown",
-		ExpectedMachineId: status.GetMachineId(),
+		ApiVersion:                  generation.APIVersion,
+		Kind:                        "ShutdownRequest",
+		Actor:                       "katlctl node shutdown",
+		ExpectedEnrollmentId:        status.GetEnrollmentId(),
+		ExpectedInventoryNodeName:   status.GetInventoryNodeName(),
+		ExpectedMachineId:           status.GetMachineId(),
+		ExpectedCurrentGenerationId: status.GetCurrentGenerationId(),
 	})
 	_ = conn.Close()
 	cancelRequest()

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -125,6 +125,7 @@ func TestHostRebootDefaultAllowsBootDeadmanRecovery(t *testing.T) {
 }
 
 func TestHostRebootHonorsBootTargetAndWaits(t *testing.T) {
+	configPath := writeHostMutationContext(t, "machine-a")
 	fake := healthyHostClient("machine-a", "before", "generation-0")
 	fake.nodeStatus.BootTargetGenerationId = "generation-staged"
 	fake.onReboot = func(req *agentapi.RebootRequest) {
@@ -135,7 +136,7 @@ func TestHostRebootHonorsBootTargetAndWaits(t *testing.T) {
 	installKatlcDial(t, nil, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "reboot", "node-a", "--context-file", configPath, "--timeout", "1s"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	if len(fake.rebootRequests) != 1 {
@@ -154,11 +155,12 @@ func TestHostRebootHonorsBootTargetAndWaits(t *testing.T) {
 }
 
 func TestHostRebootNoWaitJSON(t *testing.T) {
+	configPath := writeHostMutationContext(t, "machine-a")
 	fake := healthyHostClient("machine-a", "before", "generation-0")
 	installKatlcDial(t, nil, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "reboot", "node-a", "--context-file", configPath, "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	var report hostRebootReport
@@ -171,6 +173,7 @@ func TestHostRebootNoWaitJSON(t *testing.T) {
 }
 
 func TestHostRebootReportsUnhealthyReturn(t *testing.T) {
+	configPath := writeHostMutationContext(t, "machine-a")
 	fake := healthyHostClient("machine-a", "before", "generation-0")
 	fake.onReboot = func(*agentapi.RebootRequest) {
 		fake.nodeStatus.AgentStartId = "after"
@@ -178,26 +181,28 @@ func TestHostRebootReportsUnhealthyReturn(t *testing.T) {
 	}
 	installKatlcDial(t, nil, fake)
 
-	err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &bytes.Buffer{}, &bytes.Buffer{})
+	err := run(context.Background(), []string{"node", "reboot", "node-a", "--context-file", configPath, "--timeout", "1s"}, &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "reported generation generation-0 unhealthy after reboot") {
 		t.Fatalf("run() error = %v, want unhealthy boot error", err)
 	}
 }
 
 func TestHostRebootTimesOutWhenAgentDoesNotRestart(t *testing.T) {
+	configPath := writeHostMutationContext(t, "machine-a")
 	fake := healthyHostClient("machine-a", "before", "generation-0")
 	installKatlcDial(t, nil, fake)
 	oldInterval := upgradeRebootPollInterval
 	upgradeRebootPollInterval = time.Millisecond
 	t.Cleanup(func() { upgradeRebootPollInterval = oldInterval })
 
-	err := run(context.Background(), []string{"node", "reboot", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "10ms"}, &bytes.Buffer{}, &bytes.Buffer{})
+	err := run(context.Background(), []string{"node", "reboot", "node-a", "--context-file", configPath, "--timeout", "10ms"}, &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil || !strings.Contains(err.Error(), "node node-a did not return healthy") {
 		t.Fatalf("run() error = %v, want reboot timeout", err)
 	}
 }
 
 func TestHostShutdownWaitsForManagementAPIToStop(t *testing.T) {
+	configPath := writeHostMutationContext(t, "machine-a")
 	fake := healthyHostClient("machine-a", "agent-a", "generation-0")
 	fake.onShutdown = func(*agentapi.ShutdownRequest) {
 		fake.nodeStatusErr = context.Canceled
@@ -208,7 +213,7 @@ func TestHostShutdownWaitsForManagementAPIToStop(t *testing.T) {
 	t.Cleanup(func() { hostShutdownPollInterval = oldInterval })
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "shutdown", "node-a", "--endpoint", "node-a.test:9443", "--timeout", "1s"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "shutdown", "node-a", "--context-file", configPath, "--timeout", "1s"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	if len(fake.shutdownRequests) != 1 {
@@ -227,11 +232,12 @@ func TestHostShutdownWaitsForManagementAPIToStop(t *testing.T) {
 }
 
 func TestHostShutdownNoWaitJSON(t *testing.T) {
+	configPath := writeHostMutationContext(t, "machine-a")
 	fake := healthyHostClient("machine-a", "agent-a", "generation-0")
 	installKatlcDial(t, nil, fake)
 
 	var stdout, stderr bytes.Buffer
-	if err := run(context.Background(), []string{"node", "shutdown", "node-a", "--endpoint", "node-a.test:9443", "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"node", "shutdown", "node-a", "--context-file", configPath, "--no-wait", "--output", "json"}, &stdout, &stderr); err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
 	var report hostShutdownReport
@@ -254,6 +260,8 @@ func healthyHostClient(machineID, agentStartID, generationID string) *fakeKatlcA
 	return &fakeKatlcAgentClient{
 		nodeStatus: &agentapi.NodeStatus{
 			MachineId:           machineID,
+			EnrollmentId:        "enrollment-" + machineID,
+			InventoryNodeName:   "node-a",
 			AgentStartId:        agentStartID,
 			CurrentGenerationId: generationID,
 			Kubernetes:          &agentapi.KubernetesStatus{State: "not-configured"},
@@ -265,6 +273,23 @@ func healthyHostClient(machineID, agentStartID, generationID string) *fakeKatlcA
 			HealthState:  generation.HealthStateHealthy,
 		},
 	}
+}
+
+func writeHostMutationContext(t *testing.T, machineID string) string {
+	t.Helper()
+	return writeKatlctlConfig(t, `currentContext: lab
+contexts:
+- name: lab
+  cluster: homelab
+clusters:
+- name: homelab
+  nodes:
+  - name: node-a
+    managementEndpoint: node-a.test:9443
+    systemRole: control-plane
+    enrollmentID: enrollment-`+machineID+`
+    machineID: `+machineID+`
+`)
 }
 
 func installKatlcDial(t *testing.T, inspect func(endpoint string), client agentapi.KatlcAgentClient) {

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -218,6 +219,9 @@ func currentClusterApplyNode(ctx context.Context, nodes []inventory.Node, nodeNa
 	if err != nil {
 		return nil, "", err
 	}
+	if err := verifyEnrolledStatus(managementTarget{nodeName: selected.Name, endpoint: cluster.AgentEndpoint(selected.Address, "9443"), enrollmentID: selected.EnrollmentID, machineID: selected.MachineID}, status); err != nil {
+		return nil, "", err
+	}
 	generationID := strings.TrimSpace(status.GetCurrentGenerationId())
 	if generationID == "" {
 		return nil, "", fmt.Errorf("agent did not report a current generation")
@@ -235,7 +239,6 @@ func rebootClusterApplyJoin(ctx context.Context, nodes []inventory.Node, nodeNam
 		return "", fmt.Errorf("agent did not report its current start identity")
 	}
 	recoveryRequirement := nodeRecoveryRequirementFor(status)
-	machineID := strings.TrimSpace(status.GetMachineId())
 	var selected inventory.Node
 	for _, node := range nodes {
 		if node.Name == nodeName {
@@ -248,7 +251,7 @@ func rebootClusterApplyJoin(ctx context.Context, nodes []inventory.Node, nodeNam
 	if err != nil {
 		return "", err
 	}
-	if err := requestNodeReboot(ctx, conn.Client, "katlctl cluster apply", machineID, generationID); err != nil {
+	if err := requestNodeReboot(ctx, conn.Client, "katlctl cluster apply", status, generationID); err != nil {
 		_ = conn.Close()
 		return "", fmt.Errorf("schedule joined generation reboot: %w", err)
 	}
@@ -353,6 +356,9 @@ func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConf
 		if err != nil {
 			return nil, fmt.Errorf("status %s: %w", node.Name, err)
 		}
+		if err := verifyEnrolledStatus(managementTarget{nodeName: node.Name, endpoint: cluster.AgentEndpoint(node.Address, "9443"), enrollmentID: node.EnrollmentID, machineID: node.MachineID}, status); err != nil {
+			return nil, err
+		}
 		generationID := strings.TrimSpace(opts.generationID)
 		if value := strings.TrimSpace(generations[node.Name]); value != "" {
 			generationID = value
@@ -390,7 +396,7 @@ func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConf
 	var summary []map[string]string
 	for i, t := range targets {
 		body := kubeadmControlPlaneConfigBody(opts, t.node, t.generation, uint32(i+1), uint32(len(targets)))
-		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-dry-run-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, DryRun: true, KubeadmControlPlaneConfig: body})
+		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-dry-run-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedEnrollmentId: t.node.EnrollmentID, ExpectedInventoryNodeName: t.node.Name, ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, DryRun: true, KubeadmControlPlaneConfig: body})
 		if err != nil {
 			return nil, fmt.Errorf("dry-run %s: %w", t.node.Name, err)
 		}
@@ -406,7 +412,7 @@ func runKubeadmConfigComponent(ctx context.Context, opts kubeadmControlPlaneConf
 		if err := clusterApplyProgress(opts.progress, "component=%s node=%s phase=apply status=started", opts.component, t.node.Name); err != nil {
 			return nil, err
 		}
-		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, KubeadmControlPlaneConfig: body})
+		accepted, err := t.conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-" + t.node.Name, OperationKind: "kubeadm-control-plane-config", Actor: "katlctl cluster apply", ExpectedEnrollmentId: t.node.EnrollmentID, ExpectedInventoryNodeName: t.node.Name, ExpectedMachineId: t.machine, ExpectedCurrentGenerationId: t.generation, KubeadmControlPlaneConfig: body})
 		if err != nil {
 			return nil, fmt.Errorf("submit %s: %w", t.node.Name, err)
 		}
@@ -449,9 +455,17 @@ func kubeadmConfigInventory(opts kubeadmControlPlaneConfigOptions) (inventory.In
 		return inventory.Inventory{}, fmt.Errorf("exactly one of --config or --inventory is required")
 	}
 	if inventoryPath != "" {
-		return loadInventory(inventoryPath)
+		inv, err := loadInventory(inventoryPath)
+		if err != nil {
+			return inventory.Inventory{}, err
+		}
+		return overlayWipeContext(inv, "", "")
 	}
-	return loadWipeInventory(configPath, "", opts.progress)
+	inv, err := loadWipeInventory(configPath, "", opts.progress)
+	if err != nil {
+		return inventory.Inventory{}, err
+	}
+	return overlayWipeContext(inv, "", "")
 }
 
 type activatedClusterConfig struct {
@@ -468,6 +482,19 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 	loaded, err := loadKatlConfig(opts.configPath, configBundleCreator, configbundle.PlanningInputs{}, nil)
 	if err != nil {
 		return activatedClusterConfig{}, err
+	}
+	for index := range nodes {
+		target, ok := enrolledTarget("", "", loaded.Bundle.Manifest.ClusterName, nodes[index].Name)
+		if !ok {
+			continue
+		}
+		host, _, splitErr := net.SplitHostPort(target.endpoint)
+		if splitErr != nil {
+			return activatedClusterConfig{}, fmt.Errorf("node %q enrolled management endpoint: %w", nodes[index].Name, splitErr)
+		}
+		nodes[index].Address = host
+		nodes[index].EnrollmentID = target.enrollmentID
+		nodes[index].MachineID = target.machineID
 	}
 	now := kubeadmConfigNow()
 	generationID := strings.TrimSpace(opts.generationID)
@@ -535,13 +562,18 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			_ = conn.Close()
 			return activatedClusterConfig{}, fmt.Errorf("status %s before cluster config apply: %w", node.Name, err)
 		}
+		if err := verifyEnrolledStatus(managementTarget{nodeName: node.Name, endpoint: cluster.AgentEndpoint(node.Address, "9443"), enrollmentID: node.EnrollmentID, machineID: node.MachineID}, status); err != nil {
+			_ = conn.Close()
+			return activatedClusterConfig{}, err
+		}
 		if err := validateClusterNodeLifecycle(node, status); err != nil {
 			_ = conn.Close()
 			return activatedClusterConfig{}, err
 		}
 		validation, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion: operation.APIVersion, Kind: "ValidateConfigRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
-			Actor: "katlctl cluster apply", ExpectedMachineId: status.MachineId, ApplyMode: generation.ApplyModeAuto,
+			Actor: "katlctl cluster apply", ExpectedEnrollmentId: status.EnrollmentId, ExpectedInventoryNodeName: status.InventoryNodeName,
+			ExpectedMachineId: status.MachineId, ExpectedCurrentGenerationId: status.CurrentGenerationId, ApplyMode: generation.ApplyModeAuto,
 			CandidateGenerationId: generationID, NodeName: node.Name, ConfigYaml: string(input.configYAML),
 			DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...),
 		})
@@ -669,7 +701,8 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 		}
 		accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
-			OperationKind: operationKind, Actor: "katlctl cluster apply", ExpectedMachineId: input.machineID, ExpectedCurrentGenerationId: input.currentGeneration,
+			OperationKind: operationKind, Actor: "katlctl cluster apply", ExpectedEnrollmentId: node.EnrollmentID, ExpectedInventoryNodeName: node.Name,
+			ExpectedMachineId: input.machineID, ExpectedCurrentGenerationId: input.currentGeneration,
 			ConfigApply: &agentapi.ConfigApplyOperationRequest{CandidateGenerationId: generationID, ApplyMode: generation.ApplyModeAuto, NodeName: node.Name, ConfigYaml: string(input.configYAML), DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...)},
 		})
 		if err != nil {

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,6 +19,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/operation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/katlctl/workstation"
 )
 
 func TestOrderControlPlanesChangesCoordinatorLast(t *testing.T) {
@@ -43,14 +45,14 @@ func TestKubeadmControlPlaneConfigBodyKeepsNodeLocalKubeletOffCluster(t *testing
 func TestRunKubeadmControlPlaneConfigSubmitsSerialCoordinatorLast(t *testing.T) {
 	root := t.TempDir()
 	inventoryPath := filepath.Join(root, "inventory.yaml")
-	content := "nodes:\n  - name: cp-3\n    address: 192.0.2.3\n    systemRole: control-plane\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n  - name: cp-2\n    address: 192.0.2.2\n    systemRole: control-plane\n"
+	content := "nodes:\n  - name: cp-3\n    address: 192.0.2.3\n    systemRole: control-plane\n    enrollmentID: enrollment-cp-3\n    machineID: machine-cp-3\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n    enrollmentID: enrollment-cp-1\n    machineID: machine-cp-1\n  - name: cp-2\n    address: 192.0.2.2\n    systemRole: control-plane\n    enrollmentID: enrollment-cp-2\n    machineID: machine-cp-2\n"
 	if err := os.WriteFile(inventoryPath, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	clients := map[string]*fakeKatlcAgentClient{}
 	for index, name := range []string{"cp-1", "cp-2", "cp-3"} {
 		payloadDigest := strings.Repeat(string(rune('a'+index)), 64)
-		clients[name] = &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine-" + name}, generation: &agentapi.Generation{GenerationId: "gen-2", CommitState: "committed", HealthState: "healthy", ConfigApply: &agentapi.ConfigApplyStatus{KubeadmActionRequired: true, SelectedKubeadmConfigName: "control-plane"}, Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: payloadDigest}}}, submitAccepted: &agentapi.OperationAccepted{OperationId: "op-" + name, RequestDigest: strings.Repeat("f", 64)}, operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded}}
+		clients[name] = &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine-" + name, CurrentGenerationId: "gen-2"}, generation: &agentapi.Generation{GenerationId: "gen-2", CommitState: "committed", HealthState: "healthy", ConfigApply: &agentapi.ConfigApplyStatus{KubeadmActionRequired: true, SelectedKubeadmConfigName: "control-plane"}, Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.1", Sha256: payloadDigest}}}, submitAccepted: &agentapi.OperationAccepted{OperationId: "op-" + name, RequestDigest: strings.Repeat("f", 64)}, operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded}}
 	}
 	byEndpoint := map[string]*fakeKatlcAgentClient{"192.0.2.1:9443": clients["cp-1"], "192.0.2.2:9443": clients["cp-2"], "192.0.2.3:9443": clients["cp-3"]}
 	previous := dialKatlcAgent
@@ -272,8 +274,8 @@ func TestRunClusterApplyManagementAddressOnlyTargetsWithoutMutation(t *testing.T
 	previousDial := dialKatlcAgent
 	defer func() { dialKatlcAgent = previousDial }()
 	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
-		if endpoint != "10.0.0.12:9443" {
-			t.Fatalf("management target = %q, want updated address", endpoint)
+		if endpoint != "10.0.0.11:9443" {
+			t.Fatalf("management target = %q, want enrolled address until an identity-verified rebind", endpoint)
 		}
 		return katlcAgentConnection{Client: client, Close: func() error { return nil }}, nil
 	}
@@ -357,6 +359,7 @@ func TestRunClusterApplyStagesPostBootstrapHostOnlyChangeAndRepeatsWithoutKubead
 }
 
 func TestActivateClusterConfigPlansOneFreshReplacementNode(t *testing.T) {
+	writeControlPlaneEnrollmentContext(t, "cp-1", "cp-2", "cp-3")
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")
 	source := configBundleSource() + `    - name: cp-2
@@ -503,6 +506,7 @@ func TestClusterConfigRejectionExplainsRoleChangeRecovery(t *testing.T) {
 }
 
 func TestRunClusterApplyRefreshesReplacementGenerationAfterJoin(t *testing.T) {
+	writeControlPlaneEnrollmentContext(t, "cp-1", "cp-2")
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")
 	source := configBundleSource() + `    - name: cp-2
@@ -596,6 +600,7 @@ func TestRunClusterApplyRefreshesReplacementGenerationAfterJoin(t *testing.T) {
 }
 
 func TestActivateClusterConfigRecognizesPendingJoinReboot(t *testing.T) {
+	writeControlPlaneEnrollmentContext(t, "cp-1", "cp-2")
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")
 	source := configBundleSource() + `    - name: cp-2
@@ -645,6 +650,7 @@ func TestActivateClusterConfigRecognizesPendingJoinReboot(t *testing.T) {
 }
 
 func TestActivateClusterConfigValidatesEveryNodeBeforeMutation(t *testing.T) {
+	writeControlPlaneEnrollmentContext(t, "cp-1", "cp-2")
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")
 	source := configBundleSource() + `    - name: cp-2
@@ -686,6 +692,7 @@ func TestActivateClusterConfigValidatesEveryNodeBeforeMutation(t *testing.T) {
 }
 
 func TestActivateClusterConfigDiscoversKubeProxyPhase(t *testing.T) {
+	writeControlPlaneEnrollmentContext(t, "cp-1")
 	root := t.TempDir()
 	configPath := filepath.Join(root, "cluster.yaml")
 	source := strings.Replace(configBundleSource(), "    version: v1.36.1\n", "    version: v1.36.1\n    kubeadm:\n      configFile: ./kubeadm.yaml\n", 1)
@@ -861,4 +868,19 @@ func TestOrderControlPlanesRejectsUnknownCoordinator(t *testing.T) {
 	if err == nil {
 		t.Fatal("orderControlPlanes() error = nil")
 	}
+}
+
+func writeControlPlaneEnrollmentContext(t *testing.T, names ...string) {
+	t.Helper()
+	nodes := make([]workstation.Node, 0, len(names))
+	for index, name := range names {
+		nodes = append(nodes, workstation.Node{
+			Name:               name,
+			ManagementEndpoint: fmt.Sprintf("10.0.0.%d:9443", index+11),
+			SystemRole:         inventory.RoleControlPlane,
+			EnrollmentID:       "enrollment-" + name,
+			MachineID:          "machine-" + name,
+		})
+	}
+	writeTestEnrollmentContext(t, "lab", nodes...)
 }

--- a/cmd/katlctl/kubernetes_upgrade.go
+++ b/cmd/katlctl/kubernetes_upgrade.go
@@ -214,6 +214,7 @@ func runKubernetesUpgrade(ctx context.Context, opts kubernetesUpgradeOptions, st
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
 			ClientRequestId: "katlctl-plan-" + target.candidate, OperationKind: "kubeadm-upgrade",
 			Actor: "katlctl kubernetes upgrade", ExpectedMachineId: target.machineID,
+			ExpectedEnrollmentId: target.node.EnrollmentID, ExpectedInventoryNodeName: target.node.Name,
 			ExpectedCurrentGenerationId: target.generation, DryRun: true, KubernetesSysextUpdate: body,
 		})
 		if err != nil {
@@ -266,7 +267,7 @@ func runKubernetesUpgradeTarget(ctx context.Context, topology workstation.Resolv
 	}
 	body := kubernetesUpgradeBody(target, image, localArtifact)
 	if localArtifact != nil {
-		localRef, err := stageKubernetesUpgradeArtifact(ctx, target.conn.Client, target.machineID, *localArtifact, target.node.Name, stderr)
+		localRef, err := stageKubernetesUpgradeArtifact(ctx, target.conn.Client, target, *localArtifact, target.node.Name, stderr)
 		if err != nil {
 			nodeReport.Result = "upload-failed"
 			return nodeReport, err
@@ -277,6 +278,7 @@ func runKubernetesUpgradeTarget(ctx context.Context, topology workstation.Resolv
 		ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest",
 		ClientRequestId: "katlctl-" + target.candidate, OperationKind: "kubeadm-upgrade",
 		Actor: "katlctl kubernetes upgrade", ExpectedMachineId: target.machineID,
+		ExpectedEnrollmentId: target.node.EnrollmentID, ExpectedInventoryNodeName: target.node.Name,
 		ExpectedCurrentGenerationId: target.generation, OperationTimeout: opts.timeout.String(),
 		KubernetesSysextUpdate: body,
 	})
@@ -456,6 +458,11 @@ func connectKubernetesUpgradeTargets(ctx context.Context, topology workstation.R
 			closeTargets()
 			return nil, fmt.Errorf("status node %s: %w", node.Name, err)
 		}
+		if err := verifyEnrolledStatus(managementTarget{nodeName: node.Name, endpoint: node.ManagementEndpoint, enrollmentID: node.EnrollmentID, machineID: node.MachineID}, status); err != nil {
+			_ = conn.Close()
+			closeTargets()
+			return nil, err
+		}
 		generationID := strings.TrimSpace(status.CurrentGenerationId)
 		if generationID == "" {
 			_ = conn.Close()
@@ -590,11 +597,12 @@ func kubernetesUpgradeArtifactLogicalPath(localRef string) string {
 	return filepath.ToSlash(filepath.Join("/var/lib/katl/artifacts", localRef))
 }
 
-func stageKubernetesUpgradeArtifact(ctx context.Context, client agentapi.KatlcAgentClient, machineID string, local kubernetesUpgradeArtifact, node string, stderr io.Writer) (string, error) {
+func stageKubernetesUpgradeArtifact(ctx context.Context, client agentapi.KatlcAgentClient, target kubernetesUpgradeTarget, local kubernetesUpgradeArtifact, node string, stderr io.Writer) (string, error) {
 	return stageLocalUpgradeArtifact(ctx, client, localArtifactUpload{
 		Path: local.Path, Label: "Kubernetes", Version: local.PayloadVersion,
 		Kind: "StageKubernetesUpgradeArtifactRequest", Actor: "katlctl kubernetes upgrade",
-		MachineID: machineID, SHA256: local.SHA256, SizeBytes: local.SizeBytes,
+		MachineID: target.machineID, EnrollmentID: target.node.EnrollmentID, InventoryNodeName: target.node.Name, CurrentGenerationID: target.generation,
+		SHA256: local.SHA256, SizeBytes: local.SizeBytes,
 		LocalRef: kubernetesUpgradeArtifactLocalRef(local.SHA256), Node: node,
 	}, stderr)
 }

--- a/cmd/katlctl/kubernetes_upgrade_test.go
+++ b/cmd/katlctl/kubernetes_upgrade_test.go
@@ -28,7 +28,7 @@ func TestKubernetesUpgradePlansAndRunsControlPlanesBeforeWorkers(t *testing.T) {
 	configPath := filepath.Join(root, "katlctl.yaml")
 	var nodes strings.Builder
 	for _, node := range []struct{ name, endpoint, role string }{{"worker-1", "192.0.2.4:9443", "worker"}, {"cp-2", "192.0.2.2:9443", "control-plane"}, {"cp-1", "192.0.2.1:9443", "control-plane"}} {
-		_, _ = nodes.WriteString("      - name: " + node.name + "\n        managementEndpoint: " + node.endpoint + "\n        systemRole: " + node.role + "\n")
+		_, _ = nodes.WriteString("      - name: " + node.name + "\n        managementEndpoint: " + node.endpoint + "\n        systemRole: " + node.role + "\n        enrollmentID: enrollment-" + node.name + "\n        machineID: machine-" + node.name + "\n")
 	}
 	config := "currentContext: lab\ncontexts:\n  - name: lab\n    cluster: home\nclusters:\n  - name: home\n    controlPlaneEndpoint: 192.0.2.10:6443\n    nodes:\n" + nodes.String()
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
@@ -125,10 +125,10 @@ func TestKubernetesUpgradeBundleUsesReleaseCompatibility(t *testing.T) {
 func TestKubernetesUpgradePlanDoesNotExecute(t *testing.T) {
 	root := t.TempDir()
 	inv := filepath.Join(root, "inventory.yaml")
-	if err := os.WriteFile(inv, []byte("nodes:\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n    access:\n      method: agent\n"), 0o600); err != nil {
+	if err := os.WriteFile(inv, []byte("nodes:\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n    access:\n      method: agent\n    enrollmentID: enrollment-cp-1\n    machineID: machine\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	client := &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine", CurrentGenerationId: "gen-1"}, generation: &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0"}}}}
+	client := &fakeKatlcAgentClient{nodeStatus: &agentapi.NodeStatus{MachineId: "machine", EnrollmentId: "enrollment-cp-1", InventoryNodeName: "cp-1", CurrentGenerationId: "gen-1"}, generation: &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0"}}}}
 	previous := dialKatlcAgent
 	defer func() { dialKatlcAgent = previous }()
 	dialKatlcAgent = func(context.Context, string) (katlcAgentConnection, error) {
@@ -228,7 +228,8 @@ func TestKubernetesUpgradeRejectsMismatchedLocalArtifactVersion(t *testing.T) {
 func TestKubernetesUpgradeLocalArtifactExplainsAgentUpgradeRequirement(t *testing.T) {
 	local := writeKubernetesUpgradeArtifact(t, "v1.36.2")
 	client := &fakeKatlcAgentClient{stageArtifactErr: status.Error(codes.Unimplemented, "old agent")}
-	_, err := stageKubernetesUpgradeArtifact(context.Background(), client, "machine", local, "cp-1", io.Discard)
+	target := kubernetesUpgradeTarget{machineID: "machine", generation: "generation-1", node: workstation.TopologyNode{Name: "cp-1", EnrollmentID: "enrollment"}}
+	_, err := stageKubernetesUpgradeArtifact(context.Background(), client, target, local, "cp-1", io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "upgrade KatlOS to a build with local Kubernetes artifact support") {
 		t.Fatalf("stageKubernetesUpgradeArtifact() error = %v", err)
 	}
@@ -298,7 +299,7 @@ func TestKubernetesUpgradeStopsAfterNodeFailure(t *testing.T) {
 	var nodes strings.Builder
 	clients := map[string]*fakeKatlcAgentClient{}
 	for _, node := range []struct{ name, endpoint, role string }{{"cp-1", "192.0.2.1:9443", "control-plane"}, {"cp-2", "192.0.2.2:9443", "control-plane"}, {"worker-1", "192.0.2.3:9443", "worker"}} {
-		_, _ = nodes.WriteString("      - name: " + node.name + "\n        managementEndpoint: " + node.endpoint + "\n        systemRole: " + node.role + "\n")
+		_, _ = nodes.WriteString("      - name: " + node.name + "\n        managementEndpoint: " + node.endpoint + "\n        systemRole: " + node.role + "\n        enrollmentID: enrollment-" + node.name + "\n        machineID: machine-" + node.name + "\n")
 		client := &fakeKatlcAgentClient{
 			nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-" + node.name, AgentStartId: "before-" + node.name, CurrentGenerationId: "gen-1"},
 			generation:     &agentapi.Generation{GenerationId: "gen-1", CommitState: "committed", BootState: "good", HealthState: "healthy", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", PayloadVersion: "v1.36.0"}}},
@@ -336,7 +337,7 @@ func TestKubernetesUpgradeStopsAfterNodeFailure(t *testing.T) {
 func writeKubernetesUpgradeInventory(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "inventory.yaml")
-	if err := os.WriteFile(path, []byte("nodes:\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n    access:\n      method: agent\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte("nodes:\n  - name: cp-1\n    address: 192.0.2.1\n    systemRole: control-plane\n    access:\n      method: agent\n    enrollmentID: enrollment-cp-1\n    machineID: machine\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return path
@@ -345,7 +346,7 @@ func writeKubernetesUpgradeInventory(t *testing.T) string {
 func writeKubernetesUpgradeContext(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "katlctl.yaml")
-	config := "currentContext: lab\ncontexts:\n  - name: lab\n    cluster: home\nclusters:\n  - name: home\n    controlPlaneEndpoint: 192.0.2.1:6443\n    nodes:\n      - name: cp-1\n        managementEndpoint: 192.0.2.1:9443\n        systemRole: control-plane\n"
+	config := "currentContext: lab\ncontexts:\n  - name: lab\n    cluster: home\nclusters:\n  - name: home\n    controlPlaneEndpoint: 192.0.2.1:6443\n    nodes:\n      - name: cp-1\n        managementEndpoint: 192.0.2.1:9443\n        systemRole: control-plane\n        enrollmentID: enrollment-cp-1\n        machineID: machine\n"
 	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +355,7 @@ func writeKubernetesUpgradeContext(t *testing.T) string {
 
 func healthyKubernetesUpgradeClient() *fakeKatlcAgentClient {
 	return &fakeKatlcAgentClient{
-		nodeStatus: &agentapi.NodeStatus{MachineId: "machine", CurrentGenerationId: "gen-1"},
+		nodeStatus: &agentapi.NodeStatus{MachineId: "machine", EnrollmentId: "enrollment-cp-1", InventoryNodeName: "cp-1", CurrentGenerationId: "gen-1"},
 		generation: &agentapi.Generation{
 			GenerationId: "gen-1", CommitState: "committed", BootState: "good", HealthState: "healthy",
 			RuntimeArchitecture: "x86_64",

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -139,6 +139,7 @@ Start with "katlctl install discover" for a waiting installer or
 
 	contextCmd := &cobra.Command{Use: "context", Short: "Save and inspect workstation contexts"}
 	contextCmd.AddCommand(newContextSaveCommand(ctx, stdout, stderr))
+	contextCmd.AddCommand(newContextRebindCommand(ctx, stdout, stderr))
 	contextCmd.AddCommand(newConfigPathCommand(stdout, stderr))
 	contextCmd.AddCommand(newContextListCommand(stdout, stderr))
 	contextCmd.AddCommand(newContextCurrentCommand(stdout, stderr))
@@ -210,6 +211,7 @@ func setMinimumInvocationExamples(root *cobra.Command) {
 		"katlctl cluster etcd members":        "katlctl cluster etcd members --config cluster.yaml",
 		"katlctl cluster etcd remove":         "katlctl cluster etcd remove cp-3 --member-id MEMBER_ID --config cluster.yaml",
 		"katlctl context save":                "katlctl context save --config cluster.yaml",
+		"katlctl context rebind":              "katlctl context rebind --node cp-1 --endpoint 192.0.2.51",
 		"katlctl cluster bootstrap":           "katlctl cluster bootstrap --config cluster.yaml",
 		"katlctl cluster wipe":                "katlctl cluster wipe --config cluster.yaml --all",
 		"katlctl kubernetes":                  "katlctl kubernetes upgrade v1.36.1 --config cluster.yaml",
@@ -383,6 +385,9 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 	if err != nil {
 		return fmt.Errorf("read node status: %w", err)
 	}
+	if err := verifyEnrolledStatus(target, status); err != nil {
+		return err
+	}
 	recoveryRequirement := nodeRecoveryRequirementFor(status)
 	current, err := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: status.GetCurrentGenerationId()})
 	if err != nil {
@@ -427,7 +432,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		return writeHostUpgradeReport(stdout, opts.output, hostUpgradeReport{Node: node, Version: opts.version, Image: image, Result: operation.ResultSucceeded, BootHealth: generation.HealthStateHealthy, Kubernetes: recovery.State})
 	}
 	if localArtifact != nil && !opts.plan {
-		localRef, err := stageHostUpgradeArtifact(ctx, conn.Client, strings.TrimSpace(opts.actor), status.GetMachineId(), *localArtifact, target.nodeName, stderr)
+		localRef, err := stageHostUpgradeArtifact(ctx, conn.Client, strings.TrimSpace(opts.actor), status, *localArtifact, target.nodeName, stderr)
 		if err != nil {
 			return err
 		}
@@ -442,6 +447,8 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		ClientRequestId:             requestID,
 		OperationKind:               "host-upgrade",
 		Actor:                       strings.TrimSpace(opts.actor),
+		ExpectedEnrollmentId:        status.GetEnrollmentId(),
+		ExpectedInventoryNodeName:   status.GetInventoryNodeName(),
 		ExpectedMachineId:           status.GetMachineId(),
 		ExpectedCurrentGenerationId: status.GetCurrentGenerationId(),
 		DryRun:                      opts.plan,
@@ -475,7 +482,7 @@ func runHostUpgrade(ctx context.Context, opts hostUpgradeOptions, stdout, stderr
 		return err
 	}
 	agentStart := status.GetAgentStartId()
-	if err := requestNodeReboot(ctx, conn.Client, opts.actor, status.GetMachineId(), request.CandidateGenerationID); err != nil {
+	if err := requestNodeReboot(ctx, conn.Client, opts.actor, status, request.CandidateGenerationID); err != nil {
 		report.Result = "staged"
 		_ = writeHostUpgradeReport(stdout, opts.output, report)
 		return fmt.Errorf("reboot node %s: %w", report.Node, err)
@@ -599,22 +606,26 @@ func hostUpgradeArtifactLocalRef(sha256 string) string {
 }
 
 type localArtifactUpload struct {
-	Path      string
-	Label     string
-	Version   string
-	Kind      string
-	Actor     string
-	MachineID string
-	SHA256    string
-	SizeBytes uint64
-	LocalRef  string
-	Node      string
+	Path                string
+	Label               string
+	Version             string
+	Kind                string
+	Actor               string
+	MachineID           string
+	EnrollmentID        string
+	InventoryNodeName   string
+	CurrentGenerationID string
+	SHA256              string
+	SizeBytes           uint64
+	LocalRef            string
+	Node                string
 }
 
-func stageHostUpgradeArtifact(ctx context.Context, client agentapi.KatlcAgentClient, actor, machineID string, artifact hostUpgradeArtifact, node string, stderr io.Writer) (string, error) {
+func stageHostUpgradeArtifact(ctx context.Context, client agentapi.KatlcAgentClient, actor string, status *agentapi.NodeStatus, artifact hostUpgradeArtifact, node string, stderr io.Writer) (string, error) {
 	return stageLocalUpgradeArtifact(ctx, client, localArtifactUpload{
 		Path: artifact.Path, Label: "KatlOS", Version: artifact.Version,
-		Kind: "StageHostUpgradeArtifactRequest", Actor: actor, MachineID: machineID,
+		Kind: "StageHostUpgradeArtifactRequest", Actor: actor, MachineID: status.GetMachineId(),
+		EnrollmentID: status.GetEnrollmentId(), InventoryNodeName: status.GetInventoryNodeName(), CurrentGenerationID: status.GetCurrentGenerationId(),
 		SHA256: artifact.SHA256, SizeBytes: artifact.SizeBytes,
 		LocalRef: hostUpgradeArtifactLocalRef(artifact.SHA256), Node: node,
 	}, stderr)
@@ -647,6 +658,9 @@ func stageLocalUpgradeArtifact(ctx context.Context, client agentapi.KatlcAgentCl
 				request.Kind = upload.Kind
 				request.Actor = upload.Actor
 				request.ExpectedMachineId = upload.MachineID
+				request.ExpectedEnrollmentId = upload.EnrollmentID
+				request.ExpectedInventoryNodeName = upload.InventoryNodeName
+				request.ExpectedCurrentGenerationId = upload.CurrentGenerationID
 				request.Sha256 = upload.SHA256
 				request.SizeBytes = upload.SizeBytes
 				first = false
@@ -788,7 +802,8 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 	if connector == nil {
 		return fmt.Errorf("katlc agent connector is required")
 	}
-	if _, err := preflightWipeCluster(ctx, connector, &report, targets); err != nil {
+	statuses, err := preflightWipeCluster(ctx, connector, &report, targets)
+	if err != nil {
 		if printErr := printWipeClusterReport(stdout, report); printErr != nil {
 			return printErr
 		}
@@ -798,7 +813,7 @@ func runWipeClusterOptions(ctx context.Context, opts wipeClusterOptions, stdout,
 		report.NodeLocalOperations = plannedWipeClusterOperations(targets)
 		return printWipeClusterReport(stdout, report)
 	}
-	submitErr := submitWipeCluster(ctx, connector, &report, targets, requestID, strings.TrimSpace(opts.timeout), opts.noWait, waitTimeout, stderr)
+	submitErr := submitWipeCluster(ctx, connector, &report, targets, statuses, requestID, strings.TrimSpace(opts.timeout), opts.noWait, waitTimeout, stderr)
 	if submitErr == nil {
 		report.NextAction = wipeNextAction(opts.noWait)
 	}
@@ -825,10 +840,12 @@ func resolveWipeClusterTargets(opts wipeClusterOptions, stderr io.Writer) ([]inv
 				return nil, false, fmt.Errorf("node %q management endpoint: %w", node.Name, err)
 			}
 			plan.Nodes = append(plan.Nodes, inventory.PlannedNode{
-				Name:       node.Name,
-				Address:    host,
-				SystemRole: node.SystemRole,
-				Access:     inventory.Access{Method: "agent"},
+				Name:         node.Name,
+				Address:      host,
+				SystemRole:   node.SystemRole,
+				Access:       inventory.Access{Method: "agent"},
+				EnrollmentID: node.EnrollmentID,
+				MachineID:    node.MachineID,
 			})
 		}
 		return wipeClusterTargets(plan, opts.all, opts.selectedNodes.values)
@@ -1022,7 +1039,7 @@ func runWipeNodeOptions(ctx context.Context, opts wipeNodeOptions, stdout, stder
 		}
 	}
 
-	submitErr := submitWipeCluster(ctx, connector, &report.wipeClusterReport, []inventory.PlannedNode{target}, requestID, strings.TrimSpace(opts.timeout), opts.noWait, waitTimeout, stderr)
+	submitErr := submitWipeCluster(ctx, connector, &report.wipeClusterReport, []inventory.PlannedNode{target}, statuses, requestID, strings.TrimSpace(opts.timeout), opts.noWait, waitTimeout, stderr)
 	if submitErr == nil {
 		report.NextAction = wipeNextAction(opts.noWait)
 	}
@@ -1055,6 +1072,7 @@ func wipeNodeInventory(opts wipeNodeOptions, stderr io.Writer) (inventory.Invent
 		}
 		inv.Nodes = append(inv.Nodes, inventory.Node{
 			Name: node.Name, Address: host, SystemRole: node.SystemRole, Access: inventory.Access{Method: "agent"},
+			EnrollmentID: node.EnrollmentID, MachineID: node.MachineID,
 		})
 	}
 	return inv, nil
@@ -1079,10 +1097,12 @@ func resolveWipeNodeTarget(opts wipeNodeOptions, stderr io.Writer) (inventory.Pl
 				return inventory.PlannedNode{}, false, fmt.Errorf("node %q management endpoint: %w", node.Name, err)
 			}
 			return inventory.PlannedNode{
-				Name:       node.Name,
-				Address:    host,
-				SystemRole: node.SystemRole,
-				Access:     inventory.Access{Method: "agent"},
+				Name:         node.Name,
+				Address:      host,
+				SystemRole:   node.SystemRole,
+				Access:       inventory.Access{Method: "agent"},
+				EnrollmentID: node.EnrollmentID,
+				MachineID:    node.MachineID,
 			}, len(topology.Nodes) > 1, nil
 		}
 		return inventory.PlannedNode{}, false, fmt.Errorf("node %q is not in context %q", opts.selectedNodes.values[0], topology.ContextName)
@@ -1124,16 +1144,37 @@ func loadWipeInventory(configPath, inventoryPath string, stderr io.Writer) (inve
 	if err != nil {
 		return inventory.Inventory{}, err
 	}
-	return config.Bundle.Manifest.Cluster.BootstrapInventory, nil
+	inv := config.Bundle.Manifest.Cluster.BootstrapInventory
+	for index := range inv.Nodes {
+		enrolled, ok := enrolledTarget("", "", config.Bundle.Manifest.ClusterName, inv.Nodes[index].Name)
+		if !ok {
+			continue
+		}
+		host, _, splitErr := net.SplitHostPort(enrolled.endpoint)
+		if splitErr != nil {
+			return inventory.Inventory{}, splitErr
+		}
+		inv.Nodes[index].Address = host
+		inv.Nodes[index].EnrollmentID = enrolled.enrollmentID
+		inv.Nodes[index].MachineID = enrolled.machineID
+	}
+	return inv, nil
 }
 
 func overlayWipeContext(inv inventory.Inventory, configPath, contextName string) (inventory.Inventory, error) {
 	if strings.TrimSpace(configPath) == "" && strings.TrimSpace(contextName) == "" {
-		return inv, nil
+		complete := len(inv.Nodes) > 0
+		for _, node := range inv.Nodes {
+			complete = complete && strings.TrimSpace(node.EnrollmentID) != "" && strings.TrimSpace(node.MachineID) != ""
+		}
+		if complete {
+			return inv, nil
+		}
+		return inventory.Inventory{}, fmt.Errorf("inventory nodes are not enrolled on this workstation; run 'katlctl context save --config cluster.yaml'")
 	}
 	topology, err := workstation.ResolveTopology(workstation.ResolveRequest{ConfigPath: strings.TrimSpace(configPath), ContextName: strings.TrimSpace(contextName)})
 	if err != nil {
-		return inventory.Inventory{}, err
+		return inventory.Inventory{}, fmt.Errorf("resolve enrolled node identities: %w", err)
 	}
 	byName := make(map[string]workstation.TopologyNode, len(topology.Nodes))
 	for _, node := range topology.Nodes {
@@ -1150,6 +1191,8 @@ func overlayWipeContext(inv inventory.Inventory, configPath, contextName string)
 		}
 		inv.Nodes[index].Address = host
 		inv.Nodes[index].Access = inventory.Access{Method: "agent"}
+		inv.Nodes[index].EnrollmentID = node.EnrollmentID
+		inv.Nodes[index].MachineID = node.MachineID
 	}
 	return inv, nil
 }
@@ -1324,7 +1367,12 @@ func preflightWipeCluster(ctx context.Context, connector cluster.AgentConnector,
 		if err != nil {
 			result.Diagnostics = append(result.Diagnostics, inventory.Redact(err.Error()))
 		} else {
-			statuses[node.Name] = status
+			target := managementTarget{nodeName: node.Name, endpoint: conn.Endpoint, enrollmentID: node.EnrollmentID, machineID: node.MachineID}
+			if verifyErr := verifyEnrolledStatus(target, status); verifyErr != nil {
+				result.Diagnostics = append(result.Diagnostics, inventory.Redact(verifyErr.Error()))
+			} else {
+				statuses[node.Name] = status
+			}
 			result.Diagnostics = append(result.Diagnostics, wipeClusterStatusDiagnostics(status)...)
 		}
 		if closeErr != nil {
@@ -1391,7 +1439,7 @@ func wipeNodeOperation(node inventory.PlannedNode) wipeClusterNodeLocalOperation
 	return operation
 }
 
-func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, report *wipeClusterReport, targets []inventory.PlannedNode, clientRequestID string, timeout string, noWait bool, waitTimeout time.Duration, stderr io.Writer) error {
+func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, report *wipeClusterReport, targets []inventory.PlannedNode, statuses map[string]*agentapi.NodeStatus, clientRequestID string, timeout string, noWait bool, waitTimeout time.Duration, stderr io.Writer) error {
 	var failures []string
 	for _, node := range targets {
 		result := wipeClusterNodeResult{Node: node.Name}
@@ -1411,13 +1459,25 @@ func submitWipeCluster(ctx context.Context, connector cluster.AgentConnector, re
 		if actor == "" {
 			actor = "katlctl cluster wipe"
 		}
+		status := statuses[node.Name]
+		if status == nil {
+			result.Diagnostics = append(result.Diagnostics, "verified node status is missing")
+			report.Nodes = append(report.Nodes, result)
+			failures = append(failures, node.Name)
+			_ = closeAgentConnection(conn)
+			continue
+		}
 		accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-			ApiVersion:       operation.APIVersion,
-			Kind:             "SubmitOperationRequest",
-			ClientRequestId:  clientRequestID,
-			OperationKind:    operationSpec.OperationKind,
-			Actor:            actor,
-			OperationTimeout: timeout,
+			ApiVersion:                  operation.APIVersion,
+			Kind:                        "SubmitOperationRequest",
+			ClientRequestId:             clientRequestID,
+			OperationKind:               operationSpec.OperationKind,
+			Actor:                       actor,
+			ExpectedEnrollmentId:        status.GetEnrollmentId(),
+			ExpectedInventoryNodeName:   status.GetInventoryNodeName(),
+			ExpectedMachineId:           status.GetMachineId(),
+			ExpectedCurrentGenerationId: status.GetCurrentGenerationId(),
+			OperationTimeout:            timeout,
 			DestructiveReset: &agentapi.DestructiveResetOperationRequest{
 				InventoryNodeName:      operationSpec.Node,
 				ResetScope:             operationSpec.ResetScope,
@@ -2207,12 +2267,23 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		return err
 	}
 	defer conn.Close()
+	status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return fmt.Errorf("read status from %s: %w", target.nodeName, err)
+	}
+	if err := verifyEnrolledStatus(target, status); err != nil {
+		return err
+	}
 	if opts.plan {
 		result, err := conn.Client.ValidateConfig(ctx, &agentapi.ValidateConfigRequest{
 			ApiVersion:                         operation.APIVersion,
 			Kind:                               "ValidateConfigRequest",
 			ClientRequestId:                    requestID,
 			Actor:                              opts.actor,
+			ExpectedEnrollmentId:               target.enrollmentID,
+			ExpectedInventoryNodeName:          target.nodeName,
+			ExpectedMachineId:                  target.machineID,
+			ExpectedCurrentGenerationId:        status.GetCurrentGenerationId(),
 			ApplyMode:                          opts.mode,
 			CandidateGenerationId:              opts.candidateGeneration,
 			NodeName:                           opts.nodeConfig.nodeName,
@@ -2251,6 +2322,10 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		Kind:                               "GenerationApplyRequest",
 		ClientRequestId:                    requestID,
 		Actor:                              opts.actor,
+		ExpectedEnrollmentId:               target.enrollmentID,
+		ExpectedInventoryNodeName:          target.nodeName,
+		ExpectedMachineId:                  target.machineID,
+		ExpectedCurrentGenerationId:        status.GetCurrentGenerationId(),
 		CandidateGenerationId:              opts.candidateGeneration,
 		NodeName:                           opts.nodeConfig.nodeName,
 		ConfigYaml:                         string(configYAML),
@@ -2268,6 +2343,10 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			Kind:                               "ValidateConfigRequest",
 			ClientRequestId:                    requestID,
 			Actor:                              opts.actor,
+			ExpectedEnrollmentId:               target.enrollmentID,
+			ExpectedInventoryNodeName:          target.nodeName,
+			ExpectedMachineId:                  target.machineID,
+			ExpectedCurrentGenerationId:        status.GetCurrentGenerationId(),
 			ApplyMode:                          requestedMode,
 			CandidateGenerationId:              opts.candidateGeneration,
 			NodeName:                           opts.nodeConfig.nodeName,
@@ -2305,11 +2384,15 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			return err
 		}
 		accepted, err = conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-			ApiVersion:      operation.APIVersion,
-			Kind:            "SubmitOperationRequest",
-			ClientRequestId: requestID,
-			OperationKind:   operationKind,
-			Actor:           opts.actor,
+			ApiVersion:                  operation.APIVersion,
+			Kind:                        "SubmitOperationRequest",
+			ClientRequestId:             requestID,
+			OperationKind:               operationKind,
+			Actor:                       opts.actor,
+			ExpectedEnrollmentId:        target.enrollmentID,
+			ExpectedInventoryNodeName:   target.nodeName,
+			ExpectedMachineId:           target.machineID,
+			ExpectedCurrentGenerationId: status.GetCurrentGenerationId(),
 			ConfigApply: &agentapi.ConfigApplyOperationRequest{
 				CandidateGenerationId:              opts.candidateGeneration,
 				ApplyMode:                          requestedMode,
@@ -2803,7 +2886,22 @@ func bootstrapInventory(opts clusterBootstrapOptions, stderr io.Writer) (invento
 	if !config.Source && strings.TrimSpace(opts.kubernetesBundle) != "" {
 		return inventory.Inventory{}, "", fmt.Errorf("--kubernetes-bundle conflicts with the selection embedded in the compiled config bundle")
 	}
-	return config.Bundle.Manifest.Cluster.BootstrapInventory, config.Bundle.Manifest.ClusterName, nil
+	inv := config.Bundle.Manifest.Cluster.BootstrapInventory
+	clusterName := config.Bundle.Manifest.ClusterName
+	for index := range inv.Nodes {
+		enrolled, ok := enrolledTarget("", "", clusterName, inv.Nodes[index].Name)
+		if !ok {
+			return inventory.Inventory{}, "", fmt.Errorf("node %q is not enrolled on this workstation; run 'katlctl context save --config %s' before bootstrap planning", inv.Nodes[index].Name, configPath)
+		}
+		host, _, splitErr := net.SplitHostPort(enrolled.endpoint)
+		if splitErr != nil {
+			return inventory.Inventory{}, "", fmt.Errorf("node %q saved management endpoint: %w", inv.Nodes[index].Name, splitErr)
+		}
+		inv.Nodes[index].Address = host
+		inv.Nodes[index].EnrollmentID = enrolled.enrollmentID
+		inv.Nodes[index].MachineID = enrolled.machineID
+	}
+	return inv, clusterName, nil
 }
 
 func bootstrapDependencies(vmtestTranscriptDir string) cluster.Dependencies {
@@ -2904,6 +3002,8 @@ type nodeDocument struct {
 	Access            accessDocument        `yaml:"access"`
 	KubeadmConfig     kubeadmConfigDocument `yaml:"kubeadmConfig"`
 	KubernetesVersion string                `yaml:"kubernetesVersion"`
+	EnrollmentID      string                `yaml:"enrollmentID"`
+	MachineID         string                `yaml:"machineID"`
 }
 
 type accessDocument struct {
@@ -2936,6 +3036,8 @@ func (d inventoryDocument) inventory() inventory.Inventory {
 				Intent: node.KubeadmConfig.Intent,
 			},
 			KubernetesVersion: node.KubernetesVersion,
+			EnrollmentID:      node.EnrollmentID,
+			MachineID:         node.MachineID,
 		})
 	}
 	result := inventory.Inventory{

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -432,7 +432,7 @@ func TestHostUpgradeHelpLeadsWithClusterConfig(t *testing.T) {
 	}
 }
 
-func TestManagementTargetUsesClusterConfigAndEndpointOverride(t *testing.T) {
+func TestManagementTargetRefusesUnverifiedEnrolledEndpointOverride(t *testing.T) {
 	configPath := writeClusterConfig(t)
 	target, err := resolveManagementTarget(managementTargetOptions{clusterConfigPath: configPath})
 	if err != nil {
@@ -442,12 +442,9 @@ func TestManagementTargetUsesClusterConfigAndEndpointOverride(t *testing.T) {
 		t.Fatalf("target = %#v", target)
 	}
 
-	target, err = resolveManagementTarget(managementTargetOptions{clusterConfigPath: configPath, nodeName: "cp-1", endpoint: "192.0.2.44"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if target.nodeName != "cp-1" || target.endpoint != "192.0.2.44:9443" {
-		t.Fatalf("override target = %#v", target)
+	_, err = resolveManagementTarget(managementTargetOptions{clusterConfigPath: configPath, nodeName: "cp-1", endpoint: "192.0.2.44"})
+	if err == nil || !strings.Contains(err.Error(), "context rebind") {
+		t.Fatalf("unverified override error = %v", err)
 	}
 
 	bundlePath, _ := writeConfigBundle(t)
@@ -1632,7 +1629,7 @@ func TestWipeClusterPlanPrintsNodeLocalOperations(t *testing.T) {
 func TestWipeClusterPlanAcceptsClusterConfig(t *testing.T) {
 	sourcePath := writeClusterConfig(t)
 	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
-		"cp-1": readyWipeClusterClient("cp-machine"),
+		"cp-1": readyWipeClusterClient("machine-cp-1"),
 	})
 	old := newWipeClusterConnector
 	newWipeClusterConnector = func() cluster.AgentConnector { return connector }
@@ -1669,9 +1666,13 @@ clusters:
   - name: cp-1
     managementEndpoint: 192.0.2.11:9443
     systemRole: control-plane
+    enrollmentID: enrollment-cp-1
+    machineID: cp-machine
   - name: worker-1
     managementEndpoint: 192.0.2.21:9443
     systemRole: worker
+    enrollmentID: enrollment-worker-1
+    machineID: worker-machine
 `)
 	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
 		"cp-1":     readyWipeClusterClient("cp-machine"),
@@ -1920,9 +1921,13 @@ clusters:
   - name: cp-1
     managementEndpoint: 192.0.2.11:9443
     systemRole: control-plane
+    enrollmentID: enrollment-cp-1
+    machineID: cp-machine
   - name: worker-1
     managementEndpoint: 192.0.2.21:9443
     systemRole: worker
+    enrollmentID: enrollment-worker-1
+    machineID: worker-machine
 `)
 	connector := newFakeWipeClusterConnector(map[string]*fakeKatlcAgentClient{
 		"worker-1": readyWipeClusterClient("worker-machine"),
@@ -2203,11 +2208,13 @@ func TestConfigApplyStatusReportsActiveAndNextBootJSON(t *testing.T) {
 }
 
 func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
+	contextPath := writeNodeAEnrollmentContext(t)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeKatlcAgentClient{
+		nodeStatus: enrolledNodeAStatus(),
 		stageAccepted: &agentapi.OperationAccepted{
 			OperationId:   "generation-stage-01",
 			OperationKind: "generation-stage",
@@ -2226,6 +2233,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "apply",
+		"--context-file", contextPath,
 		"--endpoint", "node-a.example.test:9443",
 		"--config", configPath,
 		"--mode", generation.ApplyModeNextBoot,
@@ -2244,7 +2252,7 @@ func TestConfigApplySubmitsStageGenerationToAgent(t *testing.T) {
 
 func TestHostUpgradeVersionStagesRebootsAndVerifiesHealth(t *testing.T) {
 	fake := &fakeKatlcAgentClient{
-		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", AgentStartId: "before", CurrentGenerationId: "generation-current", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
 		generation:      &agentapi.Generation{GenerationId: "generation-current", Sysexts: []*agentapi.ExtensionRef{{Name: "kubernetes", Architecture: "x86_64"}}},
 		submitAccepted:  &agentapi.OperationAccepted{OperationId: "host-upgrade-01", OperationKind: "host-upgrade"},
 		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "arm-trial-boot"},
@@ -2308,7 +2316,7 @@ func TestHostUpgradeLocalArtifactUploadsStagesRebootsAndVerifiesHealth(t *testin
 		t.Fatalf("artifact chunks = %d, want 2", len(fake.stageArtifact))
 	}
 	first := fake.stageArtifact[0]
-	if first.ApiVersion != operation.APIVersion || first.Kind != "StageHostUpgradeArtifactRequest" || first.ExpectedMachineId != "machine-a" || first.Sha256 != digest || first.SizeBytes != uint64(len(contents)) {
+	if first.ApiVersion != operation.APIVersion || first.Kind != "StageHostUpgradeArtifactRequest" || first.ExpectedMachineId != "machine-cp-1" || first.Sha256 != digest || first.SizeBytes != uint64(len(contents)) {
 		t.Fatalf("first artifact chunk = %#v", first)
 	}
 	if next := fake.stageArtifact[1]; next.ApiVersion != "" || next.Kind != "" || next.Sha256 != "" || next.SizeBytes != 0 {
@@ -2396,7 +2404,7 @@ func TestHostUpgradeLocalArtifactRejectsRedundantVersion(t *testing.T) {
 
 func readyHostUpgradeClient() *fakeKatlcAgentClient {
 	fake := &fakeKatlcAgentClient{
-		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-a", AgentStartId: "before", CurrentGenerationId: "generation-current", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
+		nodeStatus:      &agentapi.NodeStatus{MachineId: "machine-cp-1", AgentStartId: "before", CurrentGenerationId: "generation-current", Kubernetes: &agentapi.KubernetesStatus{State: "not-configured"}},
 		generation:      &agentapi.Generation{GenerationId: "generation-current", RuntimeArchitecture: "x86_64"},
 		submitAccepted:  &agentapi.OperationAccepted{OperationId: "host-upgrade-01", OperationKind: "host-upgrade"},
 		operationStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded, Phase: "arm-trial-boot"},
@@ -2446,11 +2454,13 @@ func writeHostUpgradeArtifact(t *testing.T, version, architecture string, size i
 }
 
 func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
+	contextPath := writeNodeAEnrollmentContext(t)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeKatlcAgentClient{
+		nodeStatus: enrolledNodeAStatus(),
 		validateResult: &agentapi.ConfigValidationResult{
 			Accepted:              true,
 			RequestDigest:         strings.Repeat("c", 64),
@@ -2477,6 +2487,7 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "apply",
+		"--context-file", contextPath,
 		"--endpoint", "node-a.example.test:9443",
 		"--config", configPath,
 		"--candidate-generation", "generation-auto",
@@ -2515,11 +2526,13 @@ func TestNormalizeDestructiveStorageAcknowledgements(t *testing.T) {
 }
 
 func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
+	contextPath := writeNodeAEnrollmentContext(t)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeKatlcAgentClient{
+		nodeStatus: enrolledNodeAStatus(),
 		validateResult: &agentapi.ConfigValidationResult{
 			Accepted:              true,
 			RequestDigest:         strings.Repeat("c", 64),
@@ -2539,6 +2552,7 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "apply", "validate",
+		"--context-file", contextPath,
 		"--endpoint", "node-a.example.test:9443",
 		"--config", configPath,
 		"--mode", generation.ApplyModeNextBoot,
@@ -2565,13 +2579,14 @@ func TestConfigApplyPlanValidatesWithAgent(t *testing.T) {
 }
 
 func TestConfigApplyAlreadyMatchesWithoutSubmittingOperation(t *testing.T) {
+	contextPath := writeNodeAEnrollmentContext(t)
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(configPath, []byte("apiVersion: katl.dev/v1alpha1\nkind: NodeConfigurationChange\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	for _, plan := range []bool{false, true} {
 		t.Run(fmt.Sprintf("plan=%t", plan), func(t *testing.T) {
-			fake := &fakeKatlcAgentClient{validateResult: &agentapi.ConfigValidationResult{
+			fake := &fakeKatlcAgentClient{nodeStatus: enrolledNodeAStatus(), validateResult: &agentapi.ConfigValidationResult{
 				Accepted:  true,
 				NoChanges: true,
 			}}
@@ -2580,7 +2595,7 @@ func TestConfigApplyAlreadyMatchesWithoutSubmittingOperation(t *testing.T) {
 				return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
 			}
 			t.Cleanup(func() { dialKatlcAgent = oldDial })
-			args := []string{"node", "apply", "--endpoint", "node-a.example.test:9443", "--config", configPath}
+			args := []string{"node", "apply", "--context-file", contextPath, "--endpoint", "node-a.example.test:9443", "--config", configPath}
 			if plan {
 				args = append(args, "--plan")
 			}
@@ -2601,6 +2616,7 @@ func TestConfigApplyAlreadyMatchesWithoutSubmittingOperation(t *testing.T) {
 func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 	bundlePath, _ := writeConfigBundle(t)
 	fake := &fakeKatlcAgentClient{
+		nodeStatus: &agentapi.NodeStatus{MachineId: "machine-cp-1", EnrollmentId: "enrollment-cp-1", InventoryNodeName: "cp-1", CurrentGenerationId: "generation-0"},
 		validateResult: &agentapi.ConfigValidationResult{
 			Accepted:              true,
 			RequestDigest:         strings.Repeat("c", 64),
@@ -2616,7 +2632,7 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 	}
 	oldDial := dialKatlcAgent
 	dialKatlcAgent = func(_ context.Context, endpoint string) (katlcAgentConnection, error) {
-		if endpoint != "node-a.example.test:9443" {
+		if endpoint != "10.0.0.11:9443" {
 			t.Fatalf("dial endpoint=%q", endpoint)
 		}
 		return katlcAgentConnection{Client: fake, Close: func() error { return nil }}, nil
@@ -2626,7 +2642,6 @@ func TestConfigApplyRendersVerifiedBundleNode(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(context.Background(), []string{
 		"node", "apply",
-		"--endpoint", "node-a.example.test:9443",
 		"--config", bundlePath,
 		"--node", "cp-1",
 		"--desired-version", "2",
@@ -2888,6 +2903,14 @@ func (c *fakeWipeClusterConnector) Connect(_ context.Context, node inventory.Pla
 	if client == nil {
 		return cluster.AgentConnection{}, errors.New("missing fake katlc agent for " + node.Name)
 	}
+	if client.nodeStatus != nil {
+		if client.nodeStatus.EnrollmentId == "" {
+			client.nodeStatus.EnrollmentId = node.EnrollmentID
+		}
+		if client.nodeStatus.InventoryNodeName == "" {
+			client.nodeStatus.InventoryNodeName = node.Name
+		}
+	}
 	return cluster.AgentConnection{
 		Endpoint: node.Address + ":9443",
 		Client:   client,
@@ -2900,6 +2923,7 @@ func readyWipeClusterClient(machineID string) *fakeKatlcAgentClient {
 		nodeStatus: &agentapi.NodeStatus{
 			ApiVersion:              operation.APIVersion,
 			MachineId:               machineID,
+			CurrentGenerationId:     "generation-0",
 			SupportedOperationKinds: []string{wipeClusterOperationKind},
 		},
 		submitAccepted: &agentapi.OperationAccepted{
@@ -2914,6 +2938,14 @@ func readyWipeClusterClient(machineID string) *fakeKatlcAgentClient {
 func (c *fakeKatlcAgentClient) GetNodeStatus(context.Context, *agentapi.GetNodeStatusRequest, ...grpc.CallOption) (*agentapi.NodeStatus, error) {
 	if c.onGetNodeStatus != nil {
 		c.onGetNodeStatus()
+	}
+	if c.nodeStatus != nil && c.nodeStatus.EnrollmentId == "" && c.nodeStatus.MachineId != "" {
+		name := strings.TrimPrefix(c.nodeStatus.MachineId, "machine-")
+		if name == "a" {
+			name = "cp-1"
+		}
+		c.nodeStatus.InventoryNodeName = name
+		c.nodeStatus.EnrollmentId = "enrollment-" + name
 	}
 	return c.nodeStatus, c.nodeStatusErr
 }
@@ -3321,6 +3353,8 @@ nodes:
     path: /etc/katl/kubeadm/control-plane/config.yaml
     intent: control-plane
   kubernetesVersion: v1.36.1
+  enrollmentID: enrollment-cp-1
+  machineID: cp-machine
 - name: worker-1
   address: 10.0.0.21
   systemRole: worker
@@ -3331,6 +3365,8 @@ nodes:
     path: /etc/katl/kubeadm/worker/config.yaml
     intent: worker
   kubernetesVersion: v1.36.1
+  enrollmentID: enrollment-worker-1
+  machineID: worker-machine
 `
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -3393,6 +3429,13 @@ func writeConfigBundle(t *testing.T) (string, string) {
 
 func writeClusterConfig(t *testing.T) string {
 	t.Helper()
+	writeTestEnrollmentContext(t, "lab", workstation.Node{
+		Name:               "cp-1",
+		ManagementEndpoint: "10.0.0.11:9443",
+		SystemRole:         inventory.RoleControlPlane,
+		EnrollmentID:       "enrollment-cp-1",
+		MachineID:          "machine-cp-1",
+	})
 	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
 	if err := os.WriteFile(sourcePath, []byte(configBundleSource()), 0o644); err != nil {
 		t.Fatal(err)
@@ -3400,8 +3443,48 @@ func writeClusterConfig(t *testing.T) string {
 	return sourcePath
 }
 
+func writeTestEnrollmentContext(t *testing.T, clusterName string, nodes ...workstation.Node) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "katlctl.yaml")
+	cfg := workstation.Config{
+		CurrentContext: "test",
+		Contexts:       []workstation.Context{{Name: "test", Cluster: clusterName}},
+		Clusters:       []workstation.Cluster{{Name: clusterName, Nodes: nodes}},
+	}
+	if err := workstation.Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KATLCTL_CONFIG", path)
+	t.Setenv("KATLCTL_CONFIG_DIR", "")
+	return path
+}
+
+func writeNodeAEnrollmentContext(t *testing.T) string {
+	t.Helper()
+	return writeTestEnrollmentContext(t, "raw-config", workstation.Node{
+		Name:               "node-a",
+		ManagementEndpoint: "node-a.example.test:9443",
+		SystemRole:         inventory.RoleControlPlane,
+		EnrollmentID:       "enrollment-node-a",
+		MachineID:          "machine-node-a",
+	})
+}
+
+func enrolledNodeAStatus() *agentapi.NodeStatus {
+	return &agentapi.NodeStatus{
+		MachineId:           "machine-node-a",
+		EnrollmentId:        "enrollment-node-a",
+		InventoryNodeName:   "node-a",
+		CurrentGenerationId: "generation-0",
+	}
+}
+
 func writeMultiControlPlaneClusterConfig(t *testing.T) string {
 	t.Helper()
+	writeTestEnrollmentContext(t, "lab",
+		workstation.Node{Name: "cp-1", ManagementEndpoint: "10.0.0.11:9443", SystemRole: inventory.RoleControlPlane, EnrollmentID: "enrollment-cp-1", MachineID: "cp-machine"},
+		workstation.Node{Name: "cp-2", ManagementEndpoint: "10.0.0.12:9443", SystemRole: inventory.RoleControlPlane, EnrollmentID: "enrollment-cp-2", MachineID: "machine-cp-2"},
+	)
 	sourcePath := filepath.Join(t.TempDir(), "cluster.yaml")
 	source := strings.Replace(configBundleSource(), `
       install:

--- a/cmd/katlctl/operator_ux_test.go
+++ b/cmd/katlctl/operator_ux_test.go
@@ -277,6 +277,7 @@ func TestConfigApplyUsesClusterConfigAndDerivesBookkeeping(t *testing.T) {
 		t.Fatal(err)
 	}
 	fake := &fakeKatlcAgentClient{
+		nodeStatus:     &agentapi.NodeStatus{MachineId: "machine-cp-1", EnrollmentId: "enrollment-cp-1", InventoryNodeName: "cp-1", CurrentGenerationId: "generation-0"},
 		validateResult: &agentapi.ConfigValidationResult{Accepted: true, AcceptedApplyMode: "live"},
 		stageAccepted:  &agentapi.OperationAccepted{OperationId: "apply-1", OperationKind: "generation-apply", InitialStatus: &agentapi.OperationStatus{Terminal: true, Result: operation.ResultSucceeded}},
 	}

--- a/cmd/katlctl/target.go
+++ b/cmd/katlctl/target.go
@@ -13,6 +13,7 @@ import (
 	"github.com/katl-dev/katl/internal/bootstrap/cluster"
 	"github.com/katl-dev/katl/internal/bootstrap/inventory"
 	"github.com/katl-dev/katl/internal/installer/configbundle"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"github.com/katl-dev/katl/internal/katlctl/workstation"
 	"github.com/spf13/cobra"
 )
@@ -26,8 +27,10 @@ type managementTargetOptions struct {
 }
 
 type managementTarget struct {
-	nodeName string
-	endpoint string
+	nodeName     string
+	endpoint     string
+	enrollmentID string
+	machineID    string
 }
 
 func addManagementTargetFlags(cmd *cobra.Command, opts *managementTargetOptions) {
@@ -45,18 +48,21 @@ func resolveManagementTarget(opts managementTargetOptions) (managementTarget, er
 		return managementTarget{}, err
 	}
 	if configPath := strings.TrimSpace(opts.clusterConfigPath); configPath != "" {
-		if strings.TrimSpace(opts.configPath) != "" || strings.TrimSpace(opts.contextName) != "" {
-			return managementTarget{}, fmt.Errorf("--config cannot be combined with --context-file or --context")
-		}
-		inv, err := readManagementInventory(configPath)
+		resolved, err := resolveClusterConfigTopology(configPath)
 		if err != nil {
 			return managementTarget{}, err
 		}
-		target, err := targetFromInventory(inv, opts.nodeName)
+		target, err := targetFromTopology(resolved.Topology, opts.nodeName)
 		if err != nil {
 			return managementTarget{}, err
+		}
+		if enrolled, ok := enrolledTarget(strings.TrimSpace(opts.configPath), strings.TrimSpace(opts.contextName), resolved.ClusterName, target.nodeName); ok {
+			target = enrolled
 		}
 		if endpoint != "" {
+			if target.enrollmentID != "" && endpoint != target.endpoint {
+				return managementTarget{}, fmt.Errorf("node %q is enrolled at %s; use 'katlctl context rebind --node %s --endpoint %s' to verify and save a new address", target.nodeName, target.endpoint, target.nodeName, endpoint)
+			}
 			target.endpoint = endpoint
 		}
 		if target.endpoint == "" {
@@ -81,6 +87,9 @@ func resolveManagementTarget(opts managementTargetOptions) (managementTarget, er
 		return managementTarget{}, err
 	}
 	if endpoint != "" {
+		if target.enrollmentID != "" && endpoint != target.endpoint {
+			return managementTarget{}, fmt.Errorf("node %q is enrolled at %s; use 'katlctl context rebind --node %s --endpoint %s' to verify and save a new address", target.nodeName, target.endpoint, target.nodeName, endpoint)
+		}
 		target.endpoint = endpoint
 	}
 	return target, nil
@@ -145,6 +154,7 @@ func resolveClusterConfigTopology(path string) (workstation.ResolvedTopology, er
 	}
 	if source, sourceErr := configbundle.DecodeSource(bytes.NewReader(data)); sourceErr == nil {
 		resolved.ClusterName = strings.TrimSpace(source.Metadata.Name)
+		mergeEnrolledTopology(&resolved, "", "")
 		return resolved, nil
 	}
 	bundle, err := configbundle.ReadBundle(bytes.NewReader(data), "")
@@ -152,7 +162,23 @@ func resolveClusterConfigTopology(path string) (workstation.ResolvedTopology, er
 		return workstation.ResolvedTopology{}, fmt.Errorf("read --config %s: %w", path, err)
 	}
 	resolved.ClusterName = strings.TrimSpace(bundle.Manifest.ClusterName)
+	mergeEnrolledTopology(&resolved, "", "")
 	return resolved, nil
+}
+
+func mergeEnrolledTopology(resolved *workstation.ResolvedTopology, configPath, contextName string) {
+	if resolved == nil {
+		return
+	}
+	for index := range resolved.Nodes {
+		enrolled, ok := enrolledTarget(configPath, contextName, resolved.ClusterName, resolved.Nodes[index].Name)
+		if !ok {
+			continue
+		}
+		resolved.Nodes[index].ManagementEndpoint = enrolled.endpoint
+		resolved.Nodes[index].EnrollmentID = enrolled.enrollmentID
+		resolved.Nodes[index].MachineID = enrolled.machineID
+	}
 }
 
 func targetFromInventory(inv inventory.Inventory, selected string) (managementTarget, error) {
@@ -195,9 +221,76 @@ func targetFromTopology(topology workstation.Topology, selected string) (managem
 		if node.Name != nodeName {
 			continue
 		}
-		return managementTarget{nodeName: nodeName, endpoint: node.ManagementEndpoint}, nil
+		return managementTarget{nodeName: nodeName, endpoint: node.ManagementEndpoint, enrollmentID: node.EnrollmentID, machineID: node.MachineID}, nil
 	}
 	return managementTarget{}, fmt.Errorf("node %q was not found in context %q", nodeName, topology.ContextName)
+}
+
+func enrolledTarget(configPath, contextName, clusterName, nodeName string) (managementTarget, bool) {
+	path := strings.TrimSpace(configPath)
+	if path == "" {
+		resolved, err := workstation.ConfigPath()
+		if err != nil {
+			return managementTarget{}, false
+		}
+		path = resolved
+	}
+	cfg, err := workstation.Load(path)
+	if err != nil {
+		return managementTarget{}, false
+	}
+	if contextName != "" {
+		topology, err := cfg.SelectedTopology(contextName)
+		if err != nil || topology.ClusterName != clusterName {
+			return managementTarget{}, false
+		}
+		for _, node := range topology.Nodes {
+			if node.Name == nodeName && node.EnrollmentID != "" {
+				return managementTarget{nodeName: node.Name, endpoint: node.ManagementEndpoint, enrollmentID: node.EnrollmentID, machineID: node.MachineID}, true
+			}
+		}
+		return managementTarget{}, false
+	}
+	for _, cluster := range cfg.Clusters {
+		if strings.TrimSpace(cluster.Name) != clusterName {
+			continue
+		}
+		for _, node := range cluster.Nodes {
+			if strings.TrimSpace(node.Name) == nodeName && strings.TrimSpace(node.EnrollmentID) != "" {
+				return managementTarget{nodeName: nodeName, endpoint: strings.TrimSpace(node.ManagementEndpoint), enrollmentID: strings.TrimSpace(node.EnrollmentID), machineID: strings.TrimSpace(node.MachineID)}, true
+			}
+		}
+	}
+	return managementTarget{}, false
+}
+
+func requireEnrolledTarget(target managementTarget) error {
+	if strings.TrimSpace(target.enrollmentID) == "" || strings.TrimSpace(target.machineID) == "" {
+		return fmt.Errorf("node %q is not enrolled on this workstation; run 'katlctl context save --config cluster.yaml' before planning or changing it", target.nodeName)
+	}
+	return nil
+}
+
+func verifyEnrolledStatus(target managementTarget, status *agentapi.NodeStatus) error {
+	if err := requireEnrolledTarget(target); err != nil {
+		return err
+	}
+	if status == nil {
+		return fmt.Errorf("node %q did not return status", target.nodeName)
+	}
+	if got := strings.TrimSpace(status.GetInventoryNodeName()); got != target.nodeName {
+		return fmt.Errorf("node %q address answered as enrolled node %q; refusing before acceptance", target.nodeName, got)
+	}
+	if got := strings.TrimSpace(status.GetEnrollmentId()); got != target.enrollmentID {
+		return fmt.Errorf("node %q enrollment identity does not match the saved context; refusing before acceptance", target.nodeName)
+	}
+	if got := strings.TrimSpace(status.GetMachineId()); got != target.machineID {
+		return fmt.Errorf("node %q machine identity does not match the saved context; refusing before acceptance", target.nodeName)
+	}
+	if strings.TrimSpace(status.GetCurrentGenerationId()) == "" {
+		return fmt.Errorf("node %q did not report its current generation", target.nodeName)
+	}
+	return nil
 }
 
 func normalizeManagementAddress(value string) (string, error) {

--- a/cmd/katlctl/upgrade_reboot.go
+++ b/cmd/katlctl/upgrade_reboot.go
@@ -30,13 +30,16 @@ type nodeRecoveryRequirement struct {
 	ManagedEndpointReady bool
 }
 
-func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, actor, machineID, targetGeneration string) error {
+func requestNodeReboot(ctx context.Context, client agentapi.KatlcAgentClient, actor string, status *agentapi.NodeStatus, targetGeneration string) error {
 	accepted, err := client.Reboot(ctx, &agentapi.RebootRequest{
-		ApiVersion:         generation.APIVersion,
-		Kind:               "RebootRequest",
-		Actor:              strings.TrimSpace(actor),
-		ExpectedMachineId:  strings.TrimSpace(machineID),
-		TargetGenerationId: strings.TrimSpace(targetGeneration),
+		ApiVersion:                  generation.APIVersion,
+		Kind:                        "RebootRequest",
+		Actor:                       strings.TrimSpace(actor),
+		ExpectedEnrollmentId:        strings.TrimSpace(status.GetEnrollmentId()),
+		ExpectedInventoryNodeName:   strings.TrimSpace(status.GetInventoryNodeName()),
+		ExpectedMachineId:           strings.TrimSpace(status.GetMachineId()),
+		ExpectedCurrentGenerationId: strings.TrimSpace(status.GetCurrentGenerationId()),
+		TargetGenerationId:          strings.TrimSpace(targetGeneration),
 	})
 	if err != nil {
 		return err

--- a/cmd/katlctl/upgrade_reboot_test.go
+++ b/cmd/katlctl/upgrade_reboot_test.go
@@ -195,6 +195,9 @@ func TestCurrentHostUpgradeAcceptsPreservedPreCNIState(t *testing.T) {
 	const generationID = "katlos-2026.7.0-alpha.9"
 	fake := &fakeKatlcAgentClient{
 		nodeStatus: &agentapi.NodeStatus{
+			MachineId:           "machine-cp-1",
+			EnrollmentId:        "enrollment-cp-1",
+			InventoryNodeName:   "cp-1",
 			CurrentGenerationId: generationID,
 			Kubernetes: &agentapi.KubernetesStatus{
 				State:         "waiting-for-node",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,15 +134,17 @@ Expected generation 0 state is host health `OK`, an active management agent,
 and Kubernetes `not-configured` or waiting for bootstrap. Kubernetes services
 and Node readiness are not generation 0 requirements.
 
-Optionally save the verified topology for shorter day-two commands:
+Enroll the installed nodes before bootstrap or any host mutation:
 
 ```sh
 katlctl context save --config ./cluster.yaml
 katlctl context show
 ```
 
-`ClusterConfig` remains authoritative; a workstation context is only a local
-convenience.
+This records each node's install-generated enrollment identity and machine ID.
+`ClusterConfig` remains authoritative for desired state; the context is the
+operator's durable binding between that inventory identity and its current
+management address.
 
 ## 6. Bootstrap kubeadm
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -713,9 +713,11 @@ compatibility, stages the sysext, and selects it for generation 1. Operators do
 not supply a bundle tag or digest on the normal path.
 
 After all nodes are installed and reachable through their node-local `katlc`
-management endpoints, bootstrap directly from the same source:
+management endpoints, enroll their identities and then bootstrap from the same
+source:
 
 ```text
+katlctl context save --config ./cluster.yaml
 katlctl cluster bootstrap --config ./cluster.yaml \
   --init-node cp-1
 ```
@@ -731,10 +733,9 @@ handoff, nodes normally remain `NotReady` and CoreDNS pending until the user
 installs a CNI. Katl does not choose, install, or manage one.
 
 The management API is intentionally credential-free on Katl's supported
-trusted home-lab network. Bootstrap requires no enrollment or token exchange.
-`katlctl context save --config ./cluster.yaml` is optional shorthand that
-checks the management endpoints and saves their topology as the current
-workstation context for later node operations.
+trusted home-lab network. Enrollment is an identity binding, not an
+authentication token: it prevents operator inventory from targeting the wrong
+installed node when addresses are stale or exchanged.
 
 `katlctl` is a bounded client. Node-local `katlc` validates and records the
 authoritative bootstrap operations, creates generation 1, runs `kubeadm`, and

--- a/docs/internal/generations-and-operations.md
+++ b/docs/internal/generations-and-operations.md
@@ -667,13 +667,15 @@ the management listener is unauthenticated and unencrypted on the trusted
 katlctl runs off-node and connects to the katlc management endpoint advertised
   by inventory or client configuration
 katlctl does not SSH to nodes or execute remote shell commands
-operators do not enroll nodes or manage transport credentials
+operators enroll installed node identities in the workstation context; this is
+  an address-to-node safety binding, not a transport credential
 any on-host debug command is secondary to the TCP gRPC contract and must not be
   required for normal operation submission or status
 no multi-tenant RBAC beyond local OS user/group permissions
 no Kubernetes API, kubeconfig, or cluster identity required before bootstrap
-node-local katlc revalidates machine ID, stored intent, request digest, and
-  operation locks before accepting a mutating request
+node-local katlc requires and revalidates enrollment ID, enrolled inventory
+  node name, machine ID, current generation, stored intent where relevant,
+  request digest, and operation locks before accepting a mutating request
 ```
 
 This is sufficient for home-ops day one and VM validation. Stronger remote

--- a/docs/internal/katlc-agent-architecture.md
+++ b/docs/internal/katlc-agent-architecture.md
@@ -27,6 +27,15 @@ katlctl on workstation
 node-local. `katlc` does not know the whole cluster rollout plan beyond the
 explicit request it accepted for its node.
 
+Every install persists a random enrollment ID bound to the selected inventory
+node name and machine ID. `GetNodeStatus` exposes that public tuple. Every
+planning request that can authorize a later mutation, and every mutating RPC,
+must carry the workstation's expected tuple plus the relevant current
+generation. The agent compares it to its own persisted enrollment before
+validation can accept destructive acknowledgements or an operation can be
+recorded. An operation body that names an inventory node must name the node to
+which the agent itself is enrolled.
+
 ## Boundary
 
 `katlc` owns node-local KatlOS state:

--- a/docs/internal/katlctl-workstation-config.md
+++ b/docs/internal/katlctl-workstation-config.md
@@ -55,34 +55,39 @@ clusters:
   - name: cp-1
     managementEndpoint: cp-1.prod.example:9443
     systemRole: control-plane
+    enrollmentID: 0123456789abcdef0123456789abcdef
+    machineID: fedcba9876543210fedcba9876543210
   - name: worker-1
     managementEndpoint: worker-1.prod.example:9443
     systemRole: worker
+    enrollmentID: 11111111111111112222222222222222
+    machineID: 33333333333333334444444444444444
 ```
 
 `currentContext` names a context in `contexts`. Each context names a cluster in
 `clusters`. Each cluster records node-local `katlc` management endpoints,
-KatlOS system roles, and optionally the stable control-plane endpoint used by
-operator workflows.
+KatlOS system roles, the immutable install enrollment and machine identities,
+and optionally the stable control-plane endpoint used by operator workflows.
+The identities are public opaque values, not credentials.
 
 `katlctl context show` prints the resolved context topology as JSON.
 
 ## Precedence
 
-Explicit operator input is authoritative. A compiled plan, when accepted by a
-command, wins over explicit inventory. Explicit inventory wins over workstation
-config. Workstation `currentContext` is used only when a command asks for a
-profile and no explicit inventory or plan input supplies the same topology.
+ClusterConfig and compiled plans remain authoritative for desired topology and
+configuration. The workstation record is authoritative for the observed
+enrollment binding and day-two management address. A mutation must join these
+two sources by cluster and node name and refuse a missing or mismatched binding.
 
-Invocation flags that are already explicit command overrides, such as
-`--control-plane-endpoint`, `--init-node`, or `--node-address`, remain command
-overrides after the topology source is selected. `katlctl` must not silently
-borrow missing endpoints or roles from workstation config when an
-explicit inventory or plan is present.
+Bootstrap-only flags such as `--control-plane-endpoint` and `--init-node`
+remain desired-state overrides. A mutation cannot override an enrolled
+management address with `--endpoint`; the operator must use `katlctl context
+rebind`, which verifies the saved enrollment and machine identities before
+atomically changing the address.
 
 ## Boundary
 
-`katlctl` config may help locate node-local `katlc` endpoints and select an
-operator workflow target. Node-local `katlc` remains the only writer of
+`katlctl` config binds operator inventory identities to node-local `katlc`
+endpoints. Node-local `katlc` remains the only writer of
 generation specs, generation status, boot selection, operation records, and
 durable node lifecycle state.

--- a/docs/operations/access.md
+++ b/docs/operations/access.md
@@ -36,7 +36,7 @@ Expected state before Kubernetes bootstrap:
 - runtime handoff reports `waiting-for-cluster-bootstrap`; and
 - `katl-kubeadm-ready.target` is not active yet.
 
-## Save a Workstation Context (Optional)
+## Enroll Nodes on the Workstation
 
 Use the same source used for installation:
 
@@ -44,9 +44,10 @@ Use the same source used for installation:
 katlctl context save --config ./cluster.yaml
 ```
 
-For every node, the command verifies access to TCP port `9443` and writes or
-updates the selected cluster topology in `katlctl.yaml`. It does not use SSH,
-retrieve secrets, or alter the node.
+For every node, the command verifies access to TCP port `9443`, confirms that
+the answering agent is enrolled under the requested inventory node name, and
+records its immutable enrollment identity and machine ID in `katlctl.yaml`.
+It does not use SSH, retrieve secrets, or alter the node.
 
 `katlctl config init` and `katlctl install discover CLUSTER_CONFIG` also read
 supported public keys from the active SSH agent when creating the initial SSH
@@ -54,8 +55,9 @@ authorization. This works with agent-only keys such as 1Password. An explicit
 `--ssh-authorized-key PATH` remains available when only one key should be
 authorized.
 
-`ClusterConfig` remains sufficient for installation and Kubernetes bootstrap;
-saving a context is only a convenience for repeated day-two commands.
+`ClusterConfig` remains sufficient for installation. Planning, bootstrap, and
+mutating commands additionally require this saved enrollment so a stale or
+swapped address cannot target another machine.
 
 ## Connectivity Check
 
@@ -69,8 +71,15 @@ katlctl node status cp-1
 
 The save command has already performed the agent health check. Normal management
 commands now need only `--node`; `--context` selects a non-current cluster.
-An explicit `--endpoint` remains available when operating without a saved
-context.
+Read-only inspection can use an explicit `--endpoint`. Mutations use the saved
+address. When an enrolled node's address changes, verify and save it explicitly:
+
+```sh
+katlctl context rebind --node cp-1 --endpoint 192.0.2.51
+```
+
+Rebind succeeds only when the new address reports the same inventory node,
+enrollment identity, and machine ID.
 
 Use `katlctl context current` to print the selection and `katlctl context use
 NAME` to switch between saved clusters. `katlctl cluster status --config

--- a/internal/bootstrap/cluster/agent_bootstrap.go
+++ b/internal/bootstrap/cluster/agent_bootstrap.go
@@ -190,7 +190,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	}
 	for _, node := range controlPlaneJoinNodes(plan) {
 		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, Kind: "bootstrap-join-control-plane", Phase: "creating-join-material"})
-		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, initResult.Credentials, plan.ControlPlaneEndpointManaged, deps)
+		material, err := createControlPlaneJoinMaterial(ctx, initNode, node, initResult.Operation.ID, initResult.Credentials, plan.ControlPlaneEndpointManaged, deps)
 		if err != nil {
 			result.addPhase("control-plane-join", node.Name, inventory.ActionControlPlaneJoin, "failed")
 			return result, fmt.Errorf("control-plane join material for %s: %s", node.Name, inventory.Redact(err.Error()))
@@ -205,7 +205,7 @@ func RunAgentBootstrap(ctx context.Context, request Request, deps AgentBootstrap
 	}
 	for _, node := range workerNodes(plan) {
 		emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, Kind: "bootstrap-join-worker", Phase: "creating-join-material"})
-		material, err := createWorkerJoinMaterial(ctx, initNode, node, statuses[initNode.Name], initResult.Operation.ID, deps)
+		material, err := createWorkerJoinMaterial(ctx, initNode, node, initResult.Operation.ID, deps)
 		if err != nil {
 			result.addPhase("worker-join", node.Name, inventory.ActionWorkerJoin, "failed")
 			return result, fmt.Errorf("worker join material for %s: %s", node.Name, inventory.Redact(err.Error()))
@@ -320,7 +320,7 @@ func RunAgentNodeJoin(ctx context.Context, request Request, nodeName string, dep
 	}
 	switch target.Action {
 	case inventory.ActionControlPlaneJoin:
-		material, err := createJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps, "control-plane", joinDiscoveryOverride{
+		material, err := createJoinMaterial(ctx, initNode, target, "existing-cluster", deps, "control-plane", joinDiscoveryOverride{
 			Endpoint: endpointForNode(initNode),
 		})
 		if err != nil {
@@ -334,7 +334,7 @@ func RunAgentNodeJoin(ctx context.Context, request Request, nodeName string, dep
 		}
 		result.addOperationPhase("control-plane-join", target.Name, target.Action, "passed", operationRef)
 	case inventory.ActionWorkerJoin:
-		material, err := createJoinMaterial(ctx, initNode, target, statuses[initNode.Name], "existing-cluster", deps, "worker", joinDiscoveryOverride{
+		material, err := createJoinMaterial(ctx, initNode, target, "existing-cluster", deps, "worker", joinDiscoveryOverride{
 			Endpoint: endpointForNode(initNode),
 		})
 		if err != nil {
@@ -403,6 +403,18 @@ func readinessFromStatuses(plan inventory.Plan, statuses map[string]*agentapi.No
 		if status == nil {
 			nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "katlc-agent", Message: "node status is missing"})
 		} else {
+			if strings.TrimSpace(node.EnrollmentID) == "" || strings.TrimSpace(node.MachineID) == "" {
+				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "enrollment", Message: "node has no persisted workstation enrollment identity"})
+			}
+			if got := strings.TrimSpace(status.GetInventoryNodeName()); got != node.Name {
+				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "enrollment", Message: fmt.Sprintf("address answered as enrolled node %q", got)})
+			}
+			if got := strings.TrimSpace(status.GetEnrollmentId()); got != strings.TrimSpace(node.EnrollmentID) {
+				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "enrollment", Message: "node enrollment identity does not match inventory"})
+			}
+			if got := strings.TrimSpace(status.GetMachineId()); got != strings.TrimSpace(node.MachineID) {
+				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "machine-id", Message: "node machine identity does not match inventory"})
+			}
 			if status.GetApiVersion() != agentAPIVersion {
 				nodeReport.Diagnostics = append(nodeReport.Diagnostics, inventory.Diagnostic{Field: "katlc-agent", Message: fmt.Sprintf("node reports API version %q", status.GetApiVersion())})
 			}
@@ -496,17 +508,17 @@ func submitAndWaitBootstrapInit(ctx context.Context, node inventory.PlannedNode,
 	return result, nil
 }
 
-func createControlPlaneJoinMaterial(ctx context.Context, initNode, controlPlane inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, credentials AdminCredentials, managedEndpoint bool, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
+func createControlPlaneJoinMaterial(ctx context.Context, initNode, controlPlane inventory.PlannedNode, initOperationID string, credentials AdminCredentials, managedEndpoint bool, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
 	discovery := joinDiscoveryOverride{}
 	if managedEndpoint {
 		discovery.Endpoint = endpointForNode(initNode)
 		discovery.CertificateAuthorityData = credentials.CertificateAuthorityData
 	}
-	return createJoinMaterial(ctx, initNode, controlPlane, status, initOperationID, deps, "control-plane", discovery)
+	return createJoinMaterial(ctx, initNode, controlPlane, initOperationID, deps, "control-plane", discovery)
 }
 
-func createWorkerJoinMaterial(ctx context.Context, initNode, worker inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
-	return createJoinMaterial(ctx, initNode, worker, status, initOperationID, deps, "worker", joinDiscoveryOverride{})
+func createWorkerJoinMaterial(ctx context.Context, initNode, worker inventory.PlannedNode, initOperationID string, deps AgentBootstrapDependencies) (workerJoinMaterial, error) {
+	return createJoinMaterial(ctx, initNode, worker, initOperationID, deps, "worker", joinDiscoveryOverride{})
 }
 
 type joinDiscoveryOverride struct {
@@ -514,19 +526,29 @@ type joinDiscoveryOverride struct {
 	CertificateAuthorityData string
 }
 
-func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.PlannedNode, status *agentapi.NodeStatus, initOperationID string, deps AgentBootstrapDependencies, role string, discovery joinDiscoveryOverride) (workerJoinMaterial, error) {
+func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.PlannedNode, initOperationID string, deps AgentBootstrapDependencies, role string, discovery joinDiscoveryOverride) (workerJoinMaterial, error) {
 	conn, err := deps.Connector.Connect(ctx, initNode)
 	if err != nil {
 		return workerJoinMaterial{}, fmt.Errorf("connect to katlc agent: %w", err)
 	}
 	defer closeAgent(conn)
+	status, err := conn.Client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		return workerJoinMaterial{}, fmt.Errorf("refresh init node status: %w", err)
+	}
+	if err := verifyPlannedNodeIdentity(initNode, status); err != nil {
+		return workerJoinMaterial{}, fmt.Errorf("refresh init node status: %w", err)
+	}
 	requestRef := "operation:" + strings.TrimSpace(initOperationID) + "/" + role + ":" + joinNode.Name
 	response, err := conn.Client.CreateWorkerJoinMaterial(ctx, &agentapi.CreateWorkerJoinMaterialRequest{
-		ApiVersion:        agentAPIVersion,
-		Kind:              agentJoinMaterialKind,
-		Actor:             valueOrDefault(deps.Actor, "katlctl cluster bootstrap"),
-		ExpectedMachineId: strings.TrimSpace(status.GetMachineId()),
-		RequestRef:        requestRef,
+		ApiVersion:                  agentAPIVersion,
+		Kind:                        agentJoinMaterialKind,
+		Actor:                       valueOrDefault(deps.Actor, "katlctl cluster bootstrap"),
+		ExpectedEnrollmentId:        strings.TrimSpace(status.GetEnrollmentId()),
+		ExpectedInventoryNodeName:   strings.TrimSpace(status.GetInventoryNodeName()),
+		ExpectedMachineId:           strings.TrimSpace(status.GetMachineId()),
+		ExpectedCurrentGenerationId: strings.TrimSpace(status.GetCurrentGenerationId()),
+		RequestRef:                  requestRef,
 	})
 	if err != nil {
 		return workerJoinMaterial{}, fmt.Errorf("create %s join material: %w", role, err)
@@ -552,6 +574,25 @@ func createJoinMaterial(ctx context.Context, initNode, joinNode inventory.Planne
 		ref = requestRef
 	}
 	return workerJoinMaterial{Ref: ref, Material: material}, nil
+}
+
+func verifyPlannedNodeIdentity(node inventory.PlannedNode, status *agentapi.NodeStatus) error {
+	if status == nil {
+		return errors.New("node did not return status")
+	}
+	if got := strings.TrimSpace(status.GetInventoryNodeName()); got != node.Name {
+		return fmt.Errorf("node %q address answered as enrolled node %q", node.Name, got)
+	}
+	if got := strings.TrimSpace(status.GetEnrollmentId()); got != strings.TrimSpace(node.EnrollmentID) {
+		return fmt.Errorf("node %q enrollment identity does not match inventory", node.Name)
+	}
+	if got := strings.TrimSpace(status.GetMachineId()); got != strings.TrimSpace(node.MachineID) {
+		return fmt.Errorf("node %q machine identity does not match inventory", node.Name)
+	}
+	if strings.TrimSpace(status.GetCurrentGenerationId()) == "" {
+		return fmt.Errorf("node %q did not report its current generation", node.Name)
+	}
+	return nil
 }
 
 func joinMaterialWithDiscoveryEndpoint(material *agentapi.WorkerJoinMaterial, endpoint, certificateAuthorityData string) (*agentapi.WorkerJoinMaterial, error) {
@@ -690,6 +731,10 @@ func rebootAndWaitBootstrapGeneration(ctx context.Context, node inventory.Planne
 		_ = closeAgent(conn)
 		return fmt.Errorf("get node status before reboot: %w", err)
 	}
+	if err := verifyPlannedNodeIdentity(node, status); err != nil {
+		_ = closeAgent(conn)
+		return fmt.Errorf("verify node status before reboot: %w", err)
+	}
 	candidate, generationErr := conn.Client.GetGeneration(ctx, &agentapi.GetGenerationRequest{GenerationId: generationID})
 	if generationErr == nil && bootstrapGenerationHealthy(node, status, candidate, generationID) {
 		_ = closeAgent(conn)
@@ -703,11 +748,14 @@ func rebootAndWaitBootstrapGeneration(ctx context.Context, node inventory.Planne
 	}
 	emitAgentProgress(deps, AgentBootstrapProgress{Node: node.Name, Kind: "boot-health", Phase: "scheduling-reboot"})
 	accepted, err := conn.Client.Reboot(ctx, &agentapi.RebootRequest{
-		ApiVersion:         agentAPIVersion,
-		Kind:               "RebootRequest",
-		Actor:              valueOrDefault(deps.Actor, "katlctl cluster bootstrap"),
-		ExpectedMachineId:  strings.TrimSpace(status.GetMachineId()),
-		TargetGenerationId: generationID,
+		ApiVersion:                  agentAPIVersion,
+		Kind:                        "RebootRequest",
+		Actor:                       valueOrDefault(deps.Actor, "katlctl cluster bootstrap"),
+		ExpectedEnrollmentId:        strings.TrimSpace(status.GetEnrollmentId()),
+		ExpectedInventoryNodeName:   strings.TrimSpace(status.GetInventoryNodeName()),
+		ExpectedMachineId:           strings.TrimSpace(status.GetMachineId()),
+		ExpectedCurrentGenerationId: strings.TrimSpace(status.GetCurrentGenerationId()),
+		TargetGenerationId:          generationID,
 	})
 	_ = closeAgent(conn)
 	if err != nil {
@@ -798,6 +846,8 @@ func bootstrapOperationRequest(node inventory.PlannedNode, plan inventory.Plan, 
 		ClientRequestId:             clientRequestID(node, plan, kind, ""),
 		OperationKind:               kind,
 		Actor:                       valueOrDefault(deps.Actor, "katlctl cluster bootstrap"),
+		ExpectedEnrollmentId:        strings.TrimSpace(status.GetEnrollmentId()),
+		ExpectedInventoryNodeName:   strings.TrimSpace(status.GetInventoryNodeName()),
 		ExpectedMachineId:           strings.TrimSpace(status.GetMachineId()),
 		ExpectedCurrentGenerationId: strings.TrimSpace(status.GetCurrentGenerationId()),
 		DryRun:                      false,

--- a/internal/bootstrap/cluster/agent_bootstrap_test.go
+++ b/internal/bootstrap/cluster/agent_bootstrap_test.go
@@ -57,6 +57,8 @@ func TestRunAgentBootstrapSubmitsControlPlaneJoin(t *testing.T) {
 		Access:            inventory.Access{Method: "agent"},
 		KubeadmConfig:     inventory.KubeadmConfig{Ref: "control-plane", Path: "/etc/katl/kubeadm/control-plane/config.yaml", Intent: inventory.IntentControlPlane},
 		KubernetesVersion: "v1.36.1",
+		EnrollmentID:      "enrollment-cp-2",
+		MachineID:         "machine-cp-2",
 	})
 	cpClient := &fakeAgentClient{
 		status: readyAgentStatusWithKinds("machine-cp-1", "bootstrap-init"),
@@ -182,6 +184,8 @@ func TestRunAgentNodeJoinAddsControlPlaneWithoutRerunningInit(t *testing.T) {
 		Access:            inventory.Access{Method: "agent"},
 		KubeadmConfig:     inventory.KubeadmConfig{Ref: "control-plane", Path: "/etc/katl/kubeadm/control-plane/config.yaml", Intent: inventory.IntentControlPlane},
 		KubernetesVersion: "v1.36.1",
+		EnrollmentID:      "enrollment-cp-2",
+		MachineID:         "machine-cp-2",
 	})
 	cp1 := &fakeAgentClient{
 		status: readyAgentStatusWithKinds("machine-cp-1", "bootstrap-init"),
@@ -551,7 +555,7 @@ func TestRebootBootstrapGenerationSkipsAlreadyHealthyCandidate(t *testing.T) {
 			HealthState:  generation.HealthStateHealthy,
 		},
 	}
-	node := inventory.PlannedNode{Name: "cp-1", SystemRole: inventory.RoleControlPlane}
+	node := inventory.PlannedNode{Name: "cp-1", SystemRole: inventory.RoleControlPlane, EnrollmentID: "enrollment-cp-1", MachineID: "machine-cp-1"}
 	err := rebootAndWaitBootstrapGeneration(context.Background(), node, candidate, AgentBootstrapDependencies{
 		Connector: newFakeAgentConnector(map[string]*fakeAgentClient{"cp-1": client}),
 	})
@@ -759,6 +763,11 @@ func TestRunAgentBootstrapMintsWorkerJoinMaterialAndSubmitsWorkerJoin(t *testing
 			},
 		},
 	}
+	cpClient.getNodeStatusFn = func(call int, status *agentapi.NodeStatus) {
+		if call > 1 {
+			status.CurrentGenerationId = "bootstrap-init-live"
+		}
+	}
 	workerClient := &fakeAgentClient{
 		status: readyAgentStatusWithKinds("machine-worker-1", "bootstrap-join-worker"),
 		accepted: &agentapi.OperationAccepted{
@@ -790,7 +799,7 @@ func TestRunAgentBootstrapMintsWorkerJoinMaterialAndSubmitsWorkerJoin(t *testing
 		t.Fatalf("CreateWorkerJoinMaterial requests = %d, want 1", len(cpClient.createMaterialRequests))
 	}
 	materialReq := cpClient.createMaterialRequests[0]
-	if materialReq.Kind != agentJoinMaterialKind || materialReq.Actor != "test-actor" || materialReq.ExpectedMachineId != "machine-cp-1" || materialReq.RequestRef != "operation:bootstrap-init-1/worker:worker-1" {
+	if materialReq.Kind != agentJoinMaterialKind || materialReq.Actor != "test-actor" || materialReq.ExpectedMachineId != "machine-cp-1" || materialReq.ExpectedCurrentGenerationId != "bootstrap-init-live" || materialReq.RequestRef != "operation:bootstrap-init-1/worker:worker-1" {
 		t.Fatalf("join material request = %#v", materialReq)
 	}
 	if len(workerClient.submitRequests) != 1 {
@@ -869,12 +878,21 @@ func (c *fakeAgentConnector) Connect(_ context.Context, node inventory.PlannedNo
 		client = &fakeAgentClient{status: readyAgentStatus("machine-" + node.Name)}
 		c.clients[node.Name] = client
 	}
+	if client.status != nil {
+		client.status.InventoryNodeName = node.Name
+		client.status.EnrollmentId = node.EnrollmentID
+		if node.MachineID == "" {
+			node.MachineID = client.status.MachineId
+		}
+	}
 	return AgentConnection{Endpoint: node.Address, Client: client}, nil
 }
 
 type fakeAgentClient struct {
 	status                 *agentapi.NodeStatus
 	statusErr              error
+	getNodeStatusCalls     int
+	getNodeStatusFn        func(int, *agentapi.NodeStatus)
 	submitRequests         []*agentapi.SubmitOperationRequest
 	submitErr              error
 	accepted               *agentapi.OperationAccepted
@@ -895,6 +913,10 @@ type fakeAgentClient struct {
 func (c *fakeAgentClient) GetNodeStatus(context.Context, *agentapi.GetNodeStatusRequest, ...grpc.CallOption) (*agentapi.NodeStatus, error) {
 	if c.statusErr != nil {
 		return nil, c.statusErr
+	}
+	c.getNodeStatusCalls++
+	if c.getNodeStatusFn != nil {
+		c.getNodeStatusFn(c.getNodeStatusCalls, c.status)
 	}
 	return c.status, nil
 }

--- a/internal/bootstrap/cluster/cluster_test.go
+++ b/internal/bootstrap/cluster/cluster_test.go
@@ -1397,6 +1397,8 @@ func validInventory() inventory.Inventory {
 				Access:            inventory.Access{Method: "agent"},
 				KubeadmConfig:     inventory.KubeadmConfig{Ref: "control-plane", Path: "/etc/katl/kubeadm/control-plane/config.yaml", Intent: inventory.IntentControlPlane},
 				KubernetesVersion: "v1.36.1",
+				EnrollmentID:      "enrollment-cp-1",
+				MachineID:         "machine-cp-1",
 			},
 			{
 				Name:              "worker-1",
@@ -1405,6 +1407,8 @@ func validInventory() inventory.Inventory {
 				Access:            inventory.Access{Method: "agent"},
 				KubeadmConfig:     inventory.KubeadmConfig{Ref: "worker", Path: "/etc/katl/kubeadm/worker/config.yaml", Intent: inventory.IntentWorker},
 				KubernetesVersion: "v1.36.1",
+				EnrollmentID:      "enrollment-worker-1",
+				MachineID:         "machine-worker-1",
 			},
 		},
 	}

--- a/internal/bootstrap/inventory/inventory.go
+++ b/internal/bootstrap/inventory/inventory.go
@@ -71,6 +71,8 @@ type Node struct {
 	KubeadmConfig     KubeadmConfig     `json:"kubeadmConfig"`
 	KubernetesVersion string            `json:"kubernetesVersion"`
 	Labels            map[string]string `json:"labels,omitempty"`
+	EnrollmentID      string            `json:"enrollmentID,omitempty" yaml:"enrollmentID,omitempty"`
+	MachineID         string            `json:"machineID,omitempty" yaml:"machineID,omitempty"`
 }
 
 type Access struct {
@@ -113,6 +115,8 @@ type PlannedNode struct {
 	KubeadmConfig     KubeadmConfig     `json:"kubeadmConfig"`
 	KubernetesVersion string            `json:"kubernetesVersion"`
 	Labels            map[string]string `json:"labels,omitempty"`
+	EnrollmentID      string            `json:"enrollmentID,omitempty" yaml:"enrollmentID,omitempty"`
+	MachineID         string            `json:"machineID,omitempty" yaml:"machineID,omitempty"`
 }
 
 type AddressOverride struct {
@@ -318,6 +322,8 @@ func normalizeNode(node Node, inventoryVersion string) (PlannedNode, error) {
 		KubeadmConfig:     config,
 		KubernetesVersion: version,
 		Labels:            copyLabels(node.Labels),
+		EnrollmentID:      strings.TrimSpace(node.EnrollmentID),
+		MachineID:         strings.TrimSpace(node.MachineID),
 	}, nil
 }
 

--- a/internal/installer/generation/identity.go
+++ b/internal/installer/generation/identity.go
@@ -105,10 +105,56 @@ func WriteEnrollment(root, nodeName, machineID string, random io.Reader) (Enroll
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return Enrollment{}, fmt.Errorf("create enrollment identity directory: %w", err)
 	}
-	if err := os.WriteFile(path, append(data, '\n'), 0o444); err != nil {
+	if err := writeEnrollmentAtomic(path, append(data, '\n')); err != nil {
 		return Enrollment{}, fmt.Errorf("write enrollment identity: %w", err)
 	}
 	return enrollment, nil
+}
+
+func writeEnrollmentAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	temporary, err := os.CreateTemp(dir, ".enrollment.json.tmp-")
+	if err != nil {
+		return fmt.Errorf("create temporary enrollment identity: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary enrollment identity: %w", err)
+	}
+	if err := temporary.Chmod(0o444); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("protect temporary enrollment identity: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync temporary enrollment identity: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary enrollment identity: %w", err)
+	}
+	if err := os.Link(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish enrollment identity without replacement: %w", err)
+	}
+	if err := os.Remove(temporaryPath); err != nil {
+		return fmt.Errorf("remove temporary enrollment identity: %w", err)
+	}
+	cleanup = false
+	directory, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open enrollment identity directory: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync enrollment identity directory: %w", err)
+	}
+	return nil
 }
 
 func ReadEnrollment(root string) (Enrollment, error) {

--- a/internal/installer/generation/identity.go
+++ b/internal/installer/generation/identity.go
@@ -3,6 +3,7 @@ package generation
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -10,13 +11,26 @@ import (
 	"strings"
 )
 
+const EnrollmentPath = "var/lib/katl/identity/enrollment.json"
+
+type Enrollment struct {
+	APIVersion        string `json:"apiVersion"`
+	Kind              string `json:"kind"`
+	ID                string `json:"id"`
+	InventoryNodeName string `json:"inventoryNodeName"`
+	MachineID         string `json:"machineID"`
+}
+
 type IdentityRequest struct {
-	AuthorizedKeys []string
-	Random         io.Reader
+	AuthorizedKeys    []string
+	InventoryNodeName string
+	Random            io.Reader
+	EnrollmentRandom  io.Reader
 }
 
 type IdentityAssets struct {
 	MachineID      string
+	Enrollment     Enrollment
 	AuthorizedKeys string
 }
 
@@ -43,7 +57,102 @@ func WriteIdentity(root string, request IdentityRequest) (IdentityAssets, error)
 		return IdentityAssets{}, err
 	}
 	assets.MachineID = machineID
+	assets.Enrollment, err = WriteEnrollment(root, request.InventoryNodeName, machineID, request.EnrollmentRandom)
+	if err != nil {
+		return IdentityAssets{}, err
+	}
 	return assets, nil
+}
+
+func WriteEnrollment(root, nodeName, machineID string, random io.Reader) (Enrollment, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return Enrollment{}, fmt.Errorf("target root is required")
+	}
+	nodeName = strings.TrimSpace(nodeName)
+	if nodeName == "" {
+		return Enrollment{}, fmt.Errorf("inventory node name is required")
+	}
+	machineID, err := cleanMachineID(machineID)
+	if err != nil {
+		return Enrollment{}, err
+	}
+	path := filepath.Join(root, EnrollmentPath)
+	if data, err := os.ReadFile(path); err == nil {
+		enrollment, err := decodeEnrollment(data)
+		if err != nil {
+			return Enrollment{}, fmt.Errorf("decode enrollment identity: %w", err)
+		}
+		if enrollment.InventoryNodeName != nodeName || enrollment.MachineID != machineID {
+			return Enrollment{}, fmt.Errorf("existing enrollment belongs to inventory node %q and machine %q", enrollment.InventoryNodeName, enrollment.MachineID)
+		}
+		if err := os.Chmod(path, 0o444); err != nil {
+			return Enrollment{}, fmt.Errorf("protect enrollment identity: %w", err)
+		}
+		return enrollment, nil
+	} else if !os.IsNotExist(err) {
+		return Enrollment{}, fmt.Errorf("read enrollment identity: %w", err)
+	}
+	id, err := generateIdentity(random)
+	if err != nil {
+		return Enrollment{}, fmt.Errorf("generate enrollment identity: %w", err)
+	}
+	enrollment := Enrollment{APIVersion: "katl.dev/v1alpha1", Kind: "NodeEnrollment", ID: id, InventoryNodeName: nodeName, MachineID: machineID}
+	data, err := json.MarshalIndent(enrollment, "", "  ")
+	if err != nil {
+		return Enrollment{}, fmt.Errorf("encode enrollment identity: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return Enrollment{}, fmt.Errorf("create enrollment identity directory: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o444); err != nil {
+		return Enrollment{}, fmt.Errorf("write enrollment identity: %w", err)
+	}
+	return enrollment, nil
+}
+
+func ReadEnrollment(root string) (Enrollment, error) {
+	path := filepath.Join(filepath.Clean(strings.TrimSpace(root)), EnrollmentPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Enrollment{}, fmt.Errorf("read enrollment identity: %w", err)
+	}
+	enrollment, err := decodeEnrollment(data)
+	if err != nil {
+		return Enrollment{}, fmt.Errorf("decode enrollment identity: %w", err)
+	}
+	return enrollment, nil
+}
+
+func decodeEnrollment(data []byte) (Enrollment, error) {
+	var enrollment Enrollment
+	if err := json.Unmarshal(data, &enrollment); err != nil {
+		return Enrollment{}, err
+	}
+	if enrollment.APIVersion != "katl.dev/v1alpha1" || enrollment.Kind != "NodeEnrollment" {
+		return Enrollment{}, fmt.Errorf("unsupported enrollment record %s %s", enrollment.APIVersion, enrollment.Kind)
+	}
+	if _, err := hex.DecodeString(enrollment.ID); err != nil || len(enrollment.ID) != 32 || enrollment.ID != strings.ToLower(enrollment.ID) {
+		return Enrollment{}, fmt.Errorf("enrollment id must be 32 lowercase hex characters")
+	}
+	if strings.TrimSpace(enrollment.InventoryNodeName) == "" {
+		return Enrollment{}, fmt.Errorf("inventory node name is required")
+	}
+	if _, err := cleanMachineID(enrollment.MachineID); err != nil {
+		return Enrollment{}, err
+	}
+	return enrollment, nil
+}
+
+func generateIdentity(random io.Reader) (string, error) {
+	if random == nil {
+		random = rand.Reader
+	}
+	var data [16]byte
+	if _, err := io.ReadFull(random, data[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(data[:]), nil
 }
 
 func WriteMachineID(root string, random io.Reader) (string, error) {

--- a/internal/installer/generation/identity_test.go
+++ b/internal/installer/generation/identity_test.go
@@ -68,13 +68,28 @@ func TestRenderSSH(t *testing.T) {
 func TestWriteIdentity(t *testing.T) {
 	root := t.TempDir()
 	assets, err := WriteIdentity(root, IdentityRequest{
-		AuthorizedKeys: []string{sshKey},
-		Random:         bytes.NewReader([]byte("0123456789abcdef")),
+		AuthorizedKeys:    []string{sshKey},
+		InventoryNodeName: "cp-1",
+		Random:            bytes.NewReader([]byte("0123456789abcdef")),
+		EnrollmentRandom:  bytes.NewReader([]byte("fedcba9876543210")),
 	})
 	if err != nil {
 		t.Fatalf("WriteIdentity() error = %v", err)
 	}
 	assertFile(t, filepath.Join(root, "var/lib/katl/identity/machine-id"), assets.MachineID+"\n")
+	if assets.Enrollment.InventoryNodeName != "cp-1" || assets.Enrollment.MachineID != assets.MachineID || assets.Enrollment.ID != "66656463626139383736353433323130" {
+		t.Fatalf("enrollment = %+v", assets.Enrollment)
+	}
+	reused, err := WriteEnrollment(root, "cp-1", assets.MachineID, bytes.NewReader([]byte("xxxxxxxxxxxxxxxx")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused.ID != assets.Enrollment.ID {
+		t.Fatalf("reused enrollment ID = %q, want %q", reused.ID, assets.Enrollment.ID)
+	}
+	if _, err := WriteEnrollment(root, "cp-2", assets.MachineID, bytes.NewReader([]byte("xxxxxxxxxxxxxxxx"))); err == nil || !strings.Contains(err.Error(), "existing enrollment belongs") {
+		t.Fatalf("renamed enrollment error = %v", err)
+	}
 }
 
 func TestRenderSSHRejectsKey(t *testing.T) {
@@ -124,8 +139,10 @@ func TestWriteInstallIdentity(t *testing.T) {
 		TargetRoot: targetRoot,
 		BootRoot:   bootRoot,
 		Identity: IdentityRequest{
-			AuthorizedKeys: []string{sshKey},
-			Random:         bytes.NewReader([]byte("0123456789abcdef")),
+			AuthorizedKeys:    []string{sshKey},
+			InventoryNodeName: "cp-1",
+			Random:            bytes.NewReader([]byte("0123456789abcdef")),
+			EnrollmentRandom:  bytes.NewReader([]byte("fedcba9876543210")),
 		},
 		Loader: LoaderRequest{Record: record},
 	})

--- a/internal/installer/generation/identity_test.go
+++ b/internal/installer/generation/identity_test.go
@@ -2,6 +2,7 @@ package generation
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,6 +90,49 @@ func TestWriteIdentity(t *testing.T) {
 	}
 	if _, err := WriteEnrollment(root, "cp-2", assets.MachineID, bytes.NewReader([]byte("xxxxxxxxxxxxxxxx"))); err == nil || !strings.Contains(err.Error(), "existing enrollment belongs") {
 		t.Fatalf("renamed enrollment error = %v", err)
+	}
+}
+
+func TestWriteEnrollmentIgnoresInterruptedTemporaryFile(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.Dir(EnrollmentPath))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir enrollment identity dir: %v", err)
+	}
+	interrupted := filepath.Join(dir, ".enrollment.json.tmp-interrupted")
+	if err := os.WriteFile(interrupted, []byte(`{"apiVersion":`), 0o600); err != nil {
+		t.Fatalf("write interrupted temporary enrollment: %v", err)
+	}
+
+	enrollment, err := WriteEnrollment(root, "cp-1", "0123456789abcdef0123456789abcdef", bytes.NewReader([]byte("fedcba9876543210")))
+	if err != nil {
+		t.Fatalf("WriteEnrollment() after interrupted temporary write error = %v", err)
+	}
+	read, err := ReadEnrollment(root)
+	if err != nil {
+		t.Fatalf("ReadEnrollment() error = %v", err)
+	}
+	if read != enrollment {
+		t.Fatalf("persisted enrollment = %+v, want %+v", read, enrollment)
+	}
+	assertMode(t, filepath.Join(root, EnrollmentPath), 0o444)
+}
+
+func TestWriteEnrollmentAtomicPublishDoesNotReplaceExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enrollment.json")
+	if err := os.WriteFile(path, []byte("existing\n"), 0o444); err != nil {
+		t.Fatalf("write existing enrollment: %v", err)
+	}
+	if err := writeEnrollmentAtomic(path, []byte("replacement\n")); err == nil || !errors.Is(err, os.ErrExist) {
+		t.Fatalf("writeEnrollmentAtomic() error = %v, want file-exists refusal", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read existing enrollment: %v", err)
+	}
+	if string(data) != "existing\n" {
+		t.Fatalf("existing enrollment = %q, want unchanged", data)
 	}
 }
 

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -77,6 +77,7 @@ type Context struct {
 	KubeadmConfigs                     map[string]kubeadmconfig.Plan
 	SystemExtensionPayloads            []configapply.SystemExtensionPayload
 	IdentityRandom                     io.Reader
+	EnrollmentRandom                   io.Reader
 	Completed                          []StepID
 	Chown                              func(path string, uid int, gid int) error
 	InputMode                          string
@@ -796,8 +797,10 @@ func (installSeedStep) Run(ctx context.Context, install *Context) error {
 		return fmt.Errorf("target root is required")
 	}
 	request := generation.IdentityRequest{
-		AuthorizedKeys: install.Manifest.Node.Identity.SSH.AuthorizedKeys,
-		Random:         install.IdentityRandom,
+		AuthorizedKeys:    install.Manifest.Node.Identity.SSH.AuthorizedKeys,
+		InventoryNodeName: inventoryNodeName(install.Manifest),
+		Random:            install.IdentityRandom,
+		EnrollmentRandom:  install.EnrollmentRandom,
 	}
 	if install.LoaderRecord != nil {
 		bootRoot := install.BootRoot

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -54,6 +54,12 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 	if strings.TrimSpace(req.Actor) == "" {
 		return nil, status.Error(codes.InvalidArgument, "actor is required")
 	}
+	if err := s.validateMutationTarget(req.ExpectedEnrollmentId, req.ExpectedInventoryNodeName, req.ExpectedMachineId, req.ExpectedCurrentGenerationId); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.NodeName) != strings.TrimSpace(req.ExpectedInventoryNodeName) {
+		return nil, status.Error(codes.FailedPrecondition, "config nodeName does not match expectedInventoryNodeName")
+	}
 	applyMode := strings.TrimSpace(req.ApplyMode)
 	if applyMode == "" {
 		applyMode = generation.ApplyModeAuto
@@ -85,6 +91,8 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		Actor:                              req.Actor,
 		ExpectedMachineId:                  req.ExpectedMachineId,
 		ExpectedCurrentGenerationId:        req.ExpectedCurrentGenerationId,
+		ExpectedEnrollmentId:               req.ExpectedEnrollmentId,
+		ExpectedInventoryNodeName:          req.ExpectedInventoryNodeName,
 		RequestDigest:                      "",
 		OperationTimeout:                   req.OperationTimeout,
 		CandidateGenerationId:              candidateID,
@@ -264,6 +272,8 @@ func generationSubmitRequest(req *agentapi.GenerationApplyRequest, operationKind
 		Actor:                       req.Actor,
 		ExpectedMachineId:           req.ExpectedMachineId,
 		ExpectedCurrentGenerationId: req.ExpectedCurrentGenerationId,
+		ExpectedEnrollmentId:        req.ExpectedEnrollmentId,
+		ExpectedInventoryNodeName:   req.ExpectedInventoryNodeName,
 		RequestDigest:               req.RequestDigest,
 		OperationTimeout:            req.OperationTimeout,
 		ConfigApply: &agentapi.ConfigApplyOperationRequest{

--- a/internal/katlc/agent/host_upgrade_artifact.go
+++ b/internal/katlc/agent/host_upgrade_artifact.go
@@ -108,7 +108,7 @@ func (s *Server) StageHostUpgradeArtifact(stream grpc.ClientStreamingServer[agen
 		if err != nil {
 			return err
 		}
-		if request.ApiVersion != "" || request.Kind != "" || request.Actor != "" || request.ExpectedMachineId != "" || request.Sha256 != "" || request.SizeBytes != 0 {
+		if request.ApiVersion != "" || request.Kind != "" || request.Actor != "" || request.ExpectedMachineId != "" || request.ExpectedEnrollmentId != "" || request.ExpectedInventoryNodeName != "" || request.ExpectedCurrentGenerationId != "" || request.Sha256 != "" || request.SizeBytes != 0 {
 			return status.Error(codes.InvalidArgument, "artifact metadata is only allowed in the first chunk")
 		}
 		if err := writeChunk(request.Chunk); err != nil {
@@ -164,12 +164,8 @@ func (s *Server) validateStagedArtifactMetadata(request *agentapi.StageHostUpgra
 	if strings.TrimSpace(request.Actor) == "" {
 		return stagedArtifactTarget{}, status.Error(codes.InvalidArgument, "actor is required")
 	}
-	machineID, err := s.machineID()
-	if err != nil {
-		return stagedArtifactTarget{}, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
-	}
-	if strings.TrimSpace(request.ExpectedMachineId) == "" || request.ExpectedMachineId != machineID {
-		return stagedArtifactTarget{}, status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
+	if err := s.validateMutationTarget(request.ExpectedEnrollmentId, request.ExpectedInventoryNodeName, request.ExpectedMachineId, request.ExpectedCurrentGenerationId); err != nil {
+		return stagedArtifactTarget{}, err
 	}
 	if err := validateArtifactSHA256(request.Sha256); err != nil {
 		return stagedArtifactTarget{}, status.Error(codes.InvalidArgument, err.Error())

--- a/internal/katlc/agent/server.go
+++ b/internal/katlc/agent/server.go
@@ -69,6 +69,8 @@ type Server struct {
 	Root                     string
 	Store                    operation.Store
 	MachineID                string
+	EnrollmentID             string
+	InventoryNodeName        string
 	AgentStartID             string
 	StartedAt                time.Time
 	SupportedOperationKinds  []string
@@ -121,12 +123,8 @@ func (s *Server) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agen
 	if strings.TrimSpace(req.Actor) == "" {
 		return nil, status.Error(codes.InvalidArgument, "actor is required")
 	}
-	machineID, err := s.machineID()
-	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
-	}
-	if strings.TrimSpace(req.ExpectedMachineId) == "" || req.ExpectedMachineId != machineID {
-		return nil, status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
+	if err := s.validateMutationTarget(req.ExpectedEnrollmentId, req.ExpectedInventoryNodeName, req.ExpectedMachineId, req.ExpectedCurrentGenerationId); err != nil {
+		return nil, err
 	}
 	target := strings.TrimSpace(req.TargetGenerationId)
 	if err := cleanPublicID("targetGenerationID", target); err != nil {
@@ -176,12 +174,8 @@ func (s *Server) Shutdown(ctx context.Context, req *agentapi.ShutdownRequest) (*
 	if strings.TrimSpace(req.Actor) == "" {
 		return nil, status.Error(codes.InvalidArgument, "actor is required")
 	}
-	machineID, err := s.machineID()
-	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
-	}
-	if strings.TrimSpace(req.ExpectedMachineId) == "" || req.ExpectedMachineId != machineID {
-		return nil, status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
+	if err := s.validateMutationTarget(req.ExpectedEnrollmentId, req.ExpectedInventoryNodeName, req.ExpectedMachineId, req.ExpectedCurrentGenerationId); err != nil {
+		return nil, err
 	}
 	active, err := s.activeOperationIDs()
 	if err != nil {
@@ -211,6 +205,10 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 	machineID, err := s.machineID()
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
+	}
+	enrollment, err := s.enrollment()
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "read enrollment identity: %v", err)
 	}
 	currentGenerationID, _ := currentGenerationID(s.Root)
 	bootHealth := readNodeBootHealth(s.Root)
@@ -256,6 +254,8 @@ func (s *Server) GetNodeStatus(ctx context.Context, _ *agentapi.GetNodeStatusReq
 		SelectedGenerationId:    bootHealth.SelectedGenerationID,
 		BootHealthState:         bootHealth.State,
 		BootHealthDiagnostic:    bootHealth.Diagnostic,
+		EnrollmentId:            enrollment.ID,
+		InventoryNodeName:       enrollment.InventoryNodeName,
 	}, nil
 }
 
@@ -313,14 +313,8 @@ func (s *Server) CreateWorkerJoinMaterial(ctx context.Context, req *agentapi.Cre
 	if strings.TrimSpace(req.RequestRef) != "" && inventory.Redact(req.RequestRef) != req.RequestRef {
 		return nil, status.Error(codes.InvalidArgument, "requestRef must be an opaque reference, not raw join material")
 	}
-	if strings.TrimSpace(req.ExpectedMachineId) != "" {
-		machineID, err := s.machineID()
-		if err != nil {
-			return nil, status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
-		}
-		if req.ExpectedMachineId != machineID {
-			return nil, status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
-		}
+	if err := s.validateMutationTarget(req.ExpectedEnrollmentId, req.ExpectedInventoryNodeName, req.ExpectedMachineId, req.ExpectedCurrentGenerationId); err != nil {
+		return nil, err
 	}
 	ttl, err := workerJoinTTL(req.Ttl)
 	if err != nil {
@@ -790,6 +784,9 @@ func (s *Server) validateSubmit(req *agentapi.SubmitOperationRequest) error {
 	if strings.TrimSpace(req.Actor) == "" {
 		return status.Error(codes.InvalidArgument, "actor is required")
 	}
+	if err := s.validateMutationTarget(req.ExpectedEnrollmentId, req.ExpectedInventoryNodeName, req.ExpectedMachineId, req.ExpectedCurrentGenerationId); err != nil {
+		return err
+	}
 	bodyCount := 0
 	if req.GetBootstrap() != nil {
 		bodyCount++
@@ -814,6 +811,9 @@ func (s *Server) validateSubmit(req *agentapi.SubmitOperationRequest) error {
 	}
 	if bodyCount != 1 {
 		return status.Error(codes.InvalidArgument, "exactly one operation request body is required")
+	}
+	if err := validateRequestedInventoryNode(req); err != nil {
+		return err
 	}
 	if req.GetConfigApply() != nil {
 		if err := validateConfigApplyRequest(req.OperationKind, req.GetConfigApply()); err != nil {
@@ -866,24 +866,29 @@ func (s *Server) validateSubmit(req *agentapi.SubmitOperationRequest) error {
 			return status.Errorf(codes.InvalidArgument, "operationTimeout must not exceed %s", maxToolTimeout)
 		}
 	}
-	if strings.TrimSpace(req.ExpectedMachineId) != "" {
-		machineID, err := s.machineID()
-		if err != nil {
-			return status.Errorf(codes.FailedPrecondition, "read machine id: %v", err)
-		}
-		if req.ExpectedMachineId != machineID {
-			return status.Error(codes.FailedPrecondition, "expectedMachineID does not match node machine id")
-		}
-	}
-	if strings.TrimSpace(req.ExpectedCurrentGenerationId) != "" {
-		if err := s.validateExpectedCurrentGeneration(req.ExpectedCurrentGenerationId); err != nil {
-			return err
-		}
-	}
 	if strings.TrimSpace(req.ExpectedClusterIntentDigest) != "" {
 		if err := s.validateExpectedClusterIntentDigest(req.ExpectedClusterIntentDigest); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateRequestedInventoryNode(req *agentapi.SubmitOperationRequest) error {
+	expected := strings.TrimSpace(req.GetExpectedInventoryNodeName())
+	requested := ""
+	switch {
+	case req.GetBootstrap() != nil:
+		requested = strings.TrimSpace(req.GetBootstrap().GetInventoryNodeName())
+	case req.GetConfigApply() != nil:
+		requested = strings.TrimSpace(req.GetConfigApply().GetNodeName())
+	case req.GetDestructiveReset() != nil:
+		requested = strings.TrimSpace(req.GetDestructiveReset().GetInventoryNodeName())
+	case req.GetKubeadmControlPlaneConfig() != nil:
+		requested = strings.TrimSpace(req.GetKubeadmControlPlaneConfig().GetNodeName())
+	}
+	if requested != "" && requested != expected {
+		return status.Errorf(codes.FailedPrecondition, "requested inventory node %q does not match enrolled request target %q", requested, expected)
 	}
 	return nil
 }
@@ -1082,6 +1087,54 @@ func (s *Server) machineID() (string, error) {
 	return "", fmt.Errorf("machine identity is not initialized")
 }
 
+func (s *Server) enrollment() (generation.Enrollment, error) {
+	if strings.TrimSpace(s.EnrollmentID) != "" || strings.TrimSpace(s.InventoryNodeName) != "" {
+		machineID, err := s.machineID()
+		if err != nil {
+			return generation.Enrollment{}, err
+		}
+		return generation.Enrollment{ID: strings.TrimSpace(s.EnrollmentID), InventoryNodeName: strings.TrimSpace(s.InventoryNodeName), MachineID: machineID}, nil
+	}
+	root := strings.TrimSpace(s.Root)
+	if root == "" {
+		root = "/"
+	}
+	return generation.ReadEnrollment(root)
+}
+
+func (s *Server) validateMutationTarget(enrollmentID, nodeName, machineID, currentGenerationID string) error {
+	for _, required := range []struct {
+		field string
+		value string
+	}{
+		{field: "expectedEnrollmentID", value: enrollmentID},
+		{field: "expectedInventoryNodeName", value: nodeName},
+		{field: "expectedMachineID", value: machineID},
+		{field: "expectedCurrentGenerationID", value: currentGenerationID},
+	} {
+		if strings.TrimSpace(required.value) == "" {
+			return status.Errorf(codes.InvalidArgument, "%s is required for mutating requests", required.field)
+		}
+	}
+	if err := cleanPublicID("expectedCurrentGenerationID", currentGenerationID); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	enrollment, err := s.enrollment()
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "read enrollment identity: %v", err)
+	}
+	if enrollmentID != enrollment.ID {
+		return status.Error(codes.FailedPrecondition, "expectedEnrollmentID does not match node enrollment")
+	}
+	if nodeName != enrollment.InventoryNodeName {
+		return status.Errorf(codes.FailedPrecondition, "requested inventory node %q does not match enrolled node %q", nodeName, enrollment.InventoryNodeName)
+	}
+	if machineID != enrollment.MachineID {
+		return status.Error(codes.FailedPrecondition, "expectedMachineID does not match enrolled machine id")
+	}
+	return s.validateExpectedCurrentGeneration(currentGenerationID)
+}
+
 func (s *Server) operationStoreRoot() string {
 	if strings.TrimSpace(s.Store.Root) != "" {
 		return s.Store.Root
@@ -1116,16 +1169,9 @@ func (s *Server) operationID(kind string, now time.Time) (string, error) {
 }
 
 func (s *Server) validateExpectedCurrentGeneration(expected string) error {
-	selection, err := generation.ReadBootSelection(s.Root)
+	current, err := currentGenerationID(s.Root)
 	if err != nil {
-		return status.Errorf(codes.FailedPrecondition, "read boot selection for expectedCurrentGenerationID: %v", err)
-	}
-	current := strings.TrimSpace(selection.BootedGenerationID)
-	if current == "" {
-		current = strings.TrimSpace(selection.DefaultGenerationID)
-	}
-	if current == "" {
-		return status.Error(codes.FailedPrecondition, "current generation is not recorded")
+		return status.Errorf(codes.FailedPrecondition, "read current generation for expectedCurrentGenerationID: %v", err)
 	}
 	if expected != current {
 		return status.Errorf(codes.FailedPrecondition, "expectedCurrentGenerationID %q does not match current generation %q", expected, current)

--- a/internal/katlc/agent/server_test.go
+++ b/internal/katlc/agent/server_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type dispatchFunc func(context.Context, operation.OperationRecord) error
@@ -88,6 +89,84 @@ func TestOperationStatusIncludesConfigApplyActions(t *testing.T) {
 		got.GetBootHealthPending() ||
 		!strings.Contains(got.GetNextAction(), "active generation") {
 		t.Fatalf("operation status boot completion = %+v", got)
+	}
+}
+
+func TestEveryMutatingRPCRejectsWrongEnrollmentBeforeAcceptance(t *testing.T) {
+	server := newTestServer(t)
+	wrong := "ffeeddccbbaa99887766554433221100"
+	assertRejected := func(name string, err error) {
+		t.Helper()
+		if status.Code(err) != codes.FailedPrecondition || !strings.Contains(err.Error(), "expectedEnrollmentID does not match") {
+			t.Fatalf("%s error = %v, want enrollment FailedPrecondition", name, err)
+		}
+	}
+	baseSubmit := func() *agentapi.SubmitOperationRequest {
+		request := submitRequest("wrong-enrollment")
+		request.ExpectedEnrollmentId = wrong
+		request.ExpectedCurrentGenerationId = "generation-0"
+		return request
+	}
+	_, err := server.Server.SubmitOperation(context.Background(), baseSubmit())
+	assertRejected("SubmitOperation", err)
+	_, err = server.Server.ValidateConfig(context.Background(), &agentapi.ValidateConfigRequest{ApiVersion: APIVersion, Kind: "ValidateConfigRequest", Actor: "test", ExpectedEnrollmentId: wrong, ExpectedInventoryNodeName: testInventoryNodeName, ExpectedMachineId: testMachineID, ExpectedCurrentGenerationId: "generation-0"})
+	assertRejected("ValidateConfig", err)
+	apply := &agentapi.GenerationApplyRequest{ApiVersion: APIVersion, Kind: "GenerationApplyRequest", ClientRequestId: "wrong-enrollment", Actor: "test", ExpectedEnrollmentId: wrong, ExpectedInventoryNodeName: testInventoryNodeName, ExpectedMachineId: testMachineID, ExpectedCurrentGenerationId: "generation-0"}
+	_, err = server.Server.ApplyGeneration(context.Background(), apply)
+	assertRejected("ApplyGeneration", err)
+	_, err = server.Server.StageGeneration(context.Background(), apply)
+	assertRejected("StageGeneration", err)
+	_, err = server.Server.Reboot(context.Background(), &agentapi.RebootRequest{ApiVersion: APIVersion, Kind: RebootRequestKind, Actor: "test", ExpectedEnrollmentId: wrong, ExpectedInventoryNodeName: testInventoryNodeName, ExpectedMachineId: testMachineID, ExpectedCurrentGenerationId: "generation-0"})
+	assertRejected("Reboot", err)
+	_, err = server.Server.Shutdown(context.Background(), &agentapi.ShutdownRequest{ApiVersion: APIVersion, Kind: ShutdownRequestKind, Actor: "test", ExpectedEnrollmentId: wrong, ExpectedInventoryNodeName: testInventoryNodeName, ExpectedMachineId: testMachineID, ExpectedCurrentGenerationId: "generation-0"})
+	assertRejected("Shutdown", err)
+	_, err = server.Server.CreateWorkerJoinMaterial(context.Background(), &agentapi.CreateWorkerJoinMaterialRequest{ApiVersion: APIVersion, Kind: WorkerJoinMaterialRequestKind, Actor: "test", ExpectedEnrollmentId: wrong, ExpectedInventoryNodeName: testInventoryNodeName, ExpectedMachineId: testMachineID, ExpectedCurrentGenerationId: "generation-0"})
+	assertRejected("CreateWorkerJoinMaterial", err)
+	stream := newHostUpgradeArtifactServerStream(&agentapi.StageHostUpgradeArtifactRequest{ApiVersion: APIVersion, Kind: StageHostUpgradeArtifactRequestKind, Actor: "test", ExpectedEnrollmentId: wrong, ExpectedInventoryNodeName: testInventoryNodeName, ExpectedMachineId: testMachineID, ExpectedCurrentGenerationId: "generation-0"})
+	assertRejected("StageHostUpgradeArtifact", server.Server.StageHostUpgradeArtifact(stream))
+	if server.Dispatcher != nil {
+		t.Fatal("wrong enrollment configured a dispatcher")
+	}
+}
+
+func TestMutatingRequestRequiresCompleteTargetPreconditions(t *testing.T) {
+	server := newTestServer(t)
+	base := submitRequest("complete-target-preconditions")
+	base.ExpectedEnrollmentId = testEnrollmentID
+	base.ExpectedInventoryNodeName = testInventoryNodeName
+	base.ExpectedMachineId = testMachineID
+	base.ExpectedCurrentGenerationId = "generation-0"
+	for _, test := range []struct {
+		name  string
+		field string
+		clear func(*agentapi.SubmitOperationRequest)
+	}{
+		{name: "enrollment", field: "expectedEnrollmentID", clear: func(request *agentapi.SubmitOperationRequest) { request.ExpectedEnrollmentId = "" }},
+		{name: "inventory node", field: "expectedInventoryNodeName", clear: func(request *agentapi.SubmitOperationRequest) { request.ExpectedInventoryNodeName = "" }},
+		{name: "machine", field: "expectedMachineID", clear: func(request *agentapi.SubmitOperationRequest) { request.ExpectedMachineId = "" }},
+		{name: "generation", field: "expectedCurrentGenerationID", clear: func(request *agentapi.SubmitOperationRequest) { request.ExpectedCurrentGenerationId = "" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := proto.Clone(base).(*agentapi.SubmitOperationRequest)
+			test.clear(request)
+			_, err := server.Server.SubmitOperation(context.Background(), request)
+			if status.Code(err) != codes.InvalidArgument || !strings.Contains(err.Error(), test.field+" is required") {
+				t.Fatalf("SubmitOperation error = %v, want required %s", err, test.field)
+			}
+		})
+	}
+}
+
+func TestAgentRejectsRequestedInventoryNodeDifferentFromEnrollment(t *testing.T) {
+	server := newTestServer(t)
+	writeBootSelection(t, server.Root, "generation-0")
+	request := submitRequest("wrong-node-name")
+	request.ExpectedInventoryNodeName = testInventoryNodeName
+	request.ExpectedCurrentGenerationId = "generation-0"
+	request.Bootstrap.InventoryNodeName = "node-b"
+	_, err := server.Server.SubmitOperation(context.Background(), request)
+	if status.Code(err) != codes.FailedPrecondition || !strings.Contains(err.Error(), `requested inventory node "node-b"`) {
+		t.Fatalf("SubmitOperation error = %v, want enrolled node-name refusal", err)
 	}
 }
 
@@ -504,6 +583,79 @@ func TestNodeStatusReportsSelectedBootTarget(t *testing.T) {
 	}
 }
 
+func TestMutationPreconditionAcceptsCurrentLiveGenerationReportedByStatus(t *testing.T) {
+	server := newTestServer(t)
+	writeCleanGenerationZeroState(t, server.Root)
+	const (
+		operationID  = "live-activation"
+		generationID = "generation-live"
+	)
+	spec, _, err := generation.ReadGeneration(server.Root, "generation-0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec.GenerationID = generationID
+	spec.PreviousGenerationID = "generation-0"
+	spec.Boot.LoaderEntryPath = "loader/entries/katl-generation-live.conf"
+	generationStatus, err := generation.NewGenerationStatus(spec, generation.CommitStateCommitted, generation.BootStateTrying, generation.HealthStateUnknown, server.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := generation.WriteGeneration(server.Root, spec, generationStatus); err != nil {
+		t.Fatal(err)
+	}
+	completedAt := server.Now()
+	if _, err := server.Store.Create(operation.OperationRecord{
+		OperationID:           operationID,
+		OperationKind:         "config-apply",
+		Scope:                 "configuration",
+		RequestDigest:         strings.Repeat("1", 64),
+		Phase:                 "complete",
+		PhasePlan:             []string{"accepted", "complete"},
+		CompletedPhases:       []string{"accepted", "complete"},
+		PhaseIndex:            2,
+		PreviousGenerationID:  "generation-0",
+		CandidateGenerationID: generationID,
+		ActivationMode:        operation.ActivationModeLive,
+		ActivationState:       operation.ActivationStateActiveLive,
+		GenerationCommitState: operation.GenerationCommitCommitted,
+		ResourceLocks:         []string{"generation-state.lock"},
+		Terminal:              true,
+		Result:                operation.ResultSucceeded,
+		CompletedAt:           &completedAt,
+		CreatedAt:             server.Now(),
+		UpdatedAt:             server.Now(),
+	}, "accepted", server.Now()); err != nil {
+		t.Fatal(err)
+	}
+	selection, err := generation.ReadBootSelection(server.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection.TargetBootGenerationID = generationID
+	selection.TargetBootEntry = spec.Boot.LoaderEntryPath
+	selection.PendingHealthValidation = true
+	selection.PendingTransactionID = operationID
+	selection.PersistentDefaultPromotion = generation.DefaultPromotionPending
+	if err := generation.WriteBootSelection(server.Root, selection); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeStatus, err := server.GetNodeStatus(context.Background(), &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodeStatus.GetCurrentGenerationId() != generationID {
+		t.Fatalf("current generation = %q, want %q", nodeStatus.GetCurrentGenerationId(), generationID)
+	}
+	if err := server.validateMutationTarget(nodeStatus.GetEnrollmentId(), nodeStatus.GetInventoryNodeName(), nodeStatus.GetMachineId(), nodeStatus.GetCurrentGenerationId()); err != nil {
+		t.Fatalf("validate mutation against reported current generation: %v", err)
+	}
+	if err := server.validateExpectedCurrentGeneration("generation-0"); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("validate stale booted generation error = %v, want FailedPrecondition", err)
+	}
+}
+
 func TestNodeStatusReportsManualFallbackMismatch(t *testing.T) {
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
@@ -790,11 +942,14 @@ func TestSubmitOperationRejectsUnsafeHostUpgradeReference(t *testing.T) {
 
 func hostUpgradeSubmitRequest(clientRequestID string) *agentapi.SubmitOperationRequest {
 	return &agentapi.SubmitOperationRequest{
-		ApiVersion:      APIVersion,
-		Kind:            RequestKind,
-		ClientRequestId: clientRequestID,
-		OperationKind:   OperationKindHostUpgrade,
-		Actor:           "test-actor",
+		ApiVersion:                APIVersion,
+		Kind:                      RequestKind,
+		ClientRequestId:           clientRequestID,
+		OperationKind:             OperationKindHostUpgrade,
+		Actor:                     "test-actor",
+		ExpectedEnrollmentId:      testEnrollmentID,
+		ExpectedInventoryNodeName: testInventoryNodeName,
+		ExpectedMachineId:         testMachineID,
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
 			ImageUrl:              "https://updates.example.test/katlos-upgrade.squashfs",
 			CandidateGenerationId: "gen-upgrade-1",
@@ -868,7 +1023,7 @@ func TestKubernetesSysextUpdateRefusesBootstrappedNode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := newTestServer(t)
 			writeConfigApplyBaseState(t, server.Root)
-			writeKubeadmMutationEvidence(t, server, "bootstrap-evidence", tt.operationKind, tt.wantEvidence)
+			writeKubeadmMutationEvidence(t, server.Server, "bootstrap-evidence", tt.operationKind, tt.wantEvidence)
 			var dispatched atomic.Int32
 			server.Dispatcher = dispatchFunc(func(ctx context.Context, record operation.OperationRecord) error {
 				dispatched.Add(1)
@@ -961,7 +1116,7 @@ func TestKubernetesSysextUpdateRejectsRawActivationPath(t *testing.T) {
 func TestKubernetesSysextUpdateDryRunUsesRefusalPlan(t *testing.T) {
 	server := newTestServer(t)
 	writeConfigApplyBaseState(t, server.Root)
-	writeKubeadmMutationEvidence(t, server, "bootstrap-evidence", "bootstrap-init", "etc-kubernetes")
+	writeKubeadmMutationEvidence(t, server.Server, "bootstrap-evidence", "bootstrap-init", "etc-kubernetes")
 	server.Dispatcher = dispatchFunc(func(ctx context.Context, record operation.OperationRecord) error {
 		t.Fatalf("dispatcher called for dry-run Kubernetes sysext update")
 		return nil
@@ -1036,7 +1191,7 @@ func TestKubernetesSysextUpdateBootstrappedGenerationZeroUsesClusterIntent(t *te
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
 	writeInstalledClusterIntent(t, server.Root, "v1.35.0", "/var/lib/katl/artifacts/katlos-image/katl-kubernetes.raw")
-	writeKubeadmMutationEvidence(t, server, "bootstrap-evidence", "bootstrap-init", "etc-kubernetes")
+	writeKubeadmMutationEvidence(t, server.Server, "bootstrap-evidence", "bootstrap-init", "etc-kubernetes")
 	var dispatched atomic.Int32
 	server.Dispatcher = dispatchFunc(func(ctx context.Context, record operation.OperationRecord) error {
 		dispatched.Add(1)
@@ -1063,7 +1218,7 @@ func TestKubernetesSysextUpdateGenerationZeroIntentMatchStillRefuses(t *testing.
 	server := newTestServer(t)
 	writeCleanGenerationZeroState(t, server.Root)
 	writeInstalledClusterIntent(t, server.Root, "v1.35.0", "/var/lib/katl/artifacts/katlos-image/katl-kubernetes.raw")
-	writeKubeadmMutationEvidence(t, server, "bootstrap-evidence", "bootstrap-init", "etc-kubernetes")
+	writeKubeadmMutationEvidence(t, server.Server, "bootstrap-evidence", "bootstrap-init", "etc-kubernetes")
 	server.Dispatcher = dispatchFunc(func(ctx context.Context, record operation.OperationRecord) error {
 		t.Fatalf("dispatcher called for refused Kubernetes sysext update")
 		return nil
@@ -2321,6 +2476,7 @@ func TestSubmitOperationWithoutDispatcherRejectsBeforeRecord(t *testing.T) {
 
 func TestDryRunDoesNotRequireDispatcher(t *testing.T) {
 	server := newTestServer(t)
+	writeConfigApplyBaseState(t, server.Root)
 	req := submitRequest("req-dry-run-no-dispatcher")
 	req.DryRun = true
 
@@ -2477,7 +2633,7 @@ func validControlPlaneJoinMaterial() *agentapi.WorkerJoinMaterial {
 
 func TestCreateWorkerJoinMaterialRunsKubeadmTokenCreate(t *testing.T) {
 	server := newTestServer(t)
-	writeJoinMaterialAdminKubeconfig(t, server)
+	writeJoinMaterialAdminKubeconfig(t, server.Server)
 	var calls [][]string
 	server.RunJoinMaterial = func(ctx context.Context, argv []string, started func(int)) ToolResult {
 		calls = append(calls, append([]string(nil), argv...))
@@ -2541,7 +2697,7 @@ func TestCreateWorkerJoinMaterialRejectsActiveOperationLock(t *testing.T) {
 
 func TestCreateWorkerJoinMaterialSerializesWithSubmitOperation(t *testing.T) {
 	server := newTestServer(t)
-	writeJoinMaterialAdminKubeconfig(t, server)
+	writeJoinMaterialAdminKubeconfig(t, server.Server)
 	server.Dispatcher = dispatchFunc(func(ctx context.Context, record operation.OperationRecord) error {
 		return nil
 	})
@@ -2629,11 +2785,13 @@ func TestCreateWorkerJoinMaterialRedactsKubeadmFailure(t *testing.T) {
 
 func createWorkerJoinMaterialRequest() *agentapi.CreateWorkerJoinMaterialRequest {
 	return &agentapi.CreateWorkerJoinMaterialRequest{
-		ApiVersion:        APIVersion,
-		Kind:              WorkerJoinMaterialRequestKind,
-		Actor:             "test-actor",
-		ExpectedMachineId: "0123456789abcdef0123456789abcdef",
-		RequestRef:        "operation:bootstrap-init-1/worker:worker-1",
+		ApiVersion:                APIVersion,
+		Kind:                      WorkerJoinMaterialRequestKind,
+		Actor:                     "test-actor",
+		ExpectedEnrollmentId:      testEnrollmentID,
+		ExpectedInventoryNodeName: testInventoryNodeName,
+		ExpectedMachineId:         testMachineID,
+		RequestRef:                "operation:bootstrap-init-1/worker:worker-1",
 	}
 }
 
@@ -2978,7 +3136,131 @@ func TestWatchOperationHonorsDiagnosticsModeAndTerminalAtCurrentSeq(t *testing.T
 	}
 }
 
-func newTestServer(t *testing.T) *Server {
+type testServer struct{ *Server }
+
+func (s *testServer) mutationDefaults(enrollmentID, nodeName, machineID, generationID *string) {
+	if *enrollmentID == "" {
+		*enrollmentID = testEnrollmentID
+	}
+	if *nodeName == "" {
+		*nodeName = testInventoryNodeName
+	}
+	if *machineID == "" {
+		*machineID = testMachineID
+	}
+	if *generationID == "" {
+		if selection, err := generation.ReadBootSelection(s.Root); err == nil {
+			*generationID = firstNonEmpty(selection.BootedGenerationID, selection.DefaultGenerationID)
+		} else {
+			selection := generation.BootSelectionRecord{
+				APIVersion: generation.APIVersion, Kind: generation.BootSelectionKind,
+				DefaultGenerationID: "generation-0", BootedGenerationID: "generation-0", Generation0FallbackID: "generation-0",
+				DefaultBootEntry: "loader/entries/katl-generation-0.conf", BootedBootEntry: "loader/entries/katl-generation-0.conf", UpdatedAt: time.Now().UTC(),
+			}
+			if writeErr := generation.WriteBootSelection(s.Root, selection); writeErr == nil {
+				*generationID = "generation-0"
+			}
+		}
+	}
+}
+
+func (s *testServer) SubmitOperation(ctx context.Context, req *agentapi.SubmitOperationRequest) (*agentapi.OperationAccepted, error) {
+	if req != nil {
+		requestedNode := ""
+		switch {
+		case req.Bootstrap != nil:
+			requestedNode = req.Bootstrap.InventoryNodeName
+		case req.ConfigApply != nil:
+			requestedNode = req.ConfigApply.NodeName
+		case req.DestructiveReset != nil:
+			requestedNode = req.DestructiveReset.InventoryNodeName
+		case req.KubeadmControlPlaneConfig != nil:
+			requestedNode = req.KubeadmControlPlaneConfig.NodeName
+		}
+		if req.ExpectedInventoryNodeName == "" && requestedNode != "" {
+			req.ExpectedInventoryNodeName = requestedNode
+			s.InventoryNodeName = requestedNode
+		}
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+		if req.ConfigApply != nil && req.ConfigApply.NodeName == "" {
+			req.ConfigApply.NodeName = req.ExpectedInventoryNodeName
+		}
+	}
+	return s.Server.SubmitOperation(ctx, req)
+}
+
+func (s *testServer) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfigRequest) (*agentapi.ConfigValidationResult, error) {
+	if req != nil {
+		if req.ExpectedInventoryNodeName == "" && req.NodeName != "" {
+			req.ExpectedInventoryNodeName = req.NodeName
+			s.InventoryNodeName = req.NodeName
+		}
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+		if req.NodeName == "" {
+			req.NodeName = testInventoryNodeName
+		}
+	}
+	return s.Server.ValidateConfig(ctx, req)
+}
+
+func (s *testServer) StageGeneration(ctx context.Context, req *agentapi.GenerationApplyRequest) (*agentapi.OperationAccepted, error) {
+	if req != nil {
+		if req.ExpectedInventoryNodeName == "" && req.NodeName != "" {
+			req.ExpectedInventoryNodeName = req.NodeName
+			s.InventoryNodeName = req.NodeName
+		}
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+		if req.NodeName == "" {
+			req.NodeName = testInventoryNodeName
+		}
+	}
+	return s.Server.StageGeneration(ctx, req)
+}
+
+func (s *testServer) ApplyGeneration(ctx context.Context, req *agentapi.GenerationApplyRequest) (*agentapi.OperationAccepted, error) {
+	if req != nil {
+		if req.ExpectedInventoryNodeName == "" && req.NodeName != "" {
+			req.ExpectedInventoryNodeName = req.NodeName
+			s.InventoryNodeName = req.NodeName
+		}
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+		if req.NodeName == "" {
+			req.NodeName = testInventoryNodeName
+		}
+	}
+	return s.Server.ApplyGeneration(ctx, req)
+}
+
+func (s *testServer) Reboot(ctx context.Context, req *agentapi.RebootRequest) (*agentapi.RebootAccepted, error) {
+	if req != nil {
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+	}
+	return s.Server.Reboot(ctx, req)
+}
+
+func (s *testServer) Shutdown(ctx context.Context, req *agentapi.ShutdownRequest) (*agentapi.ShutdownAccepted, error) {
+	if req != nil {
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+	}
+	return s.Server.Shutdown(ctx, req)
+}
+
+func (s *testServer) CreateWorkerJoinMaterial(ctx context.Context, req *agentapi.CreateWorkerJoinMaterialRequest) (*agentapi.CreateWorkerJoinMaterialResponse, error) {
+	if req != nil {
+		s.mutationDefaults(&req.ExpectedEnrollmentId, &req.ExpectedInventoryNodeName, &req.ExpectedMachineId, &req.ExpectedCurrentGenerationId)
+	}
+	return s.Server.CreateWorkerJoinMaterial(ctx, req)
+}
+
+func (s *testServer) StageHostUpgradeArtifact(stream grpc.ClientStreamingServer[agentapi.StageHostUpgradeArtifactRequest, agentapi.HostUpgradeArtifactStaged]) error {
+	if testStream, ok := stream.(*hostUpgradeArtifactServerStream); ok && len(testStream.requests) > 0 {
+		request := testStream.requests[0]
+		s.mutationDefaults(&request.ExpectedEnrollmentId, &request.ExpectedInventoryNodeName, &request.ExpectedMachineId, &request.ExpectedCurrentGenerationId)
+	}
+	return s.Server.StageHostUpgradeArtifact(stream)
+}
+
+func newTestServer(t *testing.T) *testServer {
 	t.Helper()
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "var/lib/katl/identity"), 0o755); err != nil {
@@ -2992,6 +3274,8 @@ func newTestServer(t *testing.T) *Server {
 		t.Fatal(err)
 	}
 	server := NewServer(root, store)
+	server.EnrollmentID = testEnrollmentID
+	server.InventoryNodeName = testInventoryNodeName
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 	var seq atomic.Int64
 	server.Now = func() time.Time {
@@ -3001,17 +3285,19 @@ func newTestServer(t *testing.T) *Server {
 		next := seq.Add(1)
 		return fmt.Sprintf("%s-%02d", kind, next), nil
 	}
-	return server
+	return &testServer{Server: server}
 }
 
 func submitRequest(clientRequestID string) *agentapi.SubmitOperationRequest {
 	return &agentapi.SubmitOperationRequest{
-		ApiVersion:        APIVersion,
-		Kind:              RequestKind,
-		ClientRequestId:   clientRequestID,
-		OperationKind:     "bootstrap-init",
-		Actor:             "test-actor",
-		ExpectedMachineId: "0123456789abcdef0123456789abcdef",
+		ApiVersion:                APIVersion,
+		Kind:                      RequestKind,
+		ClientRequestId:           clientRequestID,
+		OperationKind:             "bootstrap-init",
+		Actor:                     "test-actor",
+		ExpectedEnrollmentId:      testEnrollmentID,
+		ExpectedInventoryNodeName: testInventoryNodeName,
+		ExpectedMachineId:         testMachineID,
 		Bootstrap: &agentapi.BootstrapOperationRequest{
 			InventoryNodeName:        "node-a",
 			SystemRole:               "control-plane",
@@ -3024,11 +3310,14 @@ func submitRequest(clientRequestID string) *agentapi.SubmitOperationRequest {
 
 func destructiveResetRequest(clientRequestID string) *agentapi.SubmitOperationRequest {
 	return &agentapi.SubmitOperationRequest{
-		ApiVersion:      APIVersion,
-		Kind:            RequestKind,
-		ClientRequestId: clientRequestID,
-		OperationKind:   OperationKindDestructiveReset,
-		Actor:           "test-actor",
+		ApiVersion:                APIVersion,
+		Kind:                      RequestKind,
+		ClientRequestId:           clientRequestID,
+		OperationKind:             OperationKindDestructiveReset,
+		Actor:                     "test-actor",
+		ExpectedEnrollmentId:      testEnrollmentID,
+		ExpectedInventoryNodeName: testInventoryNodeName,
+		ExpectedMachineId:         testMachineID,
 		DestructiveReset: &agentapi.DestructiveResetOperationRequest{
 			InventoryNodeName:      "node-a",
 			ResetScope:             "cluster",
@@ -3040,12 +3329,14 @@ func destructiveResetRequest(clientRequestID string) *agentapi.SubmitOperationRe
 
 func kubernetesSysextUpdateRequest(clientRequestID string, payloadVersion string, sha256Hex string) *agentapi.SubmitOperationRequest {
 	return &agentapi.SubmitOperationRequest{
-		ApiVersion:        APIVersion,
-		Kind:              RequestKind,
-		ClientRequestId:   clientRequestID,
-		OperationKind:     OperationKindKubeadmUpgrade,
-		Actor:             "test-actor",
-		ExpectedMachineId: "0123456789abcdef0123456789abcdef",
+		ApiVersion:                APIVersion,
+		Kind:                      RequestKind,
+		ClientRequestId:           clientRequestID,
+		OperationKind:             OperationKindKubeadmUpgrade,
+		Actor:                     "test-actor",
+		ExpectedEnrollmentId:      testEnrollmentID,
+		ExpectedInventoryNodeName: testInventoryNodeName,
+		ExpectedMachineId:         testMachineID,
 		KubernetesSysextUpdate: &agentapi.KubernetesSysextUpdateOperationRequest{
 			TargetPayloadVersion: payloadVersion,
 			TargetSysextPath:     "/var/lib/katl/artifacts/katlos-image/katl-kubernetes.raw",
@@ -3053,6 +3344,12 @@ func kubernetesSysextUpdateRequest(clientRequestID string, payloadVersion string
 		},
 	}
 }
+
+const (
+	testEnrollmentID      = "00112233445566778899aabbccddeeff"
+	testInventoryNodeName = "node-a"
+	testMachineID         = "0123456789abcdef0123456789abcdef"
+)
 
 func writeBootSelection(t *testing.T, root string, generationID string) {
 	t.Helper()

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -76,6 +76,8 @@ type NodeStatus struct {
 	SelectedGenerationId    string                      `protobuf:"bytes,15,opt,name=selected_generation_id,json=selectedGenerationId,proto3" json:"selected_generation_id,omitempty"`
 	BootHealthState         string                      `protobuf:"bytes,16,opt,name=boot_health_state,json=bootHealthState,proto3" json:"boot_health_state,omitempty"`
 	BootHealthDiagnostic    string                      `protobuf:"bytes,17,opt,name=boot_health_diagnostic,json=bootHealthDiagnostic,proto3" json:"boot_health_diagnostic,omitempty"`
+	EnrollmentId            string                      `protobuf:"bytes,18,opt,name=enrollment_id,json=enrollmentId,proto3" json:"enrollment_id,omitempty"`
+	InventoryNodeName       string                      `protobuf:"bytes,19,opt,name=inventory_node_name,json=inventoryNodeName,proto3" json:"inventory_node_name,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -225,6 +227,20 @@ func (x *NodeStatus) GetBootHealthState() string {
 func (x *NodeStatus) GetBootHealthDiagnostic() string {
 	if x != nil {
 		return x.BootHealthDiagnostic
+	}
+	return ""
+}
+
+func (x *NodeStatus) GetEnrollmentId() string {
+	if x != nil {
+		return x.EnrollmentId
+	}
+	return ""
+}
+
+func (x *NodeStatus) GetInventoryNodeName() string {
+	if x != nil {
+		return x.InventoryNodeName
 	}
 	return ""
 }
@@ -1189,6 +1205,8 @@ type SubmitOperationRequest struct {
 	HostUpgrade                 *HostUpgradeOperationRequest               `protobuf:"bytes,16,opt,name=host_upgrade,json=hostUpgrade,proto3" json:"host_upgrade,omitempty"`
 	KubeadmControlPlaneConfig   *KubeadmControlPlaneConfigOperationRequest `protobuf:"bytes,17,opt,name=kubeadm_control_plane_config,json=kubeadmControlPlaneConfig,proto3" json:"kubeadm_control_plane_config,omitempty"`
 	EtcdMemberRemove            *EtcdMemberRemoveOperationRequest          `protobuf:"bytes,18,opt,name=etcd_member_remove,json=etcdMemberRemove,proto3" json:"etcd_member_remove,omitempty"`
+	ExpectedEnrollmentId        string                                     `protobuf:"bytes,19,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName   string                                     `protobuf:"bytes,20,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -1347,6 +1365,20 @@ func (x *SubmitOperationRequest) GetEtcdMemberRemove() *EtcdMemberRemoveOperatio
 		return x.EtcdMemberRemove
 	}
 	return nil
+}
+
+func (x *SubmitOperationRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *SubmitOperationRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
 }
 
 type BootstrapOperationRequest struct {
@@ -1867,6 +1899,8 @@ type ValidateConfigRequest struct {
 	ClientRequestId                    string                 `protobuf:"bytes,10,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
 	OperationTimeout                   string                 `protobuf:"bytes,11,opt,name=operation_timeout,json=operationTimeout,proto3" json:"operation_timeout,omitempty"`
 	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
+	ExpectedEnrollmentId               string                 `protobuf:"bytes,13,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName          string                 `protobuf:"bytes,14,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
 	unknownFields                      protoimpl.UnknownFields
 	sizeCache                          protoimpl.SizeCache
 }
@@ -1983,6 +2017,20 @@ func (x *ValidateConfigRequest) GetDestructiveStorageAcknowledgements() []string
 		return x.DestructiveStorageAcknowledgements
 	}
 	return nil
+}
+
+func (x *ValidateConfigRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *ValidateConfigRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
 }
 
 type ConfigValidationResult struct {
@@ -2131,6 +2179,8 @@ type GenerationApplyRequest struct {
 	NodeName                           string                 `protobuf:"bytes,10,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
 	ConfigYaml                         string                 `protobuf:"bytes,11,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
 	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
+	ExpectedEnrollmentId               string                 `protobuf:"bytes,13,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName          string                 `protobuf:"bytes,14,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
 	unknownFields                      protoimpl.UnknownFields
 	sizeCache                          protoimpl.SizeCache
 }
@@ -2247,6 +2297,20 @@ func (x *GenerationApplyRequest) GetDestructiveStorageAcknowledgements() []strin
 		return x.DestructiveStorageAcknowledgements
 	}
 	return nil
+}
+
+func (x *GenerationApplyRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *GenerationApplyRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
 }
 
 type ConfigApplyOperationRequest struct {
@@ -2878,16 +2942,19 @@ func (x *HostUpgradeOperationRequest) GetCandidateGenerationId() string {
 }
 
 type StageHostUpgradeArtifactRequest struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion        string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind              string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	Actor             string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
-	ExpectedMachineId string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
-	Sha256            string                 `protobuf:"bytes,5,opt,name=sha256,proto3" json:"sha256,omitempty"`
-	SizeBytes         uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
-	Chunk             []byte                 `protobuf:"bytes,7,opt,name=chunk,proto3" json:"chunk,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                        string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor                       string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId           string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	Sha256                      string                 `protobuf:"bytes,5,opt,name=sha256,proto3" json:"sha256,omitempty"`
+	SizeBytes                   uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Chunk                       []byte                 `protobuf:"bytes,7,opt,name=chunk,proto3" json:"chunk,omitempty"`
+	ExpectedEnrollmentId        string                 `protobuf:"bytes,8,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName   string                 `protobuf:"bytes,9,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
+	ExpectedCurrentGenerationId string                 `protobuf:"bytes,10,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *StageHostUpgradeArtifactRequest) Reset() {
@@ -2969,6 +3036,27 @@ func (x *StageHostUpgradeArtifactRequest) GetChunk() []byte {
 	return nil
 }
 
+func (x *StageHostUpgradeArtifactRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
+}
+
+func (x *StageHostUpgradeArtifactRequest) GetExpectedCurrentGenerationId() string {
+	if x != nil {
+		return x.ExpectedCurrentGenerationId
+	}
+	return ""
+}
+
 type HostUpgradeArtifactStaged struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LocalRef      string                 `protobuf:"bytes,1,opt,name=local_ref,json=localRef,proto3" json:"local_ref,omitempty"`
@@ -3030,15 +3118,18 @@ func (x *HostUpgradeArtifactStaged) GetSizeBytes() uint64 {
 }
 
 type CreateWorkerJoinMaterialRequest struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion        string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind              string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	Actor             string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
-	ExpectedMachineId string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
-	RequestRef        string                 `protobuf:"bytes,5,opt,name=request_ref,json=requestRef,proto3" json:"request_ref,omitempty"`
-	Ttl               string                 `protobuf:"bytes,6,opt,name=ttl,proto3" json:"ttl,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                        string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor                       string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId           string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	RequestRef                  string                 `protobuf:"bytes,5,opt,name=request_ref,json=requestRef,proto3" json:"request_ref,omitempty"`
+	Ttl                         string                 `protobuf:"bytes,6,opt,name=ttl,proto3" json:"ttl,omitempty"`
+	ExpectedEnrollmentId        string                 `protobuf:"bytes,7,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName   string                 `protobuf:"bytes,8,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
+	ExpectedCurrentGenerationId string                 `protobuf:"bytes,9,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *CreateWorkerJoinMaterialRequest) Reset() {
@@ -3109,6 +3200,27 @@ func (x *CreateWorkerJoinMaterialRequest) GetRequestRef() string {
 func (x *CreateWorkerJoinMaterialRequest) GetTtl() string {
 	if x != nil {
 		return x.Ttl
+	}
+	return ""
+}
+
+func (x *CreateWorkerJoinMaterialRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *CreateWorkerJoinMaterialRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
+}
+
+func (x *CreateWorkerJoinMaterialRequest) GetExpectedCurrentGenerationId() string {
+	if x != nil {
+		return x.ExpectedCurrentGenerationId
 	}
 	return ""
 }
@@ -4782,14 +4894,17 @@ func (x *ConfigApplyEffect) GetDiagnostic() string {
 }
 
 type RebootRequest struct {
-	state              protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion         string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind               string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	Actor              string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
-	ExpectedMachineId  string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
-	TargetGenerationId string                 `protobuf:"bytes,5,opt,name=target_generation_id,json=targetGenerationId,proto3" json:"target_generation_id,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                        string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor                       string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId           string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	TargetGenerationId          string                 `protobuf:"bytes,5,opt,name=target_generation_id,json=targetGenerationId,proto3" json:"target_generation_id,omitempty"`
+	ExpectedEnrollmentId        string                 `protobuf:"bytes,6,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName   string                 `protobuf:"bytes,7,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
+	ExpectedCurrentGenerationId string                 `protobuf:"bytes,8,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *RebootRequest) Reset() {
@@ -4857,6 +4972,27 @@ func (x *RebootRequest) GetTargetGenerationId() string {
 	return ""
 }
 
+func (x *RebootRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *RebootRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
+}
+
+func (x *RebootRequest) GetExpectedCurrentGenerationId() string {
+	if x != nil {
+		return x.ExpectedCurrentGenerationId
+	}
+	return ""
+}
+
 type RebootAccepted struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	Scheduled          bool                   `protobuf:"varint,1,opt,name=scheduled,proto3" json:"scheduled,omitempty"`
@@ -4910,13 +5046,16 @@ func (x *RebootAccepted) GetTargetGenerationId() string {
 }
 
 type ShutdownRequest struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	ApiVersion        string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
-	Kind              string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
-	Actor             string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
-	ExpectedMachineId string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"open.v1"`
+	ApiVersion                  string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	Kind                        string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Actor                       string                 `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	ExpectedMachineId           string                 `protobuf:"bytes,4,opt,name=expected_machine_id,json=expectedMachineId,proto3" json:"expected_machine_id,omitempty"`
+	ExpectedEnrollmentId        string                 `protobuf:"bytes,5,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
+	ExpectedInventoryNodeName   string                 `protobuf:"bytes,6,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
+	ExpectedCurrentGenerationId string                 `protobuf:"bytes,7,opt,name=expected_current_generation_id,json=expectedCurrentGenerationId,proto3" json:"expected_current_generation_id,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *ShutdownRequest) Reset() {
@@ -4977,6 +5116,27 @@ func (x *ShutdownRequest) GetExpectedMachineId() string {
 	return ""
 }
 
+func (x *ShutdownRequest) GetExpectedEnrollmentId() string {
+	if x != nil {
+		return x.ExpectedEnrollmentId
+	}
+	return ""
+}
+
+func (x *ShutdownRequest) GetExpectedInventoryNodeName() string {
+	if x != nil {
+		return x.ExpectedInventoryNodeName
+	}
+	return ""
+}
+
+func (x *ShutdownRequest) GetExpectedCurrentGenerationId() string {
+	if x != nil {
+		return x.ExpectedCurrentGenerationId
+	}
+	return ""
+}
+
 type ShutdownAccepted struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Scheduled     bool                   `protobuf:"varint,1,opt,name=scheduled,proto3" json:"scheduled,omitempty"`
@@ -5026,7 +5186,7 @@ var File_internal_katlc_agentapi_agent_proto protoreflect.FileDescriptor
 const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\n" +
 	"#internal/katlc/agentapi/agent.proto\x12\rkatl.agent.v1\"\x16\n" +
-	"\x14GetNodeStatusRequest\"\xa3\a\n" +
+	"\x14GetNodeStatusRequest\"\xf8\a\n" +
 	"\n" +
 	"NodeStatus\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
@@ -5050,7 +5210,9 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\avolumes\x18\x0e \x03(\v2\x1b.katl.agent.v1.VolumeStatusR\avolumes\x124\n" +
 	"\x16selected_generation_id\x18\x0f \x01(\tR\x14selectedGenerationId\x12*\n" +
 	"\x11boot_health_state\x18\x10 \x01(\tR\x0fbootHealthState\x124\n" +
-	"\x16boot_health_diagnostic\x18\x11 \x01(\tR\x14bootHealthDiagnostic\"\xde\x02\n" +
+	"\x16boot_health_diagnostic\x18\x11 \x01(\tR\x14bootHealthDiagnostic\x12#\n" +
+	"\renrollment_id\x18\x12 \x01(\tR\fenrollmentId\x12.\n" +
+	"\x13inventory_node_name\x18\x13 \x01(\tR\x11inventoryNodeName\"\xde\x02\n" +
 	"\fVolumeStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vtarget_kind\x18\x02 \x01(\tR\n" +
@@ -5148,7 +5310,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\bpeer_asn\x18\x04 \x01(\rR\apeerAsn\x12\x14\n" +
 	"\x05state\x18\x05 \x01(\tR\x05state\x12'\n" +
 	"\x0faccepted_routes\x18\x06 \x01(\x04R\x0eacceptedRoutes\x12'\n" +
-	"\x0fexported_routes\x18\a \x01(\x04R\x0eexportedRoutes\"\xec\b\n" +
+	"\x0fexported_routes\x18\a \x01(\x04R\x0eexportedRoutes\"\xe3\t\n" +
 	"\x16SubmitOperationRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5169,7 +5331,9 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x11destructive_reset\x18\x0f \x01(\v2/.katl.agent.v1.DestructiveResetOperationRequestR\x10destructiveReset\x12M\n" +
 	"\fhost_upgrade\x18\x10 \x01(\v2*.katl.agent.v1.HostUpgradeOperationRequestR\vhostUpgrade\x12y\n" +
 	"\x1ckubeadm_control_plane_config\x18\x11 \x01(\v28.katl.agent.v1.KubeadmControlPlaneConfigOperationRequestR\x19kubeadmControlPlaneConfig\x12]\n" +
-	"\x12etcd_member_remove\x18\x12 \x01(\v2/.katl.agent.v1.EtcdMemberRemoveOperationRequestR\x10etcdMemberRemove\"\xc3\x06\n" +
+	"\x12etcd_member_remove\x18\x12 \x01(\v2/.katl.agent.v1.EtcdMemberRemoveOperationRequestR\x10etcdMemberRemove\x124\n" +
+	"\x16expected_enrollment_id\x18\x13 \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\x14 \x01(\tR\x19expectedInventoryNodeName\"\xc3\x06\n" +
 	"\x19BootstrapOperationRequest\x12.\n" +
 	"\x13inventory_node_name\x18\x01 \x01(\tR\x11inventoryNodeName\x12\x1f\n" +
 	"\vsystem_role\x18\x02 \x01(\tR\n" +
@@ -5218,7 +5382,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x10target_member_id\x18\x02 \x01(\tR\x0etargetMemberId\x12&\n" +
 	"\x0ftarget_peer_url\x18\x03 \x01(\tR\rtargetPeerUrl\x12.\n" +
 	"\x13expected_cluster_id\x18\x04 \x01(\tR\x11expectedClusterId\x122\n" +
-	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\x97\x04\n" +
+	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\x8e\x05\n" +
 	"\x15ValidateConfigRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5235,7 +5399,9 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x11client_request_id\x18\n" +
 	" \x01(\tR\x0fclientRequestId\x12+\n" +
 	"\x11operation_timeout\x18\v \x01(\tR\x10operationTimeout\x12P\n" +
-	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\"\x9e\x04\n" +
+	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\x124\n" +
+	"\x16expected_enrollment_id\x18\r \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\x0e \x01(\tR\x19expectedInventoryNodeName\"\x9e\x04\n" +
 	"\x16ConfigValidationResult\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5251,7 +5417,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	" \x01(\tR\rfailureReason\x12\x1d\n" +
 	"\n" +
 	"no_changes\x18\v \x01(\bR\tnoChanges\x12a\n" +
-	"-required_destructive_storage_acknowledgements\x18\f \x03(\tR*requiredDestructiveStorageAcknowledgements\"\xa0\x04\n" +
+	"-required_destructive_storage_acknowledgements\x18\f \x03(\tR*requiredDestructiveStorageAcknowledgements\"\x97\x05\n" +
 	"\x16GenerationApplyRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5267,7 +5433,9 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	" \x01(\tR\bnodeName\x12\x1f\n" +
 	"\vconfig_yaml\x18\v \x01(\tR\n" +
 	"configYaml\x12P\n" +
-	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\"\x84\x02\n" +
+	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\x124\n" +
+	"\x16expected_enrollment_id\x18\r \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\x0e \x01(\tR\x19expectedInventoryNodeName\"\x84\x02\n" +
 	"\x1bConfigApplyOperationRequest\x126\n" +
 	"\x17candidate_generation_id\x18\x01 \x01(\tR\x15candidateGenerationId\x12\x1d\n" +
 	"\n" +
@@ -5336,7 +5504,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x0fimage_local_ref\x18\x02 \x01(\tR\rimageLocalRef\x12!\n" +
 	"\fimage_sha256\x18\x03 \x01(\tR\vimageSha256\x12(\n" +
 	"\x10image_size_bytes\x18\x04 \x01(\x04R\x0eimageSizeBytes\x126\n" +
-	"\x17candidate_generation_id\x18\x05 \x01(\tR\x15candidateGenerationId\"\xe9\x01\n" +
+	"\x17candidate_generation_id\x18\x05 \x01(\tR\x15candidateGenerationId\"\xa5\x03\n" +
 	"\x1fStageHostUpgradeArtifactRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5346,12 +5514,16 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x06sha256\x18\x05 \x01(\tR\x06sha256\x12\x1d\n" +
 	"\n" +
 	"size_bytes\x18\x06 \x01(\x04R\tsizeBytes\x12\x14\n" +
-	"\x05chunk\x18\a \x01(\fR\x05chunk\"o\n" +
+	"\x05chunk\x18\a \x01(\fR\x05chunk\x124\n" +
+	"\x16expected_enrollment_id\x18\b \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\t \x01(\tR\x19expectedInventoryNodeName\x12C\n" +
+	"\x1eexpected_current_generation_id\x18\n" +
+	" \x01(\tR\x1bexpectedCurrentGenerationId\"o\n" +
 	"\x19HostUpgradeArtifactStaged\x12\x1b\n" +
 	"\tlocal_ref\x18\x01 \x01(\tR\blocalRef\x12\x16\n" +
 	"\x06sha256\x18\x02 \x01(\tR\x06sha256\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"\xcf\x01\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"\x8b\x03\n" +
 	"\x1fCreateWorkerJoinMaterialRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5360,7 +5532,10 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\x12\x1f\n" +
 	"\vrequest_ref\x18\x05 \x01(\tR\n" +
 	"requestRef\x12\x10\n" +
-	"\x03ttl\x18\x06 \x01(\tR\x03ttl\"\xb9\x01\n" +
+	"\x03ttl\x18\x06 \x01(\tR\x03ttl\x124\n" +
+	"\x16expected_enrollment_id\x18\a \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\b \x01(\tR\x19expectedInventoryNodeName\x12C\n" +
+	"\x1eexpected_current_generation_id\x18\t \x01(\tR\x1bexpectedCurrentGenerationId\"\xb9\x01\n" +
 	" CreateWorkerJoinMaterialResponse\x12!\n" +
 	"\fmaterial_ref\x18\x01 \x01(\tR\vmaterialRef\x12S\n" +
 	"\x14worker_join_material\x18\x02 \x01(\v2!.katl.agent.v1.WorkerJoinMaterialR\x12workerJoinMaterial\x12\x1d\n" +
@@ -5530,23 +5705,29 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x06status\x18\x03 \x01(\tR\x06status\x12\x1e\n" +
 	"\n" +
 	"diagnostic\x18\x04 \x01(\tR\n" +
-	"diagnostic\"\xbc\x01\n" +
+	"diagnostic\"\xf8\x02\n" +
 	"\rRebootRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x14\n" +
 	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
 	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\x120\n" +
-	"\x14target_generation_id\x18\x05 \x01(\tR\x12targetGenerationId\"`\n" +
+	"\x14target_generation_id\x18\x05 \x01(\tR\x12targetGenerationId\x124\n" +
+	"\x16expected_enrollment_id\x18\x06 \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\a \x01(\tR\x19expectedInventoryNodeName\x12C\n" +
+	"\x1eexpected_current_generation_id\x18\b \x01(\tR\x1bexpectedCurrentGenerationId\"`\n" +
 	"\x0eRebootAccepted\x12\x1c\n" +
 	"\tscheduled\x18\x01 \x01(\bR\tscheduled\x120\n" +
-	"\x14target_generation_id\x18\x02 \x01(\tR\x12targetGenerationId\"\x8c\x01\n" +
+	"\x14target_generation_id\x18\x02 \x01(\tR\x12targetGenerationId\"\xc8\x02\n" +
 	"\x0fShutdownRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x14\n" +
 	"\x05actor\x18\x03 \x01(\tR\x05actor\x12.\n" +
-	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\"0\n" +
+	"\x13expected_machine_id\x18\x04 \x01(\tR\x11expectedMachineId\x124\n" +
+	"\x16expected_enrollment_id\x18\x05 \x01(\tR\x14expectedEnrollmentId\x12?\n" +
+	"\x1cexpected_inventory_node_name\x18\x06 \x01(\tR\x19expectedInventoryNodeName\x12C\n" +
+	"\x1eexpected_current_generation_id\x18\a \x01(\tR\x1bexpectedCurrentGenerationId\"0\n" +
 	"\x10ShutdownAccepted\x12\x1c\n" +
 	"\tscheduled\x18\x01 \x01(\bR\tscheduled2\xe9\n" +
 	"\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -42,6 +42,8 @@ message NodeStatus {
   string selected_generation_id = 15;
   string boot_health_state = 16;
   string boot_health_diagnostic = 17;
+  string enrollment_id = 18;
+  string inventory_node_name = 19;
 }
 
 message VolumeStatus {
@@ -167,6 +169,8 @@ message SubmitOperationRequest {
   HostUpgradeOperationRequest host_upgrade = 16;
   KubeadmControlPlaneConfigOperationRequest kubeadm_control_plane_config = 17;
   EtcdMemberRemoveOperationRequest etcd_member_remove = 18;
+  string expected_enrollment_id = 19;
+  string expected_inventory_node_name = 20;
 }
 
 message BootstrapOperationRequest {
@@ -235,6 +239,8 @@ message ValidateConfigRequest {
   string client_request_id = 10;
   string operation_timeout = 11;
   repeated string destructive_storage_acknowledgements = 12;
+  string expected_enrollment_id = 13;
+  string expected_inventory_node_name = 14;
 }
 
 message ConfigValidationResult {
@@ -265,6 +271,8 @@ message GenerationApplyRequest {
   string node_name = 10;
   string config_yaml = 11;
   repeated string destructive_storage_acknowledgements = 12;
+  string expected_enrollment_id = 13;
+  string expected_inventory_node_name = 14;
 }
 
 message ConfigApplyOperationRequest {
@@ -346,6 +354,9 @@ message StageHostUpgradeArtifactRequest {
   string sha256 = 5;
   uint64 size_bytes = 6;
   bytes chunk = 7;
+  string expected_enrollment_id = 8;
+  string expected_inventory_node_name = 9;
+  string expected_current_generation_id = 10;
 }
 
 message HostUpgradeArtifactStaged {
@@ -361,6 +372,9 @@ message CreateWorkerJoinMaterialRequest {
   string expected_machine_id = 4;
   string request_ref = 5;
   string ttl = 6;
+  string expected_enrollment_id = 7;
+  string expected_inventory_node_name = 8;
+  string expected_current_generation_id = 9;
 }
 
 message CreateWorkerJoinMaterialResponse {
@@ -549,6 +563,9 @@ message RebootRequest {
   string actor = 3;
   string expected_machine_id = 4;
   string target_generation_id = 5;
+  string expected_enrollment_id = 6;
+  string expected_inventory_node_name = 7;
+  string expected_current_generation_id = 8;
 }
 
 message RebootAccepted {
@@ -561,6 +578,9 @@ message ShutdownRequest {
   string kind = 2;
   string actor = 3;
   string expected_machine_id = 4;
+  string expected_enrollment_id = 5;
+  string expected_inventory_node_name = 6;
+  string expected_current_generation_id = 7;
 }
 
 message ShutdownAccepted {

--- a/internal/katlctl/workstation/config.go
+++ b/internal/katlctl/workstation/config.go
@@ -36,6 +36,8 @@ type Node struct {
 	Name               string               `json:"name" yaml:"name"`
 	ManagementEndpoint string               `json:"managementEndpoint" yaml:"managementEndpoint"`
 	SystemRole         inventory.SystemRole `json:"systemRole" yaml:"systemRole"`
+	EnrollmentID       string               `json:"enrollmentID,omitempty" yaml:"enrollmentID,omitempty"`
+	MachineID          string               `json:"machineID,omitempty" yaml:"machineID,omitempty"`
 }
 
 type Source string
@@ -57,6 +59,8 @@ type TopologyNode struct {
 	Name               string               `json:"name"`
 	ManagementEndpoint string               `json:"managementEndpoint"`
 	SystemRole         inventory.SystemRole `json:"systemRole"`
+	EnrollmentID       string               `json:"enrollmentID,omitempty"`
+	MachineID          string               `json:"machineID,omitempty"`
 }
 
 type ResolvedTopology struct {
@@ -308,6 +312,8 @@ func topologyFromCluster(contextName string, cluster Cluster) (Topology, error) 
 			Name:               strings.TrimSpace(node.Name),
 			ManagementEndpoint: strings.TrimSpace(node.ManagementEndpoint),
 			SystemRole:         inventory.SystemRole(strings.TrimSpace(string(node.SystemRole))),
+			EnrollmentID:       strings.TrimSpace(node.EnrollmentID),
+			MachineID:          strings.TrimSpace(node.MachineID),
 		})
 	}
 	return topology, nil
@@ -324,6 +330,8 @@ func topologyFromInventory(inv inventory.Inventory) (Topology, error) {
 			Name:               node.Name,
 			ManagementEndpoint: managementEndpoint(node.Address),
 			SystemRole:         node.SystemRole,
+			EnrollmentID:       node.EnrollmentID,
+			MachineID:          node.MachineID,
 		})
 	}
 	return topologyFromCluster("", cluster)
@@ -340,6 +348,8 @@ func topologyFromPlan(plan inventory.Plan) (Topology, error) {
 			Name:               node.Name,
 			ManagementEndpoint: managementEndpoint(node.Address),
 			SystemRole:         node.SystemRole,
+			EnrollmentID:       node.EnrollmentID,
+			MachineID:          node.MachineID,
 		})
 	}
 	return topologyFromCluster("", cluster)
@@ -379,6 +389,11 @@ func validateCluster(cluster Cluster) error {
 		case inventory.RoleWorker:
 		default:
 			return fmt.Errorf("node %q systemRole %q is unsupported", name, node.SystemRole)
+		}
+		enrollmentID := strings.TrimSpace(node.EnrollmentID)
+		machineID := strings.TrimSpace(node.MachineID)
+		if (enrollmentID == "") != (machineID == "") {
+			return fmt.Errorf("node %q enrollmentID and machineID must be set together", name)
 		}
 	}
 	if controlPlanes == 0 {

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -134,6 +134,7 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 	}()
 	currentGeneration := currentGenerationFromGuest(t, ctx, guest)
 	endpoint := katlcEndpoint(t, node, plannedAddress)
+	enrollConfigApplyNode(t, ctx, result, katlctl, endpoint)
 	guest, client = runConfigApplyModeSmoke(t, ctx, &node, guest, client, result, katlctl, endpoint, currentGeneration)
 	node.Result.finish(StatusPassed, "", runner.time())
 	if err := runner.Write(scenario, node.Result); err != nil {
@@ -238,6 +239,50 @@ func katlcEndpoint(t *testing.T, node RunningInstalledRuntimeNode, plannedAddres
 	return net.JoinHostPort(address, "9443")
 }
 
+func enrollConfigApplyNode(t *testing.T, ctx context.Context, result Result, katlctl, endpoint string) {
+	t.Helper()
+	host, _, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		t.Fatalf("split config apply management endpoint %q: %v", endpoint, err)
+	}
+	directory := filepath.Join(result.RunDir, "katlctl", "enrollment")
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		t.Fatalf("create config apply enrollment directory: %v", err)
+	}
+	configPath := filepath.Join(directory, "cluster.yaml")
+	contextPath := filepath.Join(directory, "katlctl.yaml")
+	source := `apiVersion: config.katl.dev/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: config-apply-vmtest
+spec:
+  controlPlaneEndpoint:
+    host: ` + host + `
+    port: 6443
+  kubernetes:
+    version: v1.36.1
+  defaults:
+    access:
+      ssh:
+        authorizedKeys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVm katl@example
+  nodes:
+    - name: cp-1
+      controlPlane: true
+      management:
+        address: ` + host + `
+      install:
+        systemDisk:
+          byID: /dev/disk/by-id/virtio-katl-root
+`
+	if err := os.WriteFile(configPath, []byte(source), 0o600); err != nil {
+		t.Fatalf("write config apply enrollment ClusterConfig: %v", err)
+	}
+	t.Setenv("KATLCTL_CONFIG", contextPath)
+	t.Setenv("KATLCTL_CONFIG_DIR", "")
+	runKatlctl(t, ctx, result, katlctl, "context-save", "context", "save", "--config", configPath)
+}
+
 func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningInstalledRuntimeNode, guest *GuestControl, client *AgentClient, result Result, katlctl, endpoint, currentGeneration string) (*GuestControl, *AgentClient) {
 	t.Helper()
 	beforeSysext := readlinkOptional(t, ctx, guest, "/run/extensions/katl-kubernetes.raw")
@@ -248,7 +293,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 
 	rejectedArgs := []string{
 		"node", "apply", "validate",
-		"--endpoint", endpoint,
+		"--node", "cp-1",
 	}
 	rejectedArgs = append(rejectedArgs, configApplyConfigArgs(configApplyFixture(t, "rejected-live-without-preflight.yaml"))...)
 	rejectedArgs = append(rejectedArgs,
@@ -301,8 +346,8 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	}
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+liveGeneration+"/status.json",
 		`"commitState": "committed"`,
-		`"bootState": "good"`,
-		`"healthState": "healthy"`,
+		`"bootState": "trying"`,
+		`"healthState": "unknown"`,
 		`"committedByOperationID": "`+liveAccepted.OperationId+`"`,
 	)
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+liveGeneration+"/config-apply-status.json",
@@ -320,10 +365,11 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	)
 	assertGuestFileContains(t, ctx, guest, liveAccepted.RecordPath, `"operationKind": "generation-apply"`, `"applyMode": "auto"`, `"configApplyPhase": "active"`)
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/boot/selection.json",
-		`"defaultGenerationID": "`+liveGeneration+`"`,
-		`"bootedGenerationID": "`+liveGeneration+`"`,
-		`"previousKnownGoodGenerationID": "`+currentGeneration+`"`,
-		`"pendingHealthValidation": false`,
+		`"defaultGenerationID": "`+currentGeneration+`"`,
+		`"targetBootGenerationID": "`+liveGeneration+`"`,
+		`"trialGenerationID": "`+liveGeneration+`"`,
+		`"bootedGenerationID": "`+currentGeneration+`"`,
+		`"pendingHealthValidation": true`,
 	)
 	activeGeneration := runVolumeRemovalSmoke(t, ctx, guest, result, katlctl, endpoint)
 
@@ -357,7 +403,7 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	)
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/systemd/network/80-katl-vmtest-dhcp.network.d/50-address.conf", "Address=198.51.100.77/32")
 	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/generations/"+stagedGeneration+"/confext/etc/containerd/conf.d/80-katl-vmtest.toml", "oom_score = 123")
-	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/boot/selection.json", `"defaultGenerationID": "`+activeGeneration+`"`, `"targetBootGenerationID": "`+stagedGeneration+`"`, `"trialGenerationID": "`+stagedGeneration+`"`, `"pendingTransactionID": "`+stagedAccepted.OperationId+`"`, `"pendingHealthValidation": true`)
+	assertGuestFileContains(t, ctx, guest, "/var/lib/katl/boot/selection.json", `"defaultGenerationID": "`+currentGeneration+`"`, `"targetBootGenerationID": "`+stagedGeneration+`"`, `"trialGenerationID": "`+stagedGeneration+`"`, `"previousKnownGoodGenerationID": "`+currentGeneration+`"`, `"pendingTransactionID": "`+stagedAccepted.OperationId+`"`, `"pendingHealthValidation": true`)
 	assertGuestExists(t, ctx, guest, "/var/lib/katl/generations/"+currentGeneration+"/metadata.json")
 	assertOptionalReadlink(t, ctx, guest, "/run/extensions/katl-kubernetes.raw", beforeSysext)
 	assertGuestFileContains(t, ctx, guest, stagedAccepted.RecordPath, `"operationKind": "generation-stage"`, `"configApplyPhase": "next-boot"`)
@@ -368,7 +414,6 @@ func runConfigApplyModeSmoke(t *testing.T, ctx context.Context, node *RunningIns
 	previousBootID := guestBootID(t, ctx, client)
 	runKatlctl(t, ctx, result, katlctl, "host-reboot-staged-generation",
 		"node", "reboot", "cp-1",
-		"--endpoint", endpoint,
 		"--timeout", "3m",
 	)
 	_ = client.Close()
@@ -488,7 +533,7 @@ func submitKatlctlConfigApply(t *testing.T, ctx context.Context, result Result, 
 	t.Helper()
 	args := []string{
 		"node", "apply",
-		"--endpoint", endpoint,
+		"--node", "cp-1",
 	}
 	args = append(args, configApplyConfigArgs(fixture)...)
 	args = append(args,
@@ -634,7 +679,6 @@ func shutdownGuestThroughKatlctl(t *testing.T, ctx context.Context, result Resul
 	}
 	runKatlctl(t, ctx, result, katlctl, "host-shutdown",
 		"node", "shutdown", "cp-1",
-		"--endpoint", endpoint,
 		"--timeout", "2m",
 	)
 	if client != nil {
@@ -814,12 +858,20 @@ users: []
 
 	conn, client := dialKatlcAgentForVMTest(t, ctx, endpoint)
 	defer conn.Close()
+	nodeStatus, err := client.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		t.Fatalf("read enrolled node identity before Kubernetes sysext refusal: %v", err)
+	}
 	accepted, err := client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
-		ApiVersion:      operation.APIVersion,
-		Kind:            agent.RequestKind,
-		ClientRequestId: "vmtest-kubeadm-upgrade-refused",
-		OperationKind:   agent.OperationKindKubeadmUpgrade,
-		Actor:           "installed-runtime config apply vmtest",
+		ApiVersion:                  operation.APIVersion,
+		Kind:                        agent.RequestKind,
+		ClientRequestId:             "vmtest-kubeadm-upgrade-refused",
+		OperationKind:               agent.OperationKindKubeadmUpgrade,
+		Actor:                       "installed-runtime config apply vmtest",
+		ExpectedEnrollmentId:        nodeStatus.GetEnrollmentId(),
+		ExpectedInventoryNodeName:   nodeStatus.GetInventoryNodeName(),
+		ExpectedMachineId:           nodeStatus.GetMachineId(),
+		ExpectedCurrentGenerationId: nodeStatus.GetCurrentGenerationId(),
 		KubernetesSysextUpdate: &agentapi.KubernetesSysextUpdateOperationRequest{
 			TargetPayloadVersion: "v9.99.0",
 			TargetSysextPath:     "/var/lib/katl/artifacts/katlos-image/katl-kubernetes.raw",

--- a/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_three_cp_vmtest_test.go
@@ -310,7 +310,11 @@ func runThreeControlPlaneStackedEtcdSmoke(t *testing.T, smoke threeControlPlaneS
 	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeThreeControlPlaneOperationBackedInventory(inventoryPath, inputs.KubernetesVersion, kubernetesBundle, nodes, addresses); err != nil {
+	enrollments, err := readThreeControlPlaneEnrollments(ctx, addresses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeThreeControlPlaneOperationBackedInventory(inventoryPath, inputs.KubernetesVersion, kubernetesBundle, nodes, addresses, enrollments); err != nil {
 		t.Fatal(err)
 	}
 	if err := writeThreeControlPlaneSmokeArtifactManifest(result, inputs, "", etcdTranscriptDir, nodes, bootstrapFixture, kubernetesBundle, cniFixtures, imageFixtures, nil); err != nil {
@@ -458,6 +462,16 @@ func runThreeControlPlaneReplacementProof(t *testing.T, ctx context.Context, smo
 	if err := writeThreeControlPlaneReplacementConfig(filepath.Join(dir, "cluster.yaml"), configPath, addresses, smoke.Inputs.SSHAuthorizedKey, smoke.Inputs.KubernetesVersion, bundle.Ref); err != nil {
 		return nodes, err
 	}
+	enrollments, err := readThreeControlPlaneEnrollments(ctx, addresses)
+	if err != nil {
+		return nodes, err
+	}
+	contextPath := filepath.Join(dir, "katlctl.yaml")
+	if err := writeThreeControlPlaneWorkstationContext(contextPath, "replacement-vmtest", addresses, enrollments); err != nil {
+		return nodes, err
+	}
+	t.Setenv("KATLCTL_CONFIG", contextPath)
+	t.Setenv("KATLCTL_CONFIG_DIR", "")
 	cp1 := nodeByName(nodes, "cp-1")
 	cp2 := nodeByName(nodes, "cp-2")
 	cp3 := nodeByName(nodes, "cp-3")
@@ -589,6 +603,10 @@ func runThreeControlPlaneReplacementProof(t *testing.T, ctx context.Context, smo
 	}
 	if got := status.GetKubernetes().GetState(); got != "not-configured" {
 		return nodes, fmt.Errorf("reinstalled cp-3 Kubernetes state = %q, want not-configured", got)
+	}
+	enrollments["cp-3"] = status
+	if err := writeThreeControlPlaneWorkstationContext(contextPath, "replacement-vmtest", addresses, enrollments); err != nil {
+		return nodes, err
 	}
 	replacedNodes := []vmtest.RunningInstalledRuntimeNode{cp1, cp2, reinstalledCP3}
 	if err := installKubernetesBundleCA(ctx, reinstalledCP3, bundle); err != nil {
@@ -892,10 +910,18 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 	if err := os.WriteFile(requestPath, request, 0o600); err != nil {
 		return err
 	}
+	enrollments, err := readThreeControlPlaneEnrollments(ctx, addresses)
+	if err != nil {
+		return err
+	}
+	contextPath := filepath.Join(proofDir, "katlctl.yaml")
+	if err := writeThreeControlPlaneWorkstationContext(contextPath, "three-control-plane", addresses, enrollments); err != nil {
+		return err
+	}
 	katlctl := buildKatlctlCommand(t, ctx, katlRepoRoot(t))
 	for _, node := range nodes {
 		stdout, stderr, err := runProofKatlctl(ctx, katlctl, proofDir, "stage-"+node.Name,
-			"node", "apply", "--endpoint", net.JoinHostPort(addresses[node.Name], "9443"), "--config", requestPath, "--mode", "live", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof", "--output", "json")
+			"node", "apply", "--context-file", contextPath, "--node", node.Name, "--config", requestPath, "--mode", "live", "--candidate-generation", generationID, "--client-request-id", "vmtest-control-plane-config-stage-"+node.Name, "--actor", "three-control-plane release proof", "--output", "json")
 		if err != nil {
 			return fmt.Errorf("activate desired generation on %s: %w: %s", node.Name, err, stderr)
 		}
@@ -966,6 +992,19 @@ func runThreeControlPlaneConfigOperationProof(t *testing.T, ctx context.Context,
 		return err
 	}
 	return nil
+}
+
+func writeThreeControlPlaneWorkstationContext(path, clusterName string, addresses map[string]string, enrollments map[string]*agentapi.NodeStatus) error {
+	var nodes strings.Builder
+	for _, name := range []string{"cp-1", "cp-2", "cp-3"} {
+		status := enrollments[name]
+		if status == nil {
+			return fmt.Errorf("node %s enrollment status is required", name)
+		}
+		fmt.Fprintf(&nodes, "      - name: %s\n        managementEndpoint: %s\n        systemRole: control-plane\n        enrollmentID: %s\n        machineID: %s\n", name, net.JoinHostPort(addresses[name], "9443"), status.GetEnrollmentId(), status.GetMachineId())
+	}
+	data := "currentContext: vmtest\ncontexts:\n  - name: vmtest\n    cluster: " + clusterName + "\nclusters:\n  - name: " + clusterName + "\n    nodes:\n" + nodes.String()
+	return os.WriteFile(path, []byte(data), 0o600)
 }
 
 func kubeletOperationConfig(live []byte, maxPods int) ([]byte, error) {
@@ -1551,7 +1590,7 @@ func writeThreeControlPlaneInventory(path string, kubernetesVersion string, node
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
 
-func writeThreeControlPlaneOperationBackedInventory(path string, kubernetesVersion string, kubernetesBundle threeControlPlaneKubernetesPayloadBundle, nodes []vmtest.RunningInstalledRuntimeNode, addresses map[string]string) error {
+func writeThreeControlPlaneOperationBackedInventory(path string, kubernetesVersion string, kubernetesBundle threeControlPlaneKubernetesPayloadBundle, nodes []vmtest.RunningInstalledRuntimeNode, addresses map[string]string, enrollments map[string]*agentapi.NodeStatus) error {
 	if len(nodes) != 3 {
 		return fmt.Errorf("three control-plane inventory requires three nodes, got %d", len(nodes))
 	}
@@ -1564,6 +1603,10 @@ func writeThreeControlPlaneOperationBackedInventory(path string, kubernetesVersi
 	b.WriteString("kubernetesBundle: " + strconv.Quote(kubernetesBundle.Ref) + "\n")
 	b.WriteString("nodes:\n")
 	for _, node := range nodes {
+		enrollment := enrollments[node.Name]
+		if enrollment == nil {
+			return fmt.Errorf("node %s enrollment status is required", node.Name)
+		}
 		b.WriteString("- name: " + node.Name + "\n")
 		b.WriteString("  address: " + addresses[node.Name] + "\n")
 		b.WriteString("  systemRole: control-plane\n")
@@ -1574,8 +1617,25 @@ func writeThreeControlPlaneOperationBackedInventory(path string, kubernetesVersi
 		b.WriteString("    path: /etc/katl/kubeadm/control-plane/config.yaml\n")
 		b.WriteString("    intent: control-plane\n")
 		b.WriteString("  kubernetesVersion: " + kubernetesVersion + "\n")
+		b.WriteString("  enrollmentID: " + strconv.Quote(enrollment.GetEnrollmentId()) + "\n")
+		b.WriteString("  machineID: " + strconv.Quote(enrollment.GetMachineId()) + "\n")
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func readThreeControlPlaneEnrollments(ctx context.Context, addresses map[string]string) (map[string]*agentapi.NodeStatus, error) {
+	statuses := make(map[string]*agentapi.NodeStatus, 3)
+	for _, name := range []string{"cp-1", "cp-2", "cp-3"} {
+		status, err := readAgentNodeStatus(ctx, name, addresses[name])
+		if err != nil {
+			return nil, fmt.Errorf("read %s enrollment status: %w", name, err)
+		}
+		if status.GetInventoryNodeName() != name || status.GetEnrollmentId() == "" || status.GetMachineId() == "" || status.GetCurrentGenerationId() == "" {
+			return nil, fmt.Errorf("%s returned incomplete or mismatched enrollment status: %+v", name, status)
+		}
+		statuses[name] = status
+	}
+	return statuses, nil
 }
 
 type threeControlPlaneCNISpec struct {
@@ -2703,8 +2763,12 @@ func TestThreeControlPlaneOperationBackedInventoryCarriesKubernetesBundle(t *tes
 		Source: "https://192.0.2.1:9443",
 		Ref:    "192.0.2.1:9443/katl-vmtest/kubernetes:v1.36.1-katl.0@sha256:" + strings.Repeat("a", 64),
 	}
+	enrollments := map[string]*agentapi.NodeStatus{}
+	for _, node := range nodes {
+		enrollments[node.Name] = &agentapi.NodeStatus{EnrollmentId: "enrollment-" + node.Name, MachineId: "machine-" + node.Name}
+	}
 	path := filepath.Join(t.TempDir(), "inventory.yaml")
-	if err := writeThreeControlPlaneOperationBackedInventory(path, "v1.36.1", bundle, nodes, addresses); err != nil {
+	if err := writeThreeControlPlaneOperationBackedInventory(path, "v1.36.1", bundle, nodes, addresses, enrollments); err != nil {
 		t.Fatalf("writeThreeControlPlaneOperationBackedInventory() error = %v", err)
 	}
 	data, err := os.ReadFile(path)

--- a/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
+++ b/internal/vmtest/scenarios/cluster_bootstrap_vmtest_test.go
@@ -413,9 +413,6 @@ func runOperationBackedBootstrapSmoke(t *testing.T, smoke operationBackedSmokeRu
 		assertGeneration0Selection(t, beforeSelection)
 		bootSelectionsBefore[node.Name] = beforeSelectionPath
 	}
-	if err := writeOperationBackedInventory(inventoryPath, inputs.KubernetesVersion, kubernetesBundle, cpAddress, workerAddress); err != nil {
-		t.Fatal(err)
-	}
 	for _, endpoint := range []struct {
 		name    string
 		address string
@@ -429,6 +426,16 @@ func runOperationBackedBootstrapSmoke(t *testing.T, smoke operationBackedSmokeRu
 			t.Fatalf("wait for %s katlc agent TCP endpoint: %v", endpoint.name, err)
 		}
 	}
+	enrollments, err := readTwoNodeEnrollments(ctx, cpAddress, workerAddress)
+	if err != nil {
+		collectTwoNodeDiagnostics("", nodes...)
+		finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusFailed, err.Error())
+		t.Fatalf("read installed node enrollment identities: %v", err)
+	}
+	if err := writeOperationBackedInventory(inventoryPath, inputs.KubernetesVersion, kubernetesBundle, cpAddress, workerAddress, enrollments); err != nil {
+		t.Fatal(err)
+	}
+	assertSwappedEnrollmentRefused(t, ctx, result.RunDir, inputs.KubernetesVersion, kubernetesBundle, cpAddress, workerAddress, enrollments)
 	for _, node := range nodes {
 		if err := assertOperatorSSH(ctx, inputs.SSHPrivateKey, node.Result.IPAddress); err != nil {
 			collectTwoNodeDiagnostics("", nodes...)
@@ -829,7 +836,12 @@ func runTwoNodeKubeadmUpgradeProof(t *testing.T, ctx context.Context, smoke oper
 
 func runPublishedKubernetesUpgradeCLIProof(ctx context.Context, repoRoot, bundle string, cpNode, workerNode vmtest.RunningInstalledRuntimeNode, cpAddress, workerAddress, kubeconfigPath, evidenceDir string, bootIDs map[string]string) error {
 	configPath := filepath.Join(evidenceDir, "katlctl-upgrade.yaml")
-	config := fmt.Sprintf("currentContext: vmtest\ncontexts:\n  - name: vmtest\n    cluster: upgrade\nclusters:\n  - name: upgrade\n    controlPlaneEndpoint: %s:6443\n    nodes:\n      - name: cp-1\n        managementEndpoint: %s:9443\n        systemRole: control-plane\n      - name: worker-1\n        managementEndpoint: %s:9443\n        systemRole: worker\n", cpAddress, cpAddress, workerAddress)
+	enrollments, err := readTwoNodeEnrollments(ctx, cpAddress, workerAddress)
+	if err != nil {
+		return err
+	}
+	cpStatus, workerStatus := enrollments["cp-1"], enrollments["worker-1"]
+	config := fmt.Sprintf("currentContext: vmtest\ncontexts:\n  - name: vmtest\n    cluster: upgrade\nclusters:\n  - name: upgrade\n    controlPlaneEndpoint: %s:6443\n    nodes:\n      - name: cp-1\n        managementEndpoint: %s:9443\n        systemRole: control-plane\n        enrollmentID: %s\n        machineID: %s\n      - name: worker-1\n        managementEndpoint: %s:9443\n        systemRole: worker\n        enrollmentID: %s\n        machineID: %s\n", cpAddress, cpAddress, cpStatus.GetEnrollmentId(), cpStatus.GetMachineId(), workerAddress, workerStatus.GetEnrollmentId(), workerStatus.GetMachineId())
 	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		return fmt.Errorf("write katlctl upgrade context: %w", err)
 	}
@@ -977,7 +989,7 @@ func submitKubeadmUpgrade(ctx context.Context, address string, request agentapi.
 	if err != nil {
 		return nil, err
 	}
-	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: "vmtest-" + request.CandidateGenerationId, OperationKind: "kubeadm-upgrade", Actor: "vmtest:kubeadm-upgrade", ExpectedMachineId: nodeStatus.MachineId, KubernetesSysextUpdate: &request})
+	accepted, err := conn.Client.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: "vmtest-" + request.CandidateGenerationId, OperationKind: "kubeadm-upgrade", Actor: "vmtest:kubeadm-upgrade", ExpectedEnrollmentId: nodeStatus.EnrollmentId, ExpectedInventoryNodeName: nodeStatus.InventoryNodeName, ExpectedMachineId: nodeStatus.MachineId, ExpectedCurrentGenerationId: nodeStatus.CurrentGenerationId, KubernetesSysextUpdate: &request})
 	if err != nil {
 		return nil, err
 	}
@@ -1642,9 +1654,14 @@ nodes:
 	return os.WriteFile(path, []byte(data), 0o644)
 }
 
-func writeOperationBackedInventory(path, kubernetesVersion string, kubernetesBundle threeControlPlaneKubernetesPayloadBundle, cpAddress, workerAddress string) error {
+func writeOperationBackedInventory(path, kubernetesVersion string, kubernetesBundle threeControlPlaneKubernetesPayloadBundle, cpAddress, workerAddress string, enrollments map[string]*agentapi.NodeStatus) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
+	}
+	cp := enrollments["cp-1"]
+	worker := enrollments["worker-1"]
+	if cp == nil || worker == nil {
+		return errors.New("cp-1 and worker-1 enrollment status are required")
 	}
 	data := `controlPlaneEndpoint: ` + cpAddress + `:6443
 kubernetesVersion: ` + kubernetesVersion + `
@@ -1660,6 +1677,8 @@ nodes:
     path: /etc/katl/kubeadm/control-plane/config.yaml
     intent: control-plane
   kubernetesVersion: ` + kubernetesVersion + `
+  enrollmentID: ` + strconv.Quote(cp.GetEnrollmentId()) + `
+  machineID: ` + strconv.Quote(cp.GetMachineId()) + `
 - name: worker-1
   address: ` + workerAddress + `
   systemRole: worker
@@ -1670,8 +1689,41 @@ nodes:
     path: /etc/katl/kubeadm/worker/config.yaml
     intent: worker
   kubernetesVersion: ` + kubernetesVersion + `
+  enrollmentID: ` + strconv.Quote(worker.GetEnrollmentId()) + `
+  machineID: ` + strconv.Quote(worker.GetMachineId()) + `
 `
 	return os.WriteFile(path, []byte(data), 0o644)
+}
+
+func readTwoNodeEnrollments(ctx context.Context, cpAddress, workerAddress string) (map[string]*agentapi.NodeStatus, error) {
+	statuses := make(map[string]*agentapi.NodeStatus, 2)
+	for _, node := range []struct {
+		name    string
+		address string
+	}{{name: "cp-1", address: cpAddress}, {name: "worker-1", address: workerAddress}} {
+		status, err := readAgentNodeStatus(ctx, node.name, node.address)
+		if err != nil {
+			return nil, fmt.Errorf("read %s status: %w", node.name, err)
+		}
+		if status.GetInventoryNodeName() != node.name || status.GetEnrollmentId() == "" || status.GetMachineId() == "" || status.GetCurrentGenerationId() == "" {
+			return nil, fmt.Errorf("%s returned incomplete or mismatched enrollment status: %+v", node.name, status)
+		}
+		statuses[node.name] = status
+	}
+	return statuses, nil
+}
+
+func assertSwappedEnrollmentRefused(t *testing.T, ctx context.Context, runDir, kubernetesVersion string, kubernetesBundle threeControlPlaneKubernetesPayloadBundle, cpAddress, workerAddress string, enrollments map[string]*agentapi.NodeStatus) {
+	t.Helper()
+	path := filepath.Join(runDir, "swapped-bootstrap-inventory.yaml")
+	if err := writeOperationBackedInventory(path, kubernetesVersion, kubernetesBundle, workerAddress, cpAddress, enrollments); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := runKatlctlCommand(t, ctx, katlRepoRoot(t), []string{"cluster", "bootstrap", "--inventory", path, "--init-node", "cp-1", "--dry-run"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(stderr.String(), `address answered as enrolled node "worker-1"`) {
+		t.Fatalf("swapped enrollment bootstrap plan error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
 }
 
 type operationBackedArtifacts struct {

--- a/internal/vmtest/scenarios/generation0_install_vmtest_test.go
+++ b/internal/vmtest/scenarios/generation0_install_vmtest_test.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -92,6 +93,7 @@ type threeNodeGeneration0NodeEvidence struct {
 	NodeMetadata        string `json:"nodeMetadata,omitempty"`
 	MachineIDPath       string `json:"machineIDPath"`
 	PersistentMachineID string `json:"persistentMachineID"`
+	EnrollmentIdentity  string `json:"enrollmentIdentity"`
 	LayoutProbe         string `json:"layoutProbe"`
 	RerunProof          string `json:"rerunProof,omitempty"`
 }
@@ -103,6 +105,7 @@ type generation0EvidencePaths struct {
 	Metadata            string
 	MachineID           string
 	PersistentMachineID string
+	Enrollment          string
 	LayoutProbe         string
 }
 
@@ -476,6 +479,7 @@ func collectGeneration0NodeEvidence(ctx context.Context, node vmtest.RunningInst
 		{"/var/lib/katl/generations/0/confext/etc/katl/node.json", "node-metadata.json", 64 << 10},
 		{"/etc/machine-id", "machine-id.txt", 4 << 10},
 		{"/var/lib/katl/identity/machine-id", "persistent-machine-id.txt", 4 << 10},
+		{"/var/lib/katl/identity/enrollment.json", "enrollment.json", 16 << 10},
 	}
 	paths := make([]string, 0, len(files))
 	for _, file := range files {
@@ -508,6 +512,7 @@ func collectGeneration0NodeEvidence(ctx context.Context, node vmtest.RunningInst
 		Metadata:            paths[3],
 		MachineID:           paths[4],
 		PersistentMachineID: paths[5],
+		Enrollment:          paths[6],
 		LayoutProbe:         layoutProbe,
 	}, nil
 }
@@ -639,6 +644,7 @@ func collectGeneration0LayoutProbe(ctx context.Context, node vmtest.RunningInsta
 		"/var/lib/katl/generations/0/confext/etc/katl/node.json",
 		"/var/lib/katl/boot/selection.json",
 		"/var/lib/katl/identity/machine-id",
+		"/var/lib/katl/identity/enrollment.json",
 	} {
 		if _, err := guest.RunCommand(opCtx, vmtest.GuestCommandRequest{Name: filepath.Base(path), Argv: []string{"test", "-e", path}}); err != nil {
 			return "", fmt.Errorf("%s generation 0 path %s missing: %w", node.Name, path, err)
@@ -734,6 +740,14 @@ func assertGeneration0NodeEvidence(paths generation0EvidencePaths, input threeNo
 	if strings.TrimSpace(string(machineID)) != strings.TrimSpace(string(persistentMachineID)) {
 		return generation0RuntimeMetadata{}, fmt.Errorf("/etc/machine-id does not match /var/lib/katl/identity/machine-id")
 	}
+	var enrollment generation.Enrollment
+	if err := readJSONFile(paths.Enrollment, &enrollment); err != nil {
+		return generation0RuntimeMetadata{}, err
+	}
+	decodedEnrollmentID, err := hex.DecodeString(enrollment.ID)
+	if err != nil || len(decodedEnrollmentID) != 16 || enrollment.APIVersion != "katl.dev/v1alpha1" || enrollment.Kind != "NodeEnrollment" || enrollment.InventoryNodeName != input.Name || enrollment.MachineID != strings.TrimSpace(string(persistentMachineID)) {
+		return generation0RuntimeMetadata{}, fmt.Errorf("enrollment identity is incomplete or does not bind node %q to its machine: %#v", input.Name, enrollment)
+	}
 	layoutProbe, err := os.ReadFile(paths.LayoutProbe)
 	if err != nil {
 		return generation0RuntimeMetadata{}, err
@@ -785,6 +799,7 @@ func writeThreeNodeGeneration0Proof(result vmtest.Result, inputs threeNodeGenera
 			NodeMetadata:        filepath.Join(evidenceDir, "node-metadata.json"),
 			MachineIDPath:       filepath.Join(evidenceDir, "machine-id.txt"),
 			PersistentMachineID: filepath.Join(evidenceDir, "persistent-machine-id.txt"),
+			EnrollmentIdentity:  filepath.Join(evidenceDir, "enrollment.json"),
 			LayoutProbe:         filepath.Join(evidenceDir, "layout-probe.txt"),
 			RerunProof:          rerunResults[node.Name],
 		})

--- a/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
+++ b/internal/vmtest/scenarios/wipe_reinstall_vmtest_test.go
@@ -13,11 +13,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/katl-dev/katl/internal/installer/operation"
+	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
 	"github.com/katl-dev/katl/internal/vmtest"
 	"gopkg.in/yaml.v3"
 )
@@ -399,8 +401,12 @@ func runWipePreBootstrapControlPlaneSmoke(t *testing.T, run operationBackedSmoke
 	if err != nil {
 		t.Fatal(err)
 	}
+	enrollments, err := readTwoNodeEnrollments(ctx, cpAddress, otherAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
 	inventoryPath := filepath.Join(result.RunDir, "pre-bootstrap-control-plane-wipe", "inventory.yaml")
-	if err := writePreBootstrapControlPlaneWipeInventory(inventoryPath, inputs.KubernetesVersion, cpAddress, otherAddress); err != nil {
+	if err := writePreBootstrapControlPlaneWipeInventory(inventoryPath, inputs.KubernetesVersion, cpAddress, otherAddress, enrollments); err != nil {
 		t.Fatal(err)
 	}
 	oldMachineID, err := readNodeFileWithRetry(ctx, cpNode, "/var/lib/katl/identity/machine-id", 4<<10, time.Minute)
@@ -452,9 +458,14 @@ func runWipePreBootstrapControlPlaneSmoke(t *testing.T, run operationBackedSmoke
 	finishTwoNodeResult(t, runner, scenario, result, vmtest.StatusPassed, "")
 }
 
-func writePreBootstrapControlPlaneWipeInventory(path, kubernetesVersion, cpAddress, otherAddress string) error {
+func writePreBootstrapControlPlaneWipeInventory(path, kubernetesVersion, cpAddress, otherAddress string, enrollments map[string]*agentapi.NodeStatus) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
+	}
+	cp := enrollments["cp-1"]
+	other := enrollments["worker-1"]
+	if cp == nil || other == nil {
+		return errors.New("control-plane and survivor enrollment status are required")
 	}
 	data := `controlPlaneEndpoint: ` + cpAddress + `:6443
 kubernetesVersion: ` + kubernetesVersion + `
@@ -469,6 +480,8 @@ nodes:
     path: /etc/katl/kubeadm/control-plane/config.yaml
     intent: control-plane
   kubernetesVersion: ` + kubernetesVersion + `
+  enrollmentID: ` + strconv.Quote(cp.GetEnrollmentId()) + `
+  machineID: ` + strconv.Quote(cp.GetMachineId()) + `
 - name: cp-2
   address: ` + otherAddress + `
   systemRole: control-plane
@@ -479,6 +492,8 @@ nodes:
     path: /etc/katl/kubeadm/control-plane/config.yaml
     intent: control-plane
   kubernetesVersion: ` + kubernetesVersion + `
+  enrollmentID: ` + strconv.Quote(other.GetEnrollmentId()) + `
+  machineID: ` + strconv.Quote(other.GetMachineId()) + `
 `
 	return os.WriteFile(path, []byte(data), 0o644)
 }
@@ -549,7 +564,11 @@ func runReinstalledWorkerJoin(t *testing.T, ctx context.Context, run operationBa
 		return err
 	}
 	inventoryPath := filepath.Join(dir, "bootstrap-inventory.yaml")
-	if err := writeOperationBackedInventory(inventoryPath, run.Inputs.KubernetesVersion, bundle, cpAddress, workerAddress); err != nil {
+	enrollments, err := readTwoNodeEnrollments(ctx, cpAddress, workerAddress)
+	if err != nil {
+		return err
+	}
+	if err := writeOperationBackedInventory(inventoryPath, run.Inputs.KubernetesVersion, bundle, cpAddress, workerAddress, enrollments); err != nil {
 		return err
 	}
 	var stdout, stderr bytes.Buffer
@@ -830,7 +849,11 @@ func runWipeReinstallBootstrapRound(t *testing.T, ctx context.Context, run opera
 			return wipeReinstallBootstrapEvidence{}, fmt.Errorf("wait for %s katlc agent TCP endpoint: %w", endpoint.name, err)
 		}
 	}
-	if err := writeOperationBackedInventory(inventoryPath, run.Inputs.KubernetesVersion, kubernetesBundle, cpAddress, workerAddress); err != nil {
+	enrollments, err := readTwoNodeEnrollments(ctx, cpAddress, workerAddress)
+	if err != nil {
+		return wipeReinstallBootstrapEvidence{}, err
+	}
+	if err := writeOperationBackedInventory(inventoryPath, run.Inputs.KubernetesVersion, kubernetesBundle, cpAddress, workerAddress, enrollments); err != nil {
 		return wipeReinstallBootstrapEvidence{}, err
 	}
 	var stdout, stderr bytes.Buffer

--- a/internal/vmtest/sysupdate_smoke_test.go
+++ b/internal/vmtest/sysupdate_smoke_test.go
@@ -226,12 +226,23 @@ func guestFileSHA256(t *testing.T, ctx context.Context, guest *GuestControl, nam
 func submitHostUpgradeAndWait(t *testing.T, ctx context.Context, endpoint, machineID, currentGeneration, candidateGeneration, localRef string, upgrade builtUpgradeImage) (string, *agentapi.OperationStatus) {
 	t.Helper()
 	conn, katlc := dialKatlcAgentForVMTest(t, ctx, endpoint)
+	nodeStatus, err := katlc.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		conn.Close()
+		t.Fatalf("read enrolled node identity before host upgrade: %v", err)
+	}
+	if nodeStatus.GetMachineId() != machineID {
+		conn.Close()
+		t.Fatalf("host upgrade machine identity = %q, want %q", nodeStatus.GetMachineId(), machineID)
+	}
 	accepted, err := katlc.SubmitOperation(ctx, &agentapi.SubmitOperationRequest{
 		ApiVersion:                  operation.APIVersion,
 		Kind:                        agent.RequestKind,
 		ClientRequestId:             "vmtest-host-upgrade-" + candidateGeneration,
 		OperationKind:               agent.OperationKindHostUpgrade,
 		Actor:                       "installed runtime host upgrade vmtest",
+		ExpectedEnrollmentId:        nodeStatus.GetEnrollmentId(),
+		ExpectedInventoryNodeName:   nodeStatus.GetInventoryNodeName(),
 		ExpectedMachineId:           machineID,
 		ExpectedCurrentGenerationId: currentGeneration,
 		HostUpgrade: &agentapi.HostUpgradeOperationRequest{
@@ -252,6 +263,13 @@ func stageHostUpgradeArtifactForVMTest(t *testing.T, ctx context.Context, endpoi
 	t.Helper()
 	conn, katlc := dialKatlcAgentForVMTest(t, ctx, endpoint)
 	defer conn.Close()
+	nodeStatus, err := katlc.GetNodeStatus(ctx, &agentapi.GetNodeStatusRequest{})
+	if err != nil {
+		t.Fatalf("read enrolled node identity before host upgrade upload: %v", err)
+	}
+	if nodeStatus.GetMachineId() != machineID {
+		t.Fatalf("host upgrade upload machine identity = %q, want %q", nodeStatus.GetMachineId(), machineID)
+	}
 	stream, err := katlc.StageHostUpgradeArtifact(ctx)
 	if err != nil {
 		t.Fatalf("start host upgrade artifact staging: %v", err)
@@ -271,7 +289,10 @@ func stageHostUpgradeArtifactForVMTest(t *testing.T, ctx context.Context, endpoi
 				request.ApiVersion = operation.APIVersion
 				request.Kind = agent.StageHostUpgradeArtifactRequestKind
 				request.Actor = "installed runtime host upgrade vmtest"
+				request.ExpectedEnrollmentId = nodeStatus.GetEnrollmentId()
+				request.ExpectedInventoryNodeName = nodeStatus.GetInventoryNodeName()
 				request.ExpectedMachineId = machineID
+				request.ExpectedCurrentGenerationId = nodeStatus.GetCurrentGenerationId()
 				request.Sha256 = upgrade.SHA256
 				request.SizeBytes = upgrade.SizeBytes
 				first = false


### PR DESCRIPTION
## Summary

- persist a random install-time enrollment identity bound to the inventory node name and machine ID
- require the enrolled tuple and current generation on every planning and mutating agent request
- make the workstation context authoritative for the verified node-to-address binding, with an explicit identity-verified `context rebind` workflow
- refuse swapped or stale addresses before configuration, storage, host lifecycle, etcd, or Kubernetes operations can be accepted

## Root cause

`katlctl` selected an overlay by inventory node name but trusted whichever agent answered the configured address. Machine and generation preconditions were optional, and the agent did not know its enrolled inventory name, so an exchanged address could authorize a mutation on the wrong host.

## Validation

- full `go test ./...`
- release-artifact two-node VM bootstrap with deliberately exchanged addresses before the successful bootstrap path
- installed-runtime config, destructive volume acknowledgement, reboot, and shutdown VM journey
- fresh persistent `katldev` install through public `katlctl`, including enrollment, wrong-identity refusal, verified rebind, config apply, reboot, and post-reboot health
