### PR TITLE
networking: keep CNI links outside fallback DHCP

### DIFF
--- a/docs/operations/cilium.md
+++ b/docs/operations/cilium.md
@@ -97,6 +97,12 @@ Cilium connectivity test appropriate for the cluster:
 cilium connectivity test --kubeconfig ./kubeconfig
 ```
 
+Katl's default DHCP fallback does not match virtual netdev kinds, so
+`cilium_host`, Cilium veth links, and overlay devices remain unmanaged by
+systemd-networkd. If a node uses operator-authored networkd files instead of
+the fallback, keep their matches limited to host-owned links so they do not
+claim Cilium interfaces.
+
 Repeat the health, sysctl, and connectivity checks after a node reboot. This
 proves both KatlOS boot-time policy and Cilium's handling of newly created
 interfaces.

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -235,6 +235,13 @@ network configuration outside that Katl-controlled directory. Any operator
 `.network` unit replaces Katl's generated DHCP fallback; auxiliary `.link`,
 `.netdev`, and drop-in files can compose with the fallback.
 
+The fallback offers DHCP only to Ethernet links that have no virtual netdev
+kind. Interfaces created later by a CNI, including veth pairs, Cilium host
+devices, overlays, and CNI bridges, therefore remain unmanaged by networkd.
+To make a host bridge, bond, VLAN, or tunnel part of the node's own network,
+declare its native networkd units here; the operator units then replace the
+fallback and own that topology explicitly.
+
 Sysctl files with a reversible concrete-key change can apply live. Udev rules
 can reload live, but Katl does not retrigger existing devices. Module load,
 modprobe, typed sysfs settings, containerd overlays, and networkd files are

--- a/internal/installer/clusterplan/compile_test.go
+++ b/internal/installer/clusterplan/compile_test.go
@@ -242,7 +242,7 @@ func TestCompileDefaultDHCPUsesStableMACIdentity(t *testing.T) {
 	}
 	for _, node := range plan.Nodes {
 		file := nativeFile(node.NativeEtcFiles, "/etc/systemd/network/10-lan.network")
-		if file == nil || !strings.Contains(file.Content, "[DHCPv4]\nClientIdentifier=mac\nUseHostname=no") || !strings.Contains(file.Content, "[DHCPv6]\nUseHostname=no") {
+		if file == nil || !strings.Contains(file.Content, "[Match]\nType=ether\nKind=!*\n") || !strings.Contains(file.Content, "[DHCPv4]\nClientIdentifier=mac\nUseHostname=no") || !strings.Contains(file.Content, "[DHCPv6]\nUseHostname=no") {
 			t.Fatalf("%s default network = %#v", node.Name, node.NativeEtcFiles)
 		}
 	}

--- a/internal/installer/configbundle/bundle_test.go
+++ b/internal/installer/configbundle/bundle_test.go
@@ -919,7 +919,7 @@ spec:
 		t.Fatalf("defaulted install manifest = %#v", selected.InstallManifest)
 	}
 	defaultNetwork := nativeFile(selected.NodeMaterial.NativeEtcFiles, "/etc/systemd/network/10-lan.network")
-	if defaultNetwork == nil || !strings.Contains(defaultNetwork.Content, "DHCP=yes") {
+	if defaultNetwork == nil || !strings.Contains(defaultNetwork.Content, "[Match]\nType=ether\nKind=!*\n") || !strings.Contains(defaultNetwork.Content, "DHCP=yes") {
 		t.Fatalf("defaulted networkd files = %#v", selected.NodeMaterial.NativeEtcFiles)
 	}
 	if selected.NodeMaterial.KubeadmConfig.Ref != "control-plane" || selected.KubeadmConfigs["control-plane"].Config.RenderPath == "" {

--- a/internal/installer/networkdconfig/networkd.go
+++ b/internal/installer/networkdconfig/networkd.go
@@ -11,7 +11,7 @@ const (
 	DefaultPath = Directory + "/10-lan.network"
 )
 
-const DefaultContent = "[Match]\nType=ether\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\nUseHostname=no\n\n[DHCPv6]\nUseHostname=no\n"
+const DefaultContent = "[Match]\nType=ether\nKind=!*\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\nUseHostname=no\n\n[DHCPv6]\nUseHostname=no\n"
 
 func IsPath(value string) bool {
 	return strings.HasPrefix(value, Directory+"/")

--- a/internal/installer/networkdconfig/networkd_test.go
+++ b/internal/installer/networkdconfig/networkd_test.go
@@ -2,6 +2,13 @@ package networkdconfig
 
 import "testing"
 
+func TestDefaultContentOnlyMatchesUnkindedEthernetLinks(t *testing.T) {
+	want := "[Match]\nType=ether\nKind=!*\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\nUseHostname=no\n\n[DHCPv6]\nUseHostname=no\n"
+	if DefaultContent != want {
+		t.Fatalf("DefaultContent = %q, want %q", DefaultContent, want)
+	}
+}
+
 func TestValidatePathAcceptsUnitsAndDropIns(t *testing.T) {
 	for _, value := range []string{
 		"/etc/systemd/network/20-bond0.network",

--- a/internal/scriptstest/runtime_image_boundary_test.go
+++ b/internal/scriptstest/runtime_image_boundary_test.go
@@ -86,6 +86,24 @@ func TestRuntimeNetworkdLeavesKubernetesRoutesAlone(t *testing.T) {
 	}
 }
 
+func TestInstallerDHCPOnlyMatchesUnkindedEthernetLinks(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join(repoRoot(t), "mkosi.profiles", "installer-image", "mkosi.extra", "usr", "lib", "systemd", "network", "80-katl-installer-dhcp.network"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(config)
+	for _, want := range []string{
+		"[Match]",
+		"Type=ether",
+		"Kind=!*",
+		"DHCP=yes",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("installer DHCP fallback missing %q", want)
+		}
+	}
+}
+
 func TestRuntimeRootShellUsesKubeadmAdminContext(t *testing.T) {
 	profile, err := os.ReadFile(filepath.Join(repoRoot(t), "mkosi.profiles", "runtime", "mkosi.extra", "etc", "profile.d", "katl-kubernetes.sh"))
 	if err != nil {

--- a/internal/vmtest/config_apply_smoke_test.go
+++ b/internal/vmtest/config_apply_smoke_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -126,6 +127,7 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 		t.Fatalf("merged systemd-networkd configuration is missing Kubernetes route policy:\n%s", networkdConfig)
 	}
 	guestCommand(t, ctx, guest, "networkd-active", "systemctl", "is-active", "systemd-networkd.service")
+	assertDefaultNetworkdCNIOwnership(t, ctx, guest)
 	waitGuestFileContains(t, ctx, guest, "/var/lib/katl/install/status.json", `"finalHandoff": "waiting-for-cluster-bootstrap"`)
 	defer func() {
 		if t.Failed() {
@@ -144,6 +146,178 @@ func TestInstalledRuntimeConfigApplyModesSmoke(t *testing.T) {
 			t.Fatalf("write world scenario result: %v", err)
 		}
 	}
+}
+
+type networkdLinkStatus struct {
+	Name                string `json:"Name"`
+	Kind                string `json:"Kind"`
+	AdministrativeState string `json:"AdministrativeState"`
+	IPv4AddressState    string `json:"IPv4AddressState"`
+	NetworkFile         string `json:"NetworkFile"`
+	Addresses           []struct {
+		Family       int    `json:"Family"`
+		ConfigSource string `json:"ConfigSource"`
+	} `json:"Addresses"`
+	Routes []struct {
+		ConfigSource string `json:"ConfigSource"`
+	} `json:"Routes"`
+}
+
+func assertDefaultNetworkdCNIOwnership(t *testing.T, ctx context.Context, guest *GuestControl) {
+	t.Helper()
+	networkConfig := guestCommandOutput(t, ctx, guest, "networkd-default-policy",
+		"systemd-run", "--quiet", "--wait", "--collect", "--pipe",
+		"/usr/bin/systemd-analyze", "cat-config", "systemd/network/80-katl-vmtest-dhcp.network",
+	)
+	if !strings.Contains(networkConfig, "[Match]\nType=ether\nKind=!*\n") {
+		t.Fatalf("default networkd policy does not exclude virtual netdev kinds:\n%s", networkConfig)
+	}
+
+	hostLink := defaultRouteLink(t, ctx, guest)
+	before := networkdStatus(t, ctx, guest, "networkd-host-before-cni", hostLink)
+	assertNetworkdDHCPHost(t, before)
+
+	for _, module := range []string{"veth", "dummy", "geneve", "vxlan", "bridge"} {
+		guestCommand(t, ctx, guest, "networkd-cni-modprobe-"+module, "modprobe", module)
+	}
+	for _, command := range []struct {
+		name string
+		argv []string
+	}{
+		{name: "veth", argv: []string{"ip", "link", "add", "katl-veth0", "type", "veth", "peer", "name", "katl-veth1"}},
+		{name: "cilium-host", argv: []string{"ip", "link", "add", "cilium_host", "type", "dummy"}},
+		{name: "geneve", argv: []string{"ip", "link", "add", "katl-geneve", "type", "geneve", "id", "100", "remote", "192.0.2.1", "dstport", "6081"}},
+		{name: "vxlan", argv: []string{"ip", "link", "add", "katl-vxlan", "type", "vxlan", "id", "100", "dev", hostLink, "dstport", "4789"}},
+		{name: "bridge", argv: []string{"ip", "link", "add", "cni0", "type", "bridge"}},
+	} {
+		guestCommand(t, ctx, guest, "networkd-cni-create-"+command.name, command.argv...)
+	}
+	defer func() {
+		for _, name := range []string{"katl-veth0", "cilium_host", "katl-geneve", "katl-vxlan", "cni0"} {
+			_, _ = guest.RunCommand(ctx, GuestCommandRequest{
+				Name:         "networkd-cni-delete-" + name,
+				Argv:         []string{"ip", "link", "delete", name},
+				AllowFailure: true,
+			})
+		}
+	}()
+	for _, name := range []string{"katl-veth0", "katl-veth1", "cilium_host", "katl-geneve", "katl-vxlan", "cni0"} {
+		guestCommand(t, ctx, guest, "networkd-cni-up-"+name, "ip", "link", "set", name, "up")
+	}
+	guestCommand(t, ctx, guest, "networkd-cni-udev-settle", "udevadm", "settle")
+
+	wantKinds := map[string]string{
+		"katl-veth0":  "veth",
+		"cilium_host": "dummy",
+		"katl-geneve": "geneve",
+		"katl-vxlan":  "vxlan",
+		"cni0":        "bridge",
+	}
+	links := make([]string, 0, len(wantKinds))
+	for name := range wantKinds {
+		links = append(links, name)
+	}
+	slices.Sort(links)
+	statuses := waitNetworkdStatuses(t, ctx, guest, links)
+	for _, name := range links {
+		status := statuses[name]
+		if status.Kind != wantKinds[name] || status.AdministrativeState != "unmanaged" || status.NetworkFile != "" || status.IPv4AddressState != "off" {
+			t.Errorf("networkd status for %s = %+v, want kind %q and unmanaged with IPv4 off", name, status, wantKinds[name])
+		}
+		for _, address := range status.Addresses {
+			if address.Family == 2 || strings.HasPrefix(address.ConfigSource, "DHCP") {
+				t.Errorf("networkd status for %s has unexpected address %+v", name, address)
+			}
+		}
+		if len(status.Routes) != 0 {
+			t.Errorf("networkd status for %s has unexpected routes %+v", name, status.Routes)
+		}
+	}
+	after := networkdStatus(t, ctx, guest, "networkd-host-after-cni", hostLink)
+	assertNetworkdDHCPHost(t, after)
+}
+
+func defaultRouteLink(t *testing.T, ctx context.Context, guest *GuestControl) string {
+	t.Helper()
+	output := guestCommandOutput(t, ctx, guest, "networkd-default-route", "ip", "-j", "route", "show", "default")
+	var routes []struct {
+		Dev string `json:"dev"`
+	}
+	if err := json.Unmarshal([]byte(output), &routes); err != nil || len(routes) == 0 || routes[0].Dev == "" {
+		t.Fatalf("decode default route %q: routes=%+v err=%v", output, routes, err)
+	}
+	return routes[0].Dev
+}
+
+func waitNetworkdStatuses(t *testing.T, ctx context.Context, guest *GuestControl, links []string) map[string]networkdLinkStatus {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		argv := append([]string{"networkctl", "status"}, links...)
+		argv = append(argv, "--json=short")
+		record, err := guest.RunCommand(ctx, GuestCommandRequest{
+			Name:         "networkd-cni-status",
+			Argv:         argv,
+			AllowFailure: true,
+		})
+		if err == nil {
+			statuses, decodeErr := decodeNetworkdStatuses(readFile(t, record.Stdout))
+			if decodeErr == nil && len(statuses) == len(links) {
+				allSettled := true
+				for _, link := range links {
+					if statuses[link].AdministrativeState == "" || statuses[link].AdministrativeState == "pending" {
+						allSettled = false
+					}
+				}
+				if allSettled {
+					return statuses
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("networkd did not report settled status for %v", links)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func decodeNetworkdStatuses(output string) (map[string]networkdLinkStatus, error) {
+	statuses := map[string]networkdLinkStatus{}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		var status networkdLinkStatus
+		if err := json.Unmarshal([]byte(line), &status); err != nil {
+			return nil, err
+		}
+		statuses[status.Name] = status
+	}
+	return statuses, nil
+}
+
+func networkdStatus(t *testing.T, ctx context.Context, guest *GuestControl, commandName, link string) networkdLinkStatus {
+	t.Helper()
+	output := guestCommandOutput(t, ctx, guest, commandName, "networkctl", "status", link, "--json=short")
+	statuses, err := decodeNetworkdStatuses(output)
+	if err != nil {
+		t.Fatalf("decode networkd status for %s: %v\n%s", link, err, output)
+	}
+	status, ok := statuses[link]
+	if !ok {
+		t.Fatalf("networkd status for %s missing from %q", link, output)
+	}
+	return status
+}
+
+func assertNetworkdDHCPHost(t *testing.T, status networkdLinkStatus) {
+	t.Helper()
+	if status.AdministrativeState != "configured" || status.NetworkFile == "" || status.IPv4AddressState != "routable" {
+		t.Fatalf("host networkd status = %+v, want configured DHCP host link", status)
+	}
+	for _, address := range status.Addresses {
+		if address.Family == 2 && address.ConfigSource == "DHCPv4" {
+			return
+		}
+	}
+	t.Fatalf("host networkd status = %+v, want DHCPv4 address", status)
 }
 
 func requirePlannedVMHost(t testTB, runner Runner, scenario Scenario, result Result, requirements HostRequirements) Result {

--- a/internal/vmtest/first_install.go
+++ b/internal/vmtest/first_install.go
@@ -19,6 +19,7 @@ import (
 	"github.com/katl-dev/katl/internal/installer"
 	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/handoff"
+	"github.com/katl-dev/katl/internal/installer/networkdconfig"
 	"gopkg.in/yaml.v3"
 )
 
@@ -50,7 +51,7 @@ const (
 	guestHandoffAcceptedSignal = "katlos-install handoff accepted manifest="
 	installerCompletedSignal   = "katlos-install completed manifest="
 	bundleCompletedSignal      = "katlos-install completed bundle="
-	vmtestDHCPNetwork          = "[Match]\nName=en*\n\n[Network]\nDHCP=yes\n\n[DHCPv4]\nClientIdentifier=mac\nUseHostname=no\n\n[DHCPv6]\nUseHostname=no\n"
+	vmtestDHCPNetwork          = networkdconfig.DefaultContent
 )
 
 type handoffLog struct {

--- a/internal/vmtest/first_install_test.go
+++ b/internal/vmtest/first_install_test.go
@@ -267,7 +267,7 @@ func TestFirstInstallGuestHandoffUsesAnnouncementURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read handoff seed networkd file: %v", err)
 	}
-	if !strings.Contains(string(network), "Name=en*") || !strings.Contains(string(network), "DHCP=yes") || !strings.Contains(string(network), "UseHostname=no") {
+	if !strings.Contains(string(network), "Type=ether\nKind=!*") || !strings.Contains(string(network), "DHCP=yes") || !strings.Contains(string(network), "UseHostname=no") {
 		t.Fatalf("handoff seed networkd file = %q", network)
 	}
 }

--- a/internal/vmtest/first_install_world_test.go
+++ b/internal/vmtest/first_install_world_test.go
@@ -488,7 +488,7 @@ func TestPlanFirstInstallWorldRunResolvesLocalMkosiArtifacts(t *testing.T) {
 		!strings.Contains(string(manifestData), `"localRef": "katlos-install-0.0.0-dev-x86_64.squashfs"`) ||
 		!strings.Contains(string(manifestData), `"configRef": "control-plane"`) ||
 		!strings.Contains(string(manifestData), `"path": "/etc/systemd/network/80-katl-vmtest-dhcp.network"`) ||
-		!strings.Contains(string(manifestData), `Name=en*`) ||
+		!strings.Contains(string(manifestData), `Type=ether\nKind=!*`) ||
 		!strings.Contains(string(manifestData), `DHCP=yes`) ||
 		!strings.Contains(string(manifestData), `UseHostname=no`) {
 		t.Fatalf("generated manifest = %s", manifestData)

--- a/internal/vmtest/testdata/config-apply/live-udev.yaml
+++ b/internal/vmtest/testdata/config-apply/live-udev.yaml
@@ -12,7 +12,8 @@ spec:
             - path: /etc/systemd/network/80-katl-vmtest-dhcp.network
               content: |
                 [Match]
-                Name=en*
+                Type=ether
+                Kind=!*
 
                 [Network]
                 DHCP=yes

--- a/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/network/80-katl-installer-dhcp.network
+++ b/mkosi.profiles/installer-image/mkosi.extra/usr/lib/systemd/network/80-katl-installer-dhcp.network
@@ -1,5 +1,6 @@
 [Match]
 Type=ether
+Kind=!*
 
 [Network]
 DHCP=yes

--- a/scripts/check-installer-image
+++ b/scripts/check-installer-image
@@ -145,6 +145,12 @@ grep -Eq '^Wants=.*(^| )network-online\.target( |$)' "$installer_unit" ||
 grep -Eq '^After=.*(^| )network-online\.target( |$)' "$installer_unit" ||
     fail "installer service does not wait for network-online.target before URL handoff"
 
+installer_network="$initrd_root/usr/lib/systemd/network/80-katl-installer-dhcp.network"
+grep -Fxq 'Type=ether' "$installer_network" ||
+    fail "installer DHCP fallback does not match Ethernet links"
+grep -Fxq 'Kind=!*' "$installer_network" ||
+    fail "installer DHCP fallback can adopt virtual netdev kinds"
+
 for path in \
     /usr/bin/mkosi \
     /usr/bin/dnf \


### PR DESCRIPTION
## Summary

- constrain Katl's generated and installer fallback DHCP policy to Ethernet links without a virtual netdev kind
- preserve explicit operator-owned networkd configuration for deliberate bridges, bonds, VLANs, and tunnels
- document the ownership boundary and cover the installed behavior with representative CNI link kinds

The root cause was that `Type=ether` also matches virtual Ethernet kinds such as veth and dummy. A CNI-created link could therefore be selected by the fallback after boot and receive DHCP configuration. `Kind=!*` makes the fallback positively select physical-style Ethernet links while leaving virtual links without a Katl network file.

Validated with the installed-artifact VM journey and a persistent katldev install through `katlctl`: veth, Cilium host dummy, Geneve, VXLAN, and bridge links remained unmanaged with no IPv4 lease or route before and after a networkd restart, while the host NIC retained DHCP and its default route. The policy and node health also survived an identity-verified `katlctl node reboot`.
