### PR TITLE
katlctl: retain shutdown poll authentication

### DIFF
--- a/cmd/katlctl/host_management.go
+++ b/cmd/katlctl/host_management.go
@@ -341,7 +341,7 @@ func runHostShutdown(ctx context.Context, opts hostShutdownOptions, stdout, stde
 	}
 	_, _ = fmt.Fprintf(stderr, "Shutdown scheduled for %s; waiting for its management API to stop...\n", node)
 	waitCtx, cancelWait := context.WithTimeout(ctx, opts.timeout)
-	err = waitNodeOffline(waitCtx, target.endpoint)
+	err = waitNodeOffline(waitCtx, target)
 	cancelWait()
 	if err != nil {
 		return fmt.Errorf("%s did not shut down: %w", node, err)
@@ -350,10 +350,11 @@ func runHostShutdown(ctx context.Context, opts hostShutdownOptions, stdout, stde
 	return writeHostShutdown(stdout, opts.output, report)
 }
 
-func waitNodeOffline(ctx context.Context, endpoint string) error {
+func waitNodeOffline(ctx context.Context, target managementTarget) error {
 	for {
 		attemptCtx, cancelAttempt := context.WithTimeout(ctx, 2*time.Second)
-		conn, err := dialKatlcAgent(attemptCtx, endpoint)
+		attemptCtx = withManagementTarget(attemptCtx, target)
+		conn, err := dialKatlcAgent(attemptCtx, target.endpoint)
 		if err == nil {
 			_, err = conn.Client.GetNodeStatus(attemptCtx, &agentapi.GetNodeStatusRequest{})
 			_ = conn.Close()

--- a/cmd/katlctl/host_management_test.go
+++ b/cmd/katlctl/host_management_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/katl-dev/katl/internal/installer/generation"
 	agentapi "github.com/katl-dev/katl/internal/katlc/agentapi"
+	"github.com/katl-dev/katl/internal/managementidentity"
 )
 
 func TestHostStatusUsesContextAndPrintsOperatorView(t *testing.T) {
@@ -246,6 +247,27 @@ func TestHostShutdownNoWaitJSON(t *testing.T) {
 	}
 	if report.Node != "node-a" || report.Result != "scheduled" {
 		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestWaitNodeOfflineRetainsResolvedManagementIdentity(t *testing.T) {
+	credentials := &managementidentity.ClientCredentials{}
+	target := managementTarget{nodeName: "node-a", endpoint: "override.test:9443", credentials: credentials}
+	oldDial := dialKatlcAgent
+	dialKatlcAgent = func(ctx context.Context, endpoint string) (katlcAgentConnection, error) {
+		if endpoint != target.endpoint {
+			t.Fatalf("dial endpoint = %q, want %q", endpoint, target.endpoint)
+		}
+		identity, ok := ctx.Value(managementDialIdentityKey{}).(managementDialIdentity)
+		if !ok || identity.nodeName != target.nodeName || identity.credentials != credentials {
+			t.Fatalf("management identity = %#v, want resolved target credentials", identity)
+		}
+		return katlcAgentConnection{}, context.Canceled
+	}
+	t.Cleanup(func() { dialKatlcAgent = oldDial })
+
+	if err := waitNodeOffline(context.Background(), target); err != nil {
+		t.Fatalf("waitNodeOffline() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

Retain the resolved node name and management client credentials while polling for a node to go offline after an authenticated shutdown request.

## Why

The shutdown request used the explicit context correctly, but its polling loop kept only the endpoint. If that endpoint was unavailable through the default workstation context, credential lookup failed and the failure was incorrectly interpreted as proof that the node had shut down.

The regression test asserts that every poll receives the original resolved identity. A persistent `katldev` journey with the default config hidden confirmed that an explicit context remains sufficient until the VM genuinely powers off and after it restarts.
