### PR TITLE
storage: bind volumes to exact identities

### DIFF
--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -62,6 +62,9 @@ type volumeStatusReport struct {
 	SubState          string `json:"subState"`
 	Result            string `json:"result"`
 	FailureDiagnostic string `json:"failureDiagnostic,omitempty"`
+	PartitionUUID     string `json:"partitionUUID,omitempty"`
+	FilesystemUUID    string `json:"filesystemUUID,omitempty"`
+	MountSource       string `json:"mountSource,omitempty"`
 }
 
 type kubernetesStatusReport struct {
@@ -415,6 +418,7 @@ func newHostStatusReport(node, endpoint string, status *agentapi.NodeStatus, cur
 			Name: volume.GetName(), TargetKind: volume.GetTargetKind(), MountPath: volume.GetMountPath(),
 			Filesystem: volume.GetFilesystem(), LoadState: volume.GetLoadState(), ActiveState: volume.GetActiveState(),
 			SubState: volume.GetSubState(), Result: volume.GetResult(), FailureDiagnostic: volume.GetFailureDiagnostic(),
+			PartitionUUID: volume.GetPartitionUuid(), FilesystemUUID: volume.GetFilesystemUuid(), MountSource: volume.GetMountSource(),
 		})
 	}
 	return report
@@ -512,16 +516,16 @@ func writeHostStatus(stdout io.Writer, output string, report hostStatusReport) e
 	}
 	if len(report.Volumes) > 0 {
 		w = tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-		if _, err := fmt.Fprintln(w, "\nVOLUME\tTARGET\tMOUNT\tFILESYSTEM\tSTATE"); err != nil {
+		if _, err := fmt.Fprintln(w, "\nVOLUME\tTARGET\tMOUNT\tFILESYSTEM\tSOURCE\tSTATE"); err != nil {
 			return err
 		}
 		for _, volume := range report.Volumes {
 			state := firstNonEmpty(volume.ActiveState, "unknown")
-			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", volume.Name, volume.TargetKind, volume.MountPath, volume.Filesystem, state); err != nil {
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", volume.Name, volume.TargetKind, volume.MountPath, volume.Filesystem, firstNonEmpty(volume.MountSource, "unbound"), state); err != nil {
 				return err
 			}
 			if volume.FailureDiagnostic != "" {
-				if _, err := fmt.Fprintf(w, "\t\t\t\t%s\n", volume.FailureDiagnostic); err != nil {
+				if _, err := fmt.Fprintf(w, "\t\t\t\t\t%s\n", volume.FailureDiagnostic); err != nil {
 					return err
 				}
 			}

--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -62,8 +62,6 @@ type volumeStatusReport struct {
 	SubState          string `json:"subState"`
 	Result            string `json:"result"`
 	FailureDiagnostic string `json:"failureDiagnostic,omitempty"`
-	PartitionUUID     string `json:"partitionUUID,omitempty"`
-	FilesystemUUID    string `json:"filesystemUUID,omitempty"`
 	MountSource       string `json:"mountSource,omitempty"`
 }
 
@@ -418,7 +416,7 @@ func newHostStatusReport(node, endpoint string, status *agentapi.NodeStatus, cur
 			Name: volume.GetName(), TargetKind: volume.GetTargetKind(), MountPath: volume.GetMountPath(),
 			Filesystem: volume.GetFilesystem(), LoadState: volume.GetLoadState(), ActiveState: volume.GetActiveState(),
 			SubState: volume.GetSubState(), Result: volume.GetResult(), FailureDiagnostic: volume.GetFailureDiagnostic(),
-			PartitionUUID: volume.GetPartitionUuid(), FilesystemUUID: volume.GetFilesystemUuid(), MountSource: volume.GetMountSource(),
+			MountSource: volume.GetMountSource(),
 		})
 	}
 	return report

--- a/cmd/katlctl/kubeadm_control_plane_config.go
+++ b/cmd/katlctl/kubeadm_control_plane_config.go
@@ -27,6 +27,7 @@ type kubeadmControlPlaneConfigOptions struct {
 	rolloutID, component                                             string
 	progress                                                         io.Writer
 	destructiveStorageAcknowledgements                               []string
+	volumeRebinds                                                    []string
 }
 
 var kubeadmConfigNow = func() time.Time { return time.Now().UTC() }
@@ -57,6 +58,7 @@ role change. Enrolled node renames and role changes are refused here.`,
 	f.StringVar(&opts.configName, "config-name", "", "selected KubeadmConfig name")
 	f.StringVar(&opts.rolloutID, "rollout-id", "", "rollout identity")
 	f.StringArrayVar(&opts.destructiveStorageAcknowledgements, "acknowledge-storage-wipe", nil, "authorize overwriting one non-blank node volume as NODE/VOLUME (repeatable)")
+	f.StringArrayVar(&opts.volumeRebinds, "rebind-volume", nil, "authorize replacing one generation-bound volume identity as NODE/VOLUME (repeatable)")
 	for _, name := range []string{"inventory", "generation", "config-name", "rollout-id"} {
 		cmd.Flags().Lookup(name).Hidden = true
 	}
@@ -70,6 +72,11 @@ func runClusterApply(ctx context.Context, opts kubeadmControlPlaneConfigOptions,
 		return err
 	}
 	opts.destructiveStorageAcknowledgements = acknowledgements
+	rebinds, err := normalizeVolumeRebinds(opts.volumeRebinds)
+	if err != nil {
+		return err
+	}
+	opts.volumeRebinds = rebinds
 	inv, err := kubeadmConfigInventory(opts)
 	if err != nil {
 		return err
@@ -576,6 +583,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			ExpectedMachineId: status.MachineId, ExpectedCurrentGenerationId: status.CurrentGenerationId, ApplyMode: generation.ApplyModeAuto,
 			CandidateGenerationId: generationID, NodeName: node.Name, ConfigYaml: string(input.configYAML),
 			DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...),
+			VolumeRebinds:                      append([]string(nil), opts.volumeRebinds...),
 		})
 		if err != nil {
 			_ = conn.Close()
@@ -703,7 +711,7 @@ func activateClusterConfig(ctx context.Context, opts kubeadmControlPlaneConfigOp
 			ApiVersion: operation.APIVersion, Kind: "SubmitOperationRequest", ClientRequestId: opts.rolloutID + "-stage-" + node.Name,
 			OperationKind: operationKind, Actor: "katlctl cluster apply", ExpectedEnrollmentId: node.EnrollmentID, ExpectedInventoryNodeName: node.Name,
 			ExpectedMachineId: input.machineID, ExpectedCurrentGenerationId: input.currentGeneration,
-			ConfigApply: &agentapi.ConfigApplyOperationRequest{CandidateGenerationId: generationID, ApplyMode: generation.ApplyModeAuto, NodeName: node.Name, ConfigYaml: string(input.configYAML), DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...)},
+			ConfigApply: &agentapi.ConfigApplyOperationRequest{CandidateGenerationId: generationID, ApplyMode: generation.ApplyModeAuto, NodeName: node.Name, ConfigYaml: string(input.configYAML), DestructiveStorageAcknowledgements: append([]string(nil), opts.destructiveStorageAcknowledgements...), VolumeRebinds: append([]string(nil), opts.volumeRebinds...)},
 		})
 		if err != nil {
 			_ = conn.Close()

--- a/cmd/katlctl/kubeadm_control_plane_config_test.go
+++ b/cmd/katlctl/kubeadm_control_plane_config_test.go
@@ -768,14 +768,14 @@ func TestActivateClusterConfigUsesOneLiveWholeNodeGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1", destructiveStorageAcknowledgements: []string{"cp-1/data"}}, inv.Nodes)
+	activated, err := activateClusterConfig(context.Background(), kubeadmControlPlaneConfigOptions{configPath: configPath, rolloutID: "rollout-1", destructiveStorageAcknowledgements: []string{"cp-1/data"}, volumeRebinds: []string{"cp-1/data"}}, inv.Nodes)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if activated.generations["cp-1"] != "cluster-config-42" {
 		t.Fatalf("generations = %#v", activated.generations)
 	}
-	if client.validateRequest == nil || client.validateRequest.ApplyMode != "auto" || client.validateRequest.CandidateGenerationId != "cluster-config-42" || !slices.Equal(client.validateRequest.DestructiveStorageAcknowledgements, []string{"cp-1/data"}) {
+	if client.validateRequest == nil || client.validateRequest.ApplyMode != "auto" || client.validateRequest.CandidateGenerationId != "cluster-config-42" || !slices.Equal(client.validateRequest.DestructiveStorageAcknowledgements, []string{"cp-1/data"}) || !slices.Equal(client.validateRequest.VolumeRebinds, []string{"cp-1/data"}) {
 		t.Fatalf("validate request = %#v", client.validateRequest)
 	}
 	for _, required := range []string{"identity:", "controlPlaneEndpoint:", "kubeadmConfigs:"} {
@@ -791,6 +791,9 @@ func TestActivateClusterConfigUsesOneLiveWholeNodeGeneration(t *testing.T) {
 	}
 	if !slices.Equal(client.submitRequest.ConfigApply.DestructiveStorageAcknowledgements, []string{"cp-1/data"}) {
 		t.Fatalf("submit acknowledgements = %v", client.submitRequest.ConfigApply.DestructiveStorageAcknowledgements)
+	}
+	if !slices.Equal(client.submitRequest.ConfigApply.VolumeRebinds, []string{"cp-1/data"}) {
+		t.Fatalf("submit rebinds = %v", client.submitRequest.ConfigApply.VolumeRebinds)
 	}
 }
 

--- a/cmd/katlctl/main.go
+++ b/cmd/katlctl/main.go
@@ -2162,6 +2162,7 @@ type configApplyOptions struct {
 	waitTimeout                        time.Duration
 	output                             string
 	destructiveStorageAcknowledgements []string
+	volumeRebinds                      []string
 }
 
 var configApplyNow = func() time.Time { return time.Now().UTC() }
@@ -2232,6 +2233,7 @@ func addConfigApplyFlags(cmd *cobra.Command, opts *configApplyOptions) {
 	cmd.Flags().DurationVar(&opts.waitTimeout, "timeout", opts.waitTimeout, "overall operation wait timeout")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format: text or json")
 	cmd.Flags().StringArrayVar(&opts.destructiveStorageAcknowledgements, "acknowledge-storage-wipe", nil, "authorize overwriting one non-blank node volume as NODE/VOLUME (repeatable)")
+	cmd.Flags().StringArrayVar(&opts.volumeRebinds, "rebind-volume", nil, "authorize replacing one generation-bound volume identity as NODE/VOLUME (repeatable)")
 }
 
 func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr io.Writer) error {
@@ -2242,6 +2244,10 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		return fmt.Errorf("--timeout must be positive")
 	}
 	acknowledgements, err := normalizeDestructiveStorageAcknowledgements(opts.destructiveStorageAcknowledgements)
+	if err != nil {
+		return err
+	}
+	rebinds, err := normalizeVolumeRebinds(opts.volumeRebinds)
 	if err != nil {
 		return err
 	}
@@ -2305,6 +2311,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			NodeName:                           opts.nodeConfig.nodeName,
 			ConfigYaml:                         string(configYAML),
 			DestructiveStorageAcknowledgements: acknowledgements,
+			VolumeRebinds:                      rebinds,
 		})
 		if err != nil {
 			return err
@@ -2346,6 +2353,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 		NodeName:                           opts.nodeConfig.nodeName,
 		ConfigYaml:                         string(configYAML),
 		DestructiveStorageAcknowledgements: acknowledgements,
+		VolumeRebinds:                      rebinds,
 	}
 	var accepted *agentapi.OperationAccepted
 	switch requestedMode {
@@ -2368,6 +2376,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 			NodeName:                           opts.nodeConfig.nodeName,
 			ConfigYaml:                         string(configYAML),
 			DestructiveStorageAcknowledgements: acknowledgements,
+			VolumeRebinds:                      rebinds,
 		})
 		if err != nil {
 			return err
@@ -2415,6 +2424,7 @@ func runConfigApply(ctx context.Context, opts configApplyOptions, stdout, stderr
 				NodeName:                           opts.nodeConfig.nodeName,
 				ConfigYaml:                         string(configYAML),
 				DestructiveStorageAcknowledgements: acknowledgements,
+				VolumeRebinds:                      rebinds,
 			},
 		})
 	default:
@@ -2448,6 +2458,18 @@ func normalizeDestructiveStorageAcknowledgements(values []string) ([]string, err
 	sort.Strings(normalized)
 	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(normalized); err != nil {
 		return nil, fmt.Errorf("--acknowledge-storage-wipe: %w", err)
+	}
+	return normalized, nil
+}
+
+func normalizeVolumeRebinds(values []string) ([]string, error) {
+	normalized := make([]string, len(values))
+	for i, value := range values {
+		normalized[i] = strings.TrimSpace(value)
+	}
+	sort.Strings(normalized)
+	if err := disk.ValidateVolumeRebindKeys(normalized); err != nil {
+		return nil, fmt.Errorf("--rebind-volume: %w", err)
 	}
 	return normalized, nil
 }

--- a/cmd/katlctl/main_test.go
+++ b/cmd/katlctl/main_test.go
@@ -2502,15 +2502,16 @@ func TestConfigApplyDefaultsAutoAndSubmitsAcceptedOperationKind(t *testing.T) {
 		"--candidate-generation", "generation-auto",
 		"--client-request-id", "req-auto",
 		"--acknowledge-storage-wipe", "node-a/data",
+		"--rebind-volume", "node-a/data",
 		"--output", "json",
 	}, &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}
-	if fake.validateRequest == nil || fake.validateRequest.ApplyMode != generation.ApplyModeAuto || fake.validateRequest.CandidateGenerationId != "generation-auto" || fake.validateRequest.Actor != "katlctl node apply" || !slices.Equal(fake.validateRequest.DestructiveStorageAcknowledgements, []string{"node-a/data"}) {
+	if fake.validateRequest == nil || fake.validateRequest.ApplyMode != generation.ApplyModeAuto || fake.validateRequest.CandidateGenerationId != "generation-auto" || fake.validateRequest.Actor != "katlctl node apply" || !slices.Equal(fake.validateRequest.DestructiveStorageAcknowledgements, []string{"node-a/data"}) || !slices.Equal(fake.validateRequest.VolumeRebinds, []string{"node-a/data"}) {
 		t.Fatalf("validate request = %+v", fake.validateRequest)
 	}
-	if fake.submitRequest == nil || fake.submitRequest.OperationKind != "generation-apply" || fake.submitRequest.Actor != "katlctl node apply" || fake.submitRequest.GetConfigApply().GetApplyMode() != generation.ApplyModeAuto || !slices.Equal(fake.submitRequest.GetConfigApply().GetDestructiveStorageAcknowledgements(), []string{"node-a/data"}) {
+	if fake.submitRequest == nil || fake.submitRequest.OperationKind != "generation-apply" || fake.submitRequest.Actor != "katlctl node apply" || fake.submitRequest.GetConfigApply().GetApplyMode() != generation.ApplyModeAuto || !slices.Equal(fake.submitRequest.GetConfigApply().GetDestructiveStorageAcknowledgements(), []string{"node-a/data"}) || !slices.Equal(fake.submitRequest.GetConfigApply().GetVolumeRebinds(), []string{"node-a/data"}) {
 		t.Fatalf("submit request = %+v", fake.submitRequest)
 	}
 	if fake.stageRequest != nil || fake.applyRequest != nil {
@@ -2531,6 +2532,19 @@ func TestNormalizeDestructiveStorageAcknowledgements(t *testing.T) {
 		if _, err := normalizeDestructiveStorageAcknowledgements(values); err == nil || !strings.Contains(err.Error(), "--acknowledge-storage-wipe") {
 			t.Fatalf("normalize invalid %v error = %v", values, err)
 		}
+	}
+}
+
+func TestNormalizeVolumeRebinds(t *testing.T) {
+	got, err := normalizeVolumeRebinds([]string{"worker-1/cache", " cp-1/data "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, []string{"cp-1/data", "worker-1/cache"}) {
+		t.Fatalf("normalized rebinds = %v", got)
+	}
+	if _, err := normalizeVolumeRebinds([]string{"cp-1"}); err == nil || !strings.Contains(err.Error(), "--rebind-volume") {
+		t.Fatalf("normalize invalid rebind error = %v", err)
 	}
 }
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -288,6 +288,14 @@ target; a partition selector never repartitions its parent disk. Live apply
 refuses mounted or otherwise active destructive targets rather than disrupting
 workloads.
 
+Selectors are used only while provisioning or explicitly replacing a volume.
+Once Katl resolves a selector, the resulting PARTUUID (or filesystem UUID when
+no PARTUUID exists) is stored in that node generation and the systemd mount
+uses that exact identity. A second disk carrying the same `u-<name>` label
+therefore cannot redirect an existing mount. If no prior binding exists, an
+ambiguous label blocks planning and must be replaced with a unique `byID`,
+`partUUID`, or `filesystemUUID` selector.
+
 Katl provisions a discovered blank target automatically. If the selected disk
 or partition already has a partition-table, partition, or filesystem
 signature, planning stops before mutation and reports the exact `NODE/VOLUME`
@@ -306,6 +314,23 @@ Repeat the flag for multiple affected volumes. The acknowledgement belongs to
 that operation and is never written into ClusterConfig or a node generation;
 changing a selector or encountering existing contents in a later operation
 requires acknowledgement again.
+
+Replacing a generation-bound volume is a separate decision from overwriting
+its contents. Change the selector to the replacement's exact stable identity,
+plan the change, inspect the reported target, then authorize that transition:
+
+```console
+katlctl node apply --config ./cluster.yaml worker-1 \
+  --rebind-volume worker-1/data
+```
+
+`--rebind-volume` is one-shot operation authority and is not persisted in
+ClusterConfig. If the replacement is non-blank and `wipe: true`, the operation
+also requires the separately reported
+`--acknowledge-storage-wipe worker-1/data`. Removing a volume does not rebind
+or erase it: Katl retains an unmounted generation binding for that logical
+name, so re-adding the same exact identity preserves its data and selecting a
+different identity still requires `--rebind-volume`.
 
 For a routed endpoint advertised by Katl, add the VIP and fabric peers. Katl
 then installs and runs the endpoint advertiser only on control-plane nodes;

--- a/docs/internal/writable-state-layout.md
+++ b/docs/internal/writable-state-layout.md
@@ -95,7 +95,7 @@ paths for services:
 | `var.mount` | installed `KATL_STATE` partition by PARTUUID | `/var` | Required local filesystem; no `nofail`; must be active before any persistent node service starts |
 | `etc-kubernetes.mount` | `/var/lib/katl/kubernetes/etc-kubernetes` bind source | `/etc/kubernetes` | Only writable `/etc` projection in the first implementation; active after confext and before kubelet or kubeadm automation |
 | `var-lib-etcd.mount` | optional installed `KATL_ETCD` partition by PARTUUID | `/var/lib/etcd` | Generated only when a dedicated etcd partition was planned; active before kubelet, kubeadm automation, and the kubeadm-ready target |
-| `var-mnt-<name>.mount` | disk- or partition-backed Katl volume by stable identity | `/var/mnt/<name>` | Generated for each configured volume; disk initialization uses a convention-labelled `systemd-repart` partition, partition selection never repartitions its parent, and all mounts are required before boot health succeeds |
+| `var-mnt-<name>.mount` | generation-owned PARTUUID or filesystem UUID | `/var/mnt/<name>` | Generated for each configured volume; labels and selectors are discovery inputs only, the resolved identity is persisted in generation metadata, replacement requires one-shot rebind authority, and all mounts are required before boot health succeeds |
 
 No mount units are generated for `/var/lib/kubelet` or
 `/var/lib/containerd` in the default model. They are native directories on the

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -112,9 +112,9 @@ device, planning fails until the operator supplies the reported one-shot
 `filesystemUUID` selector for the replacement; an ambiguous `byVolumeName`
 label remains an error even with rebind authority. A destructive replacement
 may require both `--rebind-volume` and `--acknowledge-storage-wipe`.
-`katlctl node status NODE` reports the active mount source; its JSON output
-also includes both discovered UUIDs so the operator can verify the retained
-identity before and after the change.
+`katlctl node status NODE` reports the active exact mount source so the
+operator can verify the retained identity before and after the change without
+exposing the generation's internal binding metadata as a separate API.
 
 ## Configure Kernel Arguments
 

--- a/docs/operations/configure-nodes.md
+++ b/docs/operations/configure-nodes.md
@@ -104,6 +104,18 @@ target, it refuses the whole apply and reports one or more exact
 the command with only the acknowledgements you intend. Blank targets need no
 flag, and acknowledgements are not retained for later applies.
 
+Katl records the exact PARTUUID or filesystem UUID selected for every
+provisioned volume. Later generations mount that identity directly instead of
+following the logical label again. If a selector changes to a different
+device, planning fails until the operator supplies the reported one-shot
+`--rebind-volume NODE/VOLUME` authority. Use an exact `byID`, `partUUID`, or
+`filesystemUUID` selector for the replacement; an ambiguous `byVolumeName`
+label remains an error even with rebind authority. A destructive replacement
+may require both `--rebind-volume` and `--acknowledge-storage-wipe`.
+`katlctl node status NODE` reports the active mount source; its JSON output
+also includes both discovered UUIDs so the operator can verify the retained
+identity before and after the change.
+
 ## Configure Kernel Arguments
 
 Set `kernel.commandLine` under defaults or a concrete node:

--- a/internal/installer/configapply/executor.go
+++ b/internal/installer/configapply/executor.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/katl-dev/katl/internal/installer/bgpapivip"
 	"github.com/katl-dev/katl/internal/installer/generation"
-	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
 type Command struct {
@@ -47,7 +46,6 @@ type Executor struct {
 	StatusPath        string
 	ActionCommands    map[string][]Command
 	HostConfiguration *HostConfigurationChangePlan
-	ApplyVolumes      func(context.Context, manifest.Manifest, manifest.Manifest) error
 	Timeout           time.Duration
 	Now               func() time.Time
 }
@@ -90,23 +88,6 @@ func (e Executor) ExecuteLive(ctx context.Context, plan Result) (generation.Conf
 			return e.failBeforeActivation(status, errors.New("control-plane endpoint routing cannot be applied because VIP advertisement is not enabled"))
 		}
 	}
-	if containsDomainAction(status.DomainActions, DomainVolumes) {
-		if e.ApplyVolumes == nil {
-			return e.failBeforeActivation(status, errors.New("live volume applicator is not configured"))
-		}
-		current, err := ReadGenerationManifest(e.Root, plan.GenerationRecord.ConfigApply.PreviousGeneration)
-		if err != nil {
-			return e.failBeforeActivation(status, fmt.Errorf("read current volume manifest: %w", err))
-		}
-		desired, err := ReadGenerationManifest(e.Root, plan.GenerationRecord.GenerationID)
-		if err != nil {
-			return e.failBeforeActivation(status, fmt.Errorf("read desired volume manifest: %w", err))
-		}
-		if err := e.ApplyVolumes(ctx, current, desired); err != nil {
-			return e.failBeforeActivation(status, fmt.Errorf("prepare volumes: %w", err))
-		}
-	}
-
 	status, err = generation.MarkConfigApplyPhase(status, generation.ConfigApplyPhaseActivating, e.now())
 	if err != nil {
 		return status, err

--- a/internal/installer/configapply/executor_test.go
+++ b/internal/installer/configapply/executor_test.go
@@ -82,7 +82,7 @@ func TestExecutorRebindsKubeletWatcherOnceForKubeadmInput(t *testing.T) {
 	}
 }
 
-func TestExecutorPreparesAndActivatesVolumesBeforeReportingSuccess(t *testing.T) {
+func TestExecutorActivatesPreparedVolumesBeforeReportingSuccess(t *testing.T) {
 	root := t.TempDir()
 	plan := liveExecutorPlan(t, []Change{{Domain: DomainVolumes}})
 	current := baseManifest()
@@ -97,22 +97,14 @@ func TestExecutorPreparesAndActivatesVolumesBeforeReportingSuccess(t *testing.T)
 		t.Fatal(err)
 	}
 	runner := &fakeCommandRunner{}
-	called := false
 	status, err := Executor{
 		Root: root, Runner: runner, Activator: &fakeActivator{}, Now: fixedNow,
-		ApplyVolumes: func(_ context.Context, before, after manifest.Manifest) error {
-			called = true
-			if len(before.Install.Volumes) != 0 || len(after.Install.Volumes) != 1 {
-				t.Fatalf("volume manifests = %#v -> %#v", before.Install.Volumes, after.Install.Volumes)
-			}
-			return nil
-		},
 	}.ExecuteLive(context.Background(), plan)
 	if err != nil {
 		t.Fatalf("ExecuteLive() error = %v", err)
 	}
-	if !called || status.Phase != generation.ConfigApplyPhaseActive {
-		t.Fatalf("volume apply called=%t status=%#v", called, status)
+	if status.Phase != generation.ConfigApplyPhaseActive {
+		t.Fatalf("status=%#v", status)
 	}
 	if got, want := strings.Join(runner.commandNames(), ","), "systemd-confext-refresh,systemd-daemon-reload,volume-mount-activate"; got != want {
 		t.Fatalf("commands = %q, want %q", got, want)

--- a/internal/installer/configapply/planner.go
+++ b/internal/installer/configapply/planner.go
@@ -27,6 +27,8 @@ type NodeConfigurationChange struct {
 	KernelCommandLine              []string
 	ConfiguredKernelCommandLine    []string
 	ConfiguredKernelCommandLineSet bool
+	VolumeBindings                 []generation.VolumeBinding
+	VolumeBindingsSet              bool
 }
 
 type Apply struct {
@@ -86,6 +88,8 @@ func PlanChange(current generation.Record, request NodeConfigurationChange) (Res
 		KernelCommandLine:              request.KernelCommandLine,
 		ConfiguredKernelCommandLine:    request.ConfiguredKernelCommandLine,
 		ConfiguredKernelCommandLineSet: request.ConfiguredKernelCommandLineSet,
+		VolumeBindings:                 append([]generation.VolumeBinding(nil), request.VolumeBindings...),
+		VolumeBindingsSet:              request.VolumeBindingsSet,
 	})
 	if err != nil {
 		return Result{Decision: decision}, err

--- a/internal/installer/configapply/runtime_apply.go
+++ b/internal/installer/configapply/runtime_apply.go
@@ -56,6 +56,9 @@ type TrustedBundleRequest struct {
 	EndpointAdvertiserSysext        *generation.ExtensionRef
 	SystemExtensionPayloads         []SystemExtensionPayload
 	Executor                        *Executor
+	VolumeBindings                  []generation.VolumeBinding
+	VolumeBindingsSet               bool
+	SkipVolumeRendering             bool
 	Chown                           func(path string, uid int, gid int) error
 	Now                             func() time.Time
 }
@@ -111,6 +114,9 @@ type ConfigRequestAudit struct {
 }
 
 func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (TrustedBundleResult, error) {
+	if request.SkipVolumeRendering {
+		return TrustedBundleResult{}, fmt.Errorf("volume rendering may only be skipped during hardware preflight")
+	}
 	if strings.TrimSpace(request.Root) == "" {
 		return TrustedBundleResult{}, fmt.Errorf("runtime root is required")
 	}
@@ -180,7 +186,7 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
 		return TrustedBundleResult{Manifest: merged, Audit: audit, AuditPath: auditPath}, joinAuditError(err, auditErr)
 	}
-	volumeFiles, err := volumeMountNativeEtcFiles(merged.Install.Volumes)
+	volumeFiles, err := volumeMountNativeEtcFiles(merged.Install.Volumes, request.VolumeBindings)
 	if err != nil {
 		audit := request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
 		auditPath, auditErr := writeAudit(request.Root, sourceID, desiredVersion, audit)
@@ -305,6 +311,8 @@ func ApplyTrustedBundle(ctx context.Context, request TrustedBundleRequest) (Trus
 		),
 		ConfiguredKernelCommandLine:    slices.Clone(merged.Node.Kernel.CommandLine),
 		ConfiguredKernelCommandLineSet: true,
+		VolumeBindings:                 append([]generation.VolumeBinding(nil), request.VolumeBindings...),
+		VolumeBindingsSet:              request.VolumeBindingsSet,
 	})
 	if err != nil {
 		audit = request.audit(sourceID, desiredVersion, "", changes, nil, err, now)
@@ -485,6 +493,14 @@ func PlanTrustedBundle(request TrustedBundleRequest) (TrustedBundleResult, error
 	if err != nil {
 		return TrustedBundleResult{Manifest: merged}, err
 	}
+	var volumeFiles []confext.NativeEtcFile
+	if !request.SkipVolumeRendering {
+		volumeFiles, err = volumeMountNativeEtcFiles(merged.Install.Volumes, request.VolumeBindings)
+		if err != nil {
+			return TrustedBundleResult{Manifest: merged}, err
+		}
+	}
+	files = append(files, volumeFiles...)
 	files = append(files, unsafeFiles...)
 	status, err := generation.NewConfigApplyStatus(generation.ConfigApplyStatusRequest{
 		GenerationID:       request.GenerationID,
@@ -514,6 +530,20 @@ func PlanTrustedBundle(request TrustedBundleRequest) (TrustedBundleResult, error
 	}, nil
 }
 
+// DesiredManifest resolves the operator overlays without rendering a
+// generation. Hardware-dependent callers use it to bind volume selectors to
+// exact device identities before the final generation is planned.
+func DesiredManifest(request TrustedBundleRequest) (manifest.Manifest, error) {
+	merged, _, _, err := mergeRuntimeConfig(request)
+	if err != nil && !errors.Is(err, ErrNoChanges) {
+		return merged, err
+	}
+	if err := manifest.Validate(merged); err != nil {
+		return merged, err
+	}
+	return merged, nil
+}
+
 func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Change, []confext.NativeEtcFile, error) {
 	merged := request.CurrentManifest
 	currentHostConfiguration := request.CurrentManifest.Node.HostConfiguration
@@ -536,6 +566,11 @@ func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Chan
 		applyOverlay(&merged, nodeOverlay, request.KubernetesInitialized, &domains, &unsafeFiles)
 	}
 	if len(domains.domains) == 0 {
+		if request.VolumeBindingsSet && !volumeBindingsEqual(request.CurrentRecord.VolumeBindings, request.VolumeBindings) {
+			domains.add(DomainVolumes)
+		}
+	}
+	if len(domains.domains) == 0 {
 		endpointDrifted, err := endpointRenderingDrifted(request, merged)
 		if err != nil {
 			return manifest.Manifest{}, nil, nil, err
@@ -552,6 +587,13 @@ func mergeRuntimeConfig(request TrustedBundleRequest) (manifest.Manifest, []Chan
 		domains.hostConfiguration = &hostPlan
 	}
 	return merged, domains.changes(request.ClusterDefaults, roleOverlay, nodeOverlay), unsafeFiles, nil
+}
+
+func volumeBindingsEqual(left, right []generation.VolumeBinding) bool {
+	if len(left) == 0 && len(right) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(left, right)
 }
 
 func endpointRenderingDrifted(request TrustedBundleRequest, desired manifest.Manifest) (bool, error) {

--- a/internal/installer/configapply/volumes.go
+++ b/internal/installer/configapply/volumes.go
@@ -10,10 +10,22 @@ import (
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
-func volumeMountNativeEtcFiles(volumes []manifest.Volume) ([]confext.NativeEtcFile, error) {
+func volumeMountNativeEtcFiles(volumes []manifest.Volume, bindings []generation.VolumeBinding) ([]confext.NativeEtcFile, error) {
+	bound := make(map[string]generation.VolumeBinding, len(bindings))
+	for _, binding := range bindings {
+		if _, exists := bound[binding.Name]; exists {
+			return nil, fmt.Errorf("duplicate volume binding %q", binding.Name)
+		}
+		bound[binding.Name] = binding
+	}
 	requests := make([]generation.ExtraMountRequest, 0, len(volumes))
 	for _, volume := range volumes {
-		source, err := configuredVolumeMountSource(volume)
+		binding, ok := bound[volume.Name]
+		if !ok {
+			return nil, fmt.Errorf("volume %q has no generation-owned device binding", volume.Name)
+		}
+		delete(bound, volume.Name)
+		source, err := volumeBindingMountSource(binding)
 		if err != nil {
 			return nil, err
 		}
@@ -50,19 +62,13 @@ func volumeMountNativeEtcFiles(volumes []manifest.Volume) ([]confext.NativeEtcFi
 	return files, nil
 }
 
-func configuredVolumeMountSource(volume manifest.Volume) (string, error) {
+func volumeBindingMountSource(binding generation.VolumeBinding) (string, error) {
 	switch {
-	case volume.Selector.Disk != nil:
-		return "/dev/disk/by-partlabel/u-" + volume.Name, nil
-	case volume.Selector.Partition == nil:
-		return "", fmt.Errorf("volume %q has no selector", volume.Name)
-	case volume.Selector.Partition.ByID != "":
-		return volume.Selector.Partition.ByID, nil
-	case volume.Selector.Partition.PartUUID != "":
-		return "PARTUUID=" + volume.Selector.Partition.PartUUID, nil
-	case volume.Selector.Partition.FilesystemUUID != "":
-		return "UUID=" + volume.Selector.Partition.FilesystemUUID, nil
+	case strings.TrimSpace(binding.PartitionUUID) != "":
+		return "PARTUUID=" + strings.TrimSpace(binding.PartitionUUID), nil
+	case strings.TrimSpace(binding.FilesystemUUID) != "":
+		return "UUID=" + strings.TrimSpace(binding.FilesystemUUID), nil
 	default:
-		return "/dev/disk/by-partlabel/u-" + volume.Name, nil
+		return "", fmt.Errorf("volume binding %q has no partition or filesystem UUID", binding.Name)
 	}
 }

--- a/internal/installer/configapply/volumes_test.go
+++ b/internal/installer/configapply/volumes_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
@@ -11,6 +12,10 @@ func TestVolumeMountNativeEtcFilesUseConventionPathsAndStableSources(t *testing.
 	files, err := volumeMountNativeEtcFiles([]manifest.Volume{
 		{Name: "data", Selector: manifest.VolumeSelector{Disk: &manifest.DiskSelector{ByID: "/dev/disk/by-id/data"}}, Filesystem: "xfs"},
 		{Name: "local-hostpath", Selector: manifest.VolumeSelector{Partition: &manifest.PartitionSelector{}}, Filesystem: "xfs"},
+	}, []generation.VolumeBinding{
+		{Name: "data", PartitionUUID: "data-partuuid", FilesystemUUID: "data-fsuuid"},
+		{Name: "local-hostpath", FilesystemUUID: "hostpath-fsuuid"},
+		{Name: "removed", PartitionUUID: "removed-partuuid"},
 	})
 	if err != nil {
 		t.Fatalf("volumeMountNativeEtcFiles() error = %v", err)
@@ -20,8 +25,8 @@ func TestVolumeMountNativeEtcFilesUseConventionPathsAndStableSources(t *testing.
 		content[file.Path] = file.Content
 	}
 	for path, want := range map[string]string{
-		"/etc/systemd/system/var-mnt-data.mount":               "What=/dev/disk/by-partlabel/u-data\nWhere=/var/mnt/data",
-		"/etc/systemd/system/var-mnt-local\\x2dhostpath.mount": "What=/dev/disk/by-partlabel/u-local-hostpath\nWhere=/var/mnt/local-hostpath",
+		"/etc/systemd/system/var-mnt-data.mount":               "What=PARTUUID=data-partuuid\nWhere=/var/mnt/data",
+		"/etc/systemd/system/var-mnt-local\\x2dhostpath.mount": "What=UUID=hostpath-fsuuid\nWhere=/var/mnt/local-hostpath",
 	} {
 		if !strings.Contains(content[path], want) {
 			t.Fatalf("%s missing %q:\n%s", path, want, content[path])
@@ -29,5 +34,24 @@ func TestVolumeMountNativeEtcFilesUseConventionPathsAndStableSources(t *testing.
 	}
 	if !strings.Contains(content["/etc/systemd/system/katl-volumes.target.d/50-mounts.conf"], "Requires=var-mnt-data.mount var-mnt-local\\x2dhostpath.mount") {
 		t.Fatalf("volume target drop-in = %q", content["/etc/systemd/system/katl-volumes.target.d/50-mounts.conf"])
+	}
+}
+
+func TestVolumeMountNativeEtcFilesRequiresExactBindingSet(t *testing.T) {
+	volumes := []manifest.Volume{{Name: "data", Filesystem: "xfs"}}
+	for _, test := range []struct {
+		name     string
+		bindings []generation.VolumeBinding
+		want     string
+	}{
+		{name: "missing", want: `volume "data" has no generation-owned device binding`},
+		{name: "empty identity", bindings: []generation.VolumeBinding{{Name: "data"}}, want: `has no partition or filesystem UUID`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := volumeMountNativeEtcFiles(volumes, test.bindings)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("volumeMountNativeEtcFiles() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }

--- a/internal/installer/disk/authority.go
+++ b/internal/installer/disk/authority.go
@@ -69,15 +69,24 @@ func ValidateDestructiveVolumeAcknowledgements(node string, plans []VolumePlan, 
 // ValidateDestructiveVolumeAcknowledgementKeys validates the public
 // NODE/VOLUME acknowledgement shape independently of a particular plan.
 func ValidateDestructiveVolumeAcknowledgementKeys(values []string) error {
+	return validateVolumeAuthorityKeys("destructive storage acknowledgement", values)
+}
+
+// ValidateVolumeRebindKeys validates one-shot volume rebind authority keys.
+func ValidateVolumeRebindKeys(values []string) error {
+	return validateVolumeAuthorityKeys("volume rebind", values)
+}
+
+func validateVolumeAuthorityKeys(kind string, values []string) error {
 	seen := make(map[string]struct{}, len(values))
 	for i, raw := range values {
 		value := strings.TrimSpace(raw)
 		parts := strings.Split(value, "/")
 		if len(parts) != 2 || !validAuthoritySegment(parts[0]) || !validAuthoritySegment(parts[1]) {
-			return fmt.Errorf("destructive storage acknowledgement %d must be NODE/VOLUME using lowercase DNS-label names", i+1)
+			return fmt.Errorf("%s %d must be NODE/VOLUME using lowercase DNS-label names", kind, i+1)
 		}
 		if _, exists := seen[value]; exists {
-			return fmt.Errorf("destructive storage acknowledgement %q is duplicated", value)
+			return fmt.Errorf("%s %q is duplicated", kind, value)
 		}
 		seen[value] = struct{}{}
 	}

--- a/internal/installer/disk/layout.go
+++ b/internal/installer/disk/layout.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/katl-dev/katl/internal/installer/discovery"
 )
@@ -107,6 +108,12 @@ type VolumePlan struct {
 	Signatures  []SignatureReport
 }
 
+type VolumeBinding struct {
+	Name           string
+	PartitionUUID  string
+	FilesystemUUID string
+}
+
 type BootTargetMetadata struct {
 	RootSlot           RootSlot
 	RootPartitionLabel string
@@ -192,7 +199,7 @@ func PlanVolumes(facts HardwareFacts, target BlockDevice, requests []VolumeReque
 				}
 				plan = VolumePlan{
 					Name: request.Name, TargetKind: "disk", DevicePath: partition.Path,
-					MountSource: "/dev/disk/by-partlabel/" + label, Filesystem: request.Filesystem,
+					MountSource: volumeIdentityMountSource(partition), Filesystem: request.Filesystem,
 					MountPath: VolumeMountRoot + "/" + request.Name, Signatures: collectVolumeSignatures(partition),
 				}
 				if err := validateReusableVolume(plan, partition.FilesystemSignature); err != nil {
@@ -210,21 +217,127 @@ func PlanVolumes(facts HardwareFacts, target BlockDevice, requests []VolumeReque
 			if isKatlPartitionLabel(match.Device.GPTLabel) {
 				return nil, fmt.Errorf("volume %q resolves to Katl-managed partition %s", request.Name, match.Device.GPTLabel)
 			}
-			mountSource, err := persistentPartitionPath(match.Device, *request.Partition)
-			if err != nil {
-				return nil, fmt.Errorf("volume %q partition: %w", request.Name, err)
-			}
 			plan = VolumePlan{
-				Name: request.Name, TargetKind: "partition", DevicePath: match.Device.Path, MountSource: mountSource,
+				Name: request.Name, TargetKind: "partition", DevicePath: match.Device.Path, MountSource: volumeIdentityMountSource(match.Device),
 				Filesystem: request.Filesystem, MountPath: VolumeMountRoot + "/" + request.Name, Wipe: request.Wipe, Signatures: match.Signatures,
 			}
 			if err := validateReusableVolume(plan, match.Device.FilesystemSignature); err != nil {
 				return nil, err
 			}
 		}
+		if !plan.Repartition && strings.TrimSpace(plan.MountSource) == "" {
+			return nil, fmt.Errorf("volume %q partition has no discoverable PARTUUID or filesystem UUID", request.Name)
+		}
 		plans = append(plans, plan)
 	}
 	return plans, nil
+}
+
+func BindVolumePlans(facts HardwareFacts, plans []VolumePlan) ([]VolumePlan, []VolumeBinding, error) {
+	bound := append([]VolumePlan(nil), plans...)
+	bindings := make([]VolumeBinding, 0, len(plans))
+	for i := range bound {
+		device, err := volumePlanPartition(facts, bound[i])
+		if err != nil {
+			return nil, nil, fmt.Errorf("volume %q: %w", bound[i].Name, err)
+		}
+		binding := VolumeBinding{
+			Name:           bound[i].Name,
+			PartitionUUID:  strings.TrimSpace(device.PartitionUUID),
+			FilesystemUUID: strings.TrimSpace(device.FilesystemUUID),
+		}
+		source, err := VolumeBindingMountSource(binding)
+		if err != nil {
+			return nil, nil, err
+		}
+		bound[i].DevicePath = device.Path
+		bound[i].MountSource = source
+		bindings = append(bindings, binding)
+	}
+	return bound, bindings, nil
+}
+
+func VolumeBindingMountSource(binding VolumeBinding) (string, error) {
+	switch {
+	case strings.TrimSpace(binding.PartitionUUID) != "":
+		return "PARTUUID=" + strings.TrimSpace(binding.PartitionUUID), nil
+	case strings.TrimSpace(binding.FilesystemUUID) != "":
+		return "UUID=" + strings.TrimSpace(binding.FilesystemUUID), nil
+	default:
+		return "", fmt.Errorf("volume %q has no discovered partition or filesystem UUID", binding.Name)
+	}
+}
+
+func MatchVolumeBinding(facts HardwareFacts, binding VolumeBinding) (BlockDevice, error) {
+	var matches []BlockDevice
+	for _, candidate := range facts.BlockDevices {
+		for _, partition := range candidate.Partitions {
+			switch {
+			case strings.TrimSpace(binding.PartitionUUID) != "":
+				if partition.PartitionUUID != strings.TrimSpace(binding.PartitionUUID) {
+					continue
+				}
+			case strings.TrimSpace(binding.FilesystemUUID) != "":
+				if partition.FilesystemUUID != strings.TrimSpace(binding.FilesystemUUID) {
+					continue
+				}
+			default:
+				return BlockDevice{}, fmt.Errorf("bound identity for volume %q is empty", binding.Name)
+			}
+			matches = append(matches, partition)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return BlockDevice{}, fmt.Errorf("bound identity for volume %q matched no partitions", binding.Name)
+	case 1:
+		return matches[0], nil
+	default:
+		return BlockDevice{}, fmt.Errorf("bound identity for volume %q matched %d partitions", binding.Name, len(matches))
+	}
+}
+
+func volumePlanPartition(facts HardwareFacts, plan VolumePlan) (BlockDevice, error) {
+	if !plan.Repartition {
+		for _, disk := range facts.BlockDevices {
+			for _, partition := range disk.Partitions {
+				if partition.Path == plan.DevicePath {
+					return partition, nil
+				}
+			}
+		}
+		return BlockDevice{}, fmt.Errorf("selected partition %s was not found after preparation", plan.DevicePath)
+	}
+	var matches []BlockDevice
+	label := volumePartitionLabel(plan.Name)
+	for _, candidate := range facts.BlockDevices {
+		if candidate.Path != plan.DevicePath && plan.Repartition {
+			continue
+		}
+		for _, partition := range candidate.Partitions {
+			if partition.GPTLabel == label {
+				matches = append(matches, partition)
+			}
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return BlockDevice{}, fmt.Errorf("discovered partition label %s matched no partitions on selected disk", label)
+	case 1:
+		return matches[0], nil
+	default:
+		return BlockDevice{}, fmt.Errorf("discovered partition label %s matched %d partitions on selected disk", label, len(matches))
+	}
+}
+
+func volumeIdentityMountSource(device BlockDevice) string {
+	if value := strings.TrimSpace(device.PartitionUUID); value != "" {
+		return "PARTUUID=" + value
+	}
+	if value := strings.TrimSpace(device.FilesystemUUID); value != "" {
+		return "UUID=" + value
+	}
+	return ""
 }
 
 func volumePartitionLabel(name string) string {
@@ -278,21 +391,6 @@ func validateReusableVolume(plan VolumePlan, existingFilesystem string) error {
 		return fmt.Errorf("volume %q has filesystem %s, not requested %s; set wipe to true to reformat it", plan.Name, existingFilesystem, plan.Filesystem)
 	default:
 		return nil
-	}
-}
-
-func persistentPartitionPath(device BlockDevice, selector PartitionSelector) (string, error) {
-	switch {
-	case selector.ByID != "":
-		return selector.ByID, nil
-	case selector.PartUUID != "":
-		return "PARTUUID=" + selector.PartUUID, nil
-	case selector.FilesystemUUID != "":
-		return "UUID=" + selector.FilesystemUUID, nil
-	case selector.PartLabel != "":
-		return "/dev/disk/by-partlabel/" + selector.PartLabel, nil
-	default:
-		return "", fmt.Errorf("stable partition identity is required")
 	}
 }
 

--- a/internal/installer/disk/layout_test.go
+++ b/internal/installer/disk/layout_test.go
@@ -167,7 +167,7 @@ func TestPlanDiskLayoutReusesOnlyMatchingDiskVolumePartition(t *testing.T) {
 	extra := diskForLayout("/dev/sdb", "/dev/disk/by-id/ata-data", 16384)
 	extra.PartitionSignature = "gpt"
 	extra.Partitions = []BlockDevice{{
-		Path: "/dev/sdb1", Type: DevicePartition, GPTLabel: "u-data", FilesystemSignature: "ext4",
+		Path: "/dev/sdb1", Type: DevicePartition, GPTLabel: "u-data", PartitionUUID: "data-partuuid", FilesystemSignature: "ext4",
 	}}
 	facts := layoutFacts(
 		diskForLayout("/dev/nvme0n1", "/dev/disk/by-id/nvme-root", 32768),
@@ -236,8 +236,25 @@ func TestPlanDiskLayoutAdoptsExistingPartitionByConventionWithoutDestructiveInte
 		t.Fatalf("volume mount count = %d, want 1", len(plan.VolumeMounts))
 	}
 	volume := plan.VolumeMounts[0]
-	if volume.DevicePath != "/dev/nvme1n1p1" || volume.MountSource != "/dev/disk/by-partlabel/u-local-hostpath" || volume.MountPath != "/var/mnt/local-hostpath" || volume.Filesystem != "xfs" || volume.TargetKind != "partition" {
+	if volume.DevicePath != "/dev/nvme1n1p1" || volume.MountSource != "PARTUUID=part-uuid" || volume.MountPath != "/var/mnt/local-hostpath" || volume.Filesystem != "xfs" || volume.TargetKind != "partition" {
 		t.Fatalf("volume mount = %#v", volume)
+	}
+}
+
+func TestBindVolumePlansDoesNotFallBackToLogicalLabelWhenSelectedPartitionDisappears(t *testing.T) {
+	facts := layoutFacts(BlockDevice{
+		Path: "/dev/sdc", Type: DeviceDisk,
+		Partitions: []BlockDevice{{
+			Path: "/dev/sdc1", Type: DevicePartition, GPTLabel: "u-data",
+			PartitionUUID: "replacement-partuuid", FilesystemUUID: "replacement-fsuuid",
+		}},
+	})
+
+	_, _, err := BindVolumePlans(facts, []VolumePlan{{
+		Name: "data", DevicePath: "/dev/sdb1", MountSource: "PARTUUID=selected-partuuid",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "selected partition /dev/sdb1 was not found") {
+		t.Fatalf("BindVolumePlans() error = %v, want exact selected-partition failure", err)
 	}
 }
 

--- a/internal/installer/generation/metadata.go
+++ b/internal/installer/generation/metadata.go
@@ -43,6 +43,7 @@ type Record struct {
 	ConfiguredKernelCommandLine []string           `json:"configuredKernelCommandLine,omitempty"`
 	ConfigApply                 *ConfigApplyRecord `json:"configApply,omitempty"`
 	KubernetesUpgrade           *KubernetesUpgrade `json:"kubernetesUpgrade,omitempty"`
+	VolumeBindings              []VolumeBinding    `json:"volumeBindings,omitempty"`
 	CreatedAt                   time.Time          `json:"createdAt"`
 	BootState                   string             `json:"bootState"`
 	HealthState                 string             `json:"healthState"`
@@ -52,6 +53,12 @@ type KubernetesUpgrade struct {
 	OperationID             string `json:"operationID"`
 	TargetKubeadmAccessMode string `json:"targetKubeadmAccessMode"`
 	KubeletActivationGate   string `json:"kubeletActivationGate"`
+}
+
+type VolumeBinding struct {
+	Name           string `json:"name"`
+	PartitionUUID  string `json:"partitionUUID,omitempty"`
+	FilesystemUUID string `json:"filesystemUUID,omitempty"`
 }
 
 type RootSelection struct {
@@ -111,6 +118,7 @@ type FirstInstallRequest struct {
 	GeneratedConfext            GeneratedConfext
 	KernelCommandLine           []string
 	ConfiguredKernelCommandLine []string
+	VolumeBindings              []VolumeBinding
 	CreatedAt                   time.Time
 }
 
@@ -129,6 +137,8 @@ type RuntimeConfigRequest struct {
 	KernelCommandLine              []string
 	ConfiguredKernelCommandLine    []string
 	ConfiguredKernelCommandLineSet bool
+	VolumeBindings                 []VolumeBinding
+	VolumeBindingsSet              bool
 }
 
 type ConfigApplyRecord struct {
@@ -177,6 +187,10 @@ func NewFirstInstallRecord(request FirstInstallRequest) (Record, error) {
 	if err != nil {
 		return Record{}, err
 	}
+	volumeBindings, err := cleanVolumeBindings(request.VolumeBindings)
+	if err != nil {
+		return Record{}, err
+	}
 
 	createdAt := request.CreatedAt
 	if createdAt.IsZero() {
@@ -202,6 +216,7 @@ func NewFirstInstallRecord(request FirstInstallRequest) (Record, error) {
 		Confexts:                    []GeneratedConfext{confext},
 		KernelCommandLine:           slices.Clone(request.KernelCommandLine),
 		ConfiguredKernelCommandLine: slices.Clone(request.ConfiguredKernelCommandLine),
+		VolumeBindings:              volumeBindings,
 		CreatedAt:                   createdAt.UTC(),
 		BootState:                   "pending",
 		HealthState:                 "unknown",
@@ -265,6 +280,14 @@ func NewRuntimeConfigRecord(request RuntimeConfigRequest) (Record, error) {
 	if err != nil {
 		return Record{}, err
 	}
+	volumeBindings := request.Previous.VolumeBindings
+	if request.VolumeBindingsSet {
+		volumeBindings = request.VolumeBindings
+	}
+	volumeBindings, err = cleanVolumeBindings(volumeBindings)
+	if err != nil {
+		return Record{}, err
+	}
 	createdAt := request.CreatedAt
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
@@ -286,6 +309,7 @@ func NewRuntimeConfigRecord(request RuntimeConfigRequest) (Record, error) {
 		Confexts:                    []GeneratedConfext{confext},
 		KernelCommandLine:           runtimeKernelCommandLine(request),
 		ConfiguredKernelCommandLine: runtimeConfiguredKernelCommandLine(request),
+		VolumeBindings:              volumeBindings,
 		ConfigApply: &ConfigApplyRecord{
 			SourceDigest:       strings.ToLower(request.SourceDigest),
 			ChangedDomains:     domains,
@@ -463,7 +487,39 @@ func ValidateRecord(record Record) error {
 			return err
 		}
 	}
+	if _, err := cleanVolumeBindings(record.VolumeBindings); err != nil {
+		return err
+	}
 	return nil
+}
+
+func cleanVolumeBindings(bindings []VolumeBinding) ([]VolumeBinding, error) {
+	cleaned := make([]VolumeBinding, 0, len(bindings))
+	seen := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		binding.Name = strings.TrimSpace(binding.Name)
+		binding.PartitionUUID = strings.TrimSpace(binding.PartitionUUID)
+		binding.FilesystemUUID = strings.TrimSpace(binding.FilesystemUUID)
+		if binding.Name == "" {
+			return nil, fmt.Errorf("volume binding name is required")
+		}
+		for i, value := range binding.Name {
+			if value >= 'a' && value <= 'z' || value >= '0' && value <= '9' || value == '-' && i > 0 && i < len(binding.Name)-1 {
+				continue
+			}
+			return nil, fmt.Errorf("volume binding name %q must use lowercase letters, digits, and internal dashes", binding.Name)
+		}
+		if binding.PartitionUUID == "" && binding.FilesystemUUID == "" {
+			return nil, fmt.Errorf("volume binding %q requires a partition UUID or filesystem UUID", binding.Name)
+		}
+		if _, exists := seen[binding.Name]; exists {
+			return nil, fmt.Errorf("duplicate volume binding %q", binding.Name)
+		}
+		seen[binding.Name] = struct{}{}
+		cleaned = append(cleaned, binding)
+	}
+	sort.Slice(cleaned, func(i, j int) bool { return cleaned[i].Name < cleaned[j].Name })
+	return cleaned, nil
 }
 
 func validateConfigApplyRecord(config ConfigApplyRecord) error {

--- a/internal/installer/generation/metadata_test.go
+++ b/internal/installer/generation/metadata_test.go
@@ -145,6 +145,29 @@ func TestWriteRecordPersistsMetadataJSON(t *testing.T) {
 	}
 }
 
+func TestVolumeBindingsAreGenerationOwnedAndInherited(t *testing.T) {
+	request := validFirstInstallRequest(t.TempDir())
+	request.VolumeBindings = []VolumeBinding{{Name: "data", PartitionUUID: "part-data", FilesystemUUID: "fs-data"}}
+	first, err := NewFirstInstallRecord(request)
+	if err != nil {
+		t.Fatalf("NewFirstInstallRecord() error = %v", err)
+	}
+	if len(first.VolumeBindings) != 1 || first.VolumeBindings[0].PartitionUUID != "part-data" {
+		t.Fatalf("first install bindings = %#v", first.VolumeBindings)
+	}
+	next, err := NewRuntimeConfigRecord(RuntimeConfigRequest{
+		GenerationID: "runtime-config-2", Previous: first, SourceDigest: strings.Repeat("d", 64),
+		GeneratedConfext: runtimeConfext("runtime-config-2"),
+		ChangedDomains:   []string{"volumes"}, RequestedApplyMode: ApplyModeLive, AcceptedApplyMode: ApplyModeLive, CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeConfigRecord() error = %v", err)
+	}
+	if len(next.VolumeBindings) != 1 || next.VolumeBindings[0] != first.VolumeBindings[0] {
+		t.Fatalf("inherited bindings = %#v, want %#v", next.VolumeBindings, first.VolumeBindings)
+	}
+}
+
 func TestRuntimeConfigRecordSerializesApplyMetadata(t *testing.T) {
 	previous := abRecord(t, "2026.06.05-001", "root-a", "11111111-2222-3333-4444-555555555555", "0.1.0", "v1.36.1", time.Date(2026, 6, 5, 10, 0, 0, 0, time.UTC))
 	record, err := NewRuntimeConfigRecord(RuntimeConfigRequest{

--- a/internal/installer/generation/split.go
+++ b/internal/installer/generation/split.go
@@ -48,6 +48,7 @@ type GenerationSpec struct {
 	KernelCommandLine           []string           `json:"kernelCommandLine"`
 	ConfiguredKernelCommandLine []string           `json:"configuredKernelCommandLine,omitempty"`
 	KubernetesUpgrade           *KubernetesUpgrade `json:"kubernetesUpgrade,omitempty"`
+	VolumeBindings              []VolumeBinding    `json:"volumeBindings,omitempty"`
 	CreatedAt                   time.Time          `json:"createdAt"`
 }
 
@@ -96,6 +97,7 @@ func SpecFromRecord(record Record) GenerationSpec {
 		KernelCommandLine:           append([]string{}, record.KernelCommandLine...),
 		ConfiguredKernelCommandLine: slices.Clone(record.ConfiguredKernelCommandLine),
 		KubernetesUpgrade:           record.KubernetesUpgrade,
+		VolumeBindings:              append([]VolumeBinding(nil), record.VolumeBindings...),
 		CreatedAt:                   record.CreatedAt.UTC(),
 	}
 }
@@ -144,6 +146,7 @@ func RecordFromSplit(spec GenerationSpec, status GenerationStatus) Record {
 		KernelCommandLine:           append([]string(nil), spec.KernelCommandLine...),
 		ConfiguredKernelCommandLine: slices.Clone(spec.ConfiguredKernelCommandLine),
 		KubernetesUpgrade:           spec.KubernetesUpgrade,
+		VolumeBindings:              append([]VolumeBinding(nil), spec.VolumeBindings...),
 		CreatedAt:                   spec.CreatedAt,
 		BootState:                   status.BootState,
 		HealthState:                 status.HealthState,
@@ -450,6 +453,9 @@ func ValidateGenerationSpec(spec GenerationSpec) error {
 		if strings.TrimSpace(spec.KubernetesUpgrade.TargetKubeadmAccessMode) == "" || strings.TrimSpace(spec.KubernetesUpgrade.KubeletActivationGate) == "" {
 			return fmt.Errorf("Kubernetes upgrade access mode and kubelet activation gate are required")
 		}
+	}
+	if _, err := cleanVolumeBindings(spec.VolumeBindings); err != nil {
+		return err
 	}
 	if spec.CreatedAt.IsZero() {
 		return fmt.Errorf("generation spec createdAt is required")

--- a/internal/installer/katlosimage/host_upgrade.go
+++ b/internal/installer/katlosimage/host_upgrade.go
@@ -137,6 +137,7 @@ func (p Payload) HostUpgradePlan(request HostUpgradeRequest) (HostUpgradePlan, e
 		Confexts:                    confexts,
 		KernelCommandLine:           mergeKernelCommandLine(request.PreviousSpec.KernelCommandLine, p.Boot.Compatibility.KernelCommandLine),
 		ConfiguredKernelCommandLine: slices.Clone(request.PreviousSpec.ConfiguredKernelCommandLine),
+		VolumeBindings:              append([]generation.VolumeBinding(nil), request.PreviousSpec.VolumeBindings...),
 		CreatedAt:                   createdAt.UTC(),
 	}
 	status, err := generation.NewGenerationStatus(spec, generation.CommitStateCandidate, generation.BootStatePending, generation.HealthStateUnknown, createdAt)

--- a/internal/installer/operation/store.go
+++ b/internal/installer/operation/store.go
@@ -169,6 +169,7 @@ type ConfigApplyRequest struct {
 	ConfigYAMLPath                     string   `json:"configYAMLPath,omitempty"`
 	ConfigYAMLSHA256                   string   `json:"configYAMLSHA256,omitempty"`
 	DestructiveStorageAcknowledgements []string `json:"destructiveStorageAcknowledgements,omitempty"`
+	VolumeRebinds                      []string `json:"volumeRebinds,omitempty"`
 }
 
 type KubeadmControlPlaneConfig struct {
@@ -1172,6 +1173,7 @@ func cloneRecord(record OperationRecord) OperationRecord {
 	if record.ConfigApplyRequest != nil {
 		request := *record.ConfigApplyRequest
 		request.DestructiveStorageAcknowledgements = cloneStrings(request.DestructiveStorageAcknowledgements)
+		request.VolumeRebinds = cloneStrings(request.VolumeRebinds)
 		record.ConfigApplyRequest = &request
 	}
 	if record.KubernetesSysextUpdate != nil {
@@ -1825,6 +1827,9 @@ func validateConfigApplyRequest(request ConfigApplyRequest) error {
 		}
 	}
 	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(request.DestructiveStorageAcknowledgements); err != nil {
+		return fmt.Errorf("configApplyRequest: %w", err)
+	}
+	if err := disk.ValidateVolumeRebindKeys(request.VolumeRebinds); err != nil {
 		return fmt.Errorf("configApplyRequest: %w", err)
 	}
 	return nil

--- a/internal/installer/runner.go
+++ b/internal/installer/runner.go
@@ -73,6 +73,7 @@ type Context struct {
 	RootSlotInstaller                  disk.RootSlotInstaller
 	CurrentRootSlot                    disk.RootSlot
 	RootPartitionUUID                  string
+	VolumeBindings                     []generation.VolumeBinding
 	GenerationID                       string
 	KubeadmConfigs                     map[string]kubeadmconfig.Plan
 	SystemExtensionPayloads            []configapply.SystemExtensionPayload
@@ -402,6 +403,7 @@ func firstInstallRecordFromImage(payload katlosimage.Payload, rootPlan disk.Root
 		Sysexts:                     request.Sysexts,
 		KernelCommandLine:           request.KernelCommandLine,
 		ConfiguredKernelCommandLine: request.ConfiguredKernelCommandLine,
+		VolumeBindings:              append([]generation.VolumeBinding(nil), install.VolumeBindings...),
 		CreatedAt:                   request.CreatedAt,
 		BootState:                   "pending",
 		HealthState:                 "unknown",
@@ -458,7 +460,36 @@ func (formatFilesystemsStep) Run(ctx context.Context, install *Context) error {
 	if err := executeDiskGroup(ctx, install, disk.FormatOperations); err != nil {
 		return err
 	}
+	if err := bindInstalledVolumes(ctx, install); err != nil {
+		return err
+	}
 	return recordStep(ctx, install, FormatFilesystems)
+}
+
+func bindInstalledVolumes(ctx context.Context, install *Context) error {
+	if install.DiskLayout != nil && len(install.DiskLayout.VolumeMounts) > 0 {
+		if install.Discovery == nil {
+			return fmt.Errorf("hardware discovery is required to bind installed volumes")
+		}
+		facts, err := install.Discovery.Discover(ctx)
+		if err != nil {
+			return fmt.Errorf("rediscover installed volumes: %w", err)
+		}
+		plans, diskBindings, err := disk.BindVolumePlans(facts, install.DiskLayout.VolumeMounts)
+		if err != nil {
+			return err
+		}
+		bindings := make([]generation.VolumeBinding, 0, len(diskBindings))
+		for _, binding := range diskBindings {
+			bindings = append(bindings, generation.VolumeBinding{
+				Name: binding.Name, PartitionUUID: binding.PartitionUUID, FilesystemUUID: binding.FilesystemUUID,
+			})
+		}
+		install.HardwareFacts = facts
+		install.DiskLayout.VolumeMounts = plans
+		install.VolumeBindings = bindings
+	}
+	return nil
 }
 
 type mountTargetStep struct{}

--- a/internal/installer/runner_test.go
+++ b/internal/installer/runner_test.go
@@ -1268,7 +1268,7 @@ func TestRunnerInstallsMountUnits(t *testing.T) {
 		LoaderRecord: &record,
 		DiskLayout: &disk.DiskLayoutPlan{VolumeMounts: []disk.VolumePlan{{
 			Name:        "data",
-			MountSource: "/dev/disk/by-partlabel/u-data",
+			MountSource: "PARTUUID=data-partuuid",
 			Filesystem:  "ext4",
 			MountPath:   "/var/mnt/data",
 		}}},
@@ -1282,7 +1282,7 @@ func TestRunnerInstallsMountUnits(t *testing.T) {
 
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var.mount"), "What=PARTUUID=11111111-2222-3333-4444-555555555555")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/etc-kubernetes.mount"), "Where=/etc/kubernetes")
-	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var-mnt-data.mount"), "What=/dev/disk/by-partlabel/u-data")
+	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var-mnt-data.mount"), "What=PARTUUID=data-partuuid")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/var-mnt-data.mount"), "Where=/var/mnt/data")
 	assertContains(t, filepath.Join(targetRoot, "etc/systemd/system/katl-kubeadm-ready.target"), "Requires=systemd-sysext.service systemd-confext.service containerd.service kubelet.service etc-kubernetes.mount")
 	assertMissing(t, filepath.Join(targetRoot, "etc/systemd/system/multi-user.target.wants/katl-kubeadm-ready.target"))
@@ -1292,6 +1292,32 @@ func TestRunnerInstallsMountUnits(t *testing.T) {
 	assertDir(t, filepath.Join(targetRoot, "var/mnt/data"), 0o755)
 	if got := install.Completed; !reflect.DeepEqual(got, []StepID{InstallMountUnits}) {
 		t.Fatalf("completed steps = %#v", got)
+	}
+}
+
+func TestFormatFilesystemsBindsVolumeToDiscoveredIdentity(t *testing.T) {
+	install := &Context{
+		Commands: &NoopCommandRunner{}, Store: &MemoryStateStore{},
+		Discovery: discovery.StaticDiscoverySource{Facts: discovery.HardwareFacts{BlockDevices: []discovery.BlockDevice{{
+			Path: "/dev/vdb", Type: discovery.DeviceDisk, Partitions: []discovery.BlockDevice{{
+				Path: "/dev/vdb1", Type: discovery.DevicePartition, GPTLabel: "u-data",
+				PartitionUUID: "part-data", FilesystemUUID: "fs-data", FilesystemSignature: "xfs",
+			}},
+		}}}},
+		DiskLayout: &disk.DiskLayoutPlan{VolumeMounts: []disk.VolumePlan{{
+			Name: "data", DevicePath: "/dev/vdb1", MountSource: "/dev/disk/by-partlabel/u-data",
+			Filesystem: "xfs", MountPath: "/var/mnt/data",
+		}}},
+	}
+	if err := bindInstalledVolumes(context.Background(), install); err != nil {
+		t.Fatalf("bindInstalledVolumes() error = %v", err)
+	}
+	if got := install.DiskLayout.VolumeMounts[0].MountSource; got != "PARTUUID=part-data" {
+		t.Fatalf("bound mount source = %q", got)
+	}
+	want := []generation.VolumeBinding{{Name: "data", PartitionUUID: "part-data", FilesystemUUID: "fs-data"}}
+	if !reflect.DeepEqual(install.VolumeBindings, want) {
+		t.Fatalf("volume bindings = %#v, want %#v", install.VolumeBindings, want)
 	}
 }
 

--- a/internal/katlc/agent/generation_apply.go
+++ b/internal/katlc/agent/generation_apply.go
@@ -99,6 +99,7 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		NodeName:                           req.NodeName,
 		ConfigYaml:                         req.ConfigYaml,
 		DestructiveStorageAcknowledgements: append([]string(nil), req.DestructiveStorageAcknowledgements...),
+		VolumeRebinds:                      append([]string(nil), req.VolumeRebinds...),
 	}
 	submit := generationSubmitRequest(submitBase, provisionalOperationKind, applyMode)
 	requestDigest, err := RequestDigest(submit)
@@ -140,6 +141,20 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 	}
 	decoded.ApplyMode = applyMode
 	decoded.GenerationID = candidateID
+	desiredManifest, err := configapply.DesiredManifest(decoded)
+	if err != nil {
+		return rejected(err, nil), nil
+	}
+	volumePlan, err := s.validateVolumeTransition(ctx, req.NodeName, base.CurrentManifest, desiredManifest, base.CurrentRecord.VolumeBindings, req.DestructiveStorageAcknowledgements, req.VolumeRebinds)
+	if err != nil {
+		result := rejected(err, []string{inventory.Redact(err.Error())})
+		result.RequiredDestructiveStorageAcknowledgements = volumePlan.requiredWipeAcknowledgements
+		result.RequiredVolumeRebinds = volumePlan.requiredRebinds
+		return result, nil
+	}
+	decoded.VolumeBindings = append([]generation.VolumeBinding(nil), volumePlan.bindings...)
+	decoded.VolumeBindingsSet = len(desiredManifest.Install.Volumes) == 0 || len(volumePlan.prepare) == 0
+	decoded.SkipVolumeRendering = len(volumePlan.prepare) > 0
 	plan, err := configapply.PlanTrustedBundle(decoded)
 	if err != nil {
 		if errors.Is(err, configapply.ErrNoChanges) {
@@ -192,11 +207,8 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		}
 		return rejected(err, configApplyDiagnostics(plan.Plan.Decision)), nil
 	}
-	requiredStorage, err := s.validateDestructiveStorageAuthority(ctx, req.NodeName, base.CurrentManifest, plan.Manifest, req.DestructiveStorageAcknowledgements)
-	if err != nil {
-		result := rejected(err, []string{inventory.Redact(err.Error())})
-		result.RequiredDestructiveStorageAcknowledgements = requiredStorage
-		return result, nil
+	if err := volumePlan.validateApplyMode(plan.Plan.Decision.AcceptedMode); err != nil {
+		return rejected(err, []string{err.Error()}), nil
 	}
 	operationKind, err := configApplyOperationKind(plan.Plan.Decision.AcceptedMode)
 	if err != nil {
@@ -219,7 +231,8 @@ func (s *Server) ValidateConfig(ctx context.Context, req *agentapi.ValidateConfi
 		AcceptedApplyMode:     plan.Plan.Decision.AcceptedMode,
 		CandidateGenerationId: candidateID,
 		ChangedDomains:        append([]string(nil), plan.Plan.Decision.ChangedDomains...),
-		RequiredDestructiveStorageAcknowledgements: requiredStorage,
+		RequiredDestructiveStorageAcknowledgements: volumePlan.requiredWipeAcknowledgements,
+		RequiredVolumeRebinds:                      volumePlan.requiredRebinds,
 	}, nil
 }
 
@@ -282,6 +295,7 @@ func generationSubmitRequest(req *agentapi.GenerationApplyRequest, operationKind
 			NodeName:                           req.NodeName,
 			ConfigYaml:                         req.ConfigYaml,
 			DestructiveStorageAcknowledgements: append([]string(nil), req.DestructiveStorageAcknowledgements...),
+			VolumeRebinds:                      append([]string(nil), req.VolumeRebinds...),
 		},
 	}
 }
@@ -455,10 +469,21 @@ func (s *Server) acceptConfigApplyOperation(ctx context.Context, req *agentapi.S
 	}
 	decoded.ApplyMode = configReq.ApplyMode
 	decoded.GenerationID = configReq.CandidateGenerationID
+	desiredManifest, err := configapply.DesiredManifest(decoded)
+	if err != nil {
+		return operation.OperationRecord{}, nil, status.Errorf(codes.InvalidArgument, "config validation rejected: %v", err)
+	}
+	volumePlan, err := s.validateVolumeTransition(ctx, configReq.NodeName, base.CurrentManifest, desiredManifest, base.CurrentRecord.VolumeBindings, configReq.DestructiveStorageAcknowledgements, configReq.VolumeRebinds)
+	if err != nil {
+		return operation.OperationRecord{}, nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	decoded.VolumeBindings = append([]generation.VolumeBinding(nil), volumePlan.bindings...)
+	decoded.VolumeBindingsSet = len(desiredManifest.Install.Volumes) == 0 || len(volumePlan.prepare) == 0
+	decoded.SkipVolumeRendering = len(volumePlan.prepare) > 0
 	plan, err := configapply.PlanTrustedBundle(decoded)
 	if err == nil {
-		if _, authorityErr := s.validateDestructiveStorageAuthority(ctx, configReq.NodeName, base.CurrentManifest, plan.Manifest, configReq.DestructiveStorageAcknowledgements); authorityErr != nil {
-			return operation.OperationRecord{}, nil, status.Error(codes.FailedPrecondition, authorityErr.Error())
+		if modeErr := volumePlan.validateApplyMode(plan.Plan.Decision.AcceptedMode); modeErr != nil {
+			return operation.OperationRecord{}, nil, status.Error(codes.FailedPrecondition, modeErr.Error())
 		}
 		operationKind, err := configApplyOperationKind(plan.Plan.Decision.AcceptedMode)
 		if err != nil {
@@ -539,6 +564,23 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 	}
 	decoded.ApplyMode = record.ConfigApplyRequest.ApplyMode
 	decoded.GenerationID = record.ConfigApplyRequest.CandidateGenerationID
+	desiredManifest, err := configapply.DesiredManifest(decoded)
+	if err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "render-generation-refused", "render-generation", "render-generation", "config apply request failed desired-state resolution", err)
+		return errorsJoin(err, markErr)
+	}
+	run := e.RunTool
+	if run == nil {
+		run = runChildProcess
+	}
+	volumePlan, err := planVolumeTransition(ctx, run, base.CurrentManifest, desiredManifest, base.CurrentRecord.VolumeBindings, record.ConfigApplyRequest.NodeName, record.ConfigApplyRequest.DestructiveStorageAcknowledgements, record.ConfigApplyRequest.VolumeRebinds)
+	if err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "render-generation-refused", "render-generation", "render-generation", "volume transition preflight failed", err)
+		return errorsJoin(err, markErr)
+	}
+	decoded.VolumeBindings = append([]generation.VolumeBinding(nil), volumePlan.bindings...)
+	decoded.VolumeBindingsSet = len(desiredManifest.Install.Volumes) == 0 || len(volumePlan.prepare) == 0
+	decoded.SkipVolumeRendering = len(volumePlan.prepare) > 0
 	plan, err := configapply.PlanTrustedBundle(decoded)
 	if err != nil {
 		if errors.Is(err, configapply.ErrNoChanges) {
@@ -552,9 +594,26 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 		_, markErr := e.failRecordPhase(record.OperationID, "render-generation-refused", "render-generation", "render-generation", "config apply request failed planning", cause)
 		return errorsJoin(err, markErr)
 	}
+	if err := volumePlan.validateApplyMode(plan.Plan.Decision.AcceptedMode); err != nil {
+		_, markErr := e.failRecordPhase(record.OperationID, "render-generation-refused", "render-generation", "render-generation", "volume transition apply mode is unsafe", err)
+		return errorsJoin(err, markErr)
+	}
 	if plan.Plan.Decision.AcceptedMode == generation.ApplyModeLive {
 		if err := e.markLiveConfigApplyStarted(record.OperationID, plan, startedAt); err != nil {
 			return err
+		}
+		bindings, volumeErr := e.applyVolumes(ctx, base.CurrentManifest, desiredManifest, base.CurrentRecord.VolumeBindings, record.ConfigApplyRequest.NodeName, record.ConfigApplyRequest.DestructiveStorageAcknowledgements, record.ConfigApplyRequest.VolumeRebinds)
+		if volumeErr != nil {
+			_, markErr := e.failRecordPhase(record.OperationID, "volume-transition-failed", "render-generation", "render-generation", "volume transition failed before generation rendering", volumeErr)
+			return errorsJoin(volumeErr, markErr)
+		}
+		decoded.VolumeBindings = bindings
+		decoded.VolumeBindingsSet = true
+		decoded.SkipVolumeRendering = false
+		plan, err = configapply.PlanTrustedBundle(decoded)
+		if err != nil {
+			_, markErr := e.failRecordPhase(record.OperationID, "render-generation-refused", "render-generation", "render-generation", "config apply request failed exact volume rendering", err)
+			return errorsJoin(err, markErr)
 		}
 		runner := e.ConfigApplyRunner
 		if runner == nil {
@@ -568,10 +627,7 @@ func (e *Executor) executeConfigApply(ctx context.Context, record operation.Oper
 			Root:      e.Root,
 			Runner:    runner,
 			Activator: activator,
-			ApplyVolumes: func(ctx context.Context, current, desired manifest.Manifest) error {
-				return e.applyVolumes(ctx, current, desired, record.ConfigApplyRequest.NodeName, record.ConfigApplyRequest.DestructiveStorageAcknowledgements)
-			},
-			Now: e.clock,
+			Now:       e.clock,
 		}
 	}
 	result, err := configapply.ApplyTrustedBundle(ctx, decoded)
@@ -809,6 +865,7 @@ func configApplyRequestFromProto(req *agentapi.ConfigApplyOperationRequest) oper
 		CandidateGenerationID:              strings.TrimSpace(req.CandidateGenerationId),
 		ConfigYAML:                         strings.TrimSpace(req.ConfigYaml),
 		DestructiveStorageAcknowledgements: append([]string(nil), req.DestructiveStorageAcknowledgements...),
+		VolumeRebinds:                      append([]string(nil), req.VolumeRebinds...),
 	}
 }
 

--- a/internal/katlc/agent/volume_apply.go
+++ b/internal/katlc/agent/volume_apply.go
@@ -15,58 +15,83 @@ import (
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
-func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.Manifest, nodeName string, acknowledgements []string) error {
+type volumeTransitionPlan struct {
+	stopNames                    []string
+	prepare                      []disk.VolumePlan
+	bindings                     []generation.VolumeBinding
+	requiredWipeAcknowledgements []string
+	requiredRebinds              []string
+}
+
+func (p volumeTransitionPlan) validateApplyMode(mode string) error {
+	if mode == generation.ApplyModeLive || len(p.stopNames) == 0 && len(p.prepare) == 0 {
+		return nil
+	}
+	return fmt.Errorf("volume changes that stop or prepare devices require live apply and cannot be combined with next-boot-only changes; apply the volume change separately")
+}
+
+type VolumeRebindAuthorityError struct {
+	Required    []string
+	Transitions []string
+}
+
+func (e *VolumeRebindAuthorityError) Error() string {
+	flags := make([]string, 0, len(e.Required))
+	for _, required := range e.Required {
+		flags = append(flags, "--rebind-volume "+required)
+	}
+	message := "volume replacement requires explicit rebind authority: " + strings.Join(flags, ", ")
+	if len(e.Transitions) > 0 {
+		message += " (" + strings.Join(e.Transitions, "; ") + ")"
+	}
+	return message
+}
+
+func (e *Executor) applyVolumes(ctx context.Context, current, desired manifest.Manifest, currentBindings []generation.VolumeBinding, nodeName string, acknowledgements, rebinds []string) ([]generation.VolumeBinding, error) {
 	run := e.RunTool
 	if run == nil {
 		run = runChildProcess
 	}
-	stopNames, changed := changedVolumes(current, desired)
-	if len(stopNames) == 0 && len(changed) == 0 {
-		return nil
+	plan, err := planVolumeTransition(ctx, run, current, desired, currentBindings, nodeName, acknowledgements, rebinds)
+	if err != nil {
+		return nil, err
 	}
 
-	if len(changed) > 0 {
-		plans, err := preflightLiveVolumes(ctx, run, desired, stopNames, changed)
-		if err != nil {
-			return err
-		}
-		if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
-			return err
-		}
-	}
-
-	for _, name := range stopNames {
+	for _, name := range plan.stopNames {
 		unit, err := generation.MountUnitName("/var/mnt/" + name)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		result := run(ctx, []string{"systemctl", "stop", unit}, nil)
 		if result.Err != nil || result.ExitStatus != 0 && result.ExitStatus != 5 {
 			err := fmt.Errorf("stop volume %s: %s", name, toolFailure(result))
-			return fmt.Errorf("%w; stop workloads using /var/mnt/%s and retry", err, name)
+			return nil, fmt.Errorf("%w; stop workloads using /var/mnt/%s and retry", err, name)
 		}
 	}
-	if len(changed) == 0 {
-		return nil
+	if len(plan.prepare) == 0 {
+		return plan.bindings, nil
 	}
 
-	facts, err := discoverVolumeFacts(ctx, run)
-	if err != nil {
-		return err
-	}
-	plans, err := planLiveVolumes(facts, desired, changed)
-	if err != nil {
-		return err
-	}
-	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
-		return err
-	}
-	for _, plan := range plans {
-		if err := prepareLiveVolume(ctx, run, e.Root, plan); err != nil {
-			return err
+	for _, volume := range plan.prepare {
+		if err := prepareLiveVolume(ctx, run, e.Root, volume); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+	facts, err := discoverVolumeFacts(ctx, run)
+	if err != nil {
+		return nil, err
+	}
+	_, diskBindings, err := disk.BindVolumePlans(facts, plan.prepare)
+	if err != nil {
+		return nil, fmt.Errorf("bind prepared volumes: %w", err)
+	}
+	byName := volumeBindingsByName(plan.bindings)
+	for _, binding := range diskBindings {
+		byName[binding.Name] = generation.VolumeBinding{
+			Name: binding.Name, PartitionUUID: binding.PartitionUUID, FilesystemUUID: binding.FilesystemUUID,
+		}
+	}
+	return sortedVolumeBindings(byName), nil
 }
 
 func changedVolumes(current, desired manifest.Manifest) ([]string, []manifest.Volume) {
@@ -93,36 +118,181 @@ func changedVolumes(current, desired manifest.Manifest) ([]string, []manifest.Vo
 	return stopNames, changed
 }
 
-func preflightLiveVolumes(ctx context.Context, run ToolRunner, desired manifest.Manifest, stopNames []string, changed []manifest.Volume) ([]disk.VolumePlan, error) {
+func planVolumeTransition(ctx context.Context, run ToolRunner, current, desired manifest.Manifest, currentBindings []generation.VolumeBinding, nodeName string, acknowledgements, rebinds []string) (volumeTransitionPlan, error) {
+	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(acknowledgements); err != nil {
+		return volumeTransitionPlan{}, err
+	}
+	if err := disk.ValidateVolumeRebindKeys(rebinds); err != nil {
+		return volumeTransitionPlan{}, err
+	}
+	stopNames, _ := changedVolumes(current, desired)
+	if len(current.Install.Volumes) == 0 && len(desired.Install.Volumes) == 0 {
+		return volumeTransitionPlan{bindings: sortedVolumeBindings(volumeBindingsByName(currentBindings))}, nil
+	}
+	if len(desired.Install.Volumes) == 0 {
+		return volumeTransitionPlan{stopNames: stopNames, bindings: sortedVolumeBindings(volumeBindingsByName(currentBindings))}, nil
+	}
 	facts, err := discoverVolumeFacts(ctx, run)
 	if err != nil {
-		return nil, err
+		return volumeTransitionPlan{}, err
 	}
-	return planLiveVolumes(factsWithoutManagedVolumeMounts(facts, stopNames), desired, changed)
+	currentNames := make([]string, 0, len(current.Install.Volumes))
+	for _, volume := range current.Install.Volumes {
+		currentNames = append(currentNames, volume.Name)
+	}
+	facts = factsWithoutManagedVolumeMounts(facts, currentNames)
+
+	currentVolumes := volumesByName(current.Install.Volumes)
+	currentByName := volumeBindingsByName(currentBindings)
+	// Retain bindings for removed volumes as generation-owned tombstones. They
+	// render no mount, but prevent remove/re-add from bypassing replacement
+	// authority for the same logical name.
+	desiredBindings := volumeBindingsByName(currentBindings)
+	var prepare []disk.VolumePlan
+	var requiredRebinds []string
+	var rebindTransitions []string
+	nodeName = storageAuthorityNodeName(nodeName, current)
+
+	for _, desiredVolume := range desired.Install.Volumes {
+		before, existed := currentVolumes[desiredVolume.Name]
+		configChanged := !existed || !reflect.DeepEqual(before, desiredVolume)
+		binding, wasBound := currentByName[desiredVolume.Name]
+		if wasBound && !configChanged {
+			if _, matchErr := disk.MatchVolumeBinding(facts, diskVolumeBinding(binding)); matchErr == nil {
+				desiredBindings[binding.Name] = binding
+				continue
+			}
+		}
+
+		resolve := desiredVolume
+		if !configChanged {
+			// Wipe is desired provisioning state, not permission to repeat a
+			// destructive action merely to migrate a legacy generation binding.
+			resolve.Wipe = false
+		}
+		plans, planErr := planLiveVolumes(facts, desired, []manifest.Volume{resolve})
+		if planErr != nil {
+			return volumeTransitionPlan{}, planErr
+		}
+		candidate := plans[0]
+		var candidateBinding generation.VolumeBinding
+		if !candidate.Repartition {
+			_, bound, bindErr := disk.BindVolumePlans(facts, plans)
+			if bindErr != nil {
+				return volumeTransitionPlan{}, bindErr
+			}
+			candidateBinding = generationVolumeBinding(bound[0])
+		}
+		if wasBound && (candidate.Repartition || !sameVolumeDevice(binding, candidateBinding)) {
+			key := nodeName + "/" + desiredVolume.Name
+			requiredRebinds = append(requiredRebinds, key)
+			rebindTransitions = append(rebindTransitions, fmt.Sprintf("%s: %s -> %s", key, volumeBindingDescription(binding), candidateVolumeDescription(candidate, candidateBinding)))
+		}
+		if configChanged {
+			prepare = append(prepare, candidate)
+		} else {
+			desiredBindings[desiredVolume.Name] = candidateBinding
+		}
+	}
+
+	requiredWipes := disk.RequiredDestructiveVolumeAcknowledgements(nodeName, prepare)
+	result := volumeTransitionPlan{
+		stopNames: stopNames, prepare: prepare, bindings: sortedVolumeBindings(desiredBindings),
+		requiredWipeAcknowledgements: requiredWipes, requiredRebinds: uniqueSorted(requiredRebinds),
+	}
+	var authorityErrors []error
+	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, prepare, acknowledgements); err != nil {
+		authorityErrors = append(authorityErrors, err)
+	}
+	if missing := missingAuthorities(result.requiredRebinds, rebinds); len(missing) > 0 {
+		authorityErrors = append(authorityErrors, &VolumeRebindAuthorityError{Required: missing, Transitions: rebindTransitions})
+	}
+	if len(authorityErrors) > 0 {
+		return result, errorsJoin(authorityErrors...)
+	}
+	return result, nil
 }
 
-func (s *Server) validateDestructiveStorageAuthority(ctx context.Context, nodeName string, current, desired manifest.Manifest, acknowledgements []string) ([]string, error) {
-	if err := disk.ValidateDestructiveVolumeAcknowledgementKeys(acknowledgements); err != nil {
-		return nil, err
-	}
-	stopNames, changed := changedVolumes(current, desired)
-	if len(changed) == 0 {
-		return nil, nil
-	}
+func (s *Server) validateVolumeTransition(ctx context.Context, nodeName string, current, desired manifest.Manifest, currentBindings []generation.VolumeBinding, acknowledgements, rebinds []string) (volumeTransitionPlan, error) {
 	run := s.RunVolumeDiscovery
 	if run == nil {
 		run = runChildProcess
 	}
-	plans, err := preflightLiveVolumes(ctx, run, desired, stopNames, changed)
+	return planVolumeTransition(ctx, run, current, desired, currentBindings, nodeName, acknowledgements, rebinds)
+}
+
+func diskVolumeBinding(binding generation.VolumeBinding) disk.VolumeBinding {
+	return disk.VolumeBinding{Name: binding.Name, PartitionUUID: binding.PartitionUUID, FilesystemUUID: binding.FilesystemUUID}
+}
+
+func generationVolumeBinding(binding disk.VolumeBinding) generation.VolumeBinding {
+	return generation.VolumeBinding{Name: binding.Name, PartitionUUID: binding.PartitionUUID, FilesystemUUID: binding.FilesystemUUID}
+}
+
+func volumeBindingsByName(bindings []generation.VolumeBinding) map[string]generation.VolumeBinding {
+	out := make(map[string]generation.VolumeBinding, len(bindings))
+	for _, binding := range bindings {
+		out[binding.Name] = binding
+	}
+	return out
+}
+
+func sortedVolumeBindings(bindings map[string]generation.VolumeBinding) []generation.VolumeBinding {
+	out := make([]generation.VolumeBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		out = append(out, binding)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func sameVolumeDevice(left, right generation.VolumeBinding) bool {
+	if strings.TrimSpace(left.PartitionUUID) != "" && strings.TrimSpace(right.PartitionUUID) != "" {
+		return strings.TrimSpace(left.PartitionUUID) == strings.TrimSpace(right.PartitionUUID)
+	}
+	return strings.TrimSpace(left.FilesystemUUID) != "" && strings.TrimSpace(left.FilesystemUUID) == strings.TrimSpace(right.FilesystemUUID)
+}
+
+func volumeBindingDescription(binding generation.VolumeBinding) string {
+	source, err := disk.VolumeBindingMountSource(diskVolumeBinding(binding))
 	if err != nil {
-		return nil, err
+		return "unbound"
 	}
-	nodeName = storageAuthorityNodeName(nodeName, current)
-	required := disk.RequiredDestructiveVolumeAcknowledgements(nodeName, plans)
-	if err := disk.ValidateDestructiveVolumeAcknowledgements(nodeName, plans, acknowledgements); err != nil {
-		return required, err
+	return source
+}
+
+func candidateVolumeDescription(plan disk.VolumePlan, binding generation.VolumeBinding) string {
+	if source := volumeBindingDescription(binding); source != "unbound" {
+		return source
 	}
-	return required, nil
+	return plan.DevicePath + " (identity assigned during provisioning)"
+}
+
+func missingAuthorities(required, provided []string) []string {
+	have := make(map[string]struct{}, len(provided))
+	for _, value := range provided {
+		have[strings.TrimSpace(value)] = struct{}{}
+	}
+	var missing []string
+	for _, value := range required {
+		if _, ok := have[value]; !ok {
+			missing = append(missing, value)
+		}
+	}
+	return missing
+}
+
+func uniqueSorted(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func storageAuthorityNodeName(requested string, current manifest.Manifest) string {

--- a/internal/katlc/agent/volume_apply_test.go
+++ b/internal/katlc/agent/volume_apply_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/installer/discovery"
 	"github.com/katl-dev/katl/internal/installer/disk"
+	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 )
 
@@ -111,7 +112,7 @@ func TestApplyVolumesPreflightsBeforeStoppingExistingMount(t *testing.T) {
 			return ToolResult{Err: fmt.Errorf("unexpected command %q", argv[0]), ExitStatus: 1}
 		}
 	}
-	err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, "node-a", nil)
+	_, err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, []generation.VolumeBinding{{Name: "data", PartitionUUID: "current"}}, "node-a", nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "partition selector matched no partitions") {
 		t.Fatalf("applyVolumes() error = %v, want missing partition", err)
 	}
@@ -137,8 +138,12 @@ func TestApplyVolumesRemovalOnlyUnmountsWithoutTouchingStorage(t *testing.T) {
 		}
 		return ToolResult{}
 	}
-	if err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, "cp-1", nil); err != nil {
+	bindings, err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, []generation.VolumeBinding{{Name: "data", PartitionUUID: "keep-me"}}, "cp-1", nil, nil)
+	if err != nil {
 		t.Fatalf("applyVolumes() removal error = %v", err)
+	}
+	if !reflect.DeepEqual(bindings, []generation.VolumeBinding{{Name: "data", PartitionUUID: "keep-me"}}) {
+		t.Fatalf("removal bindings = %#v, want retained tombstone", bindings)
 	}
 	if len(calls) != 1 {
 		t.Fatalf("removal commands = %v, want only the managed mount stop", calls)
@@ -167,9 +172,9 @@ func TestDestructiveStorageAuthorityUsesDiscoveredTargetState(t *testing.T) {
 			runner := volumeAuthorityRunner(test.partitionTable, nil)
 			server := newTestServer(t)
 			server.RunVolumeDiscovery = runner
-			required, err := server.validateDestructiveStorageAuthority(context.Background(), "cp-1", current, desired, test.acknowledgements)
-			if !slices.Equal(required, test.wantRequired) {
-				t.Fatalf("required acknowledgements = %v, want %v", required, test.wantRequired)
+			plan, err := server.validateVolumeTransition(context.Background(), "cp-1", current, desired, nil, test.acknowledgements, nil)
+			if !slices.Equal(plan.requiredWipeAcknowledgements, test.wantRequired) {
+				t.Fatalf("required acknowledgements = %v, want %v", plan.requiredWipeAcknowledgements, test.wantRequired)
 			}
 			var authority *disk.DestructiveVolumeAuthorityError
 			if errors.As(err, &authority) != test.wantError {
@@ -187,7 +192,7 @@ func TestApplyVolumesRefusesNonBlankTargetBeforeMutation(t *testing.T) {
 	}}
 	var mutations [][]string
 	runner := volumeAuthorityRunner("gpt", &mutations)
-	err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, "cp-1", nil)
+	_, err := (&Executor{RunTool: runner}).applyVolumes(context.Background(), current, desired, nil, "cp-1", nil, nil)
 	var authority *disk.DestructiveVolumeAuthorityError
 	if !errors.As(err, &authority) || !reflect.DeepEqual(authority.Required, []string{"cp-1/data"}) {
 		t.Fatalf("applyVolumes() error = %#v", err)
@@ -205,7 +210,7 @@ func TestApplyVolumesMutatesNonBlankTargetOnlyWithNamedAuthority(t *testing.T) {
 	}}
 	var mutations [][]string
 	runner := volumeAuthorityRunner("gpt", &mutations)
-	err := (&Executor{Root: t.TempDir(), RunTool: runner}).applyVolumes(context.Background(), current, desired, "cp-1", []string{"cp-1/data"})
+	_, err := (&Executor{Root: t.TempDir(), RunTool: runner}).applyVolumes(context.Background(), current, desired, nil, "cp-1", []string{"cp-1/data"}, nil)
 	if err != nil {
 		t.Fatalf("applyVolumes() error = %v", err)
 	}
@@ -214,7 +219,80 @@ func TestApplyVolumesMutatesNonBlankTargetOnlyWithNamedAuthority(t *testing.T) {
 	}
 }
 
+func TestVolumeTransitionPreservesBoundDeviceWhenLabelBecomesAmbiguous(t *testing.T) {
+	current := volumeManifest(manifest.PartitionSelector{})
+	plan, err := planVolumeTransition(context.Background(), duplicateLabelVolumeRunner(), current, current,
+		[]generation.VolumeBinding{{Name: "data", PartitionUUID: "old-part", FilesystemUUID: "old-fs"}}, "cp-1", nil, nil)
+	if err != nil {
+		t.Fatalf("planVolumeTransition() error = %v", err)
+	}
+	want := []generation.VolumeBinding{{Name: "data", PartitionUUID: "old-part", FilesystemUUID: "old-fs"}}
+	if !reflect.DeepEqual(plan.bindings, want) || len(plan.prepare) != 0 || len(plan.stopNames) != 0 {
+		t.Fatalf("transition = %#v, want preserved binding only", plan)
+	}
+}
+
+func TestVolumeTransitionBlocksAmbiguousLabelWithoutPriorBinding(t *testing.T) {
+	current := volumeManifest(manifest.PartitionSelector{})
+	_, err := planVolumeTransition(context.Background(), duplicateLabelVolumeRunner(), current, current, nil, "cp-1", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "partition selector matched 2 partitions") {
+		t.Fatalf("planVolumeTransition() error = %v, want ambiguous selector", err)
+	}
+}
+
+func TestVolumeTransitionRequiresExplicitRebindForReplacement(t *testing.T) {
+	current := volumeManifest(manifest.PartitionSelector{PartUUID: "old-part"})
+	desired := volumeManifest(manifest.PartitionSelector{PartUUID: "new-part"})
+	currentBinding := []generation.VolumeBinding{{Name: "data", PartitionUUID: "old-part", FilesystemUUID: "old-fs"}}
+
+	plan, err := planVolumeTransition(context.Background(), duplicateLabelVolumeRunner(), current, desired, currentBinding, "cp-1", nil, nil)
+	var authority *VolumeRebindAuthorityError
+	if !errors.As(err, &authority) || !reflect.DeepEqual(plan.requiredRebinds, []string{"cp-1/data"}) {
+		t.Fatalf("unapproved replacement plan = %#v error = %v", plan, err)
+	}
+	plan, err = planVolumeTransition(context.Background(), duplicateLabelVolumeRunner(), current, desired, currentBinding, "cp-1", nil, []string{"cp-1/data"})
+	if err != nil {
+		t.Fatalf("approved plan error = %v", err)
+	}
+	if len(plan.prepare) != 1 || plan.prepare[0].MountSource != "PARTUUID=new-part" {
+		t.Fatalf("approved replacement plan = %#v", plan)
+	}
+}
+
+func volumeManifest(selector manifest.PartitionSelector) manifest.Manifest {
+	if selector.PartUUID == "" && selector.FilesystemUUID == "" && selector.ByID == "" {
+		// Empty manifest selectors represent the compiled byVolumeName
+		// convention through BuildVolumeRequests.
+	}
+	return manifest.Manifest{Install: manifest.InstallConfig{
+		TargetDisk: manifest.DiskSelector{Serial: "root"},
+		Volumes: []manifest.Volume{{
+			Name: "data", Selector: manifest.VolumeSelector{Partition: &selector}, Filesystem: "xfs",
+		}},
+	}}
+}
+
+func duplicateLabelVolumeRunner() ToolRunner {
+	return func(_ context.Context, argv []string, _ func(int)) ToolResult {
+		switch argv[0] {
+		case "lsblk":
+			return ToolResult{Stdout: []byte(`{"blockdevices":[
+{"name":"vda","path":"/dev/vda","type":"disk","serial":"root","size":68719476736,"ro":false,"mountpoints":[]},
+{"name":"vdb","path":"/dev/vdb","type":"disk","serial":"old","size":68719476736,"ro":false,"mountpoints":[],"children":[{"name":"vdb1","path":"/dev/vdb1","type":"part","size":68702699520,"ro":false,"fstype":"xfs","uuid":"old-fs","partuuid":"old-part","partlabel":"u-data","mountpoints":["/var/mnt/data"]}]},
+{"name":"vdc","path":"/dev/vdc","type":"disk","serial":"new","size":68719476736,"ro":false,"mountpoints":[],"children":[{"name":"vdc1","path":"/dev/vdc1","type":"part","size":68702699520,"ro":false,"fstype":"xfs","uuid":"new-fs","partuuid":"new-part","partlabel":"u-data","mountpoints":[]}]}
+]}`)}
+		case "findmnt":
+			return ToolResult{Stdout: []byte(`{"filesystems":[{"source":"/dev/vdb1","target":"/var/mnt/data","fstype":"xfs","options":"rw"}]}`)}
+		case "ip":
+			return ToolResult{Stdout: []byte(`[]`)}
+		default:
+			return ToolResult{Err: fmt.Errorf("unexpected command %q", argv[0]), ExitStatus: 1}
+		}
+	}
+}
+
 func volumeAuthorityRunner(partitionTable string, mutations *[][]string) ToolRunner {
+	prepared := false
 	return func(_ context.Context, argv []string, _ func(int)) ToolResult {
 		switch argv[0] {
 		case "lsblk":
@@ -222,15 +300,22 @@ func volumeAuthorityRunner(partitionTable string, mutations *[][]string) ToolRun
 			if partitionTable != "" {
 				pttype = `,"pttype":"` + partitionTable + `"`
 			}
+			children := ""
+			if prepared {
+				children = `,"children":[{"name":"vdb1","path":"/dev/vdb1","type":"part","size":68702699520,"ro":false,"fstype":"xfs","uuid":"fs-data","partuuid":"part-data","partlabel":"u-data","mountpoints":[]}]`
+			}
 			return ToolResult{Stdout: []byte(`{"blockdevices":[` +
 				`{"name":"vda","path":"/dev/vda","type":"disk","serial":"root","size":68719476736,"ro":false,"mountpoints":[]},` +
-				`{"name":"vdb","path":"/dev/vdb","type":"disk","serial":"data","size":68719476736,"ro":false,"mountpoints":[]` + pttype + `}` +
+				`{"name":"vdb","path":"/dev/vdb","type":"disk","serial":"data","size":68719476736,"ro":false,"mountpoints":[]` + pttype + children + `}` +
 				`]}`)}
 		case "findmnt":
 			return ToolResult{Stdout: []byte(`{"filesystems":[]}`)}
 		case "ip":
 			return ToolResult{Stdout: []byte(`[]`)}
 		default:
+			if argv[0] == "systemd-repart" {
+				prepared = true
+			}
 			if mutations != nil {
 				*mutations = append(*mutations, append([]string(nil), argv...))
 			}
@@ -262,5 +347,32 @@ func TestFactsWithoutManagedVolumeMountsOnlyClearsSelectedVolume(t *testing.T) {
 	}
 	if len(facts.Mounts) != 2 || len(facts.BlockDevices[0].Partitions[0].Mountpoints) != 1 {
 		t.Fatal("factsWithoutManagedVolumeMounts mutated its input")
+	}
+}
+
+func TestVolumeTransitionPlanRejectsDeferredDeviceMutation(t *testing.T) {
+	plan := volumeTransitionPlan{prepare: []disk.VolumePlan{{Name: "data"}}}
+	if err := plan.validateApplyMode(generation.ApplyModeNextBoot); err == nil || !strings.Contains(err.Error(), "apply the volume change separately") {
+		t.Fatalf("validateApplyMode(next-boot) error = %v", err)
+	}
+	if err := plan.validateApplyMode(generation.ApplyModeLive); err != nil {
+		t.Fatalf("validateApplyMode(live) error = %v", err)
+	}
+	if err := (volumeTransitionPlan{}).validateApplyMode(generation.ApplyModeNextBoot); err != nil {
+		t.Fatalf("validateApplyMode(binding-only next-boot) error = %v", err)
+	}
+}
+
+func TestVolumeTransitionPlanRetainsTombstonesWithoutDesiredVolumes(t *testing.T) {
+	bindings := []generation.VolumeBinding{{Name: "data", PartitionUUID: "part-data", FilesystemUUID: "fs-data"}}
+	plan, err := planVolumeTransition(context.Background(), func(context.Context, []string, func(int)) ToolResult {
+		t.Fatal("zero-volume tombstone retention must not inspect hardware")
+		return ToolResult{}
+	}, manifest.Manifest{}, manifest.Manifest{}, bindings, "cp-1", nil, nil)
+	if err != nil {
+		t.Fatalf("planVolumeTransition() error = %v", err)
+	}
+	if !reflect.DeepEqual(plan.bindings, bindings) {
+		t.Fatalf("bindings = %#v, want retained tombstone %#v", plan.bindings, bindings)
 	}
 }

--- a/internal/katlc/agent/volume_status.go
+++ b/internal/katlc/agent/volume_status.go
@@ -51,8 +51,6 @@ func nodeVolumeStatus(ctx context.Context, root, currentGeneration string, runne
 			Result:               unit.Result,
 			StateChangeTimestamp: unit.StateChangeTimestamp,
 			FailureDiagnostic:    unit.FailureDiagnostic,
-			PartitionUuid:        binding.PartitionUUID,
-			FilesystemUuid:       binding.FilesystemUUID,
 			MountSource:          mountSource,
 		})
 	}

--- a/internal/katlc/agent/volume_status.go
+++ b/internal/katlc/agent/volume_status.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/katl-dev/katl/internal/installer/disk"
 	"github.com/katl-dev/katl/internal/installer/generation"
 	"github.com/katl-dev/katl/internal/installer/manifest"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
@@ -20,6 +21,11 @@ func nodeVolumeStatus(ctx context.Context, root, currentGeneration string, runne
 		return nil, err
 	}
 	volumes := append([]manifest.Volume(nil), installManifest.Install.Volumes...)
+	spec, _, err := generation.ReadGeneration(root, currentGeneration)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	bindings := volumeBindingsByName(spec.VolumeBindings)
 	sort.Slice(volumes, func(i, j int) bool { return volumes[i].Name < volumes[j].Name })
 	out := make([]*agentapi.VolumeStatus, 0, len(volumes))
 	for _, volume := range volumes {
@@ -32,6 +38,8 @@ func nodeVolumeStatus(ctx context.Context, root, currentGeneration string, runne
 		if volume.Selector.Disk != nil {
 			targetKind = "disk"
 		}
+		binding := bindings[volume.Name]
+		mountSource, _ := disk.VolumeBindingMountSource(diskVolumeBinding(binding))
 		out = append(out, &agentapi.VolumeStatus{
 			Name:                 volume.Name,
 			TargetKind:           targetKind,
@@ -43,6 +51,9 @@ func nodeVolumeStatus(ctx context.Context, root, currentGeneration string, runne
 			Result:               unit.Result,
 			StateChangeTimestamp: unit.StateChangeTimestamp,
 			FailureDiagnostic:    unit.FailureDiagnostic,
+			PartitionUuid:        binding.PartitionUUID,
+			FilesystemUuid:       binding.FilesystemUUID,
+			MountSource:          mountSource,
 		})
 	}
 	return out, nil

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -257,6 +257,9 @@ type VolumeStatus struct {
 	Result               string                 `protobuf:"bytes,8,opt,name=result,proto3" json:"result,omitempty"`
 	StateChangeTimestamp string                 `protobuf:"bytes,9,opt,name=state_change_timestamp,json=stateChangeTimestamp,proto3" json:"state_change_timestamp,omitempty"`
 	FailureDiagnostic    string                 `protobuf:"bytes,10,opt,name=failure_diagnostic,json=failureDiagnostic,proto3" json:"failure_diagnostic,omitempty"`
+	PartitionUuid        string                 `protobuf:"bytes,11,opt,name=partition_uuid,json=partitionUuid,proto3" json:"partition_uuid,omitempty"`
+	FilesystemUuid       string                 `protobuf:"bytes,12,opt,name=filesystem_uuid,json=filesystemUuid,proto3" json:"filesystem_uuid,omitempty"`
+	MountSource          string                 `protobuf:"bytes,13,opt,name=mount_source,json=mountSource,proto3" json:"mount_source,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -357,6 +360,27 @@ func (x *VolumeStatus) GetStateChangeTimestamp() string {
 func (x *VolumeStatus) GetFailureDiagnostic() string {
 	if x != nil {
 		return x.FailureDiagnostic
+	}
+	return ""
+}
+
+func (x *VolumeStatus) GetPartitionUuid() string {
+	if x != nil {
+		return x.PartitionUuid
+	}
+	return ""
+}
+
+func (x *VolumeStatus) GetFilesystemUuid() string {
+	if x != nil {
+		return x.FilesystemUuid
+	}
+	return ""
+}
+
+func (x *VolumeStatus) GetMountSource() string {
+	if x != nil {
+		return x.MountSource
 	}
 	return ""
 }
@@ -1901,6 +1925,7 @@ type ValidateConfigRequest struct {
 	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
 	ExpectedEnrollmentId               string                 `protobuf:"bytes,13,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
 	ExpectedInventoryNodeName          string                 `protobuf:"bytes,14,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
+	VolumeRebinds                      []string               `protobuf:"bytes,15,rep,name=volume_rebinds,json=volumeRebinds,proto3" json:"volume_rebinds,omitempty"`
 	unknownFields                      protoimpl.UnknownFields
 	sizeCache                          protoimpl.SizeCache
 }
@@ -2033,6 +2058,13 @@ func (x *ValidateConfigRequest) GetExpectedInventoryNodeName() string {
 	return ""
 }
 
+func (x *ValidateConfigRequest) GetVolumeRebinds() []string {
+	if x != nil {
+		return x.VolumeRebinds
+	}
+	return nil
+}
+
 type ConfigValidationResult struct {
 	state                                      protoimpl.MessageState `protogen:"open.v1"`
 	ApiVersion                                 string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
@@ -2047,6 +2079,7 @@ type ConfigValidationResult struct {
 	FailureReason                              string                 `protobuf:"bytes,10,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
 	NoChanges                                  bool                   `protobuf:"varint,11,opt,name=no_changes,json=noChanges,proto3" json:"no_changes,omitempty"`
 	RequiredDestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=required_destructive_storage_acknowledgements,json=requiredDestructiveStorageAcknowledgements,proto3" json:"required_destructive_storage_acknowledgements,omitempty"`
+	RequiredVolumeRebinds                      []string               `protobuf:"bytes,13,rep,name=required_volume_rebinds,json=requiredVolumeRebinds,proto3" json:"required_volume_rebinds,omitempty"`
 	unknownFields                              protoimpl.UnknownFields
 	sizeCache                                  protoimpl.SizeCache
 }
@@ -2165,6 +2198,13 @@ func (x *ConfigValidationResult) GetRequiredDestructiveStorageAcknowledgements()
 	return nil
 }
 
+func (x *ConfigValidationResult) GetRequiredVolumeRebinds() []string {
+	if x != nil {
+		return x.RequiredVolumeRebinds
+	}
+	return nil
+}
+
 type GenerationApplyRequest struct {
 	state                              protoimpl.MessageState `protogen:"open.v1"`
 	ApiVersion                         string                 `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
@@ -2181,6 +2221,7 @@ type GenerationApplyRequest struct {
 	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,12,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
 	ExpectedEnrollmentId               string                 `protobuf:"bytes,13,opt,name=expected_enrollment_id,json=expectedEnrollmentId,proto3" json:"expected_enrollment_id,omitempty"`
 	ExpectedInventoryNodeName          string                 `protobuf:"bytes,14,opt,name=expected_inventory_node_name,json=expectedInventoryNodeName,proto3" json:"expected_inventory_node_name,omitempty"`
+	VolumeRebinds                      []string               `protobuf:"bytes,15,rep,name=volume_rebinds,json=volumeRebinds,proto3" json:"volume_rebinds,omitempty"`
 	unknownFields                      protoimpl.UnknownFields
 	sizeCache                          protoimpl.SizeCache
 }
@@ -2313,6 +2354,13 @@ func (x *GenerationApplyRequest) GetExpectedInventoryNodeName() string {
 	return ""
 }
 
+func (x *GenerationApplyRequest) GetVolumeRebinds() []string {
+	if x != nil {
+		return x.VolumeRebinds
+	}
+	return nil
+}
+
 type ConfigApplyOperationRequest struct {
 	state                              protoimpl.MessageState `protogen:"open.v1"`
 	CandidateGenerationId              string                 `protobuf:"bytes,1,opt,name=candidate_generation_id,json=candidateGenerationId,proto3" json:"candidate_generation_id,omitempty"`
@@ -2320,6 +2368,7 @@ type ConfigApplyOperationRequest struct {
 	NodeName                           string                 `protobuf:"bytes,3,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
 	ConfigYaml                         string                 `protobuf:"bytes,4,opt,name=config_yaml,json=configYaml,proto3" json:"config_yaml,omitempty"`
 	DestructiveStorageAcknowledgements []string               `protobuf:"bytes,5,rep,name=destructive_storage_acknowledgements,json=destructiveStorageAcknowledgements,proto3" json:"destructive_storage_acknowledgements,omitempty"`
+	VolumeRebinds                      []string               `protobuf:"bytes,6,rep,name=volume_rebinds,json=volumeRebinds,proto3" json:"volume_rebinds,omitempty"`
 	unknownFields                      protoimpl.UnknownFields
 	sizeCache                          protoimpl.SizeCache
 }
@@ -2385,6 +2434,13 @@ func (x *ConfigApplyOperationRequest) GetConfigYaml() string {
 func (x *ConfigApplyOperationRequest) GetDestructiveStorageAcknowledgements() []string {
 	if x != nil {
 		return x.DestructiveStorageAcknowledgements
+	}
+	return nil
+}
+
+func (x *ConfigApplyOperationRequest) GetVolumeRebinds() []string {
+	if x != nil {
+		return x.VolumeRebinds
 	}
 	return nil
 }
@@ -5212,7 +5268,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x11boot_health_state\x18\x10 \x01(\tR\x0fbootHealthState\x124\n" +
 	"\x16boot_health_diagnostic\x18\x11 \x01(\tR\x14bootHealthDiagnostic\x12#\n" +
 	"\renrollment_id\x18\x12 \x01(\tR\fenrollmentId\x12.\n" +
-	"\x13inventory_node_name\x18\x13 \x01(\tR\x11inventoryNodeName\"\xde\x02\n" +
+	"\x13inventory_node_name\x18\x13 \x01(\tR\x11inventoryNodeName\"\xd1\x03\n" +
 	"\fVolumeStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vtarget_kind\x18\x02 \x01(\tR\n" +
@@ -5229,7 +5285,10 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x06result\x18\b \x01(\tR\x06result\x124\n" +
 	"\x16state_change_timestamp\x18\t \x01(\tR\x14stateChangeTimestamp\x12-\n" +
 	"\x12failure_diagnostic\x18\n" +
-	" \x01(\tR\x11failureDiagnostic\"\xf3\x06\n" +
+	" \x01(\tR\x11failureDiagnostic\x12%\n" +
+	"\x0epartition_uuid\x18\v \x01(\tR\rpartitionUuid\x12'\n" +
+	"\x0ffilesystem_uuid\x18\f \x01(\tR\x0efilesystemUuid\x12!\n" +
+	"\fmount_source\x18\r \x01(\tR\vmountSource\"\xf3\x06\n" +
 	"\x15SystemExtensionStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
 	"\rdesired_state\x18\x02 \x01(\tR\fdesiredState\x12/\n" +
@@ -5382,7 +5441,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x10target_member_id\x18\x02 \x01(\tR\x0etargetMemberId\x12&\n" +
 	"\x0ftarget_peer_url\x18\x03 \x01(\tR\rtargetPeerUrl\x12.\n" +
 	"\x13expected_cluster_id\x18\x04 \x01(\tR\x11expectedClusterId\x122\n" +
-	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\x8e\x05\n" +
+	"\x15expected_member_count\x18\x05 \x01(\rR\x13expectedMemberCount\"\xb5\x05\n" +
 	"\x15ValidateConfigRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5401,7 +5460,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x11operation_timeout\x18\v \x01(\tR\x10operationTimeout\x12P\n" +
 	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\x124\n" +
 	"\x16expected_enrollment_id\x18\r \x01(\tR\x14expectedEnrollmentId\x12?\n" +
-	"\x1cexpected_inventory_node_name\x18\x0e \x01(\tR\x19expectedInventoryNodeName\"\x9e\x04\n" +
+	"\x1cexpected_inventory_node_name\x18\x0e \x01(\tR\x19expectedInventoryNodeName\x12%\n" +
+	"\x0evolume_rebinds\x18\x0f \x03(\tR\rvolumeRebinds\"\xd6\x04\n" +
 	"\x16ConfigValidationResult\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5417,7 +5477,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	" \x01(\tR\rfailureReason\x12\x1d\n" +
 	"\n" +
 	"no_changes\x18\v \x01(\bR\tnoChanges\x12a\n" +
-	"-required_destructive_storage_acknowledgements\x18\f \x03(\tR*requiredDestructiveStorageAcknowledgements\"\x97\x05\n" +
+	"-required_destructive_storage_acknowledgements\x18\f \x03(\tR*requiredDestructiveStorageAcknowledgements\x126\n" +
+	"\x17required_volume_rebinds\x18\r \x03(\tR\x15requiredVolumeRebinds\"\xbe\x05\n" +
 	"\x16GenerationApplyRequest\x12\x1f\n" +
 	"\vapi_version\x18\x01 \x01(\tR\n" +
 	"apiVersion\x12\x12\n" +
@@ -5435,7 +5496,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"configYaml\x12P\n" +
 	"$destructive_storage_acknowledgements\x18\f \x03(\tR\"destructiveStorageAcknowledgements\x124\n" +
 	"\x16expected_enrollment_id\x18\r \x01(\tR\x14expectedEnrollmentId\x12?\n" +
-	"\x1cexpected_inventory_node_name\x18\x0e \x01(\tR\x19expectedInventoryNodeName\"\x84\x02\n" +
+	"\x1cexpected_inventory_node_name\x18\x0e \x01(\tR\x19expectedInventoryNodeName\x12%\n" +
+	"\x0evolume_rebinds\x18\x0f \x03(\tR\rvolumeRebinds\"\xab\x02\n" +
 	"\x1bConfigApplyOperationRequest\x126\n" +
 	"\x17candidate_generation_id\x18\x01 \x01(\tR\x15candidateGenerationId\x12\x1d\n" +
 	"\n" +
@@ -5443,7 +5505,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\tnode_name\x18\x03 \x01(\tR\bnodeName\x12\x1f\n" +
 	"\vconfig_yaml\x18\x04 \x01(\tR\n" +
 	"configYaml\x12P\n" +
-	"$destructive_storage_acknowledgements\x18\x05 \x03(\tR\"destructiveStorageAcknowledgements\"\xbb\b\n" +
+	"$destructive_storage_acknowledgements\x18\x05 \x03(\tR\"destructiveStorageAcknowledgements\x12%\n" +
+	"\x0evolume_rebinds\x18\x06 \x03(\tR\rvolumeRebinds\"\xbb\b\n" +
 	")KubeadmControlPlaneConfigOperationRequest\x12\x1d\n" +
 	"\n" +
 	"rollout_id\x18\x01 \x01(\tR\trolloutId\x12#\n" +

--- a/internal/katlc/agentapi/agent.pb.go
+++ b/internal/katlc/agentapi/agent.pb.go
@@ -257,8 +257,6 @@ type VolumeStatus struct {
 	Result               string                 `protobuf:"bytes,8,opt,name=result,proto3" json:"result,omitempty"`
 	StateChangeTimestamp string                 `protobuf:"bytes,9,opt,name=state_change_timestamp,json=stateChangeTimestamp,proto3" json:"state_change_timestamp,omitempty"`
 	FailureDiagnostic    string                 `protobuf:"bytes,10,opt,name=failure_diagnostic,json=failureDiagnostic,proto3" json:"failure_diagnostic,omitempty"`
-	PartitionUuid        string                 `protobuf:"bytes,11,opt,name=partition_uuid,json=partitionUuid,proto3" json:"partition_uuid,omitempty"`
-	FilesystemUuid       string                 `protobuf:"bytes,12,opt,name=filesystem_uuid,json=filesystemUuid,proto3" json:"filesystem_uuid,omitempty"`
 	MountSource          string                 `protobuf:"bytes,13,opt,name=mount_source,json=mountSource,proto3" json:"mount_source,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
@@ -360,20 +358,6 @@ func (x *VolumeStatus) GetStateChangeTimestamp() string {
 func (x *VolumeStatus) GetFailureDiagnostic() string {
 	if x != nil {
 		return x.FailureDiagnostic
-	}
-	return ""
-}
-
-func (x *VolumeStatus) GetPartitionUuid() string {
-	if x != nil {
-		return x.PartitionUuid
-	}
-	return ""
-}
-
-func (x *VolumeStatus) GetFilesystemUuid() string {
-	if x != nil {
-		return x.FilesystemUuid
 	}
 	return ""
 }
@@ -5268,7 +5252,7 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x11boot_health_state\x18\x10 \x01(\tR\x0fbootHealthState\x124\n" +
 	"\x16boot_health_diagnostic\x18\x11 \x01(\tR\x14bootHealthDiagnostic\x12#\n" +
 	"\renrollment_id\x18\x12 \x01(\tR\fenrollmentId\x12.\n" +
-	"\x13inventory_node_name\x18\x13 \x01(\tR\x11inventoryNodeName\"\xd1\x03\n" +
+	"\x13inventory_node_name\x18\x13 \x01(\tR\x11inventoryNodeName\"\x8d\x03\n" +
 	"\fVolumeStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
 	"\vtarget_kind\x18\x02 \x01(\tR\n" +
@@ -5285,10 +5269,8 @@ const file_internal_katlc_agentapi_agent_proto_rawDesc = "" +
 	"\x06result\x18\b \x01(\tR\x06result\x124\n" +
 	"\x16state_change_timestamp\x18\t \x01(\tR\x14stateChangeTimestamp\x12-\n" +
 	"\x12failure_diagnostic\x18\n" +
-	" \x01(\tR\x11failureDiagnostic\x12%\n" +
-	"\x0epartition_uuid\x18\v \x01(\tR\rpartitionUuid\x12'\n" +
-	"\x0ffilesystem_uuid\x18\f \x01(\tR\x0efilesystemUuid\x12!\n" +
-	"\fmount_source\x18\r \x01(\tR\vmountSource\"\xf3\x06\n" +
+	" \x01(\tR\x11failureDiagnostic\x12!\n" +
+	"\fmount_source\x18\r \x01(\tR\vmountSourceJ\x04\b\v\x10\fJ\x04\b\f\x10\r\"\xf3\x06\n" +
 	"\x15SystemExtensionStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12#\n" +
 	"\rdesired_state\x18\x02 \x01(\tR\fdesiredState\x12/\n" +

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -57,6 +57,9 @@ message VolumeStatus {
   string result = 8;
   string state_change_timestamp = 9;
   string failure_diagnostic = 10;
+  string partition_uuid = 11;
+  string filesystem_uuid = 12;
+  string mount_source = 13;
 }
 
 message SystemExtensionStatus {
@@ -241,6 +244,7 @@ message ValidateConfigRequest {
   repeated string destructive_storage_acknowledgements = 12;
   string expected_enrollment_id = 13;
   string expected_inventory_node_name = 14;
+  repeated string volume_rebinds = 15;
 }
 
 message ConfigValidationResult {
@@ -256,6 +260,7 @@ message ConfigValidationResult {
   string failure_reason = 10;
   bool no_changes = 11;
   repeated string required_destructive_storage_acknowledgements = 12;
+  repeated string required_volume_rebinds = 13;
 }
 
 message GenerationApplyRequest {
@@ -273,6 +278,7 @@ message GenerationApplyRequest {
   repeated string destructive_storage_acknowledgements = 12;
   string expected_enrollment_id = 13;
   string expected_inventory_node_name = 14;
+  repeated string volume_rebinds = 15;
 }
 
 message ConfigApplyOperationRequest {
@@ -281,6 +287,7 @@ message ConfigApplyOperationRequest {
   string node_name = 3;
   string config_yaml = 4;
   repeated string destructive_storage_acknowledgements = 5;
+  repeated string volume_rebinds = 6;
 }
 
 message KubeadmControlPlaneConfigOperationRequest {

--- a/internal/katlc/agentapi/agent.proto
+++ b/internal/katlc/agentapi/agent.proto
@@ -57,8 +57,7 @@ message VolumeStatus {
   string result = 8;
   string state_change_timestamp = 9;
   string failure_diagnostic = 10;
-  string partition_uuid = 11;
-  string filesystem_uuid = 12;
+  reserved 11, 12;
   string mount_source = 13;
 }
 


### PR DESCRIPTION
## Summary

- persist each provisioned volume's discovered PARTUUID and filesystem UUID in generation metadata
- render mounts from the exact generation-owned identity instead of a logical partition label
- reject ambiguous discovery and require one-shot `--rebind-volume NODE/VOLUME` authority for replacement
- retain removed-volume identity tombstones and expose the active source through `katlctl node status`

## Why

Logical `u-<name>` labels were incorrectly serving as both discovery selectors and durable mount identity. If an old and replacement disk carried the same label, the kernel-visible label link could select either device. This change limits labels to discovery and makes the resolved device identity the durable contract.

## Operator impact

Existing bound volumes remain on their exact device when duplicate labels appear. A replacement fails before mounts are stopped or storage is prepared and reports the exact rebind flag plus old and new identities. Destructive overwrite authority remains separate.

Validated through the rebuilt first-install storage VM journey and a persistent `katldev` journey covering duplicate labels, rejection before mutation, explicit rebind, repeat apply, removal tombstones across later generations, reboot persistence, and Kubernetes readiness.
